### PR TITLE
ci: fetch full base history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref || 'main' }} --no-tags --prune --depth=1
+        run: git fetch origin ${{ github.base_ref || 'main' }} --no-tags --prune
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -42,7 +42,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref || 'main' }} --no-tags --prune --depth=1
+        run: git fetch origin ${{ github.base_ref || 'main' }} --no-tags --prune
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Fix: avoid shallow base fetch so git diff base...HEAD always has a merge-base.\n\n- Updates: .github/workflows/ci.yml\n- No product code changes.