### PR TITLE
文档: 扩写 current docs 第二轮现状说明

### DIFF
--- a/docs/current/architecture.md
+++ b/docs/current/architecture.md
@@ -2,32 +2,87 @@
 
 ## 总体分层
 
-- 行情层：XTData producer / consumer
-- 策略层：Guardian
-- 交易层：order management / position management / TPSL / xtquant broker
-- 展示层：Flask API + Vue Web UI
-- 数据处理层：Dagster / Gantt / Shouban30 read model
-- 观测层：runtime observability
+- 行情层
+  - `freshquant.market_data.xtdata.market_producer`
+  - `freshquant.market_data.xtdata.strategy_consumer`
+  - 负责 XTData 订阅、tick 分发、分钟 bar 生成、结构计算与缓存。
+- 策略层
+  - `freshquant.signal.astock.job.monitor_stock_zh_a_min`
+  - `freshquant.strategy.guardian`
+  - 负责把信号转换成买卖意图，但不负责订单事实。
+- 交易执行层
+  - `freshquant.order_management.*`
+  - `freshquant.position_management.*`
+  - `freshquant.tpsl.*`
+  - `fqxtrade.xtquant.broker`
+  - 负责门禁、订单受理、broker 下发、回报 ingest、止盈止损。
+- 展示层
+  - `freshquant.rear.*`
+  - `morningglory/fqwebui`
+  - 负责 API、Web UI 与历史/实时视图展示。
+- 数据处理层
+  - `freshquant.data.gantt_readmodel`
+  - `freshquant.shouban30_pool_service`
+  - `morningglory/fqdagster`
+  - 负责热门板块读模型、首板筛选读模型与工作区落库。
+- 观测层
+  - `freshquant.runtime_observability.*`
+  - 负责 runtime 事件写盘、聚合与可视化。
 
-## 关键调用链
+## 核心调用链
 
-- XTData -> consumer -> Guardian -> order management -> xtquant broker
-- XTData -> API / Web UI -> Kline / Gantt / Runtime views
-- Dagster -> Gantt / Shouban30 read model -> gantt routes -> Vue views
-- Runtime events -> observability assembler -> `/api/runtime/*` -> `/runtime-observability`
+### 实时交易链
+
+`XTData producer -> Redis tick/bar queue -> XTData consumer -> Guardian -> PositionManagement gate -> OrderManagement submit -> Redis STOCK_ORDER_QUEUE -> broker/puppet gateway -> XT 回报 ingest -> projection / TPSL profile`
+
+### 止盈止损链
+
+`XTData producer -> Redis TICK_QUOTE queue -> TpslTickConsumer -> TpslService -> OrderSubmitService -> broker -> XT 回报 ingest`
+
+### 图表与读模型链
+
+`Dagster / readmodel job -> Mongo gantt_db -> gantt routes -> GanttUnified / GanttShouban30Phase1 / KlineSlim`
+
+### 运行观测链
+
+`各模块 RuntimeEventLogger -> logs/runtime/<runtime_node>/<component>/<date>/*.jsonl -> runtime assembler -> /api/runtime/* -> RuntimeObservability.vue`
 
 ## 进程边界
 
-- Flask API：`freshquant.rear.api_server`
-- Guardian 入口：`freshquant.signal.astock.job.monitor_stock_zh_a_min`
-- 仓位 worker：`freshquant.position_management.worker`
-- TPSL worker：`freshquant.tpsl.tick_listener`
-- xtquant broker：`fqxtrade.xtquant.broker`
+- API Server
+  - `python -m freshquant.rear.api_server --port 5000`
+  - 聚合所有 HTTP 蓝图，不直接做重计算。
+- Guardian monitor
+  - `python -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event`
+  - 监听 bar 更新并调用 `StrategyGuardian`。
+- XTData producer
+  - `python -m freshquant.market_data.xtdata.market_producer`
+  - 唯一负责订阅 XTData 全量行情并向 Redis 推送 tick 事件。
+- XTData consumer
+  - `python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
+  - 唯一负责 bar 队列消费、结构计算与缓存回写。
+- Position worker
+  - `python -m freshquant.position_management.worker --interval 3`
+  - 定期刷新仓位门禁状态。
+- TPSL worker
+  - `python -m freshquant.tpsl.tick_listener`
+  - 消费 tick 队列并触发止盈止损。
+- Broker / Puppet gateway
+  - 不在本目录直接暴露 HTTP，靠 Redis 队列与 XT 回报回流。
 
 ## 模块边界
 
-- 策略层只负责生成买卖意图，不是订单事实层
-- 订单管理负责订单受理、主账本、投影、回报 ingest
-- 仓位管理负责提交门禁与仓位事实对齐
-- TPSL 是独立止盈止损模块，不与 Guardian 合并
-- TradingAgents-CN 与主交易链路保持边界隔离
+- Guardian 只负责决定“要不要下这个策略单”，不是订单账本。
+- Position Management 只负责是否允许提交，不负责真正下单。
+- Order Management 是订单事实层，维护请求、内部订单、事件、买入 lot、卖出分配与外部单对齐。
+- TPSL 是独立退出策略，依赖订单事实和持仓，不跟 Guardian 共用状态机。
+- Gantt 与 Shouban30 只消费读模型与工作区集合，不参与交易链。
+- Runtime Observability 是旁路系统，允许丢日志，不允许卡住主交易链。
+- TradingAgents-CN 与主交易链完全解耦，只共享 Mongo/Redis 基础设施和宿主机配置。
+
+## 关键耦合点
+
+- `must_pool` 与 `xt_positions` 同时影响 XTData 订阅池和 Guardian 买入范围。
+- 订单管理 ingest 会在买入成交后回写 buy lot，并为 TPSL 准备退出上下文。
+- 卖出成交后会重置 Guardian buy grid 状态，避免旧层级持续生效。
+- Shouban30 会把选中的标的同步到 `stock_pre_pools` / `stock_pools` / `must_pool`，因此既影响前端也影响策略订阅范围。

--- a/docs/current/configuration.md
+++ b/docs/current/configuration.md
@@ -2,28 +2,96 @@
 
 ## 配置真相源
 
-- Dynaconf
-- 环境变量
-- Mongo / Redis 参数
-- 根 `.env`（尤其对 TradingAgents-CN）
+FreshQuant 当前使用 Dynaconf。主入口在 `freshquant/config.py`，会按以下顺序搜索配置文件：
 
-## 当前关注的配置域
+- `freshquant/` 包目录下的 `freshquant.yaml|yml|json`
+- 可执行目录同名文件
+- `~/.freshquant/freshquant.yaml|yml|json`
+- 当前工作目录同名文件
 
-- `mongodb.*`
-- `redis.*`
-- `order_management.*`
-- `position_management.*`
-- `xtquant.*`
-- `runtime_observability.*`
+同时支持 `freshquant_*.yaml|yml|json` 形式的 include 文件。环境变量前缀是 `FRESHQUANT_`。
 
-## 配置优先级
+## 当前优先级
 
-- 环境变量覆盖文件默认值
-- Docker 并行环境优先使用映射后的宿主机端口
-- TradingAgents-CN 以根 `.env` 为单一真相源
+1. 进程启动时显式传入的环境变量。
+2. `.env` 或宿主机环境变量。
+3. Dynaconf 读取到的 `freshquant.yaml` / `freshquant_*.yaml`。
+4. 代码内默认值。
 
-## 当前模板位置
+判断配置问题时，优先确认环境变量是否覆盖了文件配置。
 
-- `deployment/examples/freshquant.yaml`
+## 关键配置项
+
+### 基础设施
+
+- `mongodb.host`
+- `mongodb.port`
+- `mongodb.db`
+- `mongodb.gantt_db`
+- `redis.host`
+- `redis.port`
+- `redis.db`
+
+当前仓库默认文件 `freshquant/freshquant.yaml` 中：
+
+- 主库默认 `freshquant`
+- Gantt 库默认 `gantt`
+- Redis 默认 `127.0.0.1:6379 db=1`
+
+Docker 并行模式通过 `deployment/examples/envs.fqnext.example` 把端口改到：
+
+- Mongo `27027`
+- Redis `6380`
+- TDXHQ `15001`
+
+### 订单与仓位
+
+- `order_management.mongo_database`
+- `order_management.projection_database`
+- `position_management.*` 主要通过代码默认值与快照服务参数控制
+
+订单管理默认单独使用 `freshquant_order_management`，投影仍写回 `freshquant`。
+仓位管理默认单独使用 `freshquant_position_management`。
+
+### XTData / 监控
+
+- `monitor.xtdata.mode`
+- `monitor.xtdata.max_symbols`
+- `monitor.xtdata.queue_backlog_threshold`
+- `XTQUANT_PORT` 环境变量
+
+常见模式：
+
+- `guardian_1m`
+  - Guardian 事件驱动模式需要该值。
+- `clx_15_30`
+  - 更偏向结构/选股链路。
+
+### 运行观测
+
+- `FQ_RUNTIME_LOG_DIR`
+  - 覆盖默认 `logs/runtime`
+
+### Symphony
+
+- `GITHUB_TOKEN`
+- `GH_TOKEN`
+- `FRESHQUANT_GITHUB_REPO`
+- `FRESHQUANT_OPENAI_SYMPHONY_ROOT`
+
+这些变量属于宿主机正式服务配置，不在仓库内保存 secret。
+
+## 当前宿主机模板
+
 - `deployment/examples/envs.fqnext.example`
+  - Docker 并行模式下 broker / xtdata / worker 连接 Docker Mongo/Redis 的标准模板。
+- `deployment/examples/freshquant.yaml`
+  - 宿主机配置样例。
 - `deployment/examples/supervisord.fqnext.example.conf`
+  - 宿主机进程编排样例。
+
+## 配置变更约束
+
+- 改配置值：属于普通改动，但应同步文档。
+- 改配置语义：属于高风险改动，必须先过 `Design Review`。
+- 运行面排障时，不要只看 `freshquant.yaml`；必须同时检查进程环境变量和 Docker `env_file`。

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -1,39 +1,99 @@
 # 当前部署
 
-## Docker 并行部署
+## 部署原则
+
+- 代码改动后，受影响模块必须重新部署；只合并不部署不算完成。
+- Docker 并行环境用于承载通用服务与前端；宿主机负责需要直连券商、XTData 或 Windows 资源的进程。
+- 部署动作结束后必须做健康检查；健康检查通过后才进入 cleanup。
+- 当前 Done 判定固定为：`merge + ci + docs sync + deploy + health check + cleanup`。
+
+## 常用部署命令
+
+### 全量并行环境
 
 ```powershell
 docker compose -f docker/compose.parallel.yaml up -d --build
 ```
 
+### 只重建 API / Web
+
+```powershell
+docker compose -f docker/compose.parallel.yaml up -d --build fq_apiserver fq_webui
+```
+
+### 只重建 TradingAgents
+
+```powershell
+docker compose -f docker/compose.parallel.yaml up -d --build ta_backend ta_frontend
+```
+
+### 宿主机重装正式 Symphony
+
+```powershell
+powershell -ExecutionPolicy Bypass -File runtime/symphony/scripts/activate_github_first_formal_service.ps1
+```
+
 ## 模块部署矩阵
 
-- `freshquant/rear/**`：重部署 API
-- `freshquant/order_management/**`：重部署后端/API，必要时重启相关 worker
-- `freshquant/position_management/**`：重启 `position_management.worker`
-- `freshquant/tpsl/**`：重启 `tpsl.tick_listener`
-- `freshquant/market_data/**`：重启 producer / consumer / reference-data worker
-- `morningglory/fqwebui/**`：重构建并部署 Web UI
-- `morningglory/fqdagster/**`：重部署 Dagster
-- `third_party/tradingagents-cn/**`：重部署 `ta_backend` / `ta_frontend`
-- `runtime/symphony/**`：同步宿主机并重启 orchestrator
+| 变更路径 | 需要部署的模块 | 最低动作 |
+| --- | --- | --- |
+| `freshquant/rear/**` | API Server | 重建 `fq_apiserver` 容器或重启 API 进程 |
+| `freshquant/order_management/**` | 订单管理、API、broker/ingest 相关宿主机进程 | 重建 API；若涉及 submit/ingest/gateway，同步重启宿主机交易链进程 |
+| `freshquant/position_management/**` | 仓位管理 | 重启 `python -m freshquant.position_management.worker --interval 3` |
+| `freshquant/tpsl/**` | TPSL | 重启 `python -m freshquant.tpsl.tick_listener` |
+| `freshquant/market_data/**` | XTData producer / consumer | 重启 producer、consumer；必要时重新 prewarm |
+| `freshquant/strategy/**` 或 `freshquant/signal/**` | Guardian | 重启 `python -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event` |
+| `freshquant/data/gantt*` / `freshquant/shouban30_pool_service.py` | Gantt/Shouban30 读模型与 API | 重建 API；必要时重跑 Dagster 任务 |
+| `morningglory/fqwebui/**` | Web UI | 重建 `fq_webui` |
+| `morningglory/fqdagster/**` / `morningglory/fqdagsterconfig/**` | Dagster | 重启 `fq_dagster_webserver` 与 `fq_dagster_daemon` |
+| `third_party/tradingagents-cn/**` | TradingAgents-CN | 重建 `ta_backend` 与 `ta_frontend` |
+| `runtime/symphony/**` | 正式 orchestrator | `sync_freshquant_symphony_service.ps1` + `reinstall_freshquant_symphony_service.ps1` 或激活脚本 |
 
 ## 健康检查
 
-- API 服务端口可访问，关键路由返回正常
-- Web 页面可打开，关键页面不空白
-- Dagster UI 或作业可加载
-- TradingAgents health 接口正常
-- Symphony 状态接口正常
-- 相关 worker 未启动即退
+### API
 
-## Done 规则
+```powershell
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:15000/api/runtime/components
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:15000/api/gantt/plates?provider=xgb
+```
 
-任务只有在以下全部完成后才算结束：
+### Web UI
 
-- merge
-- ci
-- docs sync
-- deploy
-- health check
-- cleanup
+```powershell
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:18080/
+```
+
+### TradingAgents
+
+```powershell
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:13000/api/health
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:13080/health
+```
+
+### Symphony
+
+```powershell
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:40123/api/v1/state
+```
+
+### Docker 组件状态
+
+```powershell
+docker compose -f docker/compose.parallel.yaml ps
+```
+
+## 部署后必须确认的事实
+
+- API 蓝图能返回，不是只监听端口。
+- Web UI 页面不是空白页，关键页面 `/gantt`、`/gantt/shouban30`、`/runtime-observability` 能打开。
+- XTData 相关修改后，producer/consumer 日志持续产出，Redis 队列不持续堆积。
+- TPSL / Position worker 修改后，进程没有“启动即退”。
+- Symphony 修改后，Issue 领取、Design Review、cleanup 闭环仍然可用。
+
+## Cleanup 要求
+
+- 删除已合并远端 feature branch。
+- 删除当前 issue 的 Symphony workspace 或本次临时 worktree。
+- 清理临时脚本、临时 compose override、过期 artifacts。
+- 不清理 Mongo、Redis、`.venv`、正式日志目录或在线服务。

--- a/docs/current/interfaces.md
+++ b/docs/current/interfaces.md
@@ -1,23 +1,118 @@
 # 当前接口
 
+## HTTP API
+
+统一入口：
+
+```powershell
+python -m freshquant.rear.api_server --port 5000
+```
+
+当前蓝图与主要接口：
+
+### `stock`
+
+- `/api/stock_data`
+- `/api/stock_data_v2`
+- `/api/stock_data_chanlun_structure`
+- `/api/get_stock_pools_list`
+- `/api/get_stock_pre_pools_list`
+- `/api/get_stock_must_pools_list`
+- `/api/add_to_stock_pools_by_code`
+- `/api/add_to_must_pool_by_code`
+
+### `gantt`
+
+- `/api/gantt/plates`
+- `/api/gantt/stocks`
+- `/api/gantt/stocks/reasons`
+- `/api/gantt/shouban30/plates`
+- `/api/gantt/shouban30/stocks`
+- `/api/gantt/shouban30/pre-pool/*`
+- `/api/gantt/shouban30/stock-pool/*`
+
+### `order`
+
+- `/api/order/submit`
+- `/api/order/cancel`
+- `/api/stock_order`
+- `/api/order-management/buy-lots/<buy_lot_id>`
+- `/api/order-management/stoploss/bind`
+
+### `tpsl`
+
+- `/api/tpsl/takeprofit/<symbol>`
+- `/api/tpsl/takeprofit/<symbol>/tiers/<level>/enable`
+- `/api/tpsl/takeprofit/<symbol>/tiers/<level>/disable`
+- `/api/tpsl/takeprofit/<symbol>/rearm`
+- `/api/tpsl/events`
+- `/api/tpsl/batches/<batch_id>`
+
+### `runtime`
+
+- `/api/runtime/components`
+- `/api/runtime/health/summary`
+- `/api/runtime/traces`
+- `/api/runtime/traces/<trace_id>`
+- `/api/runtime/events`
+- `/api/runtime/raw-files/files`
+- `/api/runtime/raw-files/tail`
+
 ## CLI
 
-- 入口：`freshquant/cli.py`
-- 主要命令组：`stock / etf / index / future / xt-* / om-order`
+统一入口：
 
-## API
+```powershell
+python -m freshquant.cli
+```
 
-- 入口：`freshquant/rear/api_server.py`
-- blueprint：`future / stock / general / gantt / order / runtime / tpsl`
+当前稳定命令组：
 
-## Web
+- `stock`
+- `etf`
+- `index`
+- `future`
+- `xt-asset`
+- `xt-trade`
+- `xt-order`
+- `xt-position`
+- `channel`
+- `om-order`
 
-- 前端主目录：`morningglory/fqwebui/src/views/`
-- 关键页面：Gantt、Shouban30、Kline、Runtime Observability
+订单管理 CLI：
 
-## Worker / 服务入口
+```powershell
+python -m freshquant.cli om-order submit --action buy --symbol 600000 --price 10.5 --quantity 100
+python -m freshquant.cli om-order cancel --internal-order-id <id>
+```
 
-- Guardian：`freshquant.signal.astock.job.monitor_stock_zh_a_min`
-- Position worker：`freshquant.position_management.worker`
-- TPSL：`freshquant.tpsl.tick_listener`
-- Broker：`fqxtrade.xtquant.broker`
+## 后台 worker 与服务入口
+
+- XTData producer
+  - `python -m freshquant.market_data.xtdata.market_producer`
+- XTData consumer
+  - `python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
+- Guardian monitor
+  - `python -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event`
+- Position worker
+  - `python -m freshquant.position_management.worker --interval 3`
+- TPSL worker
+  - `python -m freshquant.tpsl.tick_listener`
+- Symphony 正式服务
+  - `runtime/symphony/scripts/start_freshquant_symphony.ps1`
+  - `runtime/symphony/scripts/activate_github_first_formal_service.ps1`
+
+## Web UI 路由
+
+- `/stock-control`
+- `/kline-slim`
+- `/gantt`
+- `/gantt/shouban30`
+- `/gantt/stocks/:plateKey`
+- `/runtime-observability`
+
+## 当前接口边界
+
+- 交易主入口是 `OrderSubmitService`；HTTP 和 CLI 只是它的包装。
+- Kline 与 stock pool 仍保留一批历史接口；这些接口可继续使用，但新增页面应优先复用当前已有路由，不要再扩新的平行接口面。
+- Runtime API 只读原始日志与聚合视图，不承担修复动作。

--- a/docs/current/modules/gantt-visualization.md
+++ b/docs/current/modules/gantt-visualization.md
@@ -2,36 +2,81 @@
 
 ## 职责
 
-负责通用甘特图读模型查询与页面展示。
+通用 Gantt 页面负责展示热门板块与板块下热点标的的时间窗口分布。它是读模型展示层，不直接参与筛选写入或交易链。
 
 ## 入口
 
-- API：`freshquant.rear.gantt.routes`
-- 前端：Gantt 系列页面与 `GanttHistory`
+- 前端路由
+  - `/gantt`
+  - `/gantt/stocks/:plateKey`
+- 前端组件
+  - `GanttUnified.vue`
+  - `GanttUnifiedStocks.vue`
+  - `components/GanttHistory.vue`
+- 后端接口
+  - `/api/gantt/plates`
+  - `/api/gantt/stocks`
+  - `/api/gantt/stocks/reasons`
 
 ## 依赖
 
-- Gantt 读模型
-- Dagster 产物
+- `gantt_plate_daily`
+- `gantt_stock_daily`
+- `stock_hot_reason_daily`
+- Dagster 读模型更新
 
 ## 数据流
 
-read model -> gantt routes -> Vue views
+`Mongo gantt readmodel -> freshquant.rear.gantt.routes -> GanttHistory -> provider tabs / window switch / drill down`
+
+页面当前支持：
+
+- provider 切换
+  - `xgb`
+  - `jygs`
+- plate 视图与 stock 视图
+- `days` 窗口切换
+- 热门理由弹窗
 
 ## 存储
 
-依赖读模型集合，不直接读取原始写模型。
+通用 Gantt 只读下列集合：
+
+- `gantt_plate_daily`
+- `gantt_stock_daily`
+- `stock_hot_reason_daily`
+- `plate_reason_daily`
+
+不写工作区集合。
 
 ## 配置
 
-关注查询窗口、plate / stock 视图与图例语义。
+- `provider`
+- `days`
+- `plate_key`
+- `end_date`
+
+所有日期参数都要求 `YYYY-MM-DD`。
 
 ## 部署/运行
 
-改动后通常同时影响 API 与 Web UI。
+- 后端逻辑改动：重建 `fq_apiserver`
+- 页面改动：重建 `fq_webui`
+- 读模型改动：必要时重跑 Dagster
 
 ## 排障点
 
-- 接口为空
-- 图例错位
-- 视图切换异常
+### 板块页为空
+
+- 检查 `/api/gantt/plates?provider=xgb`
+- 检查 `gantt_plate_daily` 是否有窗口内数据
+
+### drill-down 进入标的页后为空
+
+- 检查 `plate_key` 是否在读模型中存在
+- 检查 `/api/gantt/stocks` 返回
+
+### 热门理由弹窗为空
+
+- 检查 `stock_hot_reason_daily`
+- 检查 provider 是否正确

--- a/docs/current/modules/kline-webui.md
+++ b/docs/current/modules/kline-webui.md
@@ -2,36 +2,78 @@
 
 ## 职责
 
-负责 KlineSlim 与相关图表页面展示。
+Kline Web UI 负责展示单标的多周期行情、缠论结构摘要和侧边栏股票列表，是当前最直接的实时/历史结构查看页面。
 
 ## 入口
 
-- Vue Kline 页面
-- 后端 `/api/stock_data` 及相关结构接口
+- 前端路由
+  - `/kline-slim`
+- 前端页面
+  - `KlineSlim.vue`
+- 后端接口
+  - `/api/stock_data`
+  - `/api/stock_data_v2`
+  - `/api/stock_data_chanlun_structure`
 
 ## 依赖
 
-- 历史/实时行情
-- 缠论结构接口
+- `get_data_v2`
+- Redis realtime cache
+- Chanlun structure service
+- stock pool / must_pool / positions 等列表接口
+- Gantt 热点理由接口
 
 ## 数据流
 
-API -> Kline 页面 -> 多周期图层与结构面板
+`symbol + period + endDate -> /api/stock_data -> KlineSlim 主图`
+
+`symbol + period + endDate -> /api/stock_data_chanlun_structure -> 缠论结构面板`
+
+`sidebar section -> 相关列表接口 / 热门理由接口 -> 侧边栏与 hover popover`
 
 ## 存储
 
-依赖行情与结构计算结果，不持有独立事实源。
+Kline 页面不维护自己的事实源，读取的主要是：
+
+- QuantAxis 历史数据
+- Redis realtime cache
+- 结构计算结果
+- stock pool / must_pool / xt_positions
 
 ## 配置
 
-关注 symbol 默认值、多周期显示、缩放/平移语义。
+- `symbol`
+- `period`
+- `endDate`
+- `realtimeCache`
+
+页面当前支持：
+
+- 周期按钮切换
+- 历史日期回看
+- 缠论结构面板
+- 多个侧边栏分组
+- 热门理由 hover 展示
 
 ## 部署/运行
 
-改动后通常影响 Web UI 与 stock_data 路由。
+- 前端改动：重建 `fq_webui`
+- `stock_data` 或结构接口改动：重建 `fq_apiserver`
+- 实时展示异常时，通常需要同时核对 XTData 链和页面接口
 
 ## 排障点
 
-- 页面空白
-- 图层残影
-- 多周期结构错位
+### 页面空白
+
+- 检查 `/api/stock_data` 是否 500
+- 检查路由参数是否为空
+
+### 图层残影或主图不刷新
+
+- 检查 realtime cache 是否还在更新
+- 检查前端 period 切换后是否真的重新请求
+
+### 结构面板与主图时间不一致
+
+- 检查 `endDate` 是否一致
+- 检查结构接口是否拿到了旧缓存

--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -2,37 +2,98 @@
 
 ## 职责
 
-负责实时行情生产、消费、缓存与对下游策略/展示层的分发。
+XTData 链路负责把宿主机 XTData 行情转换成 FreshQuant 可消费的实时事件流。它承担四件事：
+
+- 从 XTQuant 订阅当前监控池的全量行情。
+- 把 tick 推入 Redis 分片队列。
+- 合成 1 分钟 bar，并继续向下游发布 bar close 事件。
+- 在 consumer 侧做 prewarm、结构计算、实时缓存与运行观测。
 
 ## 入口
 
-- producer：`freshquant.market_data.xtdata.market_producer`
-- consumer：`freshquant.market_data.xtdata.strategy_consumer`
+- producer
+  - `python -m freshquant.market_data.xtdata.market_producer`
+- consumer
+  - `python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
+
+producer 是唯一 XTData 入口；consumer 是唯一 bar 队列消费入口。
 
 ## 依赖
 
-- XTData 宿主机环境
+- 宿主机 XTQuant / XTData 环境
+- `XTQUANT_PORT`，默认 `58610`
 - Redis
+- QuantAxis 历史库
+- 监控池来源
+  - `xt_positions`
+  - `must_pool`
+  - `stock_pools`
 
 ## 数据流
 
-XTData -> producer -> Redis -> consumer -> strategy / API / UI
+### Tick 链
+
+`XTData -> market_producer -> REDIS_TICK_QUEUE_PREFIX:<shard> -> TpslTickConsumer`
+
+### Bar 链
+
+`XTData -> market_producer/OneMinuteBarGenerator -> REDIS_QUEUE_PREFIX:<shard> -> strategy_consumer -> realtime cache / chanlun payload / Guardian`
+
+consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catchup 模式，暂时跳过 fullcalc，只保留最新数据。
 
 ## 存储
 
-实时数据与中间缓存依赖 Redis，部分衍生结果写入 Mongo。
+- Redis
+  - tick 分片队列
+  - bar 分片队列
+  - 实时 Kline cache
+- Mongo / QuantAxis
+  - 历史分钟线读取
+  - 实时结构或补权结果所需的基础数据
+
+当前模块本身不维护独立 Mongo 集合，而是依赖 QuantAxis 历史库与 Redis 实时缓存。
 
 ## 配置
 
-关注 XTData endpoint、Redis host/port/db、订阅池和补权刷新参数。
+- `monitor.xtdata.mode`
+  - 决定订阅池来源和 consumer 行为。
+- `monitor.xtdata.max_symbols`
+  - 限制订阅池大小。
+- `monitor.xtdata.queue_backlog_threshold`
+  - 决定 consumer 何时进入 catchup 模式。
+- `XTQUANT_PORT`
+  - XTData 连接端口。
+
+对 Guardian 主链最重要的是：
+
+- `monitor.xtdata.mode=guardian_1m`
 
 ## 部署/运行
 
-通常运行在宿主机 Supervisor 链路中。
+- 这两个进程通常运行在宿主机，不放进 Docker。
+- 修改 `freshquant/market_data/**` 后，至少重启 producer 与 consumer。
+- consumer 改动涉及结构缓存或 prewarm 逻辑时，建议带 `--prewarm` 重新拉起。
 
 ## 排障点
 
-- producer 未启动
-- consumer 卡住
-- Redis 无数据
-- 补权刷新异常
+### producer 无数据
+
+- 检查 XTQuant 是否在线。
+- 检查 `XTQUANT_PORT`。
+- 检查订阅池是否为空。
+
+### consumer 不更新
+
+- 检查 Redis bar 队列是否持续堆积。
+- 检查 `monitor.xtdata.mode` 是否匹配。
+- 检查 prewarm 是否异常退出。
+
+### Kline 页面停在旧 bar
+
+- 检查 Redis realtime cache 是否更新。
+- 检查 `/api/stock_data` 是否启用了 realtime cache。
+
+### TPSL 不收到 tick
+
+- 检查 tick 分片队列是否有目标 code。
+- 检查 producer 是否在向 `REDIS_TICK_QUEUE_PREFIX:<shard>` 推送。

--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -2,39 +2,115 @@
 
 ## 职责
 
-负责订单受理、主账本、回报 ingest、兼容投影、对账与路由。
+订单管理是当前交易链的事实层。它负责：
+
+- 统一受理 API、CLI、Guardian、TPSL 等来源的提交请求。
+- 生成内部 `request_id` / `internal_order_id`。
+- 维护订单主账本与事件流。
+- 向 broker / puppet gateway 发送队列消息。
+- ingest XT 回报并生成买入 lot、卖出分配和兼容投影。
+- 对账外部成交，处理“不是由内部请求发起”的外部单。
 
 ## 入口
 
-- API：`freshquant.rear.order.routes`
-- CLI：`om-order`
-- broker 适配：`fqxtrade.xtquant.broker`
+- HTTP
+  - `/api/order/submit`
+  - `/api/order/cancel`
+  - `/api/stock_order`
+  - `/api/order-management/buy-lots/<buy_lot_id>`
+  - `/api/order-management/stoploss/bind`
+- CLI
+  - `python -m freshquant.cli om-order submit ...`
+  - `python -m freshquant.cli om-order cancel ...`
+- 策略入口
+  - `freshquant.order_management.submit.guardian.submit_guardian_order`
+- 核心服务
+  - `freshquant.order_management.submit.service.OrderSubmitService`
 
 ## 依赖
 
 - Mongo
-- xtquant broker
-- Guardian / 手工下单入口
+- Redis
+- Position Management
+- XT broker / puppet gateway
+- XT 回报 ingest
+- Runtime Observability
 
 ## 数据流
 
-submit / cancel -> order service -> broker -> XT 回报 ingest -> projection / reconcile
+### 下单
+
+`submit_order -> intent normalize -> credit mode resolve -> tracking_create -> queue payload build -> STOCK_ORDER_QUEUE -> broker`
+
+### 撤单
+
+`cancel_order -> internal_order_id 校验 -> cancel queue payload -> broker`
+
+### 回报
+
+`XT order/trade callback -> OrderManagementXtIngestService -> om_orders / om_trade_facts / om_buy_lots / om_sell_allocations -> projection update`
+
+### 对账
+
+`ExternalOrderReconcileService -> internal_match -> externalize -> projection_update`
 
 ## 存储
 
-订单主事实由 order management 主账本维护。
+主事实集合：
+
+- `om_order_requests`
+- `om_orders`
+- `om_order_events`
+- `om_trade_facts`
+- `om_buy_lots`
+- `om_lot_slices`
+- `om_sell_allocations`
+- `om_external_candidates`
+- `om_stoploss_bindings`
+- `om_credit_subjects`
+
+旧 `xt_orders / xt_trades` 属于外部回报视角，不替代 `om_*` 主事实。
 
 ## 配置
 
-关注 broker mode、observe_only、数据库配置、信用账户参数。
+- `order_management.mongo_database`
+- `order_management.projection_database`
+- broker `observe_only`
+- account type / credit mode
+
+`observe_only` 语义是“只建内部账本和事件，不真正向 broker 发单”；排障时必须确认当前是否误开该模式。
 
 ## 部署/运行
 
-改动后至少重部署 API 与相关 worker。
+- 路由改动至少重建 `fq_apiserver`
+- submit / ingest / reconcile 逻辑改动时，要同步重启相关宿主机进程
+- 交易链改动后至少验证一次：
+  - submit
+  - XT 回报 ingest
+  - 投影更新
 
 ## 排障点
 
-- submit 不落库
-- broker 不提交
-- 回报未 ingest
-- reconcile 不收敛
+### submit 成功返回但不落库
+
+- 检查 `om_order_requests`
+- 检查 `om_orders`
+- 检查 Mongo 连接与订单库名
+
+### 已落库但 broker 没动作
+
+- 检查 Redis `STOCK_ORDER_QUEUE`
+- 检查 gateway 进程是否消费
+- 检查是否误开 `observe_only`
+
+### 成交回来了但前端无持仓
+
+- 检查 `om_trade_facts`
+- 检查 `om_buy_lots` 和投影是否更新
+- 检查 reconcile 是否把外部成交匹配成内部单
+
+### 卖出后 lot 不对
+
+- 检查 `om_sell_allocations`
+- 检查 `om_lot_slices`
+- 检查 ingest 是否识别到正确的买入 lot

--- a/docs/current/modules/position-management.md
+++ b/docs/current/modules/position-management.md
@@ -2,36 +2,78 @@
 
 ## 职责
 
-负责仓位状态、提交门禁与仓位事实对齐。
+仓位管理负责把账户资产和持仓状态转换成策略可消费的“是否允许提交”门禁结论。它不是订单提交器，也不是 broker 适配层。
 
 ## 入口
 
-- worker：`freshquant.position_management.worker`
+- worker
+  - `python -m freshquant.position_management.worker --interval 3`
+- 核心服务
+  - `freshquant.position_management.snapshot_service.PositionSnapshotService`
+  - `freshquant.position_management.service.PositionManagementService`
 
 ## 依赖
 
+- XT 资产/持仓快照
 - Mongo
-- order management
-- Guardian
+- Guardian / Order Submit
+- Runtime Observability
 
 ## 数据流
 
-订单 / 回报 -> 仓位事实更新 -> submit gate -> 策略下单前校验
+`XT credit detail -> snapshot_service.refresh_once -> pm_credit_asset_snapshots / pm_current_state -> evaluate_strategy_order -> allow/reject`
+
+提交门禁发生在 Order Management 接收策略单时。卖单原则上总是允许；买单要看当前状态。
 
 ## 存储
 
-使用独立仓位存储边界。
+仓位管理单独使用 `freshquant_position_management`，主要集合：
+
+- `pm_configs`
+- `pm_credit_asset_snapshots`
+- `pm_current_state`
+- `pm_strategy_decisions`
 
 ## 配置
 
-关注仓位数据库、stale state 规则、提交门禁策略。
+关键策略状态：
+
+- `ALLOW_OPEN`
+- `HOLDING_ONLY`
+- `FORCE_PROFIT_REDUCE`
+
+当前默认规则：
+
+- 状态超过 15 秒未刷新视为 stale
+- stale 默认按 `HOLDING_ONLY` 处理
+- 允许开仓的最低保证金默认约 `800000`
+- 仅允许持仓内操作的最低保证金默认约 `100000`
 
 ## 部署/运行
 
-改动后重启 `position_management.worker`。
+- 改动后至少重启 worker：
+
+```powershell
+python -m freshquant.position_management.worker --interval 3
+```
+
+- 涉及门禁语义时，必须同时验证 Guardian 策略单与手工/API 单。
 
 ## 排障点
 
-- 仓位不刷新
-- stale state 误判
-- gate 拒绝合法请求
+### 仓位状态一直不刷新
+
+- 检查 worker 是否在跑
+- 检查 XT 资产接口是否可读
+- 检查 `pm_credit_asset_snapshots` 最近更新时间
+
+### 所有买单都被拒绝
+
+- 检查 `pm_current_state`
+- 检查是否进入 stale
+- 检查保证金阈值是否触发 `HOLDING_ONLY` 或 `FORCE_PROFIT_REDUCE`
+
+### 盈利减仓语义异常
+
+- 检查 `FORCE_PROFIT_REDUCE` 下的 `is_profitable` 元数据
+- 检查 Guardian 卖单是否携带正确上下文

--- a/docs/current/modules/runtime-observability.md
+++ b/docs/current/modules/runtime-observability.md
@@ -2,36 +2,84 @@
 
 ## 职责
 
-负责 runtime trace、event、原始日志与观测页面展示。
+Runtime Observability 负责把交易链和数据链中的 runtime 事件写入原始 JSONL 文件，并在 API 与页面中聚合成 trace、组件健康和异常优先视图。它是排障工具，不是业务事实源。
 
 ## 入口
 
-- API：`/api/runtime/*`
-- 页面：`/runtime-observability`
+- 页面
+  - `/runtime-observability`
+- API
+  - `/api/runtime/components`
+  - `/api/runtime/health/summary`
+  - `/api/runtime/traces`
+  - `/api/runtime/traces/<trace_id>`
+  - `/api/runtime/events`
+  - `/api/runtime/raw-files/files`
+  - `/api/runtime/raw-files/tail`
 
 ## 依赖
 
-- runtime event assembler
-- 本地日志 / trace 文件
+- `RuntimeEventLogger`
+- 原始日志目录 `logs/runtime` 或 `FQ_RUNTIME_LOG_DIR`
+- trace assembler
+- component/node catalog
 
 ## 数据流
 
-runtime events -> assembler -> API -> UI
+`业务模块 emit runtime event -> queue-based logger -> logs/runtime/<runtime_node>/<component>/<date>/*.jsonl -> runtime routes -> RuntimeObservability.vue`
+
+当前 catalog 中的核心组件：
+
+- `xt_producer`
+- `xt_consumer`
+- `guardian_strategy`
+- `tpsl_worker`
+- `position_gate`
+- `order_submit`
+- `broker_gateway`
+- `puppet_gateway`
+- `xt_report_ingest`
+- `order_reconcile`
 
 ## 存储
 
-观测数据是旁路产物，不是主交易事实。
+- 原始文件：JSONL
+- 路径结构：`<root>/<runtime_node>/<component>/<date>/<component>_<date>_<pid>.jsonl`
+- 不写 Mongo，不写 Redis
+
+该模块允许丢事件：当队列满时，logger 会增加 dropped 计数，而不是阻塞主交易链。
 
 ## 配置
 
-关注 dashboard 开关、刷新周期、日志目录。
+- `FQ_RUNTIME_LOG_DIR`
+- 页面自动刷新开关
+- 页面筛选参数
+  - `trace_id`
+  - `request_id`
+  - `internal_order_id`
+  - `intent_id`
+  - `symbol`
+  - `component`
+  - `runtime_node`
 
 ## 部署/运行
 
-可与主交易链解耦部署，但通常随 API 一起发布。
+- API / 页面改动：重建 `fq_apiserver` 与 `fq_webui`
+- 业务侧只要使用 `RuntimeEventLogger` 即可写入，不需要单独部署 runtime worker
 
 ## 排障点
 
-- trace 不生成
-- API 返回空
-- 页面刷新异常
+### 页面空白
+
+- 检查日志目录是否存在
+- 检查 `/api/runtime/components`
+
+### trace 数量异常少
+
+- 检查业务进程是否真的 emit runtime event
+- 检查 logger 队列是否丢数据过多
+
+### Raw Browser 打不开
+
+- 检查请求的 `runtime_node/component/date/file` 是否存在
+- 检查路径参数是否合法

--- a/docs/current/modules/shouban30-screening.md
+++ b/docs/current/modules/shouban30-screening.md
@@ -2,36 +2,92 @@
 
 ## 职责
 
-负责首板标的筛选、盘后快照与页面工作区。
+Shouban30 模块负责“30 天首板”盘后筛选、页面工作区管理和向 `pre_pool / stock_pool / must_pool` 的落库同步。它和通用 Gantt 共用部分后端，但职责不同：Gantt 只读展示，Shouban30 负责筛选结果工作区。
 
 ## 入口
 
-- 前端：Shouban30 页面
-- 后端：gantt / shouban30 相关接口与服务
+- 前端路由
+  - `/gantt/shouban30`
+- 前端页面
+  - `GanttShouban30Phase1.vue`
+- 后端接口
+  - `/api/gantt/shouban30/plates`
+  - `/api/gantt/shouban30/stocks`
+  - `/api/gantt/shouban30/pre-pool/*`
+  - `/api/gantt/shouban30/stock-pool/*`
+- 工作区服务
+  - `freshquant.shouban30_pool_service`
 
 ## 依赖
 
-- read model
-- 股票池 / pre_pool / blk 同步逻辑
+- `shouban30_plates`
+- `shouban30_stocks`
+- `stock_pre_pools`
+- `stock_pools`
+- `must_pool`
+- `TDX_HOME/T0002/blocknew/30RYZT.blk`
 
 ## 数据流
 
-snapshot / filters -> routes -> page workspace
+`readmodel snapshot -> /api/gantt/shouban30/* -> GanttShouban30Phase1 -> save current filter / save plate / add to stock pool / add to must pool -> Mongo workspace + blk sync`
+
+页面当前支持：
+
+- provider 切换
+- `30/45/60/90` 日标的窗口
+- 额外条件筛选
+- 预选池、股票池工作区操作
+- 热门理由与缠论统计展示
 
 ## 存储
 
-依赖盘后快照和读模型投影。
+读模型集合：
+
+- `shouban30_plates`
+- `shouban30_stocks`
+
+工作区集合：
+
+- `stock_pre_pools`
+- `stock_pools`
+- `must_pool`
+
+宿主机文件：
+
+- `30RYZT.blk`
 
 ## 配置
 
-关注筛选按钮、候选/通过/失败字段语义。
+- `stock_window_days` 只能是 `30|45|60|90`
+- 当前缠论过滤版本是 `30m_v1`
+- 默认分类：
+  - `三十涨停Pro预选`
+  - `三十涨停Pro自选`
+  - `三十涨停Pro`
 
 ## 部署/运行
 
-改动后通常影响 API、Dagster、Web UI。
+- 页面或 gantt routes 改动后，重建 API 与 Web UI。
+- 读模型逻辑改动后，重跑 Dagster。
+- 工作区与 `.blk` 同步逻辑改动后，必须在宿主机验证 `TDX_HOME` 写入。
 
 ## 排障点
 
-- 快照缺失
-- 筛选条件失效
-- pool / blk 同步不一致
+### `/shouban30/plates` 返回 409
+
+- 说明快照未准备好，先检查 `shouban30_plates` 与 `shouban30_stocks`
+
+### 页面筛选按钮无效
+
+- 检查 `selected_extra_filters` 是否正确回传
+- 检查 replace context 是否写入 `stock_pre_pools.extra`
+
+### 保存到 pre_pool 成功但 `.blk` 不更新
+
+- 检查 `TDX_HOME`
+- 检查宿主机是否有写权限
+
+### 加入 must_pool 后策略仍不关注
+
+- 检查 `must_pool` 是否真的落库
+- 检查 XTData 订阅池刷新是否已生效

--- a/docs/current/modules/strategy-guardian.md
+++ b/docs/current/modules/strategy-guardian.md
@@ -2,38 +2,96 @@
 
 ## 职责
 
-负责消费行情与状态，生成买卖意图，但不直接作为订单事实层。
+Guardian 是当前 A 股实时策略层。它负责把 XTData consumer 产生的结构信号转换成“是否提交买卖单”的策略意图，但它本身不是订单事实层，也不负责直接和 broker 交互。
 
 ## 入口
 
-- `freshquant.strategy.guardian`
-- `freshquant.signal.astock.job.monitor_stock_zh_a_min`
+- 策略实现
+  - `freshquant.strategy.guardian.StrategyGuardian`
+- 事件驱动入口
+  - `python -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event`
+- 旧轮询入口
+  - 同模块 `--mode poll`
+
+当前正式运行口径是 `--mode event`。
 
 ## 依赖
 
-- XTData consumer
-- 持仓 / must_pool / stock_pool
-- order management 提交能力
+- XTData consumer 推送的 1 分钟 bar 更新
+- `must_pool`
+- `xt_positions`
+- Guardian buy grid 状态
+- Position Management 门禁
+- Order Management 提交服务
+- Redis 冷却键
 
 ## 数据流
 
-行情 -> Guardian -> submitter / order management
+`bar update -> calculate_guardian_signals_latest -> save_a_stock_signal -> StrategyGuardian.on_signal -> buy/sell decision -> submit_guardian_order -> OrderSubmitService`
+
+买入路径分为两类：
+
+- 持仓加仓
+  - `_handle_holding_buy`
+- must_pool 新开仓
+  - `_handle_new_open_buy`
+
+卖出路径：
+
+- 持仓内 `SELL_SHORT` 触发 `_handle_sell`
 
 ## 存储
 
-依赖持仓、股票池与策略状态存储，不维护订单主账本。
+Guardian 自身不维护订单账本，但依赖以下状态：
+
+- `must_pool`
+- `xt_positions`
+- Guardian buy grid 集合
+  - `guardian_buy_grid_configs`
+  - `guardian_buy_grid_states`
+  - `audit_log`
 
 ## 配置
 
-关注 guardian mode、buy grid、持仓门禁。
+- `monitor.xtdata.mode`
+  - 事件模式必须是 `guardian_1m`
+- `monitor.xtdata.max_symbols`
+- buy grid 初始金额与层级配置
+- Redis 冷却键
+  - `buy:<code>`
+  - `sell:<code>`
+  - `fq:xtrade:last_new_order_time`
+
+Guardian 对旧信号有 30 分钟时间窗限制；信号太旧会直接跳过。
 
 ## 部署/运行
 
-常作为宿主机 worker 运行。
+- 正式运行在宿主机。
+- 修改 `freshquant/strategy/**` 或 `freshquant/signal/**` 后，至少重启：
+
+```powershell
+python -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event
+```
 
 ## 排障点
 
-- worker 未启动
-- 池子数据为空
-- submit gate 拒绝
-- buy grid 参数错误
+### 有信号但完全不触发
+
+- 检查是否跑在 `--mode event`
+- 检查 `monitor.xtdata.mode=guardian_1m`
+
+### BUY_LONG 信号没有下单
+
+- 检查目标 code 是否在 `must_pool` 或 `xt_positions`
+- 检查 `buy:<code>` 冷却键
+- 检查 Position Management 是否拒绝
+
+### 新开仓长期不生效
+
+- 检查 `fq:xtrade:last_new_order_time` 是否还在冷却窗口
+- 检查 buy grid 计算出的 `quantity` 是否为 0
+
+### 卖出后继续沿用旧层级
+
+- 检查 XT 回报 ingest 是否已经调用 Guardian buy grid reset
+- 检查卖出成交是否真正进入 `om_trade_facts`

--- a/docs/current/modules/tpsl.md
+++ b/docs/current/modules/tpsl.md
@@ -2,37 +2,87 @@
 
 ## 职责
 
-作为独立模块监听实时 quote，并触发止盈 / 止损卖单。
+TPSL 模块负责在独立 tick 链路上评估止盈和止损条件，并在条件满足时批量生成退出单。它是独立模块，不和 Guardian 共享买卖状态机。
 
 ## 入口
 
-- `freshquant.tpsl.tick_listener`
-- `freshquant.rear.tpsl.routes`
+- worker
+  - `python -m freshquant.tpsl.tick_listener`
+- HTTP
+  - `/api/tpsl/takeprofit/<symbol>`
+  - `/api/tpsl/events`
+  - `/api/tpsl/batches/<batch_id>`
+- 核心服务
+  - `freshquant.tpsl.consumer.TpslTickConsumer`
+  - `freshquant.tpsl.service.TpslService`
 
 ## 依赖
 
-- Redis 实时 `TICK_QUOTE`
-- order management
-- 持仓与 lot 信息
+- Redis tick 队列 `REDIS_TICK_QUEUE_PREFIX:<shard>`
+- `xt_positions`
+- Order Management 提交能力
+- buy lot / stoploss 绑定信息
 
 ## 数据流
 
-实时 quote -> 规则判断 -> 生成卖单意图 -> order management
+`Redis tick -> TickQuoteListener -> TpslTickConsumer.handle_tick -> load_active_tpsl_codes -> evaluate_takeprofit / evaluate_stoploss -> create batch -> OrderSubmitService`
+
+执行顺序上，takeprofit 先于 stoploss 评估。
 
 ## 存储
 
-依赖持仓与规则状态，不维护订单主账本。
+TPSL 数据当前仍放在订单管理库，核心集合：
+
+- `om_takeprofit_profiles`
+- `om_takeprofit_states`
+- `om_exit_trigger_events`
+
+TPSL 还会读取：
+
+- `xt_positions`
+- `om_buy_lots`
+- `om_stoploss_bindings`
 
 ## 配置
 
-关注止盈止损阈值、重置/武装策略、Redis 配置。
+- takeprofit profile tiers
+- rearm / enable / disable 状态
+- cooldown lock（Redis 或内存 fallback）
+- Redis host/port/db
+
+当前可通过 API：
+
+- 设置 profile
+- 启用/停用 tier
+- rearm
+- 查询事件
 
 ## 部署/运行
 
-改动后重启 `tpsl.tick_listener`。
+- 改动后至少重启：
+
+```powershell
+python -m freshquant.tpsl.tick_listener
+```
+
+- 如果改了 API，同时重建 `fq_apiserver`
 
 ## 排障点
 
-- quote 未到达
-- 规则未武装
-- 卖单未生成
+### tick 到了但完全不评估
+
+- 检查 worker 是否在跑
+- 检查 active universe 是否包含目标股票
+- 检查 Redis tick 队列是否真的有目标 code
+
+### 命中止盈但没有生成退出单
+
+- 检查 profile 是否 enabled
+- 检查 cooldown 是否仍在
+- 检查 `xt_positions` 可卖数量
+
+### 触发事件落了但批次无单
+
+- 检查 `om_exit_trigger_events`
+- 检查 OrderSubmitService 是否被拒绝
+- 检查 Position Management 是否影响了退出单（理论上卖单应允许）

--- a/docs/current/modules/tradingagents-cn.md
+++ b/docs/current/modules/tradingagents-cn.md
@@ -2,41 +2,82 @@
 
 ## 职责
 
-负责 TradingAgents-CN 的当前接入、部署与运行边界。
+TradingAgents-CN 是并行接入的独立分析子系统，当前通过 Docker 并行环境对外提供分析后端和前端，不参与 FreshQuant 主交易链的订单、仓位和 TPSL 决策。
 
 ## 入口
 
-- `ta_backend`
-- `ta_frontend`
+- Docker 服务
+  - `ta_backend`
+  - `ta_frontend`
+- 并行端口
+  - backend：`13000`
+  - frontend：`13080`
 
 ## 依赖
 
-- 根 `.env`
 - Mongo
+  - 数据库 `tradingagents_cn`
 - Redis
-- Docker 并行部署
+  - `db=8`
+- 根 `.env` / `FQ_COMPOSE_ENV_FILE`
+- Docker 并行环境
 
 ## 数据流
 
-frontend -> backend -> analysis workflow -> Mongo / Redis
+`ta_frontend -> ta_backend -> analysis workflow / cache / session -> Mongo + Redis`
+
+它只共享基础设施，不共享 FreshQuant 的订单账本和策略状态机。
 
 ## 存储
 
-使用独立的 TradingAgents-CN 数据边界。
+- Mongo database：`tradingagents_cn`
+- Redis database：`8`
+- 宿主机挂载目录：
+  - `runtime/tradingagents-cn/data`
+  - `runtime/tradingagents-cn/logs`
 
 ## 配置
 
-根 `.env` 是当前单一真相源。
+compose 中的关键环境变量：
+
+- `CONFIG_SOT=file`
+- `MONGODB_URL=mongodb://fq_mongodb:27017/tradingagents_cn`
+- `REDIS_URL=redis://fq_redis:6379/8`
+- `TRADINGAGENTS_DATA_DIR=/app/data`
+- `TRADINGAGENTS_LOG_DIR=/app/logs`
+
+当前集成约束：
+
+- 配置真相源是部署环境和 compose，不把上游长文档直接当成本仓正式文档。
+- 不在 FreshQuant 主库中复用 TradingAgents 的业务集合。
 
 ## 部署/运行
 
-并行部署端口默认：
+```powershell
+docker compose -f docker/compose.parallel.yaml up -d --build ta_backend ta_frontend
+```
 
-- backend：`13000`
-- frontend：`13080`
+健康检查：
+
+```powershell
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:13000/api/health
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:13080/health
+```
 
 ## 排障点
 
-- `.env` 不一致
-- Mongo / Redis 端口错误
-- 分析请求卡住
+### backend 启不来
+
+- 检查 Mongo/Redis 是否健康
+- 检查 `.env` 是否包含所需 secret
+
+### 前端能开但分析请求卡住
+
+- 检查 backend `/api/health`
+- 检查 `runtime/tradingagents-cn/logs`
+- 检查 Redis `db=8`
+
+### 与 FreshQuant 主系统串库
+
+- 检查 Mongo URL 是否仍指向 `tradingagents_cn`
+- 检查 Redis DB 是否误改成主链使用的库

--- a/docs/current/overview.md
+++ b/docs/current/overview.md
@@ -1,32 +1,53 @@
 # 当前总览
 
-## 项目目标
+## 项目定位
 
-FreshQuant 当前阶段以“稳定现有系统、修复潜在 bug、统一当前事实文档”为主，不再以迁移过程治理为主。
+FreshQuant 当前已经完成第一阶段的模块收口，现阶段进入第二阶段：以修复潜在 bug、降低跨模块漂移、稳定部署与排障链路为主。仓库不再保存过程型治理文档，正式文档只描述当前系统事实。
 
-## 已落地核心能力
+## 当前已落地能力
 
-- Flask API：`future / stock / general / gantt / order / runtime / tpsl`
-- CLI：`stock / etf / index / future / xt-* / om-order`
-- XTData producer / consumer
-- Guardian 策略
-- 订单管理 / 仓位管理 / TPSL
-- Gantt / Shouban30 页面与读模型
-- KlineSlim 多周期图层
-- Runtime Observability
-- TradingAgents-CN 并行接入
+- HTTP API 已统一挂载 `future / stock / general / gantt / order / runtime / tpsl` 七组蓝图。
+- CLI 已收口到 `stock / etf / index / future / xt-* / om-order` 等命令组。
+- XTData producer/consumer 已形成实时 tick、1 分钟 bar、结构计算与缓存链路。
+- Guardian 已形成事件驱动的策略执行入口，并与订单管理、仓位管理、TPSL 解耦。
+- 订单管理、仓位管理、TPSL 已形成三段式交易链路。
+- Gantt、Shouban30、KlineSlim、Runtime Observability 等前端页面已落地。
+- TradingAgents-CN 已作为并行子系统接入 Docker 并行环境。
+- Symphony 正式 orchestrator 已切到 GitHub-first 工作流。
 
-## 主要目录
+## 目录与职责
 
-- `freshquant/`：核心后端、worker、CLI、API
-- `morningglory/fqwebui/`：前端页面
-- `morningglory/fqdagster/`：Dagster 运行面
-- `runtime/symphony/`：Symphony 运行模板与脚本
-- `third_party/tradingagents-cn/`：TradingAgents-CN
+- `freshquant/`
+  - 后端 API、CLI、数据接入、策略、订单、仓位、TPSL 与运行观测代码。
+- `morningglory/fqwebui/`
+  - Vue Web UI，包括 Gantt、Shouban30、KlineSlim、Runtime Observability 页面。
+- `morningglory/fqdagster/` 与 `morningglory/fqdagsterconfig/`
+  - Gantt/Shouban30 读模型的 Dagster 运行面。
+- `runtime/symphony/`
+  - GitHub-first 正式工作流模板、服务同步脚本、cleanup finalizer。
+- `third_party/tradingagents-cn/`
+  - TradingAgents-CN 源码与 Docker 构建入口。
+- `deployment/examples/`
+  - 宿主机环境与 supervisor 模板，不再放在 `docs/` 下。
+
+## 运行拓扑
+
+- Windows 宿主机承担 XTQuant、XTData、Guardian、position worker、TPSL worker 与 Symphony 正式服务。
+- Docker 并行环境承担 Mongo、Redis、API Server、TDXHQ、Dagster、Web UI、TradingAgents-CN。
+- API Server 提供对外 HTTP 面；Guardian、TPSL、position worker 等后台进程依赖相同的 Mongo/Redis。
+- Runtime Observability 以旁路方式记录事件，不参与主交易决策。
+
+## 当前真相源
+
+- 代码真相源：远程 `origin/main`。
+- 运行真相源：`fq-symphony-orchestrator` 正式服务与受影响模块的部署结果。
+- 文档真相源：`docs/current/**`。
+- 任务真相源：GitHub Issue。
+- 唯一人工门：GitHub Draft PR 上的 `Design Review`。
 
 ## 当前维护重点
 
-- 修复跨模块潜在 bug
-- 降低文档漂移
-- 收敛部署与 cleanup 语义
-- 让 Design Review、CI、deploy、health check、cleanup 连成一条闭环
+- 修复 XTData、Guardian、订单管理、仓位门禁与 TPSL 之间的边界 bug。
+- 保持 Mongo 主事实、投影集合与前端视图的一致性。
+- 把部署矩阵、健康检查与 cleanup 做成闭环，而不是停留在代码合并。
+- 让 `docs/current/**` 跟随代码演进，避免再次回到“过程文档多、现状文档少”的状态。

--- a/docs/current/reference/etf-data.md
+++ b/docs/current/reference/etf-data.md
@@ -1,3 +1,36 @@
 # ETF 数据参考
 
-当前文档用于说明 ETF 行情口径以及与 A 股行情在补权和展示上的差异。
+## 当前 ETF 口径
+
+ETF 在 FreshQuant 中与 A 股共用大部分接口，但有几处语义不同：
+
+- 识别逻辑通常依赖代码前缀，例如 `15`、`16`、`51`、`52`、`53`、`56`、`58`、`159`
+- 某些 ATR/网格参数计算会按指数/ETF 路径处理，而不是普通个股路径
+- must_pool 允许 `etf_cn`，因此 ETF 也可能进入 Guardian 订阅和交易范围
+
+## 当前入口
+
+- CLI
+  - `python -m freshquant.cli etf ...`
+- HTTP
+  - 与 A 股共用 `/api/stock_data` 等行情接口
+- 监控池
+  - `must_pool` 中 `instrument_type=etf_cn` 的记录可进入监控范围
+
+## 与普通 A 股的差异
+
+- 价格和补权语义可能更接近指数数据
+- 网格交易间距计算会走 ETF/指数的 ATR 路径
+- 页面展示仍走 Kline/Gantt 通用视图，不另开一套页面
+
+## 当前排查
+
+### ETF 在页面能查到，但策略不关注
+
+- 检查 `must_pool.instrument_type`
+- 检查监控池是否已刷新
+
+### ETF 网格结果异常
+
+- 检查是否误按普通股票 ATR 路径计算
+- 检查对应 instrument info 是否正确识别成 `etf_cn`

--- a/docs/current/reference/market-data.md
+++ b/docs/current/reference/market-data.md
@@ -1,3 +1,66 @@
 # 行情数据参考
 
-当前文档用于说明 A 股行情获取口径、实时/历史数据入口以及常用排查方向。
+## 当前行情来源
+
+FreshQuant 当前同时使用三类行情来源：
+
+- XTData / XTQuant
+  - 实时 tick 和分钟 bar 的唯一正式入口
+- QuantAxis / Mongo 历史库
+  - Kline、结构计算、历史回看使用的主要历史数据来源
+- Redis realtime cache
+  - 前端实时查询与 consumer 最新结果缓存
+
+## 正式入口
+
+- 实时 producer
+  - `python -m freshquant.market_data.xtdata.market_producer`
+- 实时 consumer
+  - `python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
+- HTTP 查询
+  - `/api/stock_data`
+  - `/api/stock_data_v2`
+  - `/api/stock_data_chanlun_structure`
+
+## 当前口径
+
+### 实时口径
+
+- producer 从 XTData 订阅监控池全量行情
+- tick 写入 Redis tick 分片队列
+- bar 写入 Redis bar 分片队列
+- consumer 计算结构后把最新结果写回 Redis realtime cache
+
+### 历史口径
+
+- `get_data_v2` 使用 QuantAxis 历史数据
+- endDate 为空时，可优先命中 Redis realtime cache
+- 指定 `endDate` 时，以历史查询为准
+
+## 当前常见字段语义
+
+- `symbol`
+  - 前端常用 `sh600000` / `sz000001`
+- `code6`
+  - 六位证券代码
+- `period`
+  - 前端周期，如 `1m`、`5m`、`30m`、`1d`
+- `endDate`
+  - `YYYY-MM-DD`
+
+## 常见排查
+
+### 历史数据有，实时不动
+
+- 检查 producer / consumer 是否在线
+- 检查 Redis cache 是否更新
+
+### `/api/stock_data` 很慢
+
+- 检查是否命中 realtime cache
+- 检查 consumer 是否刚进入 catchup 模式
+
+### 某些股票始终没有实时数据
+
+- 检查它是否在当前监控池
+- 检查 `monitor.xtdata.max_symbols` 是否裁掉了它

--- a/docs/current/reference/signal-clxs.md
+++ b/docs/current/reference/signal-clxs.md
@@ -1,3 +1,81 @@
 # CLXS 信号函数参考
 
-当前文档用于说明 CLXS 系列信号函数的现状和查询方式。
+## 当前定位
+
+CLXS 是当前仓库仍在使用的一组缠论信号函数与筛选策略，主要依赖外部扩展：
+
+- `fqcopilot.fq_clxs`
+- `fqchan04.fq_recognise_bi`
+
+它们既用于盘后选股，也用于 Guardian 事件驱动链路中的部分信号识别。
+
+## 当前主要落点
+
+- 盘后选股策略
+  - `freshquant.screening.strategies.clxs.ClxsStrategy`
+- 事件驱动辅助
+  - `freshquant.signal.astock.job.monitor_helpers_event`
+- 单一模式函数
+  - `freshquant.pattern.chanlun.macd_divergence`
+  - `freshquant.pattern.chanlun.pullback`
+  - `freshquant.pattern.chanlun.v_reversal`
+
+## 当前常见模型参数
+
+- `model_opt=8`
+  - MACD 背驰
+- `model_opt=9`
+  - 中枢回拉
+- `model_opt=12`
+  - V 反
+- `model_opt=10001`
+  - CLXS 选股默认模型
+
+常见默认参数：
+
+- `wave_opt=1560`
+- `stretch_opt=0`
+- `trend_opt=1` 或 `0`
+
+## 当前入口
+
+CLI 选股入口：
+
+```powershell
+python -m freshquant.cli stock screening --model clxs
+```
+
+常用参数：
+
+- `--wave-opt`
+- `--stretch-opt`
+- `--trend-opt`
+- `--model-opt`
+
+## 当前输出语义
+
+- 盘后选股结果可写入 `stock_pre_pools`
+- 事件驱动链路把 CLXS 结果转换成：
+  - `BUY_LONG`
+  - `SELL_SHORT`
+- 单一函数通常同时给出：
+  - 触发价
+  - 止损价
+  - 标签或中枢数量
+
+## 当前排查
+
+### CLXS 结果总是空
+
+- 检查 `fqcopilot` / `fqchan04` 是否安装
+- 检查历史数据是否完整
+
+### 同一股票重复命中
+
+- 检查去重逻辑是否按 `code + date`
+- 检查盘后扫描天数是否过大
+
+### Guardian 与盘后选股结果不一致
+
+- 检查事件驱动链路用的是最新 bar 还是盘后全量数据
+- 检查 `trend_opt` / `model_opt` 是否一致

--- a/docs/current/reference/stock-pools-and-positions.md
+++ b/docs/current/reference/stock-pools-and-positions.md
@@ -1,3 +1,77 @@
 # 股票池与持仓参考
 
-当前文档用于说明 `stock_pre_pools`、`stock_pools`、`must_pool` 与当前持仓读取口径。
+## 当前集合
+
+- `stock_pre_pools`
+  - 预选池 / 工作区
+- `stock_pools`
+  - 股票池 / 候选交易池
+- `must_pool`
+  - 策略必选池
+- `xt_positions`
+  - 外部账户当前持仓
+
+## 当前语义
+
+### `stock_pre_pools`
+
+- 用于暂存筛选结果
+- Shouban30 会把当前筛选集批量替换进这个集合
+- 允许有 `category` 和 `expire_at`
+
+### `stock_pools`
+
+- 表示进入进一步跟踪或候选交易的池子
+- `load_monitor_codes(mode=clx_15_30)` 会读取非过期 `stock_pools`
+
+### `must_pool`
+
+- 是 Guardian 新开仓范围的重要来源
+- 也是 XTData `guardian_1m` 订阅池的一部分
+- 记录止损价、首笔金额、常规 lot 金额、是否 forever
+
+### `xt_positions`
+
+- 来自外部账户回报
+- 反映当前账户持仓事实
+- 既影响 Guardian 持仓内信号，也影响 TPSL 可卖数量
+
+## 当前读取口径
+
+- 监控池总集
+  - `get_stock_monitor_codes()`
+  - 来源是 `holding + must_pool + stock_pools`
+- Guardian 新开仓关注范围
+  - `must_pool`
+- Guardian 持仓内操作范围
+  - `xt_positions`
+- Shouban30 工作区
+  - `stock_pre_pools -> stock_pools -> must_pool`
+
+## 当前高频操作
+
+- 代码加入 `stock_pools`
+  - `/api/add_to_stock_pools_by_code`
+- 代码加入 `must_pool`
+  - `/api/add_to_must_pool_by_code`
+- Shouban30 预选池转股票池
+  - `/api/gantt/shouban30/pre-pool/add-to-stock-pools`
+- Shouban30 股票池转 must_pool
+  - `/api/gantt/shouban30/stock-pool/add-to-must-pool`
+
+## 当前排查
+
+### 股票在页面工作区里，但策略不看
+
+- 检查是否只在 `stock_pre_pools`
+- 检查是否真正进入 `must_pool` 或 `stock_pools`
+
+### 股票已在 must_pool，但 XTData 还没订阅
+
+- 检查 producer 订阅池是否刷新
+- 检查 `monitor.xtdata.mode`
+
+### 持仓有票，但 Guardian 卖点不触发
+
+- 检查 `xt_positions` 是否有目标 code
+- 检查 symbol/code6 是否规格一致

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -1,31 +1,98 @@
 # 当前运行面
 
-## 运行方式
+## 宿主机与 Docker 分层
 
-- Windows 宿主机：XTData、broker、部分 worker、Supervisor
-- Docker 并行环境：API、Web UI、Dagster、Mongo、Redis、TradingAgents-CN
-- Symphony：宿主机单实例 orchestrator
+### Windows 宿主机承担
 
-## 宿主机侧关键进程
+- XTQuant / XTData 连接。
+- Guardian monitor。
+- Position management worker。
+- TPSL tick listener。
+- Symphony 正式单实例 orchestrator。
+- 需要直接访问券商、终端、`TDX_HOME` 或 Windows 本地目录的组件。
 
-- `freshquant.market_data.xtdata.market_producer`
-- `freshquant.market_data.xtdata.strategy_consumer`
-- `freshquant.signal.astock.job.monitor_stock_zh_a_min`
-- `freshquant.position_management.worker`
-- `freshquant.tpsl.tick_listener`
-- `fqxtrade.xtquant.broker`
+### Docker 并行环境承担
 
-## Docker 并行端口
+- MongoDB：`27027 -> 27017`
+- Redis：`6380 -> 6379`
+- API Server：`15000 -> 5000`
+- TDXHQ：`15001 -> 5001`
+- Dagster Webserver：`11003 -> 10003`
+- QAWebServer：`18010 -> 8010`
+- Web UI：`18080 -> 80`
+- TradingAgents backend：`13000 -> 8000`
+- TradingAgents frontend：`13080 -> 80`
 
-- Web UI：`18080`
-- API：`15000`
-- TDXHQ：`15001`
-- Dagster：`11003`
-- Redis：`6380`
-- Mongo：`27027`
+对应编排文件是 `docker/compose.parallel.yaml`。
 
-## Symphony 运行面
+## 当前正式服务
 
-- repo-versioned 模板位于 `runtime/symphony/`
-- 正式 tracker 目标为 GitHub Issue + Draft PR
-- cleanup 由 merge 后宿主机流程完成
+- Symphony 正式服务名：`fq-symphony-orchestrator`
+- Symphony 状态接口：`http://127.0.0.1:40123/api/v1/state`
+- Symphony 工作区根目录：`D:/fqpack/runtime/symphony-service/workspaces`
+- Symphony 运行模板：`runtime/symphony/WORKFLOW.freshquant.md`
+- 运行日志根目录：`logs/runtime`，可被 `FQ_RUNTIME_LOG_DIR` 覆盖
+
+## 最小可用运行面
+
+当目标是调试主交易链时，至少需要：
+
+- MongoDB
+- Redis
+- API Server
+- XTData producer
+- XTData consumer
+- Guardian monitor
+- Position worker
+- Order submit / broker / XT 回报 ingest
+- TPSL worker（如果验证退出逻辑）
+
+当目标是调试前端展示时，至少还需要：
+
+- Web UI
+- Gantt/Shouban30 对应读模型数据
+- Runtime Observability 原始日志目录
+
+## 并行环境的默认口径
+
+- 宿主机 `.env` 示例：`deployment/examples/envs.fqnext.example`
+- Docker API 使用 `FQ_COMPOSE_ENV_FILE` 指向主工作树 `.env`
+- Web UI 默认访问并行 API `http://127.0.0.1:15000`
+- TradingAgents 使用独立 Mongo 库 `tradingagents_cn` 与 Redis `db=8`
+
+## 运行依赖
+
+- XTData producer 依赖 `XTQUANT_PORT`，默认 `58610`
+- XTData producer / consumer / TPSL / Order Management 共享 Redis
+- Guardian、Position worker、Order Management、TPSL 共享 Mongo 基础库与运行时事件日志
+- Shouban30 的 `.blk` 同步依赖宿主机 `TDX_HOME`
+
+## 常见运行模式
+
+### 只调 API / 页面
+
+```powershell
+docker compose -f docker/compose.parallel.yaml up -d --build fq_mongodb fq_redis fq_apiserver fq_webui
+```
+
+### 调实时交易链
+
+```powershell
+python -m freshquant.market_data.xtdata.market_producer
+python -m freshquant.market_data.xtdata.strategy_consumer --prewarm
+python -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event
+python -m freshquant.position_management.worker --interval 3
+python -m freshquant.tpsl.tick_listener
+```
+
+### 调 Symphony 正式服务
+
+```powershell
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:40123/api/v1/state
+```
+
+## 当前阶段的运行风险
+
+- Docker 里的 Mongo/Redis 与宿主机 broker/xtdata 之间必须通过宿主机端口对齐，否则交易链会出现“页面正常、worker 无数据”。
+- Guardian event 模式要求 `monitor.xtdata.mode=guardian_1m`；模式不对时进程会启动但不会真正处理 bar 更新。
+- Runtime Observability 采用旁路写盘，日志队列满时允许丢事件；排障时要同时对照业务集合，而不是只看 runtime 页面。

--- a/docs/current/storage.md
+++ b/docs/current/storage.md
@@ -1,22 +1,101 @@
 # 当前存储
 
-## Mongo
+## Mongo 数据库分层
 
-- 主业务事实存储在 Mongo
-- 订单管理、仓位管理、Gantt / Shouban30 读模型各自有边界
-- TradingAgents-CN 使用独立数据库口径
+### `freshquant`
 
-## Redis
+基础业务库，当前主要承载：
 
-- 用于 XTData 消息流、缓存与实时 quote 分发
-- TPSL 依赖 `TICK_QUOTE` 类实时数据
+- `xt_assets`
+- `xt_positions`
+- `xt_orders`
+- `xt_trades`
+- `stock_pre_pools`
+- `stock_pools`
+- `must_pool`
+- 兼容历史的 `stock_fills`
+- 订单投影数据库中的持仓/成交兼容视图
 
-## 当前存储边界
+### `gantt` 或 `mongodb.gantt_db`
 
-- 订单事实由 order management 主账本负责
-- 仓位门禁由 position management 负责
-- Gantt / Shouban30 页面依赖读模型，不直接以原始写模型展示
+Gantt 与 Shouban30 读模型库，当前主要集合：
 
-## 变更规则
+- `plate_reason_daily`
+- `gantt_plate_daily`
+- `gantt_stock_daily`
+- `stock_hot_reason_daily`
+- `shouban30_plates`
+- `shouban30_stocks`
 
-任何 schema、集合边界、读写语义变化，都必须先经过 `Design Review`。
+### `freshquant_order_management`
+
+订单管理主事实库，当前主要集合：
+
+- `om_order_requests`
+- `om_orders`
+- `om_order_events`
+- `om_trade_facts`
+- `om_buy_lots`
+- `om_lot_slices`
+- `om_sell_allocations`
+- `om_external_candidates`
+- `om_stoploss_bindings`
+- `om_credit_subjects`
+- TPSL 相关集合
+  - `om_takeprofit_profiles`
+  - `om_takeprofit_states`
+  - `om_exit_trigger_events`
+
+### `freshquant_position_management`
+
+仓位门禁状态库，当前主要集合：
+
+- `pm_configs`
+- `pm_credit_asset_snapshots`
+- `pm_current_state`
+- `pm_strategy_decisions`
+
+### `quantaxis`
+
+由 `DBQuantAxis` / `DBQA` 访问的历史行情库，供 XTData consumer 与 Kline 视图读取分钟/日线历史。
+
+## 主事实与投影边界
+
+- 主交易事实在订单管理库中，不在旧 `xt_orders/xt_trades` 集合中。
+- `xt_orders / xt_trades / xt_positions / xt_assets` 是外部回报与当前账户视角事实，不是内部订单请求事实。
+- `stock_pre_pools / stock_pools / must_pool` 是策略与页面共享的工作区/订阅范围集合。
+- Gantt/Shouban30 集合是只读视图与筛选结果，不参与订单账本。
+
+## Redis 当前角色
+
+- XTData tick 队列
+  - `REDIS_TICK_QUEUE_PREFIX:<shard>`
+- XTData bar 队列
+  - `REDIS_QUEUE_PREFIX:<shard>`
+- 订单提交队列
+  - `STOCK_ORDER_QUEUE`
+- 冷却锁 / 节流键
+  - `buy:<code>`
+  - `sell:<code>`
+  - `fq:xtrade:last_new_order_time`
+- Kline / 分钟结构缓存
+  - `get_redis_cache_key(symbol, period)`
+- TPSL 冷却锁
+  - Redis 或内存 fallback
+
+## 读写关系
+
+- XTData producer 写 Redis tick 队列。
+- XTData consumer 读 Redis bar 队列，写 QuantAxis 风格实时缓存与 Redis cache。
+- Guardian 读 `xt_positions`、`must_pool`、Guardian grid 集合，写订单请求。
+- Position worker 读 XT 资产/持仓，写 `pm_*` 集合。
+- Order submit 写 `om_order_requests`、`om_orders`、`om_order_events`，并把 broker payload 推到 Redis。
+- XT 回报 ingest 写 `om_trade_facts`、`om_buy_lots`、`om_lot_slices`、`om_sell_allocations` 等。
+- TPSL 读 `xt_positions` 与 `om_*`，写 `om_takeprofit_*` / `om_exit_trigger_events`。
+- Gantt/Shouban30 API 读 gantt 库，并在工作区操作时写 `stock_pre_pools`、`stock_pools`、`must_pool`。
+
+## 当前排障原则
+
+- 查交易链问题时，先看 `om_*`，再看 `xt_*`，最后才回头看旧兼容集合。
+- 查前端列表问题时，先确认 Mongo 读模型集合是否有数据，再看 API，再看页面。
+- 查 TPSL 问题时，同时核对 `xt_positions` 的可用数量与 `om_takeprofit_states` 的状态。

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -1,37 +1,184 @@
 # 当前排障
 
+第二阶段的排障顺序统一为：先确认运行面，再确认数据流，再确认页面或单个模块。不要先改代码。
+
+## 基础命令
+
+```powershell
+docker compose -f docker/compose.parallel.yaml ps
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:15000/api/runtime/components
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:40123/api/v1/state
+Get-ChildItem logs/runtime -Recurse -Filter *.jsonl | Sort-Object LastWriteTime -Descending | Select-Object -First 20 FullName,LastWriteTime
+```
+
 ## API 无响应
 
-- 先检查 API 进程是否在线
-- 检查 `freshquant.rear.api_server` 端口与 compose 映射
-- 检查 blueprint 注册是否缺失
+现象：
+- `15000` 端口不可访问，或前端页面全部报接口错误。
 
-## XTData 不更新
+先检查：
+- `docker compose -f docker/compose.parallel.yaml ps`
+- `Invoke-WebRequest -UseBasicParsing http://127.0.0.1:15000/api/runtime/components`
 
-- 检查 producer / consumer 进程
-- 检查 Redis 端口与连接
-- 检查宿主机 XTData 环境
+常见根因：
+- `fq_apiserver` 没启动或容器异常退出。
+- Mongo/Redis 依赖没准备好，API 容器循环重启。
+- `.env` 没传给 `FQ_COMPOSE_ENV_FILE`。
 
-## Guardian 不下单
+处理：
+- 重建 API：`docker compose -f docker/compose.parallel.yaml up -d --build fq_apiserver`
 
-- 检查 Guardian worker 是否运行
-- 检查持仓 / must_pool / submit gate
-- 检查 order management 与 broker 链路
+## Web 页面空白
 
-## TPSL 不触发
+现象：
+- `18080` 可打开但页面白屏，或单页能进、数据区全空。
 
-- 检查 `tpsl.tick_listener` 进程
-- 检查 `TICK_QUOTE` 实时数据
-- 检查止盈止损规则是否已武装
+先检查：
+- `Invoke-WebRequest -UseBasicParsing http://127.0.0.1:18080/`
+- 浏览器 DevTools 是否是接口 4xx/5xx
+
+常见根因：
+- `fq_webui` 没使用最新构建。
+- API 正常，但对应页面依赖的路由返回空数组或 409。
+- Kline/Gantt 页面依赖的历史数据或读模型为空。
+
+处理：
+- 重建前端：`docker compose -f docker/compose.parallel.yaml up -d --build fq_webui`
+
+## XTData 链路不更新
+
+现象：
+- Kline 最新 bar 不动，Guardian 不触发，TPSL 无 tick。
+
+先检查：
+- producer 是否在跑：`python -m freshquant.market_data.xtdata.market_producer`
+- consumer 是否在跑：`python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
+- `monitor.xtdata.mode` 是否符合场景
+- `XTQUANT_PORT` 是否正确
+
+常见根因：
+- XTQuant 端口错了。
+- 订阅池为空，producer 实际没有订阅任何代码。
+- Redis 队列堆积，consumer 进入 catchup 模式。
+
+处理：
+- 修正 `monitor.xtdata.mode` 与 `monitor.xtdata.max_symbols`
+- 重启 producer / consumer
+- 通过 runtime 页面看 `xt_producer` / `xt_consumer` 心跳与 backlog
+
+## Guardian 不触发或不下单
+
+现象：
+- 页面有信号，但没有订单请求。
+
+先检查：
+- 运行命令是否是 `--mode event`
+- `monitor.xtdata.mode` 是否是 `guardian_1m`
+- `must_pool` / `xt_positions` 是否包含目标股票
+- `pm_current_state` 是否允许开仓
+
+常见根因：
+- 事件模式没开，进程实际跑的是老轮询逻辑。
+- 信号超过 30 分钟被跳过。
+- buy/sell 冷却键仍在 Redis 里。
+- Position management 因 `HOLDING_ONLY` 或 `FORCE_PROFIT_REDUCE` 拒绝。
+
+处理：
+- 查 runtime 里的 `guardian_strategy`、`position_gate`、`order_submit`
+- 需要时清理冷却键并重启 Guardian
+
+## 订单已提交但没有成交回流
+
+现象：
+- `om_order_requests` 有记录，但前端/仓位没有更新。
+
+先检查：
+- `om_orders`、`om_order_events` 是否写入
+- broker/gateway 进程是否在消费 `STOCK_ORDER_QUEUE`
+- `xt_orders`、`xt_trades` 是否有外部回报
+
+常见根因：
+- broker 队列消费异常。
+- XT 回报 ingest 没启动或报错。
+- reconcile 没把外部回报外部化成内部订单。
+
+处理：
+- 重启 broker / ingest / reconcile 对应进程
+- 对照 `om_trade_facts` 与 `xt_trades`
+
+## TPSL 不执行
+
+现象：
+- 配了 takeprofit/stoploss，但行情到了也没有退出单。
+
+先检查：
+- `python -m freshquant.tpsl.tick_listener` 是否在跑
+- Redis tick 队列是否有目标 code
+- `/api/tpsl/takeprofit/<symbol>` 是否能读到 profile
+- `xt_positions` 是否有可卖数量
+
+常见根因：
+- 目标 code 不在 active TPSL universe。
+- cooldown lock 未释放。
+- 价格触发了，但没有可用持仓数量。
+
+处理：
+- 看 `om_takeprofit_states`、`om_exit_trigger_events`
+- 重启 TPSL worker，必要时执行 rearm
 
 ## Gantt / Shouban30 无数据
 
-- 检查 Dagster 或读模型更新
-- 检查 gantt routes
-- 检查页面筛选条件与接口响应
+现象：
+- `/gantt` 页面空白，或 `/gantt/shouban30` 返回 409。
 
-## Symphony 卡住
+先检查：
+- `gantt_plate_daily`、`gantt_stock_daily`、`shouban30_plates`、`shouban30_stocks`
+- `/api/gantt/plates?provider=xgb`
+- `/api/gantt/shouban30/plates?provider=xgb`
 
-- 检查 tracker 是否收到 managed issue
-- 检查 Draft PR 上的 `APPROVED / REVISE / REJECTED`
-- 检查 deploy / cleanup 脚本日志
+常见根因：
+- Dagster 任务未跑。
+- `as_of_date` 对应快照还没生成。
+- `stock_window_days` 不在 `30|45|60|90`。
+
+处理：
+- 重跑 Dagster 作业
+- 确认读模型索引与快照日期
+
+## Runtime Observability 无 trace
+
+现象：
+- `/runtime-observability` 页面无数据。
+
+先检查：
+- `logs/runtime` 或 `FQ_RUNTIME_LOG_DIR` 是否有 `.jsonl`
+- `/api/runtime/components`
+- `/api/runtime/health/summary`
+
+常见根因：
+- 业务进程没启用或没走到 runtime logger。
+- 路径被环境变量指到别的目录。
+- 页面筛选条件过严。
+
+处理：
+- 直接 tail 原始文件，而不是只看页面
+- 清空筛选后刷新页面
+
+## Symphony 任务卡住
+
+现象：
+- Issue 被领取但不前进，或 cleanup 不收口。
+
+先检查：
+- `Invoke-WebRequest -UseBasicParsing http://127.0.0.1:40123/api/v1/state`
+- `Get-Service fq-symphony-orchestrator`
+- `runtime/symphony-service/artifacts/`
+
+常见根因：
+- Draft PR 还没完成 `Design Review`
+- GitHub token 失效
+- 正式服务没加载最新 workflow
+
+处理：
+- 看 Draft PR 评论与 `APPROVED`
+- 重装正式服务或重启 `fq-symphony-orchestrator`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,35 +1,37 @@
-# 文档索引
+# FreshQuant 当前文档索引
 
-本目录只保留 FreshQuant 的当前设计、当前实现、当前运行方式与当前排障方式。
+本目录只保留 FreshQuant 当前系统的设计、实现、运行与排障事实。第二阶段的目标不是继续记录迁移过程，而是把现有系统收敛成一套可维护、可排障、可部署的现状文档。
 
-不再保留以下正式治理文档：
+## 文档规则
 
-- RFC
-- implementation plan
-- migration progress
-- breaking changes
-- 复盘 / 过程纪要
+- `docs/current/**` 是唯一正式文档集合。
+- 文档只描述当前代码与当前运行面的事实，不记录 RFC、实施过程、进度流水或复盘。
+- 任何会改变当前系统事实的改动，必须在同一 PR 更新对应 `docs/current/**`。
+- 需要历史过程时，直接看 Git 历史、PR 和提交记录，不再在 `docs/` 中保存过程文档。
 
 ## 建议阅读顺序
 
-1. `docs/current/overview.md`
-2. `docs/current/architecture.md`
-3. `docs/current/runtime.md`
-4. `docs/current/deployment.md`
-5. `docs/current/troubleshooting.md`
+1. [当前总览](./current/overview.md)
+2. [当前架构](./current/architecture.md)
+3. [当前运行面](./current/runtime.md)
+4. [当前部署](./current/deployment.md)
+5. [当前配置](./current/configuration.md)
+6. [当前存储](./current/storage.md)
+7. [当前接口](./current/interfaces.md)
+8. [当前排障](./current/troubleshooting.md)
 
-## 核心横切文档
+## 横切文档
 
-- [当前总览](./current/overview.md)
-- [当前架构](./current/architecture.md)
-- [当前运行面](./current/runtime.md)
-- [当前部署](./current/deployment.md)
-- [当前配置](./current/configuration.md)
-- [当前存储](./current/storage.md)
-- [当前接口](./current/interfaces.md)
-- [当前排障](./current/troubleshooting.md)
+- [当前总览](./current/overview.md)：项目定位、能力清单、运行拓扑、维护重点。
+- [当前架构](./current/architecture.md)：分层、调用链、进程边界、模块职责。
+- [当前运行面](./current/runtime.md)：宿主机、Docker 并行环境、Symphony 正式运行面。
+- [当前部署](./current/deployment.md)：模块部署矩阵、健康检查、Done 判定。
+- [当前配置](./current/configuration.md)：Dynaconf、环境变量、关键参数。
+- [当前存储](./current/storage.md)：Mongo/Redis 分层、集合边界、读写关系。
+- [当前接口](./current/interfaces.md)：CLI、HTTP API、前端路由、后台 worker 入口。
+- [当前排障](./current/troubleshooting.md)：第二阶段排障入口与常用命令。
 
-## 核心模块文档
+## 核心模块
 
 - [XTData 行情链路](./current/modules/market-data-xtdata.md)
 - [Guardian 策略](./current/modules/strategy-guardian.md)
@@ -48,3 +50,14 @@
 - [ETF 数据](./current/reference/etf-data.md)
 - [股票池与持仓](./current/reference/stock-pools-and-positions.md)
 - [CLXS 信号函数](./current/reference/signal-clxs.md)
+
+## 当前阶段最常用入口
+
+- API 入口：`python -m freshquant.rear.api_server --port 5000`
+- Guardian 入口：`python -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event`
+- 仓位 worker：`python -m freshquant.position_management.worker --interval 3`
+- TPSL worker：`python -m freshquant.tpsl.tick_listener`
+- XTData producer：`python -m freshquant.market_data.xtdata.market_producer`
+- XTData consumer：`python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
+- Docker 并行环境：`docker compose -f docker/compose.parallel.yaml up -d --build`
+- Symphony 正式服务健康检查：`Invoke-WebRequest -UseBasicParsing http://127.0.0.1:40123/api/v1/state`


### PR DESCRIPTION
## 变更说明
- 扩写 docs/current 横切文档，补齐运行面、配置、存储、接口与排障事实
- 扩写核心模块文档，明确入口、数据流、集合边界、部署与排障点
- 扩写 reference 文档，收敛行情、ETF、股票池与 CLXS 查询口径

## 验证
- py -3 -m pytest -q freshquant/tests/test_check_current_docs.py freshquant/tests/test_symphony_cleanup_scripts.py