### PR TITLE
docs: align GitHub-first templates with current docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @dao1oad
 
-docs/rfcs/ @dao1oad
-docs/migration/ @dao1oad
+docs/index.md @dao1oad
+docs/current/ @dao1oad

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,22 +2,30 @@
 
 - ...
 
-## 关联 RFC
+## 关联任务
 
-- RFC：`docs/rfcs/NNNN-<topic>.md`（如不涉及迁移/模块/破坏性变更，请说明原因）
+- GitHub Issue：
+- Draft PR / Design Review（如适用）：
 
-## 迁移进度（强制）
+## 当前文档同步（强制）
 
-- [ ] 已更新 `docs/migration/progress.md`
-- [ ] 若存在破坏性变更：已更新 `docs/migration/breaking-changes.md`
+- [ ] 若当前系统事实有变化：已同步更新 `docs/current/**`
+- [ ] 若不涉及当前系统事实变化：已确认无需更新 `docs/current/**`
 
 ## 验收与测试（强制）
 
 - [ ] `pre-commit` 已通过（CI 会校验）
 - [ ] `pytest -q freshquant/tests` 已通过（CI 会校验）
+- [ ] 已明确受影响模块的部署动作
+- [ ] 已明确健康检查方式
 
-## 破坏性变更（如有）
+## 部署与健康检查
 
-- 影响面：
-- 迁移步骤：
-- 回滚方案：
+- 部署模块：
+- 健康检查：
+
+## 风险与说明（如有）
+
+- Design Review 要点：
+- 配置 / 接口 / 存储 / 运行面变化：
+- 回滚说明：


### PR DESCRIPTION
## Summary
- 对齐 `.github/pull_request_template.md` 到当前 GitHub-first / `docs/current/**` 治理口径
- 更新 `.github/CODEOWNERS`，去掉已废弃的 `docs/rfcs` / `docs/migration` 路径
- 作为 `#114` 调研中先拆出的低风险文档收敛，不包含 Shouban30 功能改动

## Test Plan
- [x] `python -m pre_commit run --files .github/CODEOWNERS .github/pull_request_template.md`
- [x] `rg -n "docs/migration|docs/rfcs" .github` 无匹配
- [ ] 全量 `pytest -q freshquant/tests`
  - 说明：在未改动代码的 `origin/main` 基线上，本地收集阶段已因 `test_xtquant_account_config.py` 的外部依赖导入失败中断；等待 GitHub CI 作为正式真值