### PR TITLE
fix: 保持 Symphony cleanup 评论 UTF-8 完整性

### DIFF
--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -38,6 +38,7 @@
 - 如果 workspace 目录存在但缺失 git 元数据，orchestrator 会在下一次执行前自愈重建一次，而不是无限重试 `not a git repository`
 - Symphony `sync/start` 会校验 workflow prompt 合约，至少要求保留 issue 标识、标题、状态、描述、URL、Design Review 禁止二次 `brainstorming`、以及 Draft PR bootstrap 规则
 - Symphony 写入 GitHub 的正式文本默认使用简体中文；仅审批信号 `APPROVED` / `REVISE:` / `REJECTED:` 保留英文控制词
+- cleanup request 的部署说明正文优先通过 UTF-8 文件传给 `request_freshquant_symphony_cleanup.ps1 -DeploymentCommentBodyPath`；不要把长中文 markdown 直接内联进 PowerShell 命令行
 - 运行日志根目录：`logs/runtime`，可被 `FQ_RUNTIME_LOG_DIR` 覆盖
 
 ## 最小可用运行面

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -220,6 +220,7 @@ Get-ChildItem logs/runtime -Recurse -Filter *.jsonl | Sort-Object LastWriteTime 
 - 如果 issue 已经有 merged PR、open non-draft PR 或 approved draft PR，但还停在 `blocked`，优先按误标处理；正式 orchestrator 现在会按这些 GitHub 真值自动恢复到 `Merging` / `Rework` / `In Progress`
 - 如果日志里反复出现 `workspace_hook_failed ... not a git repository`，先看 workspace 目录是否缺 `.git`；正式 orchestrator 现在会先自愈重建一次，再决定是否继续报错
 - 如果 PR 标题、PR 正文、Issue / PR 评论仍然出现英文说明，先检查 `WORKFLOW.freshquant.md` 与 `runtime/symphony/templates/*.md` 是否已经同步到正式服务
+- 如果 cleanup 的 GitHub done 评论出现 `?`、`\n`、`\f`、`\b` 这类乱码或控制字符，先检查是否把中文 markdown 直接内联传给了 `request_freshquant_symphony_cleanup.ps1 -DeploymentCommentBody`；当前应改为先写 UTF-8 `.md` 文件，再传 `-DeploymentCommentBodyPath`
 - 检查正式服务是否已加载最新 `runtime/symphony/WORKFLOW.freshquant.md`
 - 看 issue 当前标签与状态是否仍停在 `todo`，以及 orchestrator 日志里是否出现 `Todo -> In Progress` 自动推进记录
 - 重装正式服务或重启 `fq-symphony-orchestrator`

--- a/freshquant/tests/test_symphony_cleanup_scripts.py
+++ b/freshquant/tests/test_symphony_cleanup_scripts.py
@@ -54,6 +54,10 @@ def _run_git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, capture_output=True, text=True, check=False, cwd=cwd)
 
 
+def _normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n")
+
+
 class _GitHubApiStub:
     def __init__(self) -> None:
         self.list_pages: list[int] = []
@@ -189,6 +193,47 @@ def test_request_cleanup_writes_manifest(tmp_path: Path) -> None:
     )
     assert payload["repository"] == "dao1oad/fqpack-next"
     assert payload["artifactsRetentionDays"] == 14
+
+
+def test_request_cleanup_reads_deployment_comment_body_from_utf8_file(
+    tmp_path: Path,
+) -> None:
+    service_root = tmp_path / "service"
+    workspaces_root = service_root / "workspaces"
+    workspace_path = workspaces_root / "GH-999"
+    workspace_path.mkdir(parents=True)
+
+    comment_body = (
+        "已核对 PR `#105`\n\n"
+        "- `fq_webui` 当前为 `Up`\n"
+        "- 页面 `/kline-slim` 返回 `200`\n"
+        "- 中文说明保持原样"
+    )
+    comment_path = tmp_path / "deployment-comment.md"
+    comment_path.write_text(comment_body, encoding="utf-8")
+
+    result = _run_powershell(
+        REQUEST_SCRIPT,
+        "-ServiceRoot",
+        str(service_root),
+        "-IssueIdentifier",
+        "GH-999",
+        "-BranchName",
+        "feature/gh-999",
+        "-WorkspacePath",
+        str(workspace_path),
+        "-DeploymentCommentBodyPath",
+        str(comment_path),
+        "-OriginUrl",
+        "ssh://git@ssh.github.com:443/dao1oad/fqpack-next.git",
+        "-IssueUrl",
+        "https://github.com/dao1oad/fqpack-next/issues/999",
+    )
+
+    assert result.returncode == 0, result.stderr
+    request_path = service_root / "artifacts" / "cleanup-requests" / "GH-999.json"
+    payload = json.loads(request_path.read_text(encoding="utf-8"))
+    assert _normalize_newlines(payload["deploymentCommentBody"]) == comment_body
 
 
 def test_request_cleanup_rejects_workspace_outside_workspace_root(
@@ -425,3 +470,70 @@ def test_finalizer_keeps_active_artifacts_from_paginated_github_issue_listing(
     assert payload["success"] is True
     assert payload["issueClosed"] is True
     assert payload["githubUpdated"] is True
+
+
+def test_finalizer_posts_utf8_markdown_comment_body_from_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service_root = tmp_path / "service"
+    workspaces_root = service_root / "workspaces"
+    workspace_path = workspaces_root / "GH-999"
+    workspace_path.mkdir(parents=True)
+    (workspace_path / "tracked.txt").write_text("ok", encoding="utf-8")
+
+    comment_body = (
+        "已核对 PR `#105`、CI 和运行面。\n\n"
+        "- `fq_webui` / `fq_apiserver` 当前均为 `Up`\n"
+        "- `http://127.0.0.1:18080/kline-slim` 返回 `200`\n"
+        "- 中文不应被替换成问号"
+    )
+    comment_path = tmp_path / "deployment-comment.md"
+    comment_path.write_text(comment_body, encoding="utf-8")
+
+    request_result = _run_powershell(
+        REQUEST_SCRIPT,
+        "-ServiceRoot",
+        str(service_root),
+        "-IssueIdentifier",
+        "GH-999",
+        "-BranchName",
+        "feature/gh-999",
+        "-WorkspacePath",
+        str(workspace_path),
+        "-DeploymentCommentBodyPath",
+        str(comment_path),
+        "-OriginUrl",
+        "ssh://git@ssh.github.com:443/dao1oad/fqpack-next.git",
+        "-Repository",
+        "dao1oad/fqpack-next",
+    )
+    assert request_result.returncode == 0, request_result.stderr
+
+    with _GitHubApiStub() as stub:
+        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+        monkeypatch.setenv("FRESHQUANT_GITHUB_API_BASE_URL", stub.base_url)
+        monkeypatch.setenv("GITHUB_API_BASE_URL", stub.base_url)
+
+        finalizer_result = _run_powershell(
+            FINALIZER_SCRIPT,
+            "-ServiceRoot",
+            str(service_root),
+            "-IssueIdentifier",
+            "GH-999",
+            "-WorkspacePath",
+            str(workspace_path),
+            "-SkipRemoteBranchDelete",
+        )
+
+    assert finalizer_result.returncode == 0, finalizer_result.stderr
+    assert len(stub.comment_bodies) == 1
+    expected_comment_body = (
+        comment_body
+        + "\n## Cleanup Results\n\n"
+        + "- Remote branch cleanup: `skipped`\n"
+        + "- Workspace cleanup: `True`\n"
+        + "- Artifacts retention days: `14`\n\n"
+        + "### Pruned Artifacts\n\n"
+        + "- `none`"
+    )
+    assert _normalize_newlines(stub.comment_bodies[0]) == expected_comment_body

--- a/runtime/symphony/README.md
+++ b/runtime/symphony/README.md
@@ -136,6 +136,11 @@ Cleanup 只清理任务级资源：
   - `scripts/start_freshquant_symphony.ps1`
   - `scripts/sync_freshquant_symphony_service.ps1`
 
+`request_freshquant_symphony_cleanup.ps1` 的部署说明正文支持两种入口：
+
+- `-DeploymentCommentBody`：兼容旧调用，只适合短 ASCII 文本
+- `-DeploymentCommentBodyPath`：推荐入口，从 UTF-8 markdown 文件读取正文，避免 PowerShell 命令行把中文和反引号 markdown 破坏成 `?` 或控制字符
+
 ## 任务标签建议
 
 Issue labels：

--- a/runtime/symphony/prompts/merging.md
+++ b/runtime/symphony/prompts/merging.md
@@ -9,6 +9,7 @@ Required behavior:
 - Deploy every required runtime surface based on changed paths.
 - Run post-deploy health checks.
 - Render a structured done summary and register a cleanup request with branch name, workspace path, and deployment results.
+- When registering the cleanup request, write the deployment summary to a UTF-8 markdown file and pass `-DeploymentCommentBodyPath` instead of inlining long markdown into the PowerShell command line.
 - Let the host cleanup finalizer delete the remote branch, delete the workspace, prune old artifacts, update GitHub, and then move the task to `Done`.
 
 Deployment matrix:

--- a/runtime/symphony/scripts/invoke_freshquant_symphony_cleanup_finalizer.ps1
+++ b/runtime/symphony/scripts/invoke_freshquant_symphony_cleanup_finalizer.ps1
@@ -23,6 +23,12 @@ function Write-Utf8NoBomFile {
     [System.IO.File]::WriteAllText($Path, $Content, $encoding)
 }
 
+function Read-Utf8TextFile {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    return [System.IO.File]::ReadAllText($Path, [System.Text.Encoding]::UTF8)
+}
+
 function Get-EnvValue {
     param([Parameter(Mandatory = $true)][string]$Name)
 
@@ -214,8 +220,9 @@ function Invoke-GitHubApi {
     }
 
     if ($null -ne $Body) {
-        $invokeParams['ContentType'] = 'application/json'
-        $invokeParams['Body'] = ($Body | ConvertTo-Json -Depth 10 -Compress)
+        $jsonBody = ($Body | ConvertTo-Json -Depth 10 -Compress)
+        $invokeParams['ContentType'] = 'application/json; charset=utf-8'
+        $invokeParams['Body'] = $jsonBody
     }
 
     return Invoke-RestMethod @invokeParams
@@ -504,7 +511,7 @@ try {
         exit 0
     }
 
-    $request = Get-Content -Path $requestPath -Raw | ConvertFrom-Json
+    $request = Read-Utf8TextFile -Path $requestPath | ConvertFrom-Json
     $result.artifactsRetentionDays = [int]$request.artifactsRetentionDays
     $issueContext = $null
     $repository = Resolve-GitHubRepository -Repository $request.repository -IssueUrl $request.issueUrl -PullRequestUrl $request.pullRequestUrl -OriginUrl $request.originUrl

--- a/runtime/symphony/scripts/request_freshquant_symphony_cleanup.ps1
+++ b/runtime/symphony/scripts/request_freshquant_symphony_cleanup.ps1
@@ -7,8 +7,10 @@ param(
     [string]$BranchName,
     [Parameter(Mandatory = $true)]
     [string]$WorkspacePath,
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, ParameterSetName = 'InlineBody')]
     [string]$DeploymentCommentBody,
+    [Parameter(Mandatory = $true, ParameterSetName = 'BodyPath')]
+    [string]$DeploymentCommentBodyPath,
     [string]$OriginUrl,
     [string]$IssueUrl,
     [int]$PullRequestNumber,
@@ -27,6 +29,16 @@ function Write-Utf8NoBomFile {
 
     $encoding = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::WriteAllText($Path, $Content, $encoding)
+}
+
+function Read-Utf8TextFile {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "DeploymentCommentBodyPath does not exist: $Path"
+    }
+
+    return [System.IO.File]::ReadAllText($Path, [System.Text.Encoding]::UTF8)
 }
 
 function Get-NormalizedPath {
@@ -63,6 +75,20 @@ function Assert-NonEmptyText {
     if ([string]::IsNullOrWhiteSpace($Value)) {
         throw "$FieldName is required."
     }
+}
+
+function Resolve-DeploymentCommentBody {
+    param(
+        [string]$InlineBody,
+        [string]$BodyPath,
+        [Parameter(Mandatory = $true)][string]$ParameterSetName
+    )
+
+    if ($ParameterSetName -eq 'BodyPath') {
+        return Read-Utf8TextFile -Path $BodyPath
+    }
+
+    return $InlineBody
 }
 
 function Assert-WorkspacePathSafe {
@@ -167,7 +193,8 @@ function Resolve-GitHubRepository {
 
 Assert-IssueIdentifier -Value $IssueIdentifier
 Assert-BranchName -Value $BranchName
-Assert-NonEmptyText -Value $DeploymentCommentBody -FieldName 'DeploymentCommentBody'
+$resolvedDeploymentCommentBody = Resolve-DeploymentCommentBody -InlineBody $DeploymentCommentBody -BodyPath $DeploymentCommentBodyPath -ParameterSetName $PSCmdlet.ParameterSetName
+Assert-NonEmptyText -Value $resolvedDeploymentCommentBody -FieldName 'DeploymentCommentBody'
 
 $workspaceRoot = Join-Path $ServiceRoot 'workspaces'
 $artifactsRoot = Join-Path $ServiceRoot 'artifacts'
@@ -190,7 +217,7 @@ $payload = [ordered]@{
     workspaceRoot = $normalizedWorkspaceRoot
     artifactsRoot = $normalizedArtifactsRoot
     artifactsRetentionDays = $ArtifactsRetentionDays
-    deploymentCommentBody = $DeploymentCommentBody
+    deploymentCommentBody = $resolvedDeploymentCommentBody
     issueUrl = $IssueUrl
     pullRequestNumber = $PullRequestNumber
     pullRequestUrl = $PullRequestUrl


### PR DESCRIPTION
## 摘要
- 修复 Symphony cleanup request / finalizer 的 UTF-8 读写边界，避免 GitHub done 评论出现问号和控制字符
- 为 `request_freshquant_symphony_cleanup.ps1` 增加 `-DeploymentCommentBodyPath`，避免把长中文 markdown 直接内联进 PowerShell 命令行
- 补充脚本回归测试与运行/排障文档

## 验证
- `py -3 -m pytest freshquant/tests/test_symphony_cleanup_scripts.py -q`
- `py -3 -m pytest freshquant/tests/test_check_current_docs.py -q`
- `Invoke-WebRequest -UseBasicParsing http://127.0.0.1:40123/api/v1/state`