### PR TITLE
[任务] 收紧 Symphony Merging guardrail，禁止长等待与会话内直接 cleanup

### DIFF
--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -37,6 +37,7 @@
 - 如果 GitHub 真值已经表明 `Blocked` 只是误标，orchestrator 会自动恢复：merged PR -> `Merging`；open non-draft PR -> `Rework`；approved draft PR -> `In Progress`
 - 如果 workspace 目录存在但缺失 git 元数据，orchestrator 会在下一次执行前自愈重建一次，而不是无限重试 `not a git repository`
 - Symphony `sync/start` 会校验 workflow prompt 合约，至少要求保留 issue 标识、标题、状态、描述、URL、Design Review 禁止二次 `brainstorming`、以及 Draft PR bootstrap 规则
+- Symphony `sync/start` 也会校验 `prompts/merging.md` 的关键 guardrail：`Merging` 只能做一次性检查后结束当前 turn，不应在会话内使用 `gh pr checks --watch`、`gh run watch` 或 `Start-Sleep` 长轮询；task workspace cleanup 必须走 cleanup request + host finalizer，而不是在 Codex 会话里直接删除目录
 - Symphony 写入 GitHub 的正式文本默认使用简体中文；仅审批信号 `APPROVED` / `REVISE:` / `REJECTED:` 保留英文控制词
 - cleanup request 的部署说明正文优先通过 UTF-8 文件传给 `request_freshquant_symphony_cleanup.ps1 -DeploymentCommentBodyPath`；不要把长中文 markdown 直接内联进 PowerShell 命令行
 - 运行日志根目录：`logs/runtime`，可被 `FQ_RUNTIME_LOG_DIR` 覆盖

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -200,6 +200,8 @@ Get-ChildItem logs/runtime -Recurse -Filter *.jsonl | Sort-Object LastWriteTime 
 - 高风险任务被直接贴上 `design-review`，但 Draft PR 引导创建失败
 - 新建 issue 时手工预贴了 `design-review`，导致任务跳过 `Todo` 风险判定并直接进入高风险路径
 - 正式服务加载了一份过度简化的 `WORKFLOW.freshquant.md`，prompt 中没有 issue 标识/标题/描述，导致 agent 只会做泛化上下文扫描
+- `Merging` 会话里直接使用 `gh pr checks --watch`、`gh run watch` 或带 `Start-Sleep` 的长轮询脚本，导致单个 turn 长时间占住 agent，甚至被 stall detector 杀掉后重试
+- merge/deploy 之后没有注册 cleanup request，而是在会话里直接 `Remove-Item` / `git worktree remove` 删除 task workspace，结果 cleanup 没进入 host finalizer，任务停在 `Merging` / `Blocked` 收不了口
 - `Design Review` 任务在 Codex 会话里再次触发 `brainstorming`，硬门要求新的人工批准，结果因为会话内没有人工输入面而反复空转
 - workspace 只保留了本地路径 `origin`，没有 GitHub remote，导致 `gh pr ...` / `gh issue ...` 在 workspace 内直接失败
 - issue 被打到 `blocked`，但没有写明解除条件和应该恢复到哪个状态
@@ -214,6 +216,8 @@ Get-ChildItem logs/runtime -Recurse -Filter *.jsonl | Sort-Object LastWriteTime 
 - 如果任务是普通 bugfix 或小范围现有模块修复，但没有 Draft PR，优先按低风险路径排查，不要继续等待人工审批
 - 如果任务命中高风险条件且已经在 `Design Review`，但没有 linked Draft PR，先看 orchestrator 日志是否已触发一次引导执行；若仍没有 Draft PR，优先排查 GitHub token、`gh`/push 权限、branch/PR 创建失败，而不是继续等待审批
 - 如果日志里反复只有通用 repo 扫描而没有 issue 标识、标题、描述，先检查 `WORKFLOW.freshquant.md` 是否仍包含 issue placeholders；`sync_freshquant_symphony_service.ps1` / `start_freshquant_symphony.ps1` 现在会对这份 prompt 做合约校验
+- 如果 `Merging` 很慢，先看 session 里是否出现 `gh pr checks --watch`、`gh run watch` 或 `Start-Sleep` 轮询；正式 prompt 现在要求只做一次性检查后结束当前 turn，让 orchestrator 下一轮继续
+- 如果 merge/deploy 已完成但 cleanup 不收口，先看本轮是否真的写出了 cleanup request；`Merging` 现在要求通过 `request_freshquant_symphony_cleanup.ps1` 交给 host finalizer，而不是在会话里直接删 workspace
 - 如果日志里明确读入了 issue body，但随后又加载 `brainstorming` 并停在“等待批准”，说明 workflow 仍把 `Design Review` 错当成会话内交互设计阶段；应改成“issue body -> Draft PR packet -> GitHub approval”的单向流程
 - 如果 `gh` 在 workspace 内报 “none of the git remotes configured for this repository point to a known GitHub host”，先看当前 workspace 是否只有本地 `origin`；正式 workflow 现在会在 `after_create` / `before_run` 自动补齐 `github` remote
 - 如果 issue 停在 `blocked`，先看最新 GitHub 评论是否写清了 blocker、clear condition、evidence 和 target recovery state；没有的话先补齐，再决定是否解除

--- a/freshquant/tests/test_symphony_prompt_contract.py
+++ b/freshquant/tests/test_symphony_prompt_contract.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MERGING_PROMPT = REPO_ROOT / "runtime" / "symphony" / "prompts" / "merging.md"
+MERGING_VALIDATOR = (
+    REPO_ROOT
+    / "runtime"
+    / "symphony"
+    / "scripts"
+    / "assert_freshquant_merging_prompt.ps1"
+)
+SYNC_SCRIPT = (
+    REPO_ROOT / "runtime" / "symphony" / "scripts" / "sync_freshquant_symphony_service.ps1"
+)
+START_SCRIPT = (
+    REPO_ROOT / "runtime" / "symphony" / "scripts" / "start_freshquant_symphony.ps1"
+)
+
+
+def _run_powershell(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    executable = shutil.which("powershell") or shutil.which("pwsh")
+    if executable is None:
+        pytest.skip("PowerShell is not available in PATH")
+    assert executable is not None
+
+    command = [
+        executable,
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(script),
+        *args,
+    ]
+    return subprocess.run(
+        command, capture_output=True, text=True, check=False, cwd=REPO_ROOT
+    )
+
+
+def test_merging_prompt_contract_passes_for_repo_prompt() -> None:
+    result = _run_powershell(MERGING_VALIDATOR, "-PromptPath", str(MERGING_PROMPT))
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_merging_prompt_contract_rejects_missing_guardrails(tmp_path: Path) -> None:
+    prompt_path = tmp_path / "merging.md"
+    prompt_path.write_text(
+        """# FreshQuant Merging Prompt
+
+You are in the `Merging` phase.
+
+Required behavior:
+
+- Confirm the Draft PR is ready to merge.
+- Merge the PR to the remote `main` branch.
+- Render a structured done summary.
+""",
+        encoding="utf-8",
+    )
+
+    result = _run_powershell(MERGING_VALIDATOR, "-PromptPath", str(prompt_path))
+
+    assert result.returncode != 0
+    assert "watch" in result.stderr.lower() or "workspace" in result.stderr.lower()
+
+
+def test_sync_and_start_scripts_reference_merging_prompt_validator() -> None:
+    sync_content = SYNC_SCRIPT.read_text(encoding="utf-8")
+    start_content = START_SCRIPT.read_text(encoding="utf-8")
+
+    assert "assert_freshquant_merging_prompt.ps1" in sync_content
+    assert "assert_freshquant_merging_prompt.ps1" in start_content

--- a/runtime/symphony/README.md
+++ b/runtime/symphony/README.md
@@ -129,8 +129,10 @@ Cleanup 只清理任务级资源：
 - 感知方式：第一阶段默认 `30s` 轮询
 - secrets：不入仓
 - 正式工作流文件：`WORKFLOW.freshquant.md`
+- `sync_freshquant_symphony_service.ps1` / `start_freshquant_symphony.ps1` 会同时校验 `WORKFLOW.freshquant.md` 与 `prompts/merging.md` 的关键 contract，避免正式 prompt 被过度简化
 - 正式宿主机脚本：
   - `scripts/run_freshquant_codex_session.ps1`
+  - `scripts/assert_freshquant_merging_prompt.ps1`
   - `scripts/request_freshquant_symphony_cleanup.ps1`
   - `scripts/invoke_freshquant_symphony_cleanup_finalizer.ps1`
   - `scripts/start_freshquant_symphony.ps1`

--- a/runtime/symphony/prompts/merging.md
+++ b/runtime/symphony/prompts/merging.md
@@ -8,8 +8,12 @@ Required behavior:
 - Merge the PR to the remote `main` branch.
 - Deploy every required runtime surface based on changed paths.
 - Run post-deploy health checks.
+- Do a one-shot check and then end the turn; let the orchestrator schedule the next turn instead of blocking inside the current session.
+- Do not use `gh pr checks --watch`, `gh run watch`, or custom polling loops with `Start-Sleep` inside the `Merging` session.
 - Render a structured done summary and register a cleanup request with branch name, workspace path, and deployment results.
 - When registering the cleanup request, write the deployment summary to a UTF-8 markdown file and pass `-DeploymentCommentBodyPath` instead of inlining long markdown into the PowerShell command line.
+- Register cleanup only through `runtime/symphony/scripts/request_freshquant_symphony_cleanup.ps1`.
+- Do not run `Remove-Item`, `git worktree remove`, or other direct workspace-deletion commands against the task workspace from the Codex session.
 - Let the host cleanup finalizer delete the remote branch, delete the workspace, prune old artifacts, update GitHub, and then move the task to `Done`.
 
 Deployment matrix:

--- a/runtime/symphony/scripts/assert_freshquant_merging_prompt.ps1
+++ b/runtime/symphony/scripts/assert_freshquant_merging_prompt.ps1
@@ -1,0 +1,35 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PromptPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $PromptPath)) {
+    throw "Merging prompt file not found: $PromptPath"
+}
+
+$content = Get-Content -Path $PromptPath -Raw
+$requiredPatterns = @(
+    @{ Name = 'cleanup request registration rule'; Pattern = 'register a cleanup request' },
+    @{ Name = 'host finalizer rule'; Pattern = 'host cleanup finalizer' },
+    @{ Name = 'watch guardrail'; Pattern = 'Do not use `gh pr checks --watch`, `gh run watch`, or custom polling loops with `Start-Sleep`' },
+    @{ Name = 'one-shot check rule'; Pattern = 'Do a one-shot check and then end the turn; let the orchestrator schedule the next turn instead of blocking inside the current session' },
+    @{ Name = 'cleanup request script rule'; Pattern = 'Register cleanup only through `runtime/symphony/scripts/request_freshquant_symphony_cleanup\.ps1`' },
+    @{ Name = 'workspace delete guardrail'; Pattern = 'Do not run `Remove-Item`, `git worktree remove`, or other direct workspace-deletion commands against the task workspace from the Codex session' },
+    @{ Name = 'stay in merging during cleanup retry rule'; Pattern = 'Do not move a merged issue to `Blocked` only because cleanup or host-side retries still need to finish; keep it in `Merging` unless there is a real external blocker' }
+)
+
+$missing = @()
+foreach ($entry in $requiredPatterns) {
+    if ($content -notmatch $entry.Pattern) {
+        $missing += $entry.Name
+    }
+}
+
+if ($missing.Count -gt 0) {
+    throw "Merging prompt contract failed for $PromptPath. Missing: $($missing -join ', ')"
+}
+
+Write-Host "[freshquant] merging prompt contract OK: $PromptPath"

--- a/runtime/symphony/scripts/start_freshquant_symphony.ps1
+++ b/runtime/symphony/scripts/start_freshquant_symphony.ps1
@@ -103,6 +103,8 @@ $scriptsRoot = Join-Path $ServiceRoot 'scripts'
 $logsRoot = Join-Path $ServiceRoot 'logs'
 $workflowPath = Join-Path $configRoot 'WORKFLOW.freshquant.md'
 $workflowValidator = Join-Path $scriptsRoot 'assert_freshquant_workflow_prompt.ps1'
+$mergingPromptPath = Join-Path $configRoot 'prompts\merging.md'
+$mergingPromptValidator = Join-Path $scriptsRoot 'assert_freshquant_merging_prompt.ps1'
 $runnerPath = Join-Path $scriptsRoot 'freshquant_runner.exs'
 $stdoutLog = Join-Path $logsRoot 'stdout.log'
 $stderrLog = Join-Path $logsRoot 'stderr.log'
@@ -128,11 +130,20 @@ if (-not (Test-Path $workflowValidator)) {
     throw "Workflow validator not found: $workflowValidator"
 }
 
+if (-not (Test-Path $mergingPromptPath)) {
+    throw "Merging prompt file not found: $mergingPromptPath"
+}
+
+if (-not (Test-Path $mergingPromptValidator)) {
+    throw "Merging prompt validator not found: $mergingPromptValidator"
+}
+
 if (-not (Test-Path $runnerPath)) {
     throw "Runner file not found: $runnerPath"
 }
 
 & $workflowValidator -WorkflowPath $workflowPath
+& $mergingPromptValidator -PromptPath $mergingPromptPath
 
 $OpenAISymphonyRoot = Resolve-OpenAISymphonyRoot -RequestedPath $OpenAISymphonyRoot
 

--- a/runtime/symphony/scripts/sync_freshquant_symphony_service.ps1
+++ b/runtime/symphony/scripts/sync_freshquant_symphony_service.ps1
@@ -54,12 +54,18 @@ $sourceLayout = Get-SourceLayout -RepoRuntimeRoot $repoRuntimeRoot -ServiceRoot 
 $sourceConfigRoot = $sourceLayout.ConfigRoot
 $sourceScriptsRoot = $sourceLayout.ScriptsRoot
 $workflowValidator = Join-Path $sourceScriptsRoot 'assert_freshquant_workflow_prompt.ps1'
+$mergingPromptValidator = Join-Path $sourceScriptsRoot 'assert_freshquant_merging_prompt.ps1'
 
 if (-not (Test-Path $workflowValidator)) {
     throw "Workflow validator script not found: $workflowValidator"
 }
 
+if (-not (Test-Path $mergingPromptValidator)) {
+    throw "Merging prompt validator script not found: $mergingPromptValidator"
+}
+
 & $workflowValidator -WorkflowPath (Join-Path $sourceConfigRoot 'WORKFLOW.freshquant.md')
+& $mergingPromptValidator -PromptPath (Join-Path $sourceConfigRoot 'prompts\merging.md')
 
 $directories = @(
     $configRoot,
@@ -137,6 +143,10 @@ $copyMap = @(
     @{
         Source = (Join-Path $sourceScriptsRoot 'assert_freshquant_workflow_prompt.ps1')
         Destination = (Join-Path $scriptsRoot 'assert_freshquant_workflow_prompt.ps1')
+    },
+    @{
+        Source = (Join-Path $sourceScriptsRoot 'assert_freshquant_merging_prompt.ps1')
+        Destination = (Join-Path $scriptsRoot 'assert_freshquant_merging_prompt.ps1')
     },
     @{
         Source = (Join-Path $sourceScriptsRoot 'request_freshquant_symphony_cleanup.ps1')


### PR DESCRIPTION
## Design Review Packet

### 待评审点 1
- 决策问题：是否接受用“`Merging` prompt guardrail + validator”收紧收尾行为，而不是继续允许会话内长时间等待与直接删除 workspace。
- 推荐方案：接受。
- 推荐理由：这是最小可落地修复，能直接阻断当前已复现的两条慢路径：`gh pr checks --watch` / `Start-Sleep` 长轮询导致 stall，以及绕过 cleanup request 直接删 workspace 导致 `Merging` / `Blocked` 收不了口。
- 备选方案：
  - 直接修改 orchestrator 的 stall 判定逻辑。
  - 在 cleanup finalizer 增加句柄占用定位和自愈删除。
- 影响面：`runtime/symphony/prompts/merging.md`、`runtime/symphony/scripts/*validator*`、正式服务 `sync/start` 校验路径、`docs/current/**` 排障口径。
- 需要人工明确给出的结论：`APPROVED` / `REVISE:` / `REJECTED:`

## 变更摘要
- 为 `Merging` prompt 增加硬规则：只做一次性检查，不在会话内使用 `gh pr checks --watch`、`gh run watch` 或 `Start-Sleep` 长轮询。
- 强制 cleanup 只能走 `request_freshquant_symphony_cleanup.ps1`，禁止在 Codex 会话里直接 `Remove-Item` / `git worktree remove` 删除 task workspace。
- 新增 `assert_freshquant_merging_prompt.ps1`，并接入 `sync_freshquant_symphony_service.ps1` / `start_freshquant_symphony.ps1`。
- 同步更新 `docs/current/runtime.md`、`docs/current/troubleshooting.md`、`runtime/symphony/README.md`。
- 新增 prompt contract 测试，覆盖 validator 本身及 `sync/start` 接入点。

## 验证
- `D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m pytest freshquant/tests/test_symphony_prompt_contract.py freshquant/tests/test_symphony_cleanup_scripts.py -q`
- 本地结果：`10 passed`
- 已执行 `powershell -ExecutionPolicy Bypass -File runtime\symphony\scripts\sync_freshquant_symphony_service.ps1`，同步时 workflow / merging prompt contract 均通过。
- 宿主机 Symphony 服务已由人工重启；当前 `http://127.0.0.1:40123/api/v1/state` 可访问。
