### PR TITLE
fix: 恢复宿主机 vendored QUANTAXIS / Mongo 27027 入口优先级

### DIFF
--- a/deployment/examples/supervisord.fqnext.example.conf
+++ b/deployment/examples/supervisord.fqnext.example.conf
@@ -17,7 +17,7 @@ stderr_logfile_backups=10
 autorestart=true
 startretries=10
 envFiles=D:/fqpack/config/envs.conf
-environment=PATH=D:/fqpack/freshquant-2026.2.23/.venv;D:/fqpack/freshquant-2026.2.23/.venv/Scripts;C:/Windows/System32,PYTHONPATH=D:/fqpack/freshquant-2026.2.23;D:/fqpack/freshquant-2026.2.23/morningglory/fqxtrade
+environment=PATH=D:/fqpack/freshquant-2026.2.23/.venv;D:/fqpack/freshquant-2026.2.23/.venv/Scripts;C:/Windows/System32,PYTHONPATH=D:/fqpack/freshquant-2026.2.23;D:/fqpack/freshquant-2026.2.23/morningglory/fqxtrade;D:/fqpack/freshquant-2026.2.23/sunflower/QUANTAXIS
 
 [inet_http_server]
 port=127.0.0.1:10011

--- a/docs/current/configuration.md
+++ b/docs/current/configuration.md
@@ -116,7 +116,8 @@ vendored `QUANTAXIS` 当前 Mongo 解析规则：
 
 - CI 的 pytest job 使用 `pytest-xdist` 以文件粒度并行执行单元测试。
 - 当前命令是 `pytest -q freshquant/tests -n auto --dist loadfile`。
-- 若本地要复现同一模式，优先保证 `PYTHONPATH` 指向仓库源码与 `morningglory/fqxtrade`，避免落到过期的已安装包。
+- 若本地要复现同一模式，优先保证 `PYTHONPATH` 指向仓库源码、`morningglory/fqxtrade` 与 `sunflower/QUANTAXIS`，避免落到过期的已安装包。
+- 当前 `freshquant/__init__.py` 也会在检测到源码树时把 `sunflower/QUANTAXIS` 提前插入 `sys.path`；但正式宿主机仍应以 supervisor 模板中的显式 `PYTHONPATH` 为部署真值。
 
 ## 当前宿主机模板
 
@@ -125,7 +126,7 @@ vendored `QUANTAXIS` 当前 Mongo 解析规则：
 - `deployment/examples/freshquant.yaml`
   - 宿主机配置样例。
 - `deployment/examples/supervisord.fqnext.example.conf`
-  - 宿主机进程编排样例。
+  - 宿主机进程编排样例；当前 `PYTHONPATH` 口径应同时包含仓库根、`morningglory/fqxtrade` 和 `sunflower/QUANTAXIS`。
 
 ## 配置变更约束
 

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -105,10 +105,13 @@ Get-ChildItem logs/runtime -Recurse -Filter *.jsonl | Sort-Object LastWriteTime 
 常见根因：
 - 只修了 FreshQuant Dynaconf，vendored `QUANTAXIS` 仍沿用 `qaenv` 的本地 `27017` 默认值
 - `qifiserver` 在 import 阶段初始化 manager，模块一导入就连库
+- 宿主机进程的 `PYTHONPATH` 没带 `sunflower/QUANTAXIS`，实际导入落到了 `.venv/Lib/site-packages/QUANTAXIS`
 
 处理：
 - 宿主机链路统一改到 `127.0.0.1:27027`
 - Docker 容器内部继续保持 `fq_mongodb:27017`
+- 宿主机 supervisor 模板里的 `PYTHONPATH` 要同时包含仓库根、`morningglory/fqxtrade` 和 `sunflower/QUANTAXIS`
+- 当前 `freshquant` 在源码树运行时会优先插入 vendored `QUANTAXIS`；如果仍然打到 `27017`，优先怀疑正式 checkout 还没更新到包含该 bootstrap 与 lazy-init 修复的最新源码
 - 如果仍失败，说明 Mongo 端口问题已排除，继续看下一层真实依赖
 
 ## 订单已提交但没有成交回流

--- a/freshquant/__init__.py
+++ b/freshquant/__init__.py
@@ -1,5 +1,9 @@
 import logging
 import warnings
 
+from freshquant.runtime.import_path import ensure_vendored_quantaxis_path
+
+ensure_vendored_quantaxis_path()
+
 logging.disable(logging.INFO)
 warnings.filterwarnings("ignore")

--- a/freshquant/runtime/import_path.py
+++ b/freshquant/runtime/import_path.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _normalize_path(entry: str | Path) -> str:
+    try:
+        return str(Path(entry).resolve()).casefold()
+    except OSError:
+        return str(entry).strip().casefold()
+
+
+def ensure_vendored_quantaxis_path(repo_root: str | Path | None = None) -> str | None:
+    root = (
+        Path(repo_root)
+        if repo_root is not None
+        else Path(__file__).resolve().parents[2]
+    )
+    vendored_root = root / "sunflower" / "QUANTAXIS"
+    vendored_init = vendored_root / "QUANTAXIS" / "__init__.py"
+    if not vendored_init.exists():
+        return None
+
+    vendored_root_str = str(vendored_root)
+    normalized_root = _normalize_path(vendored_root)
+    sys.path[:] = [
+        entry for entry in sys.path if _normalize_path(entry) != normalized_root
+    ]
+    sys.path.insert(0, vendored_root_str)
+    return vendored_root_str

--- a/freshquant/tests/test_host_runtime_pythonpath.py
+++ b/freshquant/tests/test_host_runtime_pythonpath.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def test_supervisord_example_adds_vendored_quantaxis_to_pythonpath() -> None:
+    config = Path("deployment/examples/supervisord.fqnext.example.conf").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "PYTHONPATH="
+        "D:/fqpack/freshquant-2026.2.23;"
+        "D:/fqpack/freshquant-2026.2.23/morningglory/fqxtrade;"
+        "D:/fqpack/freshquant-2026.2.23/sunflower/QUANTAXIS"
+    ) in config
+
+
+def test_configuration_docs_call_out_vendored_quantaxis_pythonpath() -> None:
+    configuration = Path("docs/current/configuration.md").read_text(encoding="utf-8")
+
+    assert (
+        "若本地要复现同一模式，优先保证 `PYTHONPATH` 指向仓库源码、"
+        "`morningglory/fqxtrade` 与 `sunflower/QUANTAXIS`"
+    ) in configuration

--- a/freshquant/tests/test_vendored_quantaxis_bootstrap.py
+++ b/freshquant/tests/test_vendored_quantaxis_bootstrap.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_bootstrap(script: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        cwd=PROJECT_ROOT,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_importing_freshquant_prefers_vendored_quantaxis_path() -> None:
+    result = _run_bootstrap(
+        f"""
+        import importlib.util
+        import site
+        import sys
+
+        repo_root = r"{PROJECT_ROOT}"
+        site_packages = next(
+            entry for entry in site.getsitepackages() if entry.endswith("site-packages")
+        )
+        remaining = [
+            entry
+            for entry in sys.path
+            if entry not in {{repo_root, site_packages}}
+        ]
+        sys.path[:] = [
+            repo_root,
+            site_packages,
+            *remaining,
+        ]
+
+        import freshquant
+
+        print(importlib.util.find_spec("QUANTAXIS").origin)
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "sunflower/QUANTAXIS/QUANTAXIS/__init__.py" in result.stdout.replace(
+        "\\", "/"
+    )


### PR DESCRIPTION
## 变更\n- 修正宿主机 supervisor 模板的 PYTHONPATH，显式加入 sunflower/QUANTAXIS\n- 在 reshquant/__init__.py 增加源码树运行时 bootstrap，优先加载 vendored QUANTAXIS\n- 增加宿主机 PYTHONPATH 与 bootstrap 回归测试\n- 同步更新 docs/current/configuration.md 与 docs/current/troubleshooting.md\n\n## 验证\n- D:/fqpack/freshquant-2026.2.23/.venv/Scripts/python.exe -m pytest -q freshquant/tests/test_host_mongodb_runtime_defaults.py freshquant/tests/test_vendored_quantaxis_bootstrap.py freshquant/tests/test_host_runtime_pythonpath.py freshquant/tests/test_quantaxis_mongo_runtime.py freshquant/tests/test_project_python_policy.py\n- 只给仓库根与 morningglory/fqxtrade 时，import freshquant 后 QUANTAXIS 解析到 vendored 源码路径\n- 按真实入口导入 reshquant.signal.astock.job.monitor_stock_zh_a_min 时，不再停在 Mongo 127.0.0.1:27017，而是继续推进到无关的 qchan01 DLL 问题\n\n## 说明\n- 截至 2026-03-13，github/main 已包含 GH-124 的 QUANTAXIS lazy-init / 27027 源码修复\n- 本 PR 修复的是宿主机仍可能落到旧 .venv/Lib/site-packages/QUANTAXIS 的运行时入口问题\n\nCloses #132