### PR TITLE
[GH-136] 修复 Docker API Mongo 端口混用

### DIFF
--- a/docker/compose.parallel.yaml
+++ b/docker/compose.parallel.yaml
@@ -41,6 +41,10 @@ services:
       TZ: Asia/Shanghai
       PYTHONUNBUFFERED: "1"
       FQ_RUNTIME_LOG_DIR: /freshquant/logs/runtime
+      FRESHQUANT_MONGODB__HOST: fq_mongodb
+      FRESHQUANT_MONGODB__PORT: "27017"
+      FRESHQUANT_REDIS__HOST: fq_redis
+      FRESHQUANT_REDIS__PORT: "6379"
     command: ["/freshquant/.venv/bin/python", "-m", "freshquant.rear.api_server", "--port", "5000"]
     ports:
       - "15000:5000"
@@ -60,6 +64,10 @@ services:
     environment:
       TZ: Asia/Shanghai
       PYTHONUNBUFFERED: "1"
+      FRESHQUANT_MONGODB__HOST: fq_mongodb
+      FRESHQUANT_MONGODB__PORT: "27017"
+      FRESHQUANT_REDIS__HOST: fq_redis
+      FRESHQUANT_REDIS__PORT: "6379"
     command: ["/freshquant/.venv/bin/python", "-m", "freshquant.gateway.tdxhq", "--port", "5001"]
     ports:
       - "15001:5001"
@@ -77,6 +85,10 @@ services:
       PYTHONUNBUFFERED: "1"
       JYGS_ENV_FILE: /run/host-config/envs.conf
       FRESHQUANT_TDX_ROOT: /run/host-tdx
+      FRESHQUANT_MONGODB__HOST: fq_mongodb
+      FRESHQUANT_MONGODB__PORT: "27017"
+      FRESHQUANT_REDIS__HOST: fq_redis
+      FRESHQUANT_REDIS__PORT: "6379"
     command:
       [
         "sh",
@@ -111,6 +123,10 @@ services:
       PYTHONUNBUFFERED: "1"
       JYGS_ENV_FILE: /run/host-config/envs.conf
       FRESHQUANT_TDX_ROOT: /run/host-tdx
+      FRESHQUANT_MONGODB__HOST: fq_mongodb
+      FRESHQUANT_MONGODB__PORT: "27017"
+      FRESHQUANT_REDIS__HOST: fq_redis
+      FRESHQUANT_REDIS__PORT: "6379"
     command:
       [
         "sh",
@@ -141,6 +157,10 @@ services:
     environment:
       TZ: Asia/Shanghai
       PYTHONUNBUFFERED: "1"
+      FRESHQUANT_MONGODB__HOST: fq_mongodb
+      FRESHQUANT_MONGODB__PORT: "27017"
+      FRESHQUANT_REDIS__HOST: fq_redis
+      FRESHQUANT_REDIS__PORT: "6379"
     command: ["/freshquant/.venv/bin/python", "-m", "QUANTAXIS.QAWebServer.server"]
     ports:
       - "18010:8010"

--- a/docs/current/configuration.md
+++ b/docs/current/configuration.md
@@ -45,6 +45,15 @@ Docker 并行模式通过 `deployment/examples/envs.fqnext.example` 把端口改
 - Redis `6380`
 - TDXHQ `15001`
 
+当前 `docker/compose.parallel.yaml` 对 FreshQuant 容器额外显式覆盖：
+
+- `FRESHQUANT_MONGODB__HOST=fq_mongodb`
+- `FRESHQUANT_MONGODB__PORT=27017`
+- `FRESHQUANT_REDIS__HOST=fq_redis`
+- `FRESHQUANT_REDIS__PORT=6379`
+
+也就是说，主工作树 `.env` 继续保留宿主机口径 `127.0.0.1:27027` / `6380`；Docker 容器内部链路不再直接继承这组宿主机地址。
+
 vendored `QUANTAXIS` 当前 Mongo 解析规则：
 
 - 显式 `MONGOURI` 或 `FRESHQUANT_MONGODB__URI` 优先。

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -68,6 +68,7 @@
 
 - 宿主机 `.env` 示例：`deployment/examples/envs.fqnext.example`
 - Docker API 使用 `FQ_COMPOSE_ENV_FILE` 指向主工作树 `.env`
+- `docker/compose.parallel.yaml` 会对 `fq_apiserver`、`fq_tdxhq`、`fq_dagster_webserver`、`fq_dagster_daemon`、`fq_qawebserver` 显式覆盖 `FRESHQUANT_MONGODB__HOST/PORT=fq_mongodb:27017` 与 `FRESHQUANT_REDIS__HOST/PORT=fq_redis:6379`
 - 宿主机 FreshQuant / FQXTrade / vendored QUANTAXIS 默认统一解析到 `127.0.0.1:27027`
 - Docker 容器内部 Mongo 继续使用服务名 `fq_mongodb:27017`
 - Web UI 默认访问并行 API `http://127.0.0.1:15000`

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -19,11 +19,13 @@ Get-ChildItem logs/runtime -Recurse -Filter *.jsonl | Sort-Object LastWriteTime 
 先检查：
 - `docker compose -f docker/compose.parallel.yaml ps`
 - `Invoke-WebRequest -UseBasicParsing http://127.0.0.1:15000/api/runtime/components`
+- `docker compose -f docker/compose.parallel.yaml config | Select-String "FRESHQUANT_MONGODB__HOST|FRESHQUANT_MONGODB__PORT|FRESHQUANT_REDIS__HOST|FRESHQUANT_REDIS__PORT"`
 
 常见根因：
 - `fq_apiserver` 没启动或容器异常退出。
 - Mongo/Redis 依赖没准备好，API 容器循环重启。
 - `.env` 没传给 `FQ_COMPOSE_ENV_FILE`。
+- compose 渲染结果里缺少容器内 `fq_mongodb:27017` / `fq_redis:6379` 覆写，导致宿主机 `.env` 的 `127.0.0.1:27027`、`6380` 或 `fq_mongodb:27027` 误灌进容器。
 
 处理：
 - 重建 API：`docker compose -f docker/compose.parallel.yaml up -d --build fq_apiserver`

--- a/freshquant/tests/test_docker_runtime_policy.py
+++ b/freshquant/tests/test_docker_runtime_policy.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 
@@ -27,3 +28,29 @@ def test_compose_builds_rear_image_once() -> None:
 def test_ci_uses_uv_sync() -> None:
     text = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
     assert "uv sync --frozen" in text
+
+
+def _compose_service_block(text: str, service_name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(service_name)}:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_]+:|\Z)",
+        text,
+    )
+    assert match is not None, f"missing compose service block: {service_name}"
+    return match.group("body")
+
+
+def test_freshquant_compose_services_override_container_data_plane_addresses() -> None:
+    text = Path("docker/compose.parallel.yaml").read_text(encoding="utf-8")
+
+    for service_name in (
+        "fq_apiserver",
+        "fq_tdxhq",
+        "fq_dagster_webserver",
+        "fq_dagster_daemon",
+        "fq_qawebserver",
+    ):
+        block = _compose_service_block(text, service_name)
+        assert "FRESHQUANT_MONGODB__HOST: fq_mongodb" in block
+        assert 'FRESHQUANT_MONGODB__PORT: "27017"' in block
+        assert "FRESHQUANT_REDIS__HOST: fq_redis" in block
+        assert 'FRESHQUANT_REDIS__PORT: "6379"' in block


### PR DESCRIPTION
<!-- symphony-design-review -->

# 设计评审包

## 1. 任务摘要

- 任务：修复 Docker API 运行面继续读取宿主机 `.env`，导致容器内 Mongo 解析成 `fq_mongodb:27027` 并触发接口超时
- 目标：让 Docker Python 服务在容器内稳定解析 `fq_mongodb:27017`，并一并收口同类基础设施地址混用风险，恢复 `15000` API 运行面健康检查
- 非目标：不改宿主机 FreshQuant / Guardian 的 Mongo 口径，不改业务接口语义，不改存储 schema

## 2. 范围

- 影响模块：`docker/compose.parallel.yaml`、`script/docker_parallel_runtime.py`、相关回归测试、`docs/current/**`
- 行为变化：Docker Python 服务不再直接消费主工作树宿主机 `.env` 中的基础设施 host/port；容器内链路统一使用 compose service 名称与容器端口
- 部署范围：重建所有通过 `FQ_COMPOSE_ENV_FILE` 读取基础设施配置的 Docker Python 服务，至少包含 `fq_apiserver`，并按实现结果同步重建 `fq_tdxhq`、`fq_dagster_webserver`、`fq_dagster_daemon`、`fq_webui`
- 需同步文档：`docs/current/runtime.md`、`docs/current/configuration.md`、`docs/current/troubleshooting.md`

## 3. 推荐设计

- 推荐方案：引入 Docker 专用 compose env 输入或等价的服务级覆盖，让容器内部统一使用 `fq_mongodb:27017`，并补齐同一入口下 Redis 等基础设施的容器内地址；宿主机 `.env` 继续只作为宿主机进程真值
- 推荐理由：当前文档已经把宿主机和容器口径分开，问题出在 compose/runtime helper 仍把主工作树 `.env` 直接塞进容器；在编排层修复最贴近根因，范围也小于改 Dynaconf 默认语义
- 主要风险：如果覆盖范围不完整，其他同样复用 `FQ_COMPOSE_ENV_FILE` 的 Docker Python 服务仍可能继续拿到宿主机地址；需要用测试锁住 helper 与 compose 入口
- 测试计划：补 Docker compose env 解析回归测试；本地运行相关 pytest；部署后复核 `/api/runtime/components`、`/api/runtime/health/summary`、`/api/gantt/plates?provider=xgb`，以及 Web UI 代理下的 `/api/get_stock_signal_list?page=1&size=10`
- 回滚说明：回退本 PR，并重新执行 `docker compose -f docker/compose.parallel.yaml up -d --build` 重建受影响容器

## 4. 待决策点

- 无待评审点，按推荐方案执行

## 5. 审批方式

- 回复 `APPROVED`
- 或回复 `REVISE: ...`
- 或回复 `REJECTED: ...`

Refs #136
