### PR TITLE
[治理] 增加 Symphony 管理员计划任务桥接

### DIFF
--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -35,6 +35,27 @@ docker compose -f docker/compose.parallel.yaml up -d --build ta_backend ta_front
 powershell -ExecutionPolicy Bypass -File runtime/symphony/scripts/activate_github_first_formal_service.ps1
 ```
 
+### 宿主机仅同步并重载 Symphony
+
+首次安装按需管理员桥接任务：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File runtime/symphony/scripts/install_freshquant_symphony_restart_task.ps1
+```
+
+- 该脚本会先把当前 `runtime/symphony/**` 同步到 `D:\fqpack\runtime\symphony-service`，再注册计划任务
+
+后续普通会话更新 `runtime/symphony/**` 时：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File runtime/symphony/scripts/sync_freshquant_symphony_service.ps1
+powershell -ExecutionPolicy Bypass -File runtime/symphony/scripts/invoke_freshquant_symphony_restart_task.ps1
+```
+
+- 默认计划任务名：`fq-symphony-orchestrator-restart`
+- 默认状态文件：`D:\fqpack\runtime\symphony-service\artifacts\admin-bridge\restart-status.json`
+- 如果计划任务尚未安装，或需要重装正式服务本体，仍使用 `reinstall_freshquant_symphony_service.ps1` / 激活脚本并在提升权限 PowerShell 中执行
+
 ### 宿主机同步 Python 依赖
 
 ```powershell
@@ -59,7 +80,7 @@ powershell -ExecutionPolicy Bypass -File runtime/symphony/scripts/activate_githu
 | `morningglory/fqwebui/**` | Web UI | 重建 `fq_webui` |
 | `morningglory/fqdagster/**` / `morningglory/fqdagsterconfig/**` | Dagster | 重启 `fq_dagster_webserver` 与 `fq_dagster_daemon` |
 | `third_party/tradingagents-cn/**` | TradingAgents-CN | 重建 `ta_backend` 与 `ta_frontend` |
-| `runtime/symphony/**` | 正式 orchestrator | `sync_freshquant_symphony_service.ps1` + `reinstall_freshquant_symphony_service.ps1` 或激活脚本 |
+| `runtime/symphony/**` | 正式 orchestrator | 已预装计划任务时执行 `sync_freshquant_symphony_service.ps1` + `invoke_freshquant_symphony_restart_task.ps1`；否则使用 `reinstall_freshquant_symphony_service.ps1` 或激活脚本 |
 
 ## 健康检查
 
@@ -104,6 +125,7 @@ docker compose -f docker/compose.parallel.yaml ps
 - 如果改了运行观测或 XTData runtime 埋点，确认 `/runtime-observability` 页面能看到 `xt_producer` / `xt_consumer` 的 5 分钟 heartbeat 与关键指标，而不是只看到启动事件。
 - TPSL / Position worker 修改后，进程没有“启动即退”。
 - Symphony 修改后，`Merging -> Global Stewardship` handoff、批量 deploy 判定和 follow-up issue only 规则仍然可用。
+- 如果通过计划任务桥接重载 Symphony，还要确认 `artifacts\admin-bridge\restart-status.json` 记录 `success=true` 且 `health_status_code=200`。
 
 ## Global Stewardship 收口规则
 

--- a/docs/current/interfaces.md
+++ b/docs/current/interfaces.md
@@ -125,6 +125,8 @@ python -m freshquant.cli om-order cancel --internal-order-id <id>
 - Symphony 正式服务
   - `runtime/symphony/scripts/start_freshquant_symphony.ps1`
   - `runtime/symphony/scripts/activate_github_first_formal_service.ps1`
+  - `runtime/symphony/scripts/install_freshquant_symphony_restart_task.ps1`
+  - `runtime/symphony/scripts/invoke_freshquant_symphony_restart_task.ps1`
 
 ## Web UI 路由
 

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -31,12 +31,15 @@
 - Symphony 正式服务名：`fq-symphony-orchestrator`
 - Symphony 状态接口：`http://127.0.0.1:40123/api/v1/state`
 - Symphony 工作区根目录：`D:/fqpack/runtime/symphony-service/workspaces`
+- Symphony 按需管理员计划任务：`fq-symphony-orchestrator-restart`
+- Symphony 管理员桥接状态文件：`D:/fqpack/runtime/symphony-service/artifacts/admin-bridge/restart-status.json`
 - Symphony 运行模板：`runtime/symphony/WORKFLOW.freshquant.md`
 - 全局 Codex 自动化提示词模板：`runtime/symphony/prompts/global_stewardship.md`
 - GitHub 新任务默认通过 issue template 创建，初始标签应为 `symphony + todo`；不要在创建时预贴 `design-review`
 - Symphony workspace 默认从本地工作树 clone，但 `after_create` / `before_run` 会补齐 `github` remote 并把 `remote.pushDefault` 设为 `github`
 - `Merging` 现在只负责 merge 到 remote `main`、写 handoff comment，并把 issue 转入 `Global Stewardship`
 - `Global Stewardship` 由单个全局 Codex 自动化负责；它统一处理 deploy、health check、cleanup 和 follow-up issue 创建
+- 如果当前 Codex 会话没有管理员权限，`runtime/symphony/**` 的重载应走预装的计划任务桥接：普通会话先 `sync_freshquant_symphony_service.ps1`，再调用 `invoke_freshquant_symphony_restart_task.ps1`
 - `Blocked` 只用于真实外部阻塞；进入 `Blocked` 时必须同时记录阻塞原因、解除条件、当前证据和恢复目标状态（`In Progress` / `Rework` / `Global Stewardship`）
 - 如果 GitHub 真值已经表明 `Blocked` 只是误标，orchestrator 会自动恢复：merged PR, pending ops -> `Global Stewardship`；open non-draft PR -> `Rework`；approved draft PR -> `In Progress`
 - 如果 workspace 目录存在但缺失 git 元数据，orchestrator 会在下一次执行前自愈重建一次，而不是无限重试 `not a git repository`

--- a/runtime/symphony/README.md
+++ b/runtime/symphony/README.md
@@ -147,6 +147,7 @@ Cleanup 只清理任务级资源：
   - `templates/global_stewardship_done_comment.md`
   - `templates/follow_up_issue.md`
 - `sync_freshquant_symphony_service.ps1` / `start_freshquant_symphony.ps1` 会同时校验 `WORKFLOW.freshquant.md`、`prompts/merging.md` 与 `prompts/global_stewardship.md` 的关键 contract，避免正式 prompt 被过度简化
+- 如果当前 Codex 会话没有管理员权限，可预装一个按需触发的 Windows 计划任务，由它以 `SYSTEM` 身份重启 `fq-symphony-orchestrator` 并写回状态文件；普通会话只负责触发任务和读取结果
 - 正式宿主机脚本：
   - `scripts/run_freshquant_codex_session.ps1`
   - `scripts/assert_freshquant_merging_prompt.ps1`
@@ -154,6 +155,9 @@ Cleanup 只清理任务级资源：
   - `scripts/invoke_freshquant_symphony_cleanup_finalizer.ps1`
   - `scripts/start_freshquant_symphony.ps1`
   - `scripts/sync_freshquant_symphony_service.ps1`
+  - `scripts/install_freshquant_symphony_restart_task.ps1`
+  - `scripts/invoke_freshquant_symphony_restart_task.ps1`
+  - `scripts/run_freshquant_symphony_restart_task.ps1`
 
 `request_freshquant_symphony_cleanup.ps1` 的部署说明正文支持两种入口：
 

--- a/runtime/symphony/scripts/install_freshquant_symphony_restart_task.ps1
+++ b/runtime/symphony/scripts/install_freshquant_symphony_restart_task.ps1
@@ -1,0 +1,91 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$TaskName = 'fq-symphony-orchestrator-restart',
+    [string]$ServiceName = 'fq-symphony-orchestrator',
+    [string]$ServiceRoot = 'D:\fqpack\runtime\symphony-service',
+    [int]$Port = 40123,
+    [string]$StatusPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-IsElevatedSession {
+    $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [System.Security.Principal.WindowsPrincipal]::new($identity)
+    return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Resolve-StatusPath {
+    param(
+        [string]$ExplicitPath,
+        [string]$ResolvedServiceRoot
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitPath)) {
+        return [System.IO.Path]::GetFullPath($ExplicitPath)
+    }
+
+    return Join-Path $ResolvedServiceRoot 'artifacts\admin-bridge\restart-status.json'
+}
+
+$resolvedServiceRoot = [System.IO.Path]::GetFullPath($ServiceRoot).TrimEnd('\')
+$syncScriptPath = Join-Path $PSScriptRoot 'sync_freshquant_symphony_service.ps1'
+$taskScriptPath = Join-Path $resolvedServiceRoot 'scripts\run_freshquant_symphony_restart_task.ps1'
+$resolvedStatusPath = Resolve-StatusPath -ExplicitPath $StatusPath -ResolvedServiceRoot $resolvedServiceRoot
+$statusDirectory = Split-Path -Parent $resolvedStatusPath
+
+if (-not (Test-Path $syncScriptPath)) {
+    throw "Sync script not found: $syncScriptPath"
+}
+
+if (-not [string]::IsNullOrWhiteSpace($statusDirectory)) {
+    New-Item -ItemType Directory -Force -Path $statusDirectory | Out-Null
+}
+
+& $syncScriptPath -ServiceRoot $resolvedServiceRoot -WhatIf:$WhatIfPreference
+
+if (-not (Test-Path $taskScriptPath)) {
+    if ($WhatIfPreference) {
+        Write-Warning "Restart task script is not present yet at $taskScriptPath. This is expected when sync runs under -WhatIf."
+    }
+    else {
+        throw "Restart task script not found after sync: $taskScriptPath"
+    }
+}
+
+$powershellExe = Join-Path $PSHOME 'powershell.exe'
+$arguments = @(
+    '-NoProfile',
+    '-ExecutionPolicy', 'Bypass',
+    '-File', ('"{0}"' -f $taskScriptPath),
+    '-ServiceName', ('"{0}"' -f $ServiceName),
+    '-ServiceRoot', ('"{0}"' -f $resolvedServiceRoot),
+    '-Port', $Port.ToString(),
+    '-StatusPath', ('"{0}"' -f $resolvedStatusPath)
+) -join ' '
+
+$action = New-ScheduledTaskAction -Execute $powershellExe -Argument $arguments
+$principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 10) `
+    -MultipleInstances IgnoreNew `
+    -StartWhenAvailable
+
+if ($PSCmdlet.ShouldProcess($TaskName, 'Register FreshQuant Symphony restart task')) {
+    if (-not (Test-IsElevatedSession)) {
+        throw 'Registering the restart task requires an elevated PowerShell session (Run as Administrator).'
+    }
+
+    Register-ScheduledTask `
+        -TaskName $TaskName `
+        -Action $action `
+        -Principal $principal `
+        -Settings $settings `
+        -Description 'Restart FreshQuant Symphony orchestrator and verify its local health endpoint.' `
+        -Force | Out-Null
+}
+
+Write-Host "[freshquant] restart task ready: $TaskName"
+Write-Host "[freshquant] invoke from normal sessions with runtime/symphony/scripts/invoke_freshquant_symphony_restart_task.ps1"

--- a/runtime/symphony/scripts/invoke_freshquant_symphony_restart_task.ps1
+++ b/runtime/symphony/scripts/invoke_freshquant_symphony_restart_task.ps1
@@ -1,0 +1,75 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$TaskName = 'fq-symphony-orchestrator-restart',
+    [string]$ServiceRoot = 'D:\fqpack\runtime\symphony-service',
+    [string]$StatusPath,
+    [int]$TimeoutSeconds = 180,
+    [int]$PollIntervalSeconds = 2
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-StatusPath {
+    param(
+        [string]$ExplicitPath,
+        [string]$ResolvedServiceRoot
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitPath)) {
+        return [System.IO.Path]::GetFullPath($ExplicitPath)
+    }
+
+    return Join-Path $ResolvedServiceRoot 'artifacts\admin-bridge\restart-status.json'
+}
+
+function Read-TaskStatus {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return $null
+    }
+
+    return Get-Content -Raw -Path $Path | ConvertFrom-Json
+}
+
+$resolvedServiceRoot = [System.IO.Path]::GetFullPath($ServiceRoot).TrimEnd('\')
+$resolvedStatusPath = Resolve-StatusPath -ExplicitPath $StatusPath -ResolvedServiceRoot $resolvedServiceRoot
+$task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+
+if (-not $task) {
+    throw "Scheduled task '$TaskName' not found. Install it first with runtime/symphony/scripts/install_freshquant_symphony_restart_task.ps1 from an elevated PowerShell session."
+}
+
+$previousWriteTimeUtc = if (Test-Path $resolvedStatusPath) { (Get-Item $resolvedStatusPath).LastWriteTimeUtc } else { [datetime]::MinValue }
+
+if ($PSCmdlet.ShouldProcess($TaskName, 'Run FreshQuant Symphony restart task')) {
+    Start-ScheduledTask -TaskName $TaskName
+}
+
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+$status = $null
+do {
+    Start-Sleep -Seconds $PollIntervalSeconds
+
+    if (Test-Path $resolvedStatusPath) {
+        $currentWriteTimeUtc = (Get-Item $resolvedStatusPath).LastWriteTimeUtc
+        if ($currentWriteTimeUtc -gt $previousWriteTimeUtc) {
+            $status = Read-TaskStatus -Path $resolvedStatusPath
+            if ($null -ne $status -and -not [string]::IsNullOrWhiteSpace($status.completed_at)) {
+                break
+            }
+        }
+    }
+} while ((Get-Date) -lt $deadline)
+
+if ($null -eq $status -or [string]::IsNullOrWhiteSpace($status.completed_at)) {
+    throw "Timed out waiting for scheduled task '$TaskName' to update $resolvedStatusPath."
+}
+
+if (-not $status.success) {
+    $message = if ([string]::IsNullOrWhiteSpace($status.error)) { 'Unknown error.' } else { $status.error }
+    throw "FreshQuant Symphony restart task reported failure: $message"
+}
+
+Write-Host "[freshquant] restart task completed with HTTP $($status.health_status_code)"
+$status

--- a/runtime/symphony/scripts/run_freshquant_symphony_restart_task.ps1
+++ b/runtime/symphony/scripts/run_freshquant_symphony_restart_task.ps1
@@ -1,0 +1,104 @@
+[CmdletBinding()]
+param(
+    [string]$ServiceName = 'fq-symphony-orchestrator',
+    [string]$ServiceRoot = 'D:\fqpack\runtime\symphony-service',
+    [int]$Port = 40123,
+    [string]$StatusPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-StatusPath {
+    param(
+        [string]$ExplicitPath,
+        [string]$ResolvedServiceRoot
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ExplicitPath)) {
+        return [System.IO.Path]::GetFullPath($ExplicitPath)
+    }
+
+    return Join-Path $ResolvedServiceRoot 'artifacts\admin-bridge\restart-status.json'
+}
+
+function Write-TaskStatus {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary]$Status,
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $directory = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($directory)) {
+        New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    }
+
+    $Status | ConvertTo-Json -Depth 5 | Set-Content -Path $Path -Encoding UTF8
+}
+
+function Wait-ServiceRunning {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [int]$TimeoutSeconds = 60
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $service = Get-Service -Name $Name -ErrorAction Stop
+        if ($service.Status -eq 'Running') {
+            return $service
+        }
+
+        Start-Sleep -Seconds 2
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Service '$Name' did not reach Running within $TimeoutSeconds seconds."
+}
+
+$resolvedServiceRoot = [System.IO.Path]::GetFullPath($ServiceRoot).TrimEnd('\')
+$resolvedStatusPath = Resolve-StatusPath -ExplicitPath $StatusPath -ResolvedServiceRoot $resolvedServiceRoot
+$status = [ordered]@{
+    started_at = (Get-Date).ToString('o')
+    completed_at = $null
+    success = $false
+    service_name = $ServiceName
+    service_root = $resolvedServiceRoot
+    port = $Port
+    host = $env:COMPUTERNAME
+    service_status = $null
+    health_status_code = $null
+    error = $null
+}
+
+Write-TaskStatus -Status $status -Path $resolvedStatusPath
+
+try {
+    Restart-Service -Name $ServiceName -ErrorAction Stop
+    $service = Wait-ServiceRunning -Name $ServiceName
+    $response = Invoke-WebRequest -UseBasicParsing "http://127.0.0.1:$Port/api/v1/state"
+
+    $status.success = $true
+    $status.service_status = $service.Status.ToString()
+    $status.health_status_code = [int]$response.StatusCode
+}
+catch {
+    $status.error = $_.Exception.Message
+
+    try {
+        $service = Get-Service -Name $ServiceName -ErrorAction Stop
+        $status.service_status = $service.Status.ToString()
+    }
+    catch {
+        $status.service_status = 'Unknown'
+    }
+}
+finally {
+    $status.completed_at = (Get-Date).ToString('o')
+    Write-TaskStatus -Status $status -Path $resolvedStatusPath
+}
+
+if (-not $status.success) {
+    throw "FreshQuant Symphony restart task failed: $($status.error)"
+}

--- a/runtime/symphony/scripts/sync_freshquant_symphony_service.ps1
+++ b/runtime/symphony/scripts/sync_freshquant_symphony_service.ps1
@@ -167,6 +167,18 @@ $copyMap = @(
         Destination = (Join-Path $scriptsRoot 'sync_freshquant_symphony_service.ps1')
     },
     @{
+        Source = (Join-Path $sourceScriptsRoot 'run_freshquant_symphony_restart_task.ps1')
+        Destination = (Join-Path $scriptsRoot 'run_freshquant_symphony_restart_task.ps1')
+    },
+    @{
+        Source = (Join-Path $sourceScriptsRoot 'install_freshquant_symphony_restart_task.ps1')
+        Destination = (Join-Path $scriptsRoot 'install_freshquant_symphony_restart_task.ps1')
+    },
+    @{
+        Source = (Join-Path $sourceScriptsRoot 'invoke_freshquant_symphony_restart_task.ps1')
+        Destination = (Join-Path $scriptsRoot 'invoke_freshquant_symphony_restart_task.ps1')
+    },
+    @{
         Source = (Join-Path $sourceScriptsRoot 'assert_freshquant_workflow_prompt.ps1')
         Destination = (Join-Path $scriptsRoot 'assert_freshquant_workflow_prompt.ps1')
     },


### PR DESCRIPTION
## 摘要
- 为 `runtime/symphony/**` 增加基于 Windows 计划任务的管理员桥接，允许普通 Codex 会话触发 `fq-symphony-orchestrator` 重启
- 新增安装、触发、执行三段式脚本，并把它们接入 `sync_freshquant_symphony_service.ps1` 的同步链路
- 同步更新 `docs/current/**` 与 `runtime/symphony/README.md`，明确当前推荐的重载路径与状态文件位置

## Design Review Packet
### 决策问题
当 Codex app 本身无法整体以管理员模式稳定运行时，`runtime/symphony/**` 更新后应如何完成需要管理员权限的 orchestrator 重载？

### 推荐方案
预装一个按需触发的 Windows 计划任务 `fq-symphony-orchestrator-restart`，由它以 `SYSTEM + Highest` 身份执行 `run_freshquant_symphony_restart_task.ps1`；普通会话在 `sync_freshquant_symphony_service.ps1` 之后调用 `invoke_freshquant_symphony_restart_task.ps1`，再依据 `D:\fqpack\runtime\symphony-service\artifacts\admin-bridge\restart-status.json` 和 `40123` 健康接口确认结果。

### 推荐理由
- 不再依赖整体提权运行 Codex app，而是把特权面缩到单一任务
- 复用现有 `sync` / `reinstall` / `activate` 逻辑，不重写服务安装流程
- 普通自动化可以获得确定性的完成信号，而不是只能记录权限 blocker

### 备选方案
1. 继续要求整体以管理员身份运行 Codex app
   - 已证实当前 Store/MSIX 形态不适合作为稳定方案
2. 每次手工开管理员 PowerShell 执行 `Restart-Service`
   - 简单，但自动化无法闭环，仍需要人工介入
3. 新增常驻本地管理服务/API
   - 能力最强，但对当前需求明显过重

### 影响面
- `runtime/symphony/scripts/**`
- `docs/current/deployment.md`
- `docs/current/runtime.md`
- `docs/current/interfaces.md`
- `runtime/symphony/README.md`
- Windows Task Scheduler（新增一个按需任务）

### 需要人工明确结论
是否接受“预装 Windows 计划任务”作为 FreshQuant 正式的 Symphony 特权桥接通道？

## 验证
- `py -3 script/ci/check_current_docs.py --base-ref github/main --head-ref HEAD`
- `git diff --check github/main...HEAD`
- PowerShell 语法解析：`run/install/invoke/sync` 四个脚本 `PARSE_OK`

## 已知限制
- 这条 Codex 会话仍非提升权限 token，所以本次 PR 还没有实际注册计划任务，也没有执行真实服务重启
- 桌面环境策略会拦截我在本会话里做嵌套 PowerShell 的 `install ... -WhatIf` 干跑，因此动态 dry-run 仍待管理员 PowerShell 侧验证