### PR TITLE
GH-149 修复 browser spec 并发共享 fqwebui/web 产物导致偶发超时

### DIFF
--- a/morningglory/fqwebui/.gitignore
+++ b/morningglory/fqwebui/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 node_modules
+.playwright-vite
+test-results
 
 # local env files
 .env.local

--- a/morningglory/fqwebui/tests/gantt-sidebar-hover-alignment.browser.spec.mjs
+++ b/morningglory/fqwebui/tests/gantt-sidebar-hover-alignment.browser.spec.mjs
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
+import path from 'node:path'
 
-import { runLockedBuild } from './vite-build-lock.mjs'
+import { createIsolatedViteArtifactsContext, runLockedBuild } from './vite-build-lock.mjs'
 import {
   cleanupServerPort,
   startPreviewServer,
@@ -11,6 +12,7 @@ import {
 const DEV_SERVER_PORT = 18089
 const DEV_SERVER_URL = `http://127.0.0.1:${DEV_SERVER_PORT}`
 const TARGET_URL = `${DEV_SERVER_URL}/gantt?p=xgb&days=90`
+const PREVIEW_ARTIFACTS = createIsolatedViteArtifactsContext(import.meta.url)
 
 let devServerProcess = null
 
@@ -54,28 +56,26 @@ function createGanttPayload({ dateCount = 12, plateCount = 100 } = {}) {
 async function runBuild() {
   await runLockedBuild(
     () => {
-      if (process.platform === 'win32') {
-        return {
-          command: 'cmd.exe',
-          args: ['/d', '/s', '/c', 'pnpm build']
-        }
-      }
-
       return {
-        command: 'pnpm',
-        args: ['build']
+        command: process.execPath,
+        args: [path.join(process.cwd(), 'node_modules', 'vite', 'bin', 'vite.js'), 'build']
       }
     },
-    process.cwd()
+    process.cwd(),
+    {
+      outDir: PREVIEW_ARTIFACTS.outDirRelative
+    }
   )
 }
 
 test.beforeAll(async () => {
+  test.setTimeout(90000)
   cleanupServerPort(DEV_SERVER_PORT)
   await runBuild()
   devServerProcess = startPreviewServer({
     port: DEV_SERVER_PORT,
-    cwd: process.cwd()
+    cwd: process.cwd(),
+    outDir: PREVIEW_ARTIFACTS.outDirRelative
   })
 
   await waitForServer(DEV_SERVER_URL)
@@ -89,8 +89,6 @@ test.afterAll(async () => {
 test('gantt sidebar rows fit the visible chart window when dense data would otherwise break hover alignment', async ({
   page
 }) => {
-  test.setTimeout(90000)
-
   await page.route('**/api/**', async (route) => {
     const url = new URL(route.request().url())
     if (!url.pathname.startsWith('/api/')) {

--- a/morningglory/fqwebui/tests/kline-slim-boundary.browser.spec.mjs
+++ b/morningglory/fqwebui/tests/kline-slim-boundary.browser.spec.mjs
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
+import path from 'node:path'
 
-import { runLockedBuild } from './vite-build-lock.mjs'
+import { createIsolatedViteArtifactsContext, runLockedBuild } from './vite-build-lock.mjs'
 import {
   cleanupServerPort,
   installVmHelpers,
@@ -16,6 +17,7 @@ const DEV_SERVER_PORT = 18088
 const DEV_SERVER_URL = `http://127.0.0.1:${DEV_SERVER_PORT}`
 const TARGET_URL = `${DEV_SERVER_URL}/kline-slim?symbol=sz002262&period=5m`
 const DAY = '2026-03-12'
+const PREVIEW_ARTIFACTS = createIsolatedViteArtifactsContext(import.meta.url)
 
 let devServerProcess = null
 
@@ -110,28 +112,26 @@ function create15mPayload() {
 async function runBuild() {
   await runLockedBuild(
     () => {
-      if (process.platform === 'win32') {
-        return {
-          command: 'cmd.exe',
-          args: ['/d', '/s', '/c', 'pnpm build']
-        }
-      }
-
       return {
-        command: 'pnpm',
-        args: ['build']
+        command: process.execPath,
+        args: [path.join(process.cwd(), 'node_modules', 'vite', 'bin', 'vite.js'), 'build']
       }
     },
-    process.cwd()
+    process.cwd(),
+    {
+      outDir: PREVIEW_ARTIFACTS.outDirRelative
+    }
   )
 }
 
 test.beforeAll(async () => {
+  test.setTimeout(90000)
   cleanupServerPort(DEV_SERVER_PORT)
   await runBuild()
   devServerProcess = startPreviewServer({
     port: DEV_SERVER_PORT,
-    cwd: process.cwd()
+    cwd: process.cwd(),
+    outDir: PREVIEW_ARTIFACTS.outDirRelative
   })
 
   let startupOutput = ''

--- a/morningglory/fqwebui/tests/kline-slim-browser-helpers.mjs
+++ b/morningglory/fqwebui/tests/kline-slim-browser-helpers.mjs
@@ -1,6 +1,9 @@
 import { createHash } from 'node:crypto'
 import { spawn, spawnSync } from 'node:child_process'
+import path from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
+
+import { appendViteOutDirArgs } from './vite-build-lock.mjs'
 
 export async function waitForServer(url, timeoutMs = 30000) {
   const deadline = Date.now() + timeoutMs
@@ -40,21 +43,16 @@ export function cleanupServerPort(port) {
   )
 }
 
-export function startPreviewServer({ port, cwd }) {
-  if (process.platform === 'win32') {
-    return spawn(
-      'cmd.exe',
-      ['/d', '/s', '/c', `pnpm preview --host 127.0.0.1 --port ${port} --strictPort`],
-      {
-        cwd,
-        stdio: ['ignore', 'pipe', 'pipe']
-      }
-    )
-  }
+export function startPreviewServer({ port, cwd, outDir }) {
+  const viteCliEntry = path.join(cwd, 'node_modules', 'vite', 'bin', 'vite.js')
+  const previewArgs = appendViteOutDirArgs(
+    [viteCliEntry, 'preview', '--host', '127.0.0.1', '--port', String(port), '--strictPort'],
+    outDir
+  )
 
   return spawn(
-    'pnpm',
-    ['preview', '--host', '127.0.0.1', '--port', String(port), '--strictPort'],
+    process.execPath,
+    previewArgs,
     {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe']

--- a/morningglory/fqwebui/tests/kline-slim-ghosting.browser.spec.mjs
+++ b/morningglory/fqwebui/tests/kline-slim-ghosting.browser.spec.mjs
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
+import path from 'node:path'
 
-import { runLockedBuild } from './vite-build-lock.mjs'
+import { createIsolatedViteArtifactsContext, runLockedBuild } from './vite-build-lock.mjs'
 import {
   captureRenderedFrame,
   cleanupServerPort,
@@ -33,6 +34,7 @@ const DAY = '2026-03-11'
 const EXTRA_PERIOD_LEGENDS = ['15m', '30m']
 const ALL_PERIOD_LEGENDS = ['1m', '15m', '30m']
 const ZOOM_SWITCH_SEQUENCE = ['sh510050', 'sz000001', 'sz002262']
+const PREVIEW_ARTIFACTS = createIsolatedViteArtifactsContext(import.meta.url)
 
 const SYMBOL_VARIANTS = {
   sz002262: {
@@ -251,19 +253,15 @@ function buildStockDataPayload(symbol, period) {
 async function runBuild() {
   await runLockedBuild(
     () => {
-      if (process.platform === 'win32') {
-        return {
-          command: 'cmd.exe',
-          args: ['/d', '/s', '/c', 'pnpm build']
-        }
-      }
-
       return {
-        command: 'pnpm',
-        args: ['build']
+        command: process.execPath,
+        args: [path.join(process.cwd(), 'node_modules', 'vite', 'bin', 'vite.js'), 'build']
       }
     },
-    process.cwd()
+    process.cwd(),
+    {
+      outDir: PREVIEW_ARTIFACTS.outDirRelative
+    }
   )
 }
 
@@ -417,11 +415,13 @@ async function runZoomSwitchSequence(page) {
 }
 
 test.beforeAll(async () => {
+  test.setTimeout(90000)
   cleanupServerPort(DEV_SERVER_PORT)
   await runBuild()
   devServerProcess = startPreviewServer({
     port: DEV_SERVER_PORT,
-    cwd: process.cwd()
+    cwd: process.cwd(),
+    outDir: PREVIEW_ARTIFACTS.outDirRelative
   })
 
   let startupOutput = ''

--- a/morningglory/fqwebui/tests/kline-slim-zoom-pan.browser.spec.mjs
+++ b/morningglory/fqwebui/tests/kline-slim-zoom-pan.browser.spec.mjs
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
+import path from 'node:path'
 
-import { runLockedBuild } from './vite-build-lock.mjs'
+import { createIsolatedViteArtifactsContext, runLockedBuild } from './vite-build-lock.mjs'
 import {
   cleanupServerPort,
   installVmHelpers,
@@ -16,6 +17,7 @@ const DEV_SERVER_PORT = 18086
 const DEV_SERVER_URL = `http://127.0.0.1:${DEV_SERVER_PORT}`
 const DAY = '2026-03-10'
 const TARGET_URL = `${DEV_SERVER_URL}/kline-slim?symbol=sz002262&period=5m&endDate=${DAY}`
+const PREVIEW_ARTIFACTS = createIsolatedViteArtifactsContext(import.meta.url)
 
 let devServerProcess = null
 
@@ -125,28 +127,26 @@ function buildStockDataPayload(period, revision = 0) {
 async function runBuild() {
   await runLockedBuild(
     () => {
-      if (process.platform === 'win32') {
-        return {
-          command: 'cmd.exe',
-          args: ['/d', '/s', '/c', 'pnpm build']
-        }
-      }
-
       return {
-        command: 'pnpm',
-        args: ['build']
+        command: process.execPath,
+        args: [path.join(process.cwd(), 'node_modules', 'vite', 'bin', 'vite.js'), 'build']
       }
     },
-    process.cwd()
+    process.cwd(),
+    {
+      outDir: PREVIEW_ARTIFACTS.outDirRelative
+    }
   )
 }
 
 test.beforeAll(async () => {
+  test.setTimeout(90000)
   cleanupServerPort(DEV_SERVER_PORT)
   await runBuild()
   devServerProcess = startPreviewServer({
     port: DEV_SERVER_PORT,
-    cwd: process.cwd()
+    cwd: process.cwd(),
+    outDir: PREVIEW_ARTIFACTS.outDirRelative
   })
 
   let startupOutput = ''

--- a/morningglory/fqwebui/tests/vite-build-lock.mjs
+++ b/morningglory/fqwebui/tests/vite-build-lock.mjs
@@ -1,9 +1,55 @@
+import { createHash } from 'node:crypto'
 import { spawnSync } from 'node:child_process'
 import { mkdir, rm } from 'node:fs/promises'
 import path from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
+import { fileURLToPath } from 'node:url'
 
 const BUILD_LOCK_DIRNAME = '.playwright-vite-build.lock'
+const PLAYWRIGHT_VITE_DIRNAME = '.playwright-vite'
+
+function normalizeSpecReference(specReference) {
+  if (specReference instanceof URL) {
+    return fileURLToPath(specReference)
+  }
+
+  if (typeof specReference === 'string' && specReference.startsWith('file:')) {
+    return fileURLToPath(specReference)
+  }
+
+  return specReference
+}
+
+function sanitizeSpecName(specPath) {
+  return path
+    .basename(specPath, path.extname(specPath))
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+export function createIsolatedViteArtifactsContext(specReference, cwd = process.cwd()) {
+  const specPath = normalizeSpecReference(specReference)
+  const relativeSpecPath = path.relative(cwd, specPath) || path.basename(specPath)
+  const specHash = createHash('sha1').update(relativeSpecPath).digest('hex').slice(0, 8)
+  const outDirRelative = path.join(
+    PLAYWRIGHT_VITE_DIRNAME,
+    `${sanitizeSpecName(specPath)}-${specHash}`
+  )
+
+  return {
+    outDirRelative,
+    outDir: path.join(cwd, outDirRelative)
+  }
+}
+
+export function appendViteOutDirArgs(args, outDir) {
+  const nextArgs = [...args]
+  if (outDir) {
+    nextArgs.push('--outDir', outDir)
+  }
+  return nextArgs
+}
 
 async function acquireBuildLock(cwd) {
   const lockDir = path.join(cwd, BUILD_LOCK_DIRNAME)
@@ -20,17 +66,18 @@ async function acquireBuildLock(cwd) {
   }
 }
 
-export async function runLockedBuild(getBuildCommand, cwd = process.cwd()) {
+export async function runLockedBuild(getBuildCommand, cwd = process.cwd(), { outDir } = {}) {
   const lockDir = await acquireBuildLock(cwd)
   try {
     const { command, args } = getBuildCommand()
-    const result = spawnSync(command, args, {
+    const commandArgs = appendViteOutDirArgs(args, outDir)
+    const buildResult = spawnSync(command, commandArgs, {
       cwd,
       encoding: 'utf8'
     })
 
-    if (result.status !== 0) {
-      throw new Error(result.stderr || result.stdout || 'pnpm build failed')
+    if (buildResult.status !== 0) {
+      throw new Error(buildResult.stderr || buildResult.stdout || 'pnpm build failed')
     }
   } finally {
     await rm(lockDir, {

--- a/morningglory/fqwebui/tests/vite-build-lock.test.mjs
+++ b/morningglory/fqwebui/tests/vite-build-lock.test.mjs
@@ -1,0 +1,91 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  appendViteOutDirArgs,
+  createIsolatedViteArtifactsContext,
+  runLockedBuild
+} from './vite-build-lock.mjs'
+
+const projectDir = fileURLToPath(new URL('..', import.meta.url))
+
+test('createIsolatedViteArtifactsContext returns a stable isolated outDir per spec file', () => {
+  const ghostingSpecUrl = new URL('./kline-slim-ghosting.browser.spec.mjs', import.meta.url).href
+  const ghostingContextA = createIsolatedViteArtifactsContext(ghostingSpecUrl, projectDir)
+  const ghostingContextB = createIsolatedViteArtifactsContext(ghostingSpecUrl, projectDir)
+  const ganttContext = createIsolatedViteArtifactsContext(
+    new URL('./gantt-sidebar-hover-alignment.browser.spec.mjs', import.meta.url).href,
+    projectDir
+  )
+
+  assert.equal(ghostingContextA.outDir, ghostingContextB.outDir)
+  assert.equal(ghostingContextA.outDirRelative, ghostingContextB.outDirRelative)
+  assert.notEqual(ghostingContextA.outDir, ganttContext.outDir)
+  assert.match(
+    ghostingContextA.outDirRelative.replaceAll(path.sep, '/'),
+    /^\.playwright-vite\/kline-slim-ghosting-browser-spec-[a-f0-9]{8}$/
+  )
+  assert.equal(
+    ghostingContextA.outDir,
+    path.join(projectDir, ghostingContextA.outDirRelative)
+  )
+})
+
+test('appendViteOutDirArgs appends a preview/build outDir without mutating the base args', () => {
+  const baseArgs = ['preview', '--host', '127.0.0.1', '--port', '18087', '--strictPort']
+  const nextArgs = appendViteOutDirArgs(baseArgs, '.playwright-vite/ghosting-12345678')
+
+  assert.deepEqual(baseArgs, [
+    'preview',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '18087',
+    '--strictPort'
+  ])
+  assert.deepEqual(nextArgs, [
+    'preview',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '18087',
+    '--strictPort',
+    '--outDir',
+    '.playwright-vite/ghosting-12345678'
+  ])
+})
+
+test('runLockedBuild executes the build command once with the isolated outDir appended', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'vite-build-lock-'))
+  const captureFile = path.join(tempDir, 'args.json')
+
+  try {
+    await runLockedBuild(
+      () => ({
+        command: process.execPath,
+        args: [
+          '-e',
+          "const fs = require('node:fs'); const output = process.argv[1]; const records = fs.existsSync(output) ? JSON.parse(fs.readFileSync(output, 'utf8')) : []; records.push(process.argv.slice(2)); fs.writeFileSync(output, JSON.stringify(records));",
+          captureFile
+        ]
+      }),
+      projectDir,
+      {
+        outDir: '.playwright-vite/ghosting-12345678'
+      }
+    )
+
+    const records = JSON.parse(await readFile(captureFile, 'utf8'))
+    assert.equal(records.length, 1)
+    assert.deepEqual(records[0], ['--outDir', '.playwright-vite/ghosting-12345678'])
+  } finally {
+    await rm(tempDir, {
+      recursive: true,
+      force: true
+    })
+  }
+})


### PR DESCRIPTION
## 概要
- 为每个 browser spec 派生独立的 `.playwright-vite/<spec>-<hash>` 构建与预览目录，避免并发覆盖共享 `web/` 产物。
- 将 browser spec 的 build/preview 链路改为直接调用本地 Vite CLI，并在 `beforeAll` 内显式放宽 hook 超时，覆盖冷启动与锁等待场景。
- 新增 `vite-build-lock.test.mjs`，回归验证 outDir 派生稳定性和构建命令只执行一次。

## 验证
- [x] `node --test tests/vite-build-lock.test.mjs`
- [x] `pnpm exec playwright test tests/kline-slim-ghosting.browser.spec.mjs tests/gantt-sidebar-hover-alignment.browser.spec.mjs --workers=2 --repeat-each=3 --reporter=line`
- [x] `pnpm exec playwright test tests/kline-slim-zoom-pan.browser.spec.mjs tests/kline-slim-boundary.browser.spec.mjs --workers=2 --reporter=line`

Refs #149