### PR TITLE
fix: 修复标的管理明细接口 500

### DIFF
--- a/freshquant/subject_management/dashboard_service.py
+++ b/freshquant/subject_management/dashboard_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from bson import ObjectId
+
 from freshquant.order_management.repository import OrderManagementRepository
 from freshquant.tpsl.repository import TpslRepository
 from freshquant.util.code import normalize_to_base_code
@@ -148,29 +150,31 @@ class SubjectManagementDashboardService:
         )
         pm_summary = dict(self.pm_summary_loader() or {})
 
-        return {
-            "subject": {
-                "symbol": normalized_symbol,
-                "name": (
-                    position.get("name")
-                    or (must_pool or {}).get("name")
-                    or str(((takeprofit_profile or {}).get("name") or "")).strip()
-                ),
-                "category": (must_pool or {}).get("category"),
-            },
-            "must_pool": must_pool,
-            "guardian_buy_grid_config": guardian_config,
-            "guardian_buy_grid_state": guardian_state,
-            "takeprofit": takeprofit,
-            "buy_lots": buy_lots,
-            "runtime_summary": {
-                "position_quantity": int(position.get("quantity") or 0),
-                "position_amount": _safe_float(position.get("amount")),
-                "last_trigger_time": latest_event.get("created_at"),
-                "last_trigger_kind": latest_event.get("kind"),
-            },
-            "position_management_summary": pm_summary,
-        }
+        return _json_safe_payload(
+            {
+                "subject": {
+                    "symbol": normalized_symbol,
+                    "name": (
+                        position.get("name")
+                        or (must_pool or {}).get("name")
+                        or str(((takeprofit_profile or {}).get("name") or "")).strip()
+                    ),
+                    "category": (must_pool or {}).get("category"),
+                },
+                "must_pool": must_pool,
+                "guardian_buy_grid_config": guardian_config,
+                "guardian_buy_grid_state": guardian_state,
+                "takeprofit": takeprofit,
+                "buy_lots": buy_lots,
+                "runtime_summary": {
+                    "position_quantity": int(position.get("quantity") or 0),
+                    "position_amount": _safe_float(position.get("amount")),
+                    "last_trigger_time": latest_event.get("created_at"),
+                    "last_trigger_kind": latest_event.get("kind"),
+                },
+                "position_management_summary": pm_summary,
+            }
+        )
 
     def _must_pool_map(self):
         rows = {}
@@ -372,3 +376,17 @@ def _default_pm_summary_loader():
         "allow_open_min_bail": thresholds.get("allow_open_min_bail"),
         "holding_only_min_bail": thresholds.get("holding_only_min_bail"),
     }
+
+
+def _json_safe_payload(value):
+    if isinstance(value, dict):
+        return {
+            key: _json_safe_payload(item) for key, item in value.items() if key != "_id"
+        }
+    if isinstance(value, list):
+        return [_json_safe_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe_payload(item) for item in value]
+    if isinstance(value, ObjectId):
+        return str(value)
+    return value

--- a/freshquant/tests/test_subject_management_service.py
+++ b/freshquant/tests/test_subject_management_service.py
@@ -1,3 +1,7 @@
+import json
+
+from bson import ObjectId
+
 from freshquant.subject_management.dashboard_service import (
     SubjectManagementDashboardService,
 )
@@ -380,3 +384,52 @@ def test_subject_management_detail_returns_must_pool_guardian_takeprofit_buy_lot
     assert detail["buy_lots"][0]["stoploss"]["stop_price"] == 9.2
     assert detail["runtime_summary"]["position_quantity"] == 500
     assert detail["position_management_summary"]["effective_state"] == "HOLDING_ONLY"
+
+
+def test_subject_management_detail_strips_mongo_ids_from_nested_documents():
+    database = FakeDatabase()
+    tpsl_repository = InMemoryTpslRepository()
+    tpsl_repository.states["002262"] = {
+        "_id": ObjectId(),
+        "symbol": "002262",
+        "armed_levels": {1: True},
+    }
+    order_repository = InMemoryOrderManagementRepository()
+    order_repository.buy_lots.extend(
+        [
+            {
+                "_id": ObjectId(),
+                "buy_lot_id": "lot_1",
+                "symbol": "002262",
+                "date": 20260316,
+                "time": "10:31:00",
+                "remaining_quantity": 200,
+            }
+        ]
+    )
+    order_repository.stoploss_bindings.extend(
+        [
+            {
+                "_id": ObjectId(),
+                "buy_lot_id": "lot_1",
+                "symbol": "002262",
+                "stop_price": 18.6,
+                "enabled": True,
+            }
+        ]
+    )
+
+    service = SubjectManagementDashboardService(
+        database=database,
+        tpsl_repository=tpsl_repository,
+        order_repository=order_repository,
+        position_loader=lambda: [],
+        pm_summary_loader=lambda: {},
+    )
+
+    detail = service.get_detail("002262")
+
+    json.dumps(detail)
+    assert "_id" not in detail["takeprofit"]["state"]
+    assert "_id" not in detail["buy_lots"][0]
+    assert "_id" not in detail["buy_lots"][0]["stoploss"]


### PR DESCRIPTION
## 背景
“标的管理”页面点击部分标的时，前端会报 `Request failed with status code 500`。定位后确认是明细接口 `/api/subject-management/<symbol>` 在返回值里混入了 Mongo 原始文档中的 `_id/ObjectId`，Flask `jsonify` 无法序列化。

## 目标
让标的管理明细接口对 Mongo 原始文档保持 JSON 安全，点击总览行时不再出现 500。

## 范围
- 在 `SubjectManagementDashboardService.get_detail()` 返回前统一清洗嵌套 payload
- 去掉响应中的 Mongo `_id`
- 将残留 `ObjectId` 转成字符串
- 增加回归测试覆盖该场景

## 非目标
- 不调整前端交互
- 不改 overview 聚合逻辑
- 不修改存储结构

## 验收标准
- 相关 pytest 通过
- `pre_commit` 通过
- 点击历史上会报错的标的明细不再返回 500

## 部署影响
- 需要重部署 `fq_apiserver`
- 由于前端页面依赖该接口，沿用既有 API/Web 部署链路一起验证
