### PR TITLE
修复镜像发布 workflow 的浅克隆 diff 失败

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/freshquant/tests/test_deploy_build_cache_policy.py
+++ b/freshquant/tests/test_deploy_build_cache_policy.py
@@ -140,6 +140,13 @@ def test_docker_images_workflow_uses_dynamic_publish_matrix() -> None:
     assert "docker buildx imagetools create" in text
 
 
+def test_docker_images_workflow_fetches_full_history_for_diff_planning() -> None:
+    text = Path(".github/workflows/docker-images.yml").read_text(encoding="utf-8")
+
+    assert "resolve-publish-plan" in text
+    assert "fetch-depth: 0" in text
+
+
 def test_deploy_production_workflow_runs_on_successful_docker_publish() -> None:
     text = Path(".github/workflows/deploy-production.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 背景
- PR #213 已于 2026-03-17 合并到 `main`，但 merge 后的 `Docker Images` workflow（run `23182202287`）在 `resolve-publish-plan` 失败。
- 根因是 `resolve-publish-plan` job 使用默认浅克隆，runner 中只有 merge 后的 `HEAD`，缺少 `github.event.before` 对应对象，导致 `git diff base..head` 在 `script/ci/resolve_docker_image_publish_plan.py` 中直接退出 `128`。

## 目标
- 让 `docker-images.yml` 在 `main` push 场景下能够稳定拿到 `base_sha` 和 `head_sha`，不再因为浅克隆导致 diff planning 失败。

## 范围
- 为 `resolve-publish-plan` job 的 checkout 显式启用 `fetch-depth: 0`。
- 补 workflow 契约测试，覆盖“diff planning 需要完整历史”这一要求。

## 非目标
- 不改动镜像发布矩阵逻辑。
- 不改动正式 deploy orchestrator。
- 不改动 Docker 镜像 tag / retag 语义。

## 验收标准
- `docker-images.yml` 的 `resolve-publish-plan` job 明确获取完整历史。
- `freshquant/tests/test_deploy_build_cache_policy.py` 覆盖该契约。
- 相关 `pre-commit` 与 pytest 通过。

## 部署影响
- 无额外运行面变更；这是修复 merge 后镜像发布工作流的 follow-up。
- 该修复合并后，`main` 上的 `Docker Images` 与后续 `Deploy Production` 才能恢复自动链路。

## 测试
- [x] `py -3.12 -m uv tool run pre-commit run --show-diff-on-failure --color=always --files .github/workflows/docker-images.yml freshquant/tests/test_deploy_build_cache_policy.py`
- [x] `py -3.12 -m pytest -q freshquant/tests/test_freshquant_deploy_plan.py freshquant/tests/test_docker_parallel_compose.py freshquant/tests/test_deploy_build_cache_policy.py freshquant/tests/test_docker_image_publish_plan.py freshquant/tests/test_formal_deploy_orchestrator.py freshquant/tests/test_check_current_docs.py`