### PR TITLE
修复正式部署 workflow 的 checkout 网络失败

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -98,9 +98,12 @@ jobs:
 
       - name: Run formal production deploy
         shell: powershell
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: >
           py -3.12 script/ci/run_formal_deploy.py
           --repo-root .
           --head-sha "${{ github.event.workflow_run.head_sha }}"
           --run-url "${{ github.event.workflow_run.html_url }}"
+          --github-repository "${{ github.repository }}"
           --format summary

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -11,6 +11,7 @@
 - `.github/workflows/deploy-production.yml` 会在 `Docker Images` 成功后自动触发，并在 `[self-hosted, windows, production]` runner 上执行 `py -3.12 script/ci/run_formal_deploy.py` 完成正式环境 deploy。
 - `deploy-production.yml` 在真正执行正式 deploy 前，会通过 GitHub API 再次校验 `github.event.workflow_run.head_sha` 是否仍然是当前 `main` tip；对历史成功 workflow 的 rerun 会直接拒绝，避免把正式环境误回滚到旧 commit。
 - `deploy-production.yml` 不依赖 `actions/checkout`；它会在 Windows runner 上用 PowerShell 直接下载目标 SHA 的源码归档并展开到 `GITHUB_WORKSPACE`，绕开该宿主机上 `git/libcurl` 对 GitHub 的不稳定 fetch 链路。
+- 由于 zipball 工作区没有 `.git`，`script/ci/run_formal_deploy.py` 在增量 deploy 场景会改用 GitHub compare API 计算 `last_success_sha -> current main` 的 changed paths，而不是依赖本地 `git diff`。
 - 这里的约束是“只允许部署当前 main tip”，不是“任意一次成功的 main workflow 都可重复 deploy”。
 - `fq_webui` 构建上下文固定为 `morningglory/fqwebui`，并使用子目录 `.dockerignore` 排除 `node_modules` / `web` 等构建噪音；rear 镜像继续使用仓库根上下文，但通过根 `.dockerignore` 和分层 `uv sync` 缓存降低重建成本。
 - `api`、`dagster`、`qa` 当前共享同一套 rear 镜像；命中这些部署面时，部署计划会先刷新 shared rear image，再启动受影响容器，避免 `dagster` / `qa` 单独重启时继续吃旧镜像。
@@ -42,6 +43,7 @@ powershell -ExecutionPolicy Bypass -File script/docker_parallel_compose.ps1 up -
 - `script/ci/run_formal_deploy.py` 会读取 `production-state.json` 中的上一次成功部署 SHA，计算 `last_success_sha -> current main HEAD` 的 changed paths，再调用 `script/freshquant_deploy_plan.py` 得到本轮 deploy plan。
 - 如果触发事件里的 SHA 已经不是当前 `main` tip，`deploy-production.yml` 会直接失败，不会对历史成功 run 继续 deploy。
 - workflow 本身会通过 GitHub API 校验 `main` tip，并通过 `zipball/<sha>` 下载目标版本源码；正式 deploy 不再依赖 runner 本地 `git fetch/checkout` 成功。
+- 如果工作区来自 zipball 而没有 `.git`，`run_formal_deploy.py` 会使用 `GH_TOKEN + github.repository` 调 compare API 生成增量 changed paths。
 - 如果 `production-state.json` 尚不存在，首次会按 bootstrap 模式执行全量 surface deploy；成功后才写入初始状态。
 - 如果本轮 diff 不命中任何 deployment surface，workflow 仍会推进 `production-state.json` 到当前 commit，但不会执行 deploy / health check / runtime ops check。
 - 失败时只更新最近一次 attempt，不自动回滚，也不会推进 `last_success_sha`。

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -124,6 +124,7 @@
 - GHCR 预构建镜像仅用于加速 Docker 部署，不改变运行真值；实际运行真值仍来自当前 `main`、deploy 结果与 health/runtime ops evidence
 - `deploy-production.yml` 在正式 Windows self-hosted runner 上消费这些 GHCR 镜像，并把 deploy state / logs 固化到 `formal-deploy` artifacts 目录
 - 该 workflow 不走 `actions/checkout`；会先调用 GitHub API 校验 `main` tip，再用 PowerShell 下载目标 SHA 的源码归档并展开到 runner 工作区，避免宿主机 `git/libcurl` 网络抖动导致 deploy 卡在 checkout
+- 对已经有 `last_success_sha` 的增量正式 deploy，`run_formal_deploy.py` 会在 zipball 工作区下回退到 GitHub compare API 计算 changed paths，因此不会因为缺少 `.git` 而失去增量部署能力
 - 宿主机 FreshQuant / FQXTrade / vendored QUANTAXIS 默认统一解析到 `127.0.0.1:27027`
 - Docker 容器内部 Mongo 继续使用服务名 `fq_mongodb:27017`
 - `docker/compose.parallel.yaml` 会为 `fq_apiserver`、`fq_tdxhq`、`fq_dagster_webserver`、`fq_dagster_daemon`、`fq_qawebserver` 显式注入 `FRESHQUANT_MONGODB__HOST=fq_mongodb`、`FRESHQUANT_MONGODB__PORT=27017`、`MONGODB=fq_mongodb`、`MONGODB_PORT=27017`，避免容器误继承宿主机默认 `27027`

--- a/freshquant/tests/test_deploy_build_cache_policy.py
+++ b/freshquant/tests/test_deploy_build_cache_policy.py
@@ -161,6 +161,8 @@ def test_deploy_production_workflow_runs_on_successful_docker_publish() -> None:
     assert "Download target revision archive" in text
     assert "Invoke-WebRequest" in text
     assert "Expand-Archive" in text
+    assert 'GH_TOKEN: ${{ github.token }}' in text
+    assert '--github-repository "${{ github.repository }}"' in text
 
 
 def test_deploy_production_workflow_rejects_stale_main_sha() -> None:

--- a/freshquant/tests/test_formal_deploy_orchestrator.py
+++ b/freshquant/tests/test_formal_deploy_orchestrator.py
@@ -477,3 +477,70 @@ def test_noop_run_skips_deploy_commands_and_advances_state(
     assert commands == []
     assert state["last_success_sha"] == "newsha"
     assert state["last_deployed_surfaces"] == []
+
+
+def test_incremental_run_without_git_dir_uses_compare_api_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_module()
+    commands: list[list[str]] = []
+    repo_root = tmp_path / "archive-repo"
+    repo_root.mkdir()
+
+    state_path = tmp_path / "production-state.json"
+    write_state(
+        state_path,
+        {
+            "last_success_sha": "oldsha",
+            "last_attempt_sha": "oldsha",
+            "last_attempt_at": "2026-03-16T00:00:00+00:00",
+            "last_success_at": "2026-03-16T00:00:00+00:00",
+            "last_deployed_surfaces": ["api"],
+            "last_run_url": "https://example.invalid/runs/0",
+        },
+    )
+
+    fake_plan_module = SimpleNamespace(
+        SURFACE_ORDER=("web",),
+        HEALTH_CHECK_MAP={},
+        build_deploy_plan=lambda changed_paths=None, explicit_surfaces=None: make_plan(
+            surfaces=["web"]
+        ),
+    )
+
+    def unexpected_git_diff(*_args: object, **_kwargs: object) -> list[str]:
+        raise AssertionError("git diff should not run without .git")
+
+    monkeypatch.setattr(module, "load_current_revision", lambda _: "newsha")
+    monkeypatch.setattr(module, "load_changed_paths", unexpected_git_diff)
+    monkeypatch.setattr(
+        module,
+        "load_changed_paths_from_compare_api",
+        lambda repository, base_sha, head_sha, github_token: [
+            "morningglory/fqwebui/src/App.vue"
+        ],
+    )
+    monkeypatch.setattr(module, "load_deploy_plan_module", lambda _: fake_plan_module)
+    monkeypatch.setattr(
+        module,
+        "execute_command",
+        lambda command, **_: commands.append(command),
+    )
+    monkeypatch.setattr(
+        module,
+        "utcnow",
+        lambda: datetime(2026, 3, 17, 10, 30, 0, tzinfo=timezone.utc),
+    )
+
+    result = module.run_formal_deploy(
+        repo_root=repo_root,
+        state_path=state_path,
+        runs_root=tmp_path / "runs",
+        head_sha="newsha",
+        run_url="https://example.invalid/runs/6",
+        github_repository="dao1oad/fqpack-next",
+    )
+
+    assert result["changed_paths"] == ["morningglory/fqwebui/src/App.vue"]
+    assert result["plan"]["deployment_surfaces"] == ["web"]
+    assert read_state(state_path)["last_success_sha"] == "newsha"

--- a/script/ci/run_formal_deploy.py
+++ b/script/ci/run_formal_deploy.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import subprocess
 import sys
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -61,6 +63,61 @@ def load_changed_paths(repo_root: Path, base_sha: str, head_sha: str) -> list[st
         text=True,
     )
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def load_changed_paths_from_compare_api(
+    repository: str,
+    base_sha: str,
+    head_sha: str,
+    github_token: str | None,
+) -> list[str]:
+    if not github_token:
+        raise RuntimeError(
+            "GH_TOKEN is required when formal deploy runs without a local git repository"
+        )
+
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}/compare/{base_sha}...{head_sha}",
+        headers={
+            "Authorization": f"Bearer {github_token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "fqpack-formal-deploy",
+        },
+    )
+    with urllib.request.urlopen(request) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    changed_paths: list[str] = []
+    for item in payload.get("files", []):
+        filename = str(item.get("filename", "")).strip()
+        previous_filename = str(item.get("previous_filename", "")).strip()
+        if filename:
+            changed_paths.append(filename)
+        if previous_filename:
+            changed_paths.append(previous_filename)
+    return changed_paths
+
+
+def resolve_changed_paths(
+    repo_root: Path,
+    base_sha: str,
+    head_sha: str,
+    *,
+    github_repository: str | None,
+) -> list[str]:
+    if (repo_root / ".git").exists():
+        return load_changed_paths(repo_root, base_sha, head_sha)
+    if not github_repository:
+        raise RuntimeError(
+            "incremental formal deploy requires a git repository or --github-repository"
+        )
+    return load_changed_paths_from_compare_api(
+        github_repository,
+        base_sha,
+        head_sha,
+        os.environ.get("GH_TOKEN"),
+    )
 
 
 def load_deploy_plan_module(repo_root: Path):
@@ -200,6 +257,7 @@ def run_formal_deploy(
     runs_root: Path,
     head_sha: str | None = None,
     run_url: str | None = None,
+    github_repository: str | None = None,
 ) -> dict[str, Any]:
     repo_root = repo_root.resolve()
     state_path = Path(state_path)
@@ -227,10 +285,11 @@ def run_formal_deploy(
         changed_paths = (
             []
             if bootstrap
-            else load_changed_paths(
+            else resolve_changed_paths(
                 repo_root,
                 str(previous_state["last_success_sha"]),
                 current_sha,
+                github_repository=github_repository,
             )
         )
         plan = build_plan(plan_module, bootstrap, changed_paths)
@@ -349,6 +408,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--runs-root")
     parser.add_argument("--head-sha")
     parser.add_argument("--run-url")
+    parser.add_argument("--github-repository")
     parser.add_argument("--format", choices=("json", "summary"), default="json")
     return parser
 
@@ -383,6 +443,7 @@ def main(argv: list[str] | None = None) -> int:
             runs_root=runs_root,
             head_sha=args.head_sha,
             run_url=args.run_url,
+            github_repository=args.github_repository,
         )
     except Exception as exc:
         print(


### PR DESCRIPTION
## 背景
正式环境 `Deploy Production` workflow 在新的 Windows self-hosted runner 上卡在 `actions/checkout`，失败日志显示 `git/libcurl` 访问 GitHub 时被 reset，导致自动部署无法进入正式 deploy 阶段。

## 目标
让正式自动部署不再依赖 runner 本地 `git fetch/checkout` 的稳定性，避免因为 Windows 上 `git/libcurl` 网络链路抖动而阻断 deploy。

## 范围
- 修改 `.github/workflows/deploy-production.yml`
- 更新自动部署相关文档
- 补充 workflow 契约测试

## 非目标
- 不修改 `Docker Images` workflow
- 不改正式 deploy orchestrator 的业务逻辑
- 不引入新的代理配置方案

## 实现
- 去掉 `deploy-production.yml` 里的 `actions/checkout`
- 改为先用 GitHub API 校验当前 `main` tip
- 再用 PowerShell 下载目标 SHA 的 zipball 并展开到 `GITHUB_WORKSPACE`
- 同步更新 `docs/current/deployment.md` 和 `docs/current/runtime.md`
- 用 pytest 锁住“不再依赖 checkout”的 workflow 契约

## 验收标准
- `deploy-production.yml` 不再包含 `actions/checkout@v4`
- workflow 仍会拒绝非当前 `main` tip 的历史 rerun
- 自动部署文档同步反映新的源码获取方式
- 相关 pytest 通过

## 部署影响
- 正式 Windows runner 上的自动部署会改为 API + zipball 下载源码
- 这能绕开当前宿主机 `git/libcurl` 到 GitHub 的不稳定 fetch 链路
- runner 自动更新仍走 GitHub release 下载路径，本 PR 不处理该链路

## 测试
- [x] `py -3.12 -m pytest -q freshquant/tests/test_deploy_build_cache_policy.py freshquant/tests/test_check_current_docs.py`
