### PR TITLE
修复正式部署 workflow 的 PowerShell 执行策略

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: [self-hosted, windows, production]
     steps:
       - name: Validate main tip freshness
-        shell: powershell
+        shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -44,7 +44,7 @@ jobs:
           }
 
       - name: Download target revision archive
-        shell: powershell
+        shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -89,15 +89,15 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        shell: powershell
+        shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
         run: python -m pip install --upgrade pip uv
 
       - name: Sync locked environment
-        shell: powershell
+        shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
         run: uv sync --frozen
 
       - name: Run formal production deploy
-        shell: powershell
+        shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
         env:
           GH_TOKEN: ${{ github.token }}
         run: >

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -12,6 +12,7 @@
 - `deploy-production.yml` 在真正执行正式 deploy 前，会通过 GitHub API 再次校验 `github.event.workflow_run.head_sha` 是否仍然是当前 `main` tip；对历史成功 workflow 的 rerun 会直接拒绝，避免把正式环境误回滚到旧 commit。
 - `deploy-production.yml` 不依赖 `actions/checkout`；它会在 Windows runner 上用 PowerShell 直接下载目标 SHA 的源码归档并展开到 `GITHUB_WORKSPACE`，绕开该宿主机上 `git/libcurl` 对 GitHub 的不稳定 fetch 链路。
 - 由于 zipball 工作区没有 `.git`，`script/ci/run_formal_deploy.py` 在增量 deploy 场景会改用 GitHub compare API 计算 `last_success_sha -> current main` 的 changed paths，而不是依赖本地 `git diff`。
+- `deploy-production.yml` 中仓库自定义的 PowerShell step 固定使用 `-NoProfile -ExecutionPolicy Bypass -File {0}`；正式 self-hosted runner 即使本机 PowerShell policy 更严格，也不会在 step 启动前被策略拦截。
 - 这里的约束是“只允许部署当前 main tip”，不是“任意一次成功的 main workflow 都可重复 deploy”。
 - `fq_webui` 构建上下文固定为 `morningglory/fqwebui`，并使用子目录 `.dockerignore` 排除 `node_modules` / `web` 等构建噪音；rear 镜像继续使用仓库根上下文，但通过根 `.dockerignore` 和分层 `uv sync` 缓存降低重建成本。
 - `api`、`dagster`、`qa` 当前共享同一套 rear 镜像；命中这些部署面时，部署计划会先刷新 shared rear image，再启动受影响容器，避免 `dagster` / `qa` 单独重启时继续吃旧镜像。

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -125,6 +125,7 @@
 - `deploy-production.yml` 在正式 Windows self-hosted runner 上消费这些 GHCR 镜像，并把 deploy state / logs 固化到 `formal-deploy` artifacts 目录
 - 该 workflow 不走 `actions/checkout`；会先调用 GitHub API 校验 `main` tip，再用 PowerShell 下载目标 SHA 的源码归档并展开到 runner 工作区，避免宿主机 `git/libcurl` 网络抖动导致 deploy 卡在 checkout
 - 对已经有 `last_success_sha` 的增量正式 deploy，`run_formal_deploy.py` 会在 zipball 工作区下回退到 GitHub compare API 计算 changed paths，因此不会因为缺少 `.git` 而失去增量部署能力
+- 该 workflow 中的 PowerShell steps 固定带 `-ExecutionPolicy Bypass`，避免 self-hosted Windows runner 的本机执行策略在 step 启动前拦截临时脚本
 - 宿主机 FreshQuant / FQXTrade / vendored QUANTAXIS 默认统一解析到 `127.0.0.1:27027`
 - Docker 容器内部 Mongo 继续使用服务名 `fq_mongodb:27017`
 - `docker/compose.parallel.yaml` 会为 `fq_apiserver`、`fq_tdxhq`、`fq_dagster_webserver`、`fq_dagster_daemon`、`fq_qawebserver` 显式注入 `FRESHQUANT_MONGODB__HOST=fq_mongodb`、`FRESHQUANT_MONGODB__PORT=27017`、`MONGODB=fq_mongodb`、`MONGODB_PORT=27017`，避免容器误继承宿主机默认 `27027`

--- a/freshquant/tests/test_deploy_build_cache_policy.py
+++ b/freshquant/tests/test_deploy_build_cache_policy.py
@@ -163,6 +163,8 @@ def test_deploy_production_workflow_runs_on_successful_docker_publish() -> None:
     assert "Expand-Archive" in text
     assert 'GH_TOKEN: ${{ github.token }}' in text
     assert '--github-repository "${{ github.repository }}"' in text
+    assert "shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}" in text
+    assert "shell: powershell\n" not in text
 
 
 def test_deploy_production_workflow_rejects_stale_main_sha() -> None:


### PR DESCRIPTION
## 背景
PR #215 合并后，正式 `Deploy Production` run `23185040356` 仍然失败，但这次失败不在 GitHub 网络链路，而是在 self-hosted Windows runner 的 PowerShell 执行策略：workflow 的 `shell: powershell` 会先 dot-source 临时脚本，结果被本机 execution policy 直接拦截。

## 目标
让正式 deploy workflow 不依赖 runner 本机 PowerShell policy，保证 repo 自带的 PowerShell step 在 self-hosted Windows 上稳定启动。

## 范围
- 修改 `.github/workflows/deploy-production.yml`
- 同步更新当前部署/运行文档
- 补充 workflow 契约测试

## 非目标
- 不改 Docker Images workflow
- 不调整 runner 机器的系统级 execution policy
- 不修改 formal deploy orchestrator 业务逻辑

## 实现
- 把 `deploy-production.yml` 里的 repo-owned PowerShell step 统一改成 `powershell -NoProfile -ExecutionPolicy Bypass -File {0}`
- 保留前一轮引入的 GitHub API / zipball / compare API fallback 逻辑
- 文档中明确 self-hosted runner 需要 workflow 自带 `ExecutionPolicy Bypass`

## 验收标准
- `deploy-production.yml` 不再使用默认的 `shell: powershell`
- workflow 契约测试覆盖 `ExecutionPolicy Bypass`
- 相关 docs/current 文档同步更新
- 相关 pytest 通过

## 部署影响
- 仅影响正式自动部署 workflow 的 step 启动方式
- 不需要管理员去修改 runner 主机的全局 PowerShell policy
- 合并后会再次触发 `Docker Images -> Deploy Production`

## 测试
- [x] `py -3.12 -m pytest -q freshquant/tests/test_deploy_build_cache_policy.py freshquant/tests/test_check_current_docs.py`
