### PR TITLE
恢复正式部署 PowerShell step 的 fail-fast 语义

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          $ErrorActionPreference = 'Stop'
           $headers = @{
             Authorization = "Bearer $env:GH_TOKEN"
             Accept = "application/vnd.github+json"
@@ -48,6 +49,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          $ErrorActionPreference = 'Stop'
           $headers = @{
             Authorization = "Bearer $env:GH_TOKEN"
             Accept = "application/vnd.github+json"
@@ -90,20 +92,25 @@ jobs:
 
       - name: Install uv
         shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
-        run: python -m pip install --upgrade pip uv
+        run: |
+          $ErrorActionPreference = 'Stop'
+          python -m pip install --upgrade pip uv
 
       - name: Sync locked environment
         shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
-        run: uv sync --frozen
+        run: |
+          $ErrorActionPreference = 'Stop'
+          uv sync --frozen
 
       - name: Run formal production deploy
         shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >
-          py -3.12 script/ci/run_formal_deploy.py
-          --repo-root .
-          --head-sha "${{ github.event.workflow_run.head_sha }}"
-          --run-url "${{ github.event.workflow_run.html_url }}"
-          --github-repository "${{ github.repository }}"
-          --format summary
+        run: |
+          $ErrorActionPreference = 'Stop'
+          py -3.12 script/ci/run_formal_deploy.py `
+            --repo-root . `
+            --head-sha "${{ github.event.workflow_run.head_sha }}" `
+            --run-url "${{ github.event.workflow_run.html_url }}" `
+            --github-repository "${{ github.repository }}" `
+            --format summary

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -13,6 +13,7 @@
 - `deploy-production.yml` 不依赖 `actions/checkout`；它会在 Windows runner 上用 PowerShell 直接下载目标 SHA 的源码归档并展开到 `GITHUB_WORKSPACE`，绕开该宿主机上 `git/libcurl` 对 GitHub 的不稳定 fetch 链路。
 - 由于 zipball 工作区没有 `.git`，`script/ci/run_formal_deploy.py` 在增量 deploy 场景会改用 GitHub compare API 计算 `last_success_sha -> current main` 的 changed paths，而不是依赖本地 `git diff`。
 - `deploy-production.yml` 中仓库自定义的 PowerShell step 固定使用 `-NoProfile -ExecutionPolicy Bypass -File {0}`；正式 self-hosted runner 即使本机 PowerShell policy 更严格，也不会在 step 启动前被策略拦截。
+- 这些自定义 PowerShell step 会在脚本首行显式设置 `$ErrorActionPreference = 'Stop'`，保留 fail-fast 行为，避免 `Remove-Item` / `Copy-Item` 这类 non-terminating cmdlet error 被静默放过。
 - 这里的约束是“只允许部署当前 main tip”，不是“任意一次成功的 main workflow 都可重复 deploy”。
 - `fq_webui` 构建上下文固定为 `morningglory/fqwebui`，并使用子目录 `.dockerignore` 排除 `node_modules` / `web` 等构建噪音；rear 镜像继续使用仓库根上下文，但通过根 `.dockerignore` 和分层 `uv sync` 缓存降低重建成本。
 - `api`、`dagster`、`qa` 当前共享同一套 rear 镜像；命中这些部署面时，部署计划会先刷新 shared rear image，再启动受影响容器，避免 `dagster` / `qa` 单独重启时继续吃旧镜像。

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -126,6 +126,7 @@
 - 该 workflow 不走 `actions/checkout`；会先调用 GitHub API 校验 `main` tip，再用 PowerShell 下载目标 SHA 的源码归档并展开到 runner 工作区，避免宿主机 `git/libcurl` 网络抖动导致 deploy 卡在 checkout
 - 对已经有 `last_success_sha` 的增量正式 deploy，`run_formal_deploy.py` 会在 zipball 工作区下回退到 GitHub compare API 计算 changed paths，因此不会因为缺少 `.git` 而失去增量部署能力
 - 该 workflow 中的 PowerShell steps 固定带 `-ExecutionPolicy Bypass`，避免 self-hosted Windows runner 的本机执行策略在 step 启动前拦截临时脚本
+- 该 workflow 也会显式设置 `$ErrorActionPreference = 'Stop'`，确保 PowerShell cmdlet 的 non-terminating error 仍然按 fail-fast 方式中断正式 deploy
 - 宿主机 FreshQuant / FQXTrade / vendored QUANTAXIS 默认统一解析到 `127.0.0.1:27027`
 - Docker 容器内部 Mongo 继续使用服务名 `fq_mongodb:27017`
 - `docker/compose.parallel.yaml` 会为 `fq_apiserver`、`fq_tdxhq`、`fq_dagster_webserver`、`fq_dagster_daemon`、`fq_qawebserver` 显式注入 `FRESHQUANT_MONGODB__HOST=fq_mongodb`、`FRESHQUANT_MONGODB__PORT=27017`、`MONGODB=fq_mongodb`、`MONGODB_PORT=27017`，避免容器误继承宿主机默认 `27027`

--- a/freshquant/tests/test_deploy_build_cache_policy.py
+++ b/freshquant/tests/test_deploy_build_cache_policy.py
@@ -165,6 +165,7 @@ def test_deploy_production_workflow_runs_on_successful_docker_publish() -> None:
     assert '--github-repository "${{ github.repository }}"' in text
     assert "shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}" in text
     assert "shell: powershell\n" not in text
+    assert text.count("$ErrorActionPreference = 'Stop'") >= 5
 
 
 def test_deploy_production_workflow_rejects_stale_main_sha() -> None:


### PR DESCRIPTION
## 背景
PR #216 已经把 self-hosted Windows runner 的 `ExecutionPolicy Bypass` 修复并合入 `main`，但随后收到一条有效 review：自定义 PowerShell shell 会失去 GitHub Actions 默认的 fail-fast 包装，如果不显式恢复严格错误处理，`Remove-Item` / `Copy-Item` 等 non-terminating cmdlet error 可能被吞掉。

## 目标
在保留 `ExecutionPolicy Bypass` 的同时，恢复 `Deploy Production` workflow 的 PowerShell fail-fast 行为。

## 范围
- 修改 `.github/workflows/deploy-production.yml`
- 更新当前部署/运行文档
- 补充 workflow 契约测试

## 非目标
- 不改 Docker Images workflow
- 不修改 formal deploy orchestrator 业务逻辑
- 不调整 runner 主机的系统级配置

## 实现
- 在 `deploy-production.yml` 的自定义 PowerShell step 开头统一设置 `$ErrorActionPreference = 'Stop'`
- 保持 `-NoProfile -ExecutionPolicy Bypass -File {0}` 不变
- 文档中补充 fail-fast 语义说明

## 验收标准
- workflow 契约测试明确要求 deploy PowerShell step 保留 fail-fast 行为
- 相关 docs/current 文档同步更新
- 相关 pytest 通过

## 部署影响
- 只影响正式 deploy workflow 的错误处理语义
- 合并后自动部署若遇到 PowerShell cmdlet 错误会更早失败，不会带着部分工作区继续 deploy

## 测试
- [x] `py -3.12 -m pytest -q freshquant/tests/test_deploy_build_cache_policy.py freshquant/tests/test_check_current_docs.py`
