### PR TITLE
修复正式自动部署对 setup-python 的依赖

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -85,22 +85,17 @@ jobs:
             Copy-Item -LiteralPath $_.FullName -Destination $env:GITHUB_WORKSPACE -Recurse -Force
           }
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
       - name: Install uv
         shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
         run: |
           $ErrorActionPreference = 'Stop'
-          python -m pip install --upgrade pip uv
+          py -3.12 -m pip install --upgrade pip uv
 
       - name: Sync locked environment
         shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
         run: |
           $ErrorActionPreference = 'Stop'
-          uv sync --frozen
+          py -3.12 -m uv sync --frozen
 
       - name: Run formal production deploy
         shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -9,6 +9,7 @@
 - Docker 侧正式入口优先使用 `powershell -ExecutionPolicy Bypass -File script/docker_parallel_compose.ps1 ...`；该脚本会自动解析主工作树 `.env` / runtime log 目录、注入当前 `HEAD` 到镜像 label、开启 BuildKit，并优先拉取 GHCR 中与当前 commit 匹配的预构建镜像；若远端镜像不可用，再保守回退到本机构建。
 - `.github/workflows/docker-images.yml` 在 `main` push 后会先解析受影响镜像；只有改到的服务真正 build，未改到的服务只把现有 `:main` digest retag 成当前 commit SHA，保持 registry-first deploy 命中。
 - `.github/workflows/deploy-production.yml` 会在 `Docker Images` 成功后自动触发，并在 `[self-hosted, windows, production]` runner 上执行 `py -3.12 script/ci/run_formal_deploy.py` 完成正式环境 deploy。
+- 该 workflow 依赖正式 Windows runner 宿主机已安装的 Python 3.12，不再使用 `actions/setup-python`；原因是该 runner 的本机执行策略会拦截 action 解压后调用的 `setup.ps1`。
 - `deploy-production.yml` 在真正执行正式 deploy 前，会通过 GitHub API 再次校验 `github.event.workflow_run.head_sha` 是否仍然是当前 `main` tip；对历史成功 workflow 的 rerun 会直接拒绝，避免把正式环境误回滚到旧 commit。
 - `deploy-production.yml` 不依赖 `actions/checkout`；它会在 Windows runner 上用 PowerShell 直接下载目标 SHA 的源码归档并展开到 `GITHUB_WORKSPACE`，绕开该宿主机上 `git/libcurl` 对 GitHub 的不稳定 fetch 链路。
 - 由于 zipball 工作区没有 `.git`，`script/ci/run_formal_deploy.py` 在增量 deploy 场景会改用 GitHub compare API 计算 `last_success_sha -> current main` 的 changed paths，而不是依赖本地 `git diff`。
@@ -45,6 +46,7 @@ powershell -ExecutionPolicy Bypass -File script/docker_parallel_compose.ps1 up -
 - `script/ci/run_formal_deploy.py` 会读取 `production-state.json` 中的上一次成功部署 SHA，计算 `last_success_sha -> current main HEAD` 的 changed paths，再调用 `script/freshquant_deploy_plan.py` 得到本轮 deploy plan。
 - 如果触发事件里的 SHA 已经不是当前 `main` tip，`deploy-production.yml` 会直接失败，不会对历史成功 run 继续 deploy。
 - workflow 本身会通过 GitHub API 校验 `main` tip，并通过 `zipball/<sha>` 下载目标版本源码；正式 deploy 不再依赖 runner 本地 `git fetch/checkout` 成功。
+- workflow 在下载源码后直接调用宿主机已安装的 Python 3.12 执行 `pip/uv` 与 deploy orchestrator，不再依赖 `actions/setup-python` 的安装阶段。
 - 如果工作区来自 zipball 而没有 `.git`，`run_formal_deploy.py` 会使用 `GH_TOKEN + github.repository` 调 compare API 生成增量 changed paths。
 - 如果 `production-state.json` 尚不存在，首次会按 bootstrap 模式执行全量 surface deploy；成功后才写入初始状态。
 - 如果本轮 diff 不命中任何 deployment surface，workflow 仍会推进 `production-state.json` 到当前 commit，但不会执行 deploy / health check / runtime ops check。

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -37,6 +37,7 @@
 - 正式自动部署 workflow：`.github/workflows/deploy-production.yml`
 - 正式自动部署 state：`D:/fqpack/runtime/symphony-service/artifacts/formal-deploy/production-state.json`
 - 正式自动部署单次运行 artifacts：`D:/fqpack/runtime/symphony-service/artifacts/formal-deploy/runs`
+- 正式自动部署 workflow 依赖宿主机已安装的 Python 3.12；self-hosted Windows runner 不再通过 `actions/setup-python` 临时安装 Python。
 - 管理员桥接任务以 `SYSTEM` + `Highest` 运行；安装脚本会给执行安装的 Windows 用户追加该任务的读取/执行权限，供普通 Codex 会话调用。
 - Symphony 运行模板：`runtime/symphony/WORKFLOW.freshquant.md`
 - 全局 Codex 自动化提示词模板：`runtime/symphony/prompts/global_stewardship.md`
@@ -125,6 +126,7 @@
 - `deploy-production.yml` 在正式 Windows self-hosted runner 上消费这些 GHCR 镜像，并把 deploy state / logs 固化到 `formal-deploy` artifacts 目录
 - 该 workflow 不走 `actions/checkout`；会先调用 GitHub API 校验 `main` tip，再用 PowerShell 下载目标 SHA 的源码归档并展开到 runner 工作区，避免宿主机 `git/libcurl` 网络抖动导致 deploy 卡在 checkout
 - 对已经有 `last_success_sha` 的增量正式 deploy，`run_formal_deploy.py` 会在 zipball 工作区下回退到 GitHub compare API 计算 changed paths，因此不会因为缺少 `.git` 而失去增量部署能力
+- 该 workflow 下载源码后直接使用宿主机已安装的 Python 3.12 执行 `py -3.12 -m pip install --upgrade pip uv` 和 `py -3.12 -m uv sync --frozen`，绕开 `actions/setup-python` 在本机执行策略下触发的 `setup.ps1` 拦截
 - 该 workflow 中的 PowerShell steps 固定带 `-ExecutionPolicy Bypass`，避免 self-hosted Windows runner 的本机执行策略在 step 启动前拦截临时脚本
 - 该 workflow 也会显式设置 `$ErrorActionPreference = 'Stop'`，确保 PowerShell cmdlet 的 non-terminating error 仍然按 fail-fast 方式中断正式 deploy
 - 宿主机 FreshQuant / FQXTrade / vendored QUANTAXIS 默认统一解析到 `127.0.0.1:27027`

--- a/freshquant/tests/test_deploy_build_cache_policy.py
+++ b/freshquant/tests/test_deploy_build_cache_policy.py
@@ -158,6 +158,7 @@ def test_deploy_production_workflow_runs_on_successful_docker_publish() -> None:
     assert "run_formal_deploy.py" in text
     assert "github.event.workflow_run.head_sha" in text
     assert "actions/checkout@v4" not in text
+    assert "actions/setup-python@v5" not in text
     assert "Download target revision archive" in text
     assert "Invoke-WebRequest" in text
     assert "Expand-Archive" in text
@@ -165,6 +166,8 @@ def test_deploy_production_workflow_runs_on_successful_docker_publish() -> None:
     assert '--github-repository "${{ github.repository }}"' in text
     assert "shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}" in text
     assert "shell: powershell\n" not in text
+    assert "py -3.12 -m pip install --upgrade pip uv" in text
+    assert "py -3.12 -m uv sync --frozen" in text
     assert text.count("$ErrorActionPreference = 'Stop'") >= 5
 
 
@@ -185,5 +188,7 @@ def test_current_docs_cover_automatic_production_deploy_state() -> None:
     assert "production-state.json" in deployment_text
     assert "上一次成功部署" in deployment_text
     assert "当前 main tip" in deployment_text
+    assert "宿主机已安装的 Python 3.12" in deployment_text
     assert "deploy-production.yml" in runtime_text
     assert "formal-deploy" in runtime_text
+    assert "宿主机已安装的 Python 3.12" in runtime_text


### PR DESCRIPTION
修复 Deploy Production 在 Windows self-hosted runner 上因 actions/setup-python 调用 setup.ps1 被执行策略拦截的问题。改为直接使用宿主机已安装的 py -3.12 执行 pip/uv 与正式 deploy，并同步补充 workflow 契约测试和 docs/current。