### PR TITLE
增强正式自动部署的归档下载稳定性

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -50,12 +50,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $headers = @{
-            Authorization = "Bearer $env:GH_TOKEN"
-            Accept = "application/vnd.github+json"
-            "X-GitHub-Api-Version" = "2022-11-28"
-            "User-Agent" = "fqpack-deploy-production"
-          }
           $targetSha = "${{ github.event.workflow_run.head_sha }}"
           $archiveUrl = "https://api.github.com/repos/${{ github.repository }}/zipball/$targetSha"
           $archivePath = Join-Path $env:RUNNER_TEMP "deploy-target.zip"
@@ -69,11 +63,46 @@ jobs:
           }
           Get-ChildItem -LiteralPath $env:GITHUB_WORKSPACE -Force | Remove-Item -Recurse -Force
 
-          Invoke-WebRequest `
-            -Uri $archiveUrl `
-            -Headers $headers `
-            -OutFile $archivePath `
-            -MaximumRedirection 5
+          $codeloadIp = $null
+          for ($attempt = 1; $attempt -le 3 -and -not $codeloadIp; $attempt++) {
+            try {
+              $codeloadIp = Resolve-DnsName codeload.github.com -Type A -ErrorAction Stop |
+                Where-Object { $_.IPAddress } |
+                Select-Object -First 1 -ExpandProperty IPAddress
+            } catch {
+              if ($attempt -ge 3) {
+                throw
+              }
+              Start-Sleep -Seconds (2 * $attempt)
+            }
+          }
+          if (-not $codeloadIp) {
+            throw "failed to resolve codeload.github.com for deploy archive download"
+          }
+
+          $curlArgs = @(
+            "--location",
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--http1.1",
+            "--retry", "5",
+            "--retry-all-errors",
+            "--retry-delay", "3",
+            "--connect-timeout", "30",
+            "--max-time", "600",
+            "--resolve", "codeload.github.com:443:$codeloadIp",
+            "-H", "Authorization: Bearer $env:GH_TOKEN",
+            "-H", "Accept: application/vnd.github+json",
+            "-H", "X-GitHub-Api-Version: 2022-11-28",
+            "-H", "User-Agent: fqpack-deploy-production",
+            "--output", $archivePath,
+            $archiveUrl
+          )
+          & curl.exe @curlArgs
+          if ($LASTEXITCODE -ne 0) {
+            throw "curl archive download failed with exit code $LASTEXITCODE"
+          }
           Expand-Archive -Path $archivePath -DestinationPath $extractRoot -Force
 
           $sourceRoot = Get-ChildItem -Path $extractRoot -Directory | Select-Object -First 1

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -10,6 +10,7 @@
 - `.github/workflows/docker-images.yml` 在 `main` push 后会先解析受影响镜像；只有改到的服务真正 build，未改到的服务只把现有 `:main` digest retag 成当前 commit SHA，保持 registry-first deploy 命中。
 - `.github/workflows/deploy-production.yml` 会在 `Docker Images` 成功后自动触发，并在 `[self-hosted, windows, production]` runner 上执行 `py -3.12 script/ci/run_formal_deploy.py` 完成正式环境 deploy。
 - 该 workflow 依赖正式 Windows runner 宿主机已安装的 Python 3.12，不再使用 `actions/setup-python`；原因是该 runner 的本机执行策略会拦截 action 解压后调用的 `setup.ps1`。
+- 该 workflow 下载 `zipball/<sha>` 时不再使用 PowerShell `Invoke-WebRequest`，而是用 `curl.exe` 配合 `Resolve-DnsName codeload.github.com`、显式 `--resolve` 和重试参数，降低正式 runner 上 `codeload.github.com` DNS/连接不稳定导致的下载失败。
 - `deploy-production.yml` 在真正执行正式 deploy 前，会通过 GitHub API 再次校验 `github.event.workflow_run.head_sha` 是否仍然是当前 `main` tip；对历史成功 workflow 的 rerun 会直接拒绝，避免把正式环境误回滚到旧 commit。
 - `deploy-production.yml` 不依赖 `actions/checkout`；它会在 Windows runner 上用 PowerShell 直接下载目标 SHA 的源码归档并展开到 `GITHUB_WORKSPACE`，绕开该宿主机上 `git/libcurl` 对 GitHub 的不稳定 fetch 链路。
 - 由于 zipball 工作区没有 `.git`，`script/ci/run_formal_deploy.py` 在增量 deploy 场景会改用 GitHub compare API 计算 `last_success_sha -> current main` 的 changed paths，而不是依赖本地 `git diff`。
@@ -47,6 +48,7 @@ powershell -ExecutionPolicy Bypass -File script/docker_parallel_compose.ps1 up -
 - 如果触发事件里的 SHA 已经不是当前 `main` tip，`deploy-production.yml` 会直接失败，不会对历史成功 run 继续 deploy。
 - workflow 本身会通过 GitHub API 校验 `main` tip，并通过 `zipball/<sha>` 下载目标版本源码；正式 deploy 不再依赖 runner 本地 `git fetch/checkout` 成功。
 - workflow 在下载源码后直接调用宿主机已安装的 Python 3.12 执行 `pip/uv` 与 deploy orchestrator，不再依赖 `actions/setup-python` 的安装阶段。
+- 上述源码下载链路当前固定经由 `curl.exe` 拉取 archive，并对 `codeload.github.com` 做显式解析与重试；这一步是正式 deploy 成功的必要前置，不再依赖 PowerShell 默认 web client 的连接稳定性。
 - 如果工作区来自 zipball 而没有 `.git`，`run_formal_deploy.py` 会使用 `GH_TOKEN + github.repository` 调 compare API 生成增量 changed paths。
 - 如果 `production-state.json` 尚不存在，首次会按 bootstrap 模式执行全量 surface deploy；成功后才写入初始状态。
 - 如果本轮 diff 不命中任何 deployment surface，workflow 仍会推进 `production-state.json` 到当前 commit，但不会执行 deploy / health check / runtime ops check。

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -38,6 +38,7 @@
 - 正式自动部署 state：`D:/fqpack/runtime/symphony-service/artifacts/formal-deploy/production-state.json`
 - 正式自动部署单次运行 artifacts：`D:/fqpack/runtime/symphony-service/artifacts/formal-deploy/runs`
 - 正式自动部署 workflow 依赖宿主机已安装的 Python 3.12；self-hosted Windows runner 不再通过 `actions/setup-python` 临时安装 Python。
+- 正式自动部署 workflow 现在通过 `curl.exe` 下载目标 `zipball/<sha>`，并在 runner 本地先解析 `codeload.github.com`，再用显式 `--resolve` 和重试参数拉取源码归档。
 - 管理员桥接任务以 `SYSTEM` + `Highest` 运行；安装脚本会给执行安装的 Windows 用户追加该任务的读取/执行权限，供普通 Codex 会话调用。
 - Symphony 运行模板：`runtime/symphony/WORKFLOW.freshquant.md`
 - 全局 Codex 自动化提示词模板：`runtime/symphony/prompts/global_stewardship.md`
@@ -125,6 +126,7 @@
 - GHCR 预构建镜像仅用于加速 Docker 部署，不改变运行真值；实际运行真值仍来自当前 `main`、deploy 结果与 health/runtime ops evidence
 - `deploy-production.yml` 在正式 Windows self-hosted runner 上消费这些 GHCR 镜像，并把 deploy state / logs 固化到 `formal-deploy` artifacts 目录
 - 该 workflow 不走 `actions/checkout`；会先调用 GitHub API 校验 `main` tip，再用 PowerShell 下载目标 SHA 的源码归档并展开到 runner 工作区，避免宿主机 `git/libcurl` 网络抖动导致 deploy 卡在 checkout
+- 该 workflow 当前使用 `curl.exe` 而不是 PowerShell `Invoke-WebRequest` 下载 archive，并对 `codeload.github.com` 做显式解析、`--resolve` 和 retry，避免 self-hosted runner 在归档重定向链路上出现 DNS 解析失败或连接意外关闭
 - 对已经有 `last_success_sha` 的增量正式 deploy，`run_formal_deploy.py` 会在 zipball 工作区下回退到 GitHub compare API 计算 changed paths，因此不会因为缺少 `.git` 而失去增量部署能力
 - 该 workflow 下载源码后直接使用宿主机已安装的 Python 3.12 执行 `py -3.12 -m pip install --upgrade pip uv` 和 `py -3.12 -m uv sync --frozen`，绕开 `actions/setup-python` 在本机执行策略下触发的 `setup.ps1` 拦截
 - 该 workflow 中的 PowerShell steps 固定带 `-ExecutionPolicy Bypass`，避免 self-hosted Windows runner 的本机执行策略在 step 启动前拦截临时脚本

--- a/freshquant/tests/test_deploy_build_cache_policy.py
+++ b/freshquant/tests/test_deploy_build_cache_policy.py
@@ -160,7 +160,10 @@ def test_deploy_production_workflow_runs_on_successful_docker_publish() -> None:
     assert "actions/checkout@v4" not in text
     assert "actions/setup-python@v5" not in text
     assert "Download target revision archive" in text
-    assert "Invoke-WebRequest" in text
+    assert "curl.exe" in text
+    assert "Resolve-DnsName codeload.github.com" in text
+    assert "--retry-all-errors" in text
+    assert "--http1.1" in text
     assert "Expand-Archive" in text
     assert 'GH_TOKEN: ${{ github.token }}' in text
     assert '--github-repository "${{ github.repository }}"' in text
@@ -189,6 +192,9 @@ def test_current_docs_cover_automatic_production_deploy_state() -> None:
     assert "上一次成功部署" in deployment_text
     assert "当前 main tip" in deployment_text
     assert "宿主机已安装的 Python 3.12" in deployment_text
+    assert "codeload.github.com" in deployment_text
+    assert "curl.exe" in deployment_text
     assert "deploy-production.yml" in runtime_text
     assert "formal-deploy" in runtime_text
     assert "宿主机已安装的 Python 3.12" in runtime_text
+    assert "codeload.github.com" in runtime_text


### PR DESCRIPTION
修复 Deploy Production 在 self-hosted Windows runner 上下载 zipball 归档时对 codeload.github.com 的 DNS/连接稳定性依赖。改为用 curl.exe 配合 Resolve-DnsName、显式 --resolve、HTTP/1.1 和 retry 拉取 archive，并同步更新 workflow 契约测试与 docs/current。