### PR TITLE
docs: 补充项目冷记忆参考

### DIFF
--- a/.codex/memory/data-truth-sources.md
+++ b/.codex/memory/data-truth-sources.md
@@ -1,0 +1,33 @@
+# 数据真值与存储边界
+
+- `freshquant` 是基础业务库，当前承载 `xt_*`、`stock_pre_pools`、`stock_pools`、`must_pool`、`stock_signals`、`realtime_screen_multi_period` 等集合。
+- `freshquant_order_management` 才是订单主事实库，正式事实集合包括：
+  - `om_order_requests`
+  - `om_orders`
+  - `om_order_events`
+  - `om_trade_facts`
+  - `om_buy_lots`
+  - `om_lot_slices`
+  - `om_sell_allocations`
+  - `om_stoploss_bindings`
+  - `om_takeprofit_profiles`
+  - `om_takeprofit_states`
+- `xt_orders / xt_trades / xt_positions / xt_assets` 是外部账户与回报视角事实，不是内部订单账本真值。
+- `freshquant_position_management` 是仓位门禁状态库，核心集合是 `pm_configs`、`pm_current_state`、`pm_credit_asset_snapshots`、`pm_strategy_decisions`。
+- `gantt` 是 Gantt / Shouban30 读模型库，不参与交易账本。
+- `fqscreening` 是每日选股正式结果库，真值集合固定是：
+  - `daily_screening_runs`
+  - `daily_screening_memberships`
+  - `daily_screening_stock_snapshots`
+- `stock_pre_pools / stock_pools / must_pool` 现在只是共享工作区与订阅范围集合，不再承担每日选股正式结果真值。
+- 每日选股只在显式 `add-to-pre-pool` / `add-batch-to-pre-pool` 动作时把 `fqscreening` 结果复制到工作区。
+- `fq_memory` 是 agent 旁路热记忆库，保存 `task_state`、`task_events`、`deploy_runs`、`health_results`、`knowledge_items`、`module_status`、`context_packs`。
+- Redis 当前只承担运行队列与缓存角色，不承担正式持久化真值：
+  - XTData tick/bar queue
+  - `STOCK_ORDER_QUEUE`
+  - 冷却锁 / 节流键
+  - Kline / 分钟结构缓存
+- 查交易链问题时，优先顺序固定是：
+  - 先看 `om_*`
+  - 再看 `xt_*`
+  - 最后再看旧兼容集合

--- a/.codex/memory/product-surfaces.md
+++ b/.codex/memory/product-surfaces.md
@@ -1,0 +1,47 @@
+# 产品与模块面
+
+- 当前主要前端工作台路由固定包括：
+  - `/stock-control`
+  - `/gantt`
+  - `/gantt/shouban30`
+  - `/daily-screening`
+  - `/kline-slim`
+  - `/order-management`
+  - `/position-management`
+  - `/subject-management`
+  - `/system-settings`
+  - `/tpsl`
+  - `/runtime-observability`
+- 每日选股是“股票视角的统一盘后筛选工作台”，它把 `CLXS`、`chanlun`、`shouban30_agg90`、`market_flags` 收口到 `/daily-screening`。
+- 每日选股正式 scope 只有两类：
+  - `trade_date:<YYYY-MM-DD>`
+  - `run:<run_id>`
+- 每日选股页面当前通过 SSE 消费：
+  - `run_started`
+  - `stage_started`
+  - `stage_progress`
+  - `stage_completed`
+  - `run_completed`
+  - `run_failed`
+  - `heartbeat`
+- 标的管理 `/subject-management` 当前是单标的工作台，统一收口：
+  - `must_pool`
+  - Guardian 阶梯买入价
+  - 标的级止盈
+  - buy lot 级止损
+  - 只读运行态与仓位门禁摘要
+- 运行观测 `/runtime-observability` 是排障页，不是业务事实页。
+- Runtime Trace 当前只按强关联键组装：
+  - `trace_id`
+  - `intent_id`
+  - `request_id`
+  - `internal_order_id`
+- `heartbeat`、`bootstrap`、`config_resolve`、`subscription_load` 这类事件只进 Event / health 视图，不进 Trace 列表。
+- `/api/runtime/health/summary` 固定返回核心组件全集；无数据组件也不会消失，而是 `status=unknown`、`is_placeholder=true`。
+- Runtime 日志当前只保留最近 5 个交易日，不要把 `logs/runtime` 当长期历史仓库。
+- 当前模块文档清单里要特别注意最近新增或变化较大的模块：
+  - `daily-screening`
+  - `runtime-observability`
+  - `subject-management`
+  - `market-data-xtdata`
+  - `order-management`

--- a/.codex/memory/repo-guardrails.md
+++ b/.codex/memory/repo-guardrails.md
@@ -1,0 +1,30 @@
+# 仓库交付护栏
+
+- 正式工作流已经收口为 GitHub-first：
+  - 代码交付真值是 `PR + CI + merge gate`
+  - 高影响任务可走 GitHub Issue
+  - 轻量更新允许直接 `feature branch -> PR`
+- 当前 `Done` 固定不是“merge 即完成”，而是：
+  - `merge + ci + docs sync + deploy + health check + cleanup`
+- `Merging` 只负责 merge 与 handoff，不负责 deploy、health check 或 cleanup。
+- `Global Stewardship` 固定负责：
+  - deploy
+  - health check
+  - runtime ops check
+  - cleanup
+  - follow-up issue
+- 当前提交前正式预检入口是：
+  - `powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure`
+- 当前仓库 `git push` 通过 `.githooks/pre-push` 自动触发本地预检；hook 丢失时用 `script/install_repo_hooks.ps1` 恢复。
+- 本地预检当前会阻断：
+  - docs guard 失败
+  - pre-commit 失败
+  - pytest 失败
+  - 当前分支关联 PR 上存在 unresolved review threads
+- 当前开 PR 的正式入口是：
+  - `powershell -ExecutionPolicy Bypass -File script/fq_open_pr.ps1 -- --fill`
+- 正式 deploy 已改为本机 mirror 路径：
+  - canonical repo root：`D:\fqpack\freshquant-2026.2.23`
+  - deploy mirror：`D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production`
+- 正式 deploy workflow 会先校验目标 SHA 仍是 `main` tip，再在 mirror 中执行本地构建，不再依赖下载 zipball 或把 GHCR 当正式前置。
+- 任何 memory context 与 GitHub、`docs/current/**` 或 deploy 证据冲突时，正式真值优先。

--- a/.codex/memory/runtime-surfaces.md
+++ b/.codex/memory/runtime-surfaces.md
@@ -1,0 +1,48 @@
+# 运行面与入口
+
+- Windows 宿主机承担：
+  - XTQuant / XTData 连接
+  - `fqnext-supervisord` 及其托管进程
+  - Guardian monitor
+  - Position worker
+  - TPSL worker
+  - Symphony 正式服务
+- Docker 并行环境承担：
+  - Mongo：`27027 -> 27017`
+  - Redis：`6380 -> 6379`
+  - API：`15000 -> 5000`
+  - TDXHQ：`15001 -> 5001`
+  - Dagster：`11003 -> 10003`
+  - QAWebServer：`18010 -> 8010`
+  - Web UI：`18080 -> 80`
+  - TradingAgents backend/frontend：`13000 / 13080`
+- 正式宿主机服务名固定为：
+  - `fq-symphony-orchestrator`
+  - `fqnext-supervisord`
+- 运行面常用正式入口固定为：
+  - Docker：`script/docker_parallel_compose.ps1`
+  - 宿主机进程控制：`script/fqnext_host_runtime_ctl.ps1`
+  - 共享部署计划：`script/freshquant_deploy_plan.py`
+  - selective deploy：`script/fq_apply_deploy_plan.ps1`
+  - 本地预检：`script/fq_local_preflight.ps1`
+  - 本地开 PR：`script/fq_open_pr.ps1`
+- 自由 Codex 会话硬入口固定为：
+  - `codex_run/start_codex_cli.bat`
+  - `codex_run/start_codex_app_server.bat`
+  - 两者都会先执行 `bootstrap_freshquant_memory.py`
+- `codex app-server` 默认走 `stdio://` 前台模式；窗口关闭或 `Ctrl+C` 即停止服务。
+- 当前 memory 默认从 `origin/main` 读取 `.codex/memory/**` 与 `docs/current/modules/*.md`，再写入 `fq_memory` 和 context pack。
+- 调主交易链的最小可用运行面至少需要：
+  - Mongo
+  - Redis
+  - API
+  - XTData producer / consumer
+  - Guardian
+  - Position worker
+  - Order submit / broker / XT 回报 ingest
+  - TPSL
+- 调前端展示时，还要额外确认：
+  - Web UI
+  - Gantt / Shouban30 读模型
+  - `logs/runtime`
+  - `/runtime-observability` 的 heartbeat 与组件 Event

--- a/.codex/memory/system-topology.md
+++ b/.codex/memory/system-topology.md
@@ -1,0 +1,27 @@
+# 系统拓扑
+
+- FreshQuant 当前阶段已经从迁移治理转到“现状收敛、边界修复、部署与排障可维护”。
+- 当前总体分层固定为：
+  - 行情层：`freshquant.market_data.xtdata.*`
+  - 策略层：`freshquant.signal.*` 与 `freshquant.strategy.guardian`
+  - 交易执行层：`freshquant.order_management.*`、`freshquant.position_management.*`、`freshquant.tpsl.*`、`fqxtrade.xtquant.broker`
+  - 展示层：`freshquant.rear.*` 与 `morningglory/fqwebui`
+  - 盘后选股工作台层：`freshquant.daily_screening.*`
+  - 数据处理层：`freshquant.data.gantt_readmodel`、`freshquant.shouban30_pool_service`、`morningglory/fqdagster`
+  - 观测层：`freshquant.runtime_observability.*`
+  - 记忆层：`freshquant.runtime.memory.*`
+- 实时交易主链固定是：
+  - `XTData producer -> Redis tick/bar queue -> XTData consumer -> Guardian -> PositionManagement gate -> OrderManagement submit -> Redis STOCK_ORDER_QUEUE -> broker/puppet gateway -> XT 回报 ingest`
+- 止盈止损链固定是：
+  - `XTData producer -> Redis TICK_QUOTE queue -> TpslTickConsumer -> TpslService -> OrderSubmitService -> broker -> XT 回报 ingest`
+- 每日选股正式链固定是：
+  - `DailyScreening.vue -> /api/daily-screening/* -> DailyScreeningService -> CLXS / chanlun / shouban30_agg90 / market_flags -> fqscreening`
+- 运行观测链固定是：
+  - `RuntimeEventLogger -> logs/runtime/<runtime_node>/<component>/<date>/*.jsonl -> /api/runtime/* -> RuntimeObservability.vue`
+- 记忆编译链固定是：
+  - `reference_ref:.codex/memory/** + reference_ref:docs/current/modules/*.md + cleanup/deploy artifacts -> fq_memory -> context pack markdown`
+- 当前正式真值面固定分三层：
+  - 代码真值：远程 `origin/main`
+  - 文档真值：`docs/current/**`
+  - 运行交付真值：deploy + health check + cleanup
+- 记忆层是旁路摘要系统，只减少 agent 重复探索，不覆盖 GitHub、`docs/current/**` 或部署证据。

--- a/freshquant/tests/test_runtime_memory_docs.py
+++ b/freshquant/tests/test_runtime_memory_docs.py
@@ -139,6 +139,46 @@ def test_cold_memory_deploy_surfaces_cover_current_release_matrix() -> None:
     )
 
 
+def test_additional_cold_memory_files_capture_current_project_facts() -> None:
+    topology_text = Path(".codex/memory/system-topology.md").read_text(encoding="utf-8")
+    runtime_text = Path(".codex/memory/runtime-surfaces.md").read_text(encoding="utf-8")
+    data_text = Path(".codex/memory/data-truth-sources.md").read_text(encoding="utf-8")
+    guardrails_text = Path(".codex/memory/repo-guardrails.md").read_text(
+        encoding="utf-8"
+    )
+    product_text = Path(".codex/memory/product-surfaces.md").read_text(encoding="utf-8")
+
+    assert "系统拓扑" in topology_text
+    assert "daily_screening" in topology_text
+    assert "origin/main" in topology_text
+    assert "记忆编译链" in topology_text
+
+    assert "运行面与入口" in runtime_text
+    assert "fq-symphony-orchestrator" in runtime_text
+    assert "fqnext-supervisord" in runtime_text
+    assert "fq_local_preflight.ps1" in runtime_text
+    assert "stdio://" in runtime_text
+
+    assert "数据真值与存储边界" in data_text
+    assert "freshquant_order_management" in data_text
+    assert "fqscreening" in data_text
+    assert "fq_memory" in data_text
+    assert "STOCK_ORDER_QUEUE" in data_text
+
+    assert "仓库交付护栏" in guardrails_text
+    assert "fq_local_preflight.ps1" in guardrails_text
+    assert "script/fq_open_pr.ps1" in guardrails_text
+    assert "main-deploy-production" in guardrails_text
+    assert "review threads" in guardrails_text
+
+    assert "产品与模块面" in product_text
+    assert "/daily-screening" in product_text
+    assert "/runtime-observability" in product_text
+    assert "subject-management" in product_text
+    assert "trace_id" in product_text
+    assert "5 个交易日" in product_text
+
+
 def test_current_deployment_docs_reference_selective_deploy_and_build_cache() -> None:
     deployment_text = Path("docs/current/deployment.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 背景

当前 `.codex/memory` 只有 3 份冷记忆文件，能覆盖工作流和部署面，但不足以反映项目当前代码的整体现状。新会话虽然能读到模块索引，但缺少系统拓扑、运行入口、数据真值边界、交付护栏和当前主要产品面的长期参考。

## 目标

补充项目级冷记忆源文件，让 memory refresh / compile 产出的 context pack 更完整地体现当前代码现状。

## 范围

- 新增系统拓扑、运行面、数据真值、仓库交付护栏、产品模块面 5 份冷记忆文件
- 补充文档测试，约束这些冷记忆文件持续覆盖当前项目事实

## 非目标

- 不修改业务代码
- 不改 deploy / health / cleanup 流程
- 不调整 memory runtime 实现逻辑

## 验收标准

- `.codex/memory` 新增 5 份项目级冷记忆文件
- `freshquant/tests/test_runtime_memory_docs.py` 覆盖新增冷记忆文件的关键事实
- 本地 `pytest` 与 `pre-commit` 通过

## 部署影响

- 无运行时部署动作
- 影响新的 memory refresh / compile 产物内容

## Summary

- 补充 5 份项目级冷记忆源文件，覆盖系统拓扑、运行面、数据真值、交付护栏和产品模块面
- 为新增冷记忆补文档测试，防止后续项目事实漂移时记忆源失真
- 让后续 memory context pack 能更完整反映当前代码结构与入口事实

## Test Plan

- [x] `py -3.12 -m pytest freshquant/tests/test_runtime_memory_docs.py -q`
- [x] `py -3.12 -m pre_commit run --files freshquant/tests/test_runtime_memory_docs.py .codex/memory/system-topology.md .codex/memory/runtime-surfaces.md .codex/memory/data-truth-sources.md .codex/memory/repo-guardrails.md .codex/memory/product-surfaces.md`