### PR TITLE
fix: 修复 daily-screening snapshot 兼容索引冲突

### DIFF
--- a/freshquant/daily_screening/repository.py
+++ b/freshquant/daily_screening/repository.py
@@ -499,7 +499,7 @@ class DailyScreeningRepository:
         payload = self._normalize_snapshot(item, scope_id=scope_id)
         if trade_date is not None:
             payload.setdefault("trade_date", trade_date)
-        return payload
+        return self._apply_legacy_condition_identity(payload)
 
     def _apply_legacy_condition_identity(
         self, payload: dict[str, Any]

--- a/freshquant/tests/test_daily_screening_repository.py
+++ b/freshquant/tests/test_daily_screening_repository.py
@@ -117,6 +117,22 @@ class LegacyIndexedCollection(SimpleCollection):
             existing.add(key)
         return super().insert_many(documents, ordered=ordered)
 
+    def replace_one(self, query, document, upsert=False):
+        for index, doc in enumerate(self.docs):
+            if all(doc.get(key) == value for key, value in query.items()):
+                self.docs[index] = dict(document)
+                return SimpleNamespace(matched_count=1, modified_count=1)
+        if upsert:
+            key = tuple(document.get(field) for field in self.LEGACY_KEY_FIELDS)
+            existing = {
+                tuple(doc.get(field) for field in self.LEGACY_KEY_FIELDS)
+                for doc in self.docs
+            }
+            if key in existing:
+                raise AssertionError(f"legacy duplicate key: {key}")
+            self.docs.append(dict(document))
+        return SimpleNamespace(matched_count=0, modified_count=0)
+
 
 class FakeDB(dict):
     def __getitem__(self, name):
@@ -211,6 +227,8 @@ def test_repository_upserts_snapshot_metrics_by_scope_and_code():
 
     assert fake_db["daily_screening_stock_snapshots"].docs[0] == {
         "scope_id": "trade_date:2026-03-18",
+        "scope": "trade_date:2026-03-18",
+        "run_id": "trade_date:2026-03-18",
         "trade_date": "2026-03-18",
         "code": "000001",
         "symbol": "sz000001",
@@ -335,6 +353,46 @@ def test_repository_condition_memberships_do_not_conflict_with_legacy_unique_ide
     )
 
     assert len(fake_db["daily_screening_memberships"].docs) == 3
+
+
+def test_repository_condition_snapshots_fill_legacy_identity_from_scope_id():
+    from freshquant.daily_screening.repository import DailyScreeningRepository
+
+    fake_db = FakeDB(
+        daily_screening_stock_snapshots=LegacyIndexedCollection(
+            "daily_screening_stock_snapshots"
+        )
+    )
+    repo = DailyScreeningRepository(db=fake_db)
+
+    repo.upsert_stock_snapshots(
+        scope_id="trade_date:2026-03-18",
+        trade_date="2026-03-18",
+        snapshots=[{"code": "000010", "name": "alpha"}],
+    )
+    repo.upsert_stock_snapshots(
+        scope_id="trade_date:2026-03-19",
+        trade_date="2026-03-19",
+        snapshots=[{"code": "000010", "name": "alpha"}],
+    )
+
+    assert sorted(
+        (row.get("scope_id"), row.get("run_id"), row.get("scope"), row.get("code"))
+        for row in fake_db["daily_screening_stock_snapshots"].docs
+    ) == [
+        (
+            "trade_date:2026-03-18",
+            "trade_date:2026-03-18",
+            "trade_date:2026-03-18",
+            "000010",
+        ),
+        (
+            "trade_date:2026-03-19",
+            "trade_date:2026-03-19",
+            "trade_date:2026-03-19",
+            "000010",
+        ),
+    ]
 
 
 def test_repository_query_scope_stocks_strips_mongo_internal_id():


### PR DESCRIPTION
## 背景
- `daily_screening_postclose_job` 在部署 #240 后重跑失败。
- 失败点在 `daily_screening_snapshot_assemble` 落库 `daily_screening_stock_snapshots` 时触发 Mongo `DuplicateKeyError`。

## 根因
- `scope_id` 路径的 snapshot 归一化没有回填 legacy `run_id/scope`。
- 生产库仍保留历史唯一索引 `daily_screening_stock_snapshots_run_scope_code(run_id, scope, code)`。
- 同一只股票写入不同 `trade_date scope` 时，会因为 `run_id/scope` 都是空值而撞旧索引。

## 修复
- 让 `condition snapshot` 和 `condition membership` 一样回填 legacy identity。
- 新增 repository 测试，覆盖多 `trade_date scope` 下同码快照不会再撞旧索引。

## 测试
- `py -3.12 -m pytest freshquant/tests/test_daily_screening_repository.py freshquant/tests/test_daily_screening_service.py freshquant/tests/test_daily_screening_routes.py freshquant/tests/test_daily_screening_dagster.py -q`
- `py -3.12 script/ci/check_current_docs.py`
