### PR TITLE
修复 runtime observability Trace 500 与 XT 成交回放重入

### DIFF
--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -168,9 +168,13 @@
 - CI `pytest-shards` 当前按 `script/ci/pytest_file_durations.json` 的文件级耗时权重做 shard 分配，不再只按文件序号轮询
 - FQNext 宿主机 Supervisor 仍托管 `fqnext_realtime_xtdata_producer`、`fqnext_realtime_xtdata_consumer`、`fqnext_guardian_event`、`fqnext_xt_account_sync_worker`、`fqnext_tpsl_worker`、`fqnext_xtquant_broker`、`fqnext_xtdata_adj_refresh_worker`
 - `fqnext_xt_account_sync_worker` 当前是唯一 XT 主动查询进程；它串行执行持仓、成交、委托、资产、信用账户与 `credit_subjects` 补偿同步
+- `fqnext_xt_account_sync_worker` 默认每 `3` 秒轮询一次 XT 当日成交；`xt_trades` 或 runtime 事件按约 `3` 秒节奏刷新，不等于每次都是新成交
 - 宿主机当前不再保留独立的 `position_management.worker` 或 `credit_subjects.worker` 入口；相关账户同步职责统一收敛到 `fqnext_xt_account_sync_worker`
 - `fqnext_xtquant_broker` 当前为 worker-only 进程，不再暴露本地 Tornado HTTP 接口或 `10088` 端口；运行健康以 supervisor 进程状态和 broker 日志为准
 - `observe_only` 现在只绕过 broker 的真实提交/撤单，不会停掉 XT 连接、callback ingest 或 `fqnext_xt_account_sync_worker`
+- `xt_report_ingest.trade_match` 当前表示“该笔成交回报已进入订单域 ingest 处理”；它不是“新增成交事实”的直接真值
+- 如果 `xt_report_ingest.trade_match` 的 `status=skipped` 且 `payload.created=false`、`payload.dedup_hit=true`，表示同一 `broker_trade_id` 的重复回放已被幂等拦截，不会再次改写持仓投影或 `sell_allocations`
+- 同一笔成交是否真实新增，以 `om_trade_facts` 按 `broker_trade_id` 去重后的结果为准，而不是只看 runtime event 次数
 
 ## 常见运行模式
 

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -394,6 +394,46 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
 - 清空筛选后刷新页面
 - 如果 API 有数据但页面统计卡、recent feed、component board 全空，优先重建并重新部署 `fq_webui`，然后强刷浏览器缓存
 
+## Runtime Observability Trace 列表 500
+
+现象：
+- 点击 `/runtime-observability` 左侧组件卡片后，前端提示 `Trace 列表加载失败：Request failed with status code 500`
+
+先检查：
+- 直接访问 `/api/runtime/traces`
+- 目标时间窗里是否存在大量重复的 `request_id` / `internal_order_id` / `broker_trade_id` 关联链
+
+常见根因：
+- 旧版 runtime assembler 对强关联 ID 分组仍使用递归 union-find；当 `xt_report_ingest` 因重复回放把链路拉得很深时，会触发 `RecursionError`
+- API 已更新，但 `fq_webui` 仍在跑旧静态资源或浏览器缓存没刷新
+
+处理：
+- 优先重建并部署 `fq_apiserver`
+- 如果 API 已恢复 `200` 但前端仍报错，再重建 `fq_webui` 并强刷浏览器缓存
+- 如果同一时间窗里 `XT 回报接入.trade_match` 明显按 `3` 秒节奏重复刷，继续看下一节排查 replay 根因
+
+## XT 回报接入.trade_match 高频
+
+现象：
+- `/runtime-observability` 中 `XT 回报接入.trade_match` 高频出现，看起来像“每秒都在新增成交”
+
+先检查：
+- 同一 `broker_trade_id` 是否反复出现
+- 事件是否集中在约 `3` 秒轮询节奏
+- `trade_match` 的 `status` 是否为 `skipped`
+- `trade_match.payload.created` / `trade_match.payload.dedup_hit` 是什么
+- 对照 `om_trade_facts`、`om_sell_allocations`、Guardian open slices，确认是否真的重复写入
+
+常见根因：
+- `fqnext_xt_account_sync_worker` 每 `3` 秒轮询一次 XT 当日全部成交
+- 同一 `broker_trade_id` 的成交回报被重复回放
+- 旧版代码把 `reconcile_trade_reports()` 的空结果误判成“未处理”，导致同一笔成交反复进入 `xt_report_ingest`
+
+处理：
+- 如果 `status=skipped` 且 `payload.created=false`、`payload.dedup_hit=true`，说明重复回放已被当前代码拦截；这不是新成交
+- 如果重复事件仍是 `status=info`，或 `om_sell_allocations` / Guardian open slices 仍被重复改写，优先确认 `order_management`、`xt_account_sync`、`xtquant_broker` 是否已部署到包含幂等修复的最新代码
+- 真实成交次数以 `om_trade_facts` 中唯一 `broker_trade_id` 数量为准，不要只看 runtime event 次数
+
 ## 初始化程序第 3 步提示未连接到交易系统或账户信息缺失
 
 现象：

--- a/freshquant/order_management/ingest/xt_reports.py
+++ b/freshquant/order_management/ingest/xt_reports.py
@@ -77,47 +77,66 @@ class OrderManagementXtIngestService:
                 "report_receive", report, extra_payload={"report_type": "trade"}
             )
             current_node = "trade_match"
-            trade_fact = self.tracking_service.ingest_trade_report(report)
+            if hasattr(self.tracking_service, "ingest_trade_report_with_meta"):
+                ingest_result = self.tracking_service.ingest_trade_report_with_meta(
+                    report
+                )
+            else:
+                ingest_result = {
+                    "trade_fact": self.tracking_service.ingest_trade_report(report),
+                    "created": True,
+                }
+            trade_fact = ingest_result["trade_fact"]
+            created = bool(ingest_result.get("created"))
             symbol = trade_fact["symbol"]
             buy_lot = None
             lot_slices = []
             sell_allocations = []
             holdings_changed = False
 
-            if trade_fact["side"] == "buy":
+            if created:
+                if trade_fact["side"] == "buy":
+                    buy_lot = self.repository.find_buy_lot_by_origin_trade_fact_id(
+                        trade_fact["trade_fact_id"]
+                    )
+                    if buy_lot is None:
+                        buy_lot = build_buy_lot_from_trade_fact(trade_fact)
+                        self.repository.insert_buy_lot(buy_lot)
+                        lot_slices = arrange_buy_lot(
+                            buy_lot,
+                            lot_amount=lot_amount,
+                            grid_interval=grid_interval_lookup(symbol, trade_fact),
+                        )
+                        self.repository.replace_lot_slices_for_lot(
+                            buy_lot["buy_lot_id"],
+                            lot_slices,
+                        )
+                        holdings_changed = True
+                        self._notify_new_buy_trade(
+                            symbol=symbol,
+                            price=trade_fact["price"],
+                        )
+                    else:
+                        lot_slices = self.repository.list_open_slices(symbol)
+                elif trade_fact["side"] == "sell":
+                    buy_lots = self.repository.list_buy_lots(symbol)
+                    open_slices = self.repository.list_open_slices(symbol)
+                    sell_allocations = allocate_sell_to_slices(
+                        buy_lots=buy_lots,
+                        open_slices=open_slices,
+                        sell_trade_fact=trade_fact,
+                    )
+                    for item in buy_lots:
+                        self.repository.replace_buy_lot(item)
+                    self.repository.replace_open_slices(open_slices)
+                    self.repository.insert_sell_allocations(sell_allocations)
+                    holdings_changed = bool(sell_allocations)
+                    self._reset_guardian_buy_grid_after_sell(symbol)
+            elif trade_fact["side"] == "buy":
                 buy_lot = self.repository.find_buy_lot_by_origin_trade_fact_id(
                     trade_fact["trade_fact_id"]
                 )
-                if buy_lot is None:
-                    buy_lot = build_buy_lot_from_trade_fact(trade_fact)
-                    self.repository.insert_buy_lot(buy_lot)
-                    lot_slices = arrange_buy_lot(
-                        buy_lot,
-                        lot_amount=lot_amount,
-                        grid_interval=grid_interval_lookup(symbol, trade_fact),
-                    )
-                    self.repository.replace_lot_slices_for_lot(
-                        buy_lot["buy_lot_id"],
-                        lot_slices,
-                    )
-                    holdings_changed = True
-                    self._notify_new_buy_trade(symbol=symbol, price=trade_fact["price"])
-                else:
-                    lot_slices = self.repository.list_open_slices(symbol)
-            elif trade_fact["side"] == "sell":
-                buy_lots = self.repository.list_buy_lots(symbol)
-                open_slices = self.repository.list_open_slices(symbol)
-                sell_allocations = allocate_sell_to_slices(
-                    buy_lots=buy_lots,
-                    open_slices=open_slices,
-                    sell_trade_fact=trade_fact,
-                )
-                for item in buy_lots:
-                    self.repository.replace_buy_lot(item)
-                self.repository.replace_open_slices(open_slices)
-                self.repository.insert_sell_allocations(sell_allocations)
-                holdings_changed = bool(sell_allocations)
-                self._reset_guardian_buy_grid_after_sell(symbol)
+                lot_slices = self.repository.list_open_slices(symbol)
 
             buy_lots = self.repository.list_buy_lots(symbol)
             open_slices = self.repository.list_open_slices(symbol)
@@ -127,10 +146,14 @@ class OrderManagementXtIngestService:
                 "trade_match",
                 report,
                 internal_order_id=trade_fact["internal_order_id"],
+                status="info" if created else "skipped",
+                reason_code="" if created else "duplicate_trade_report",
                 extra_payload={
                     "side": trade_fact["side"],
                     "quantity": trade_fact["quantity"],
                     "holdings_changed": holdings_changed,
+                    "created": created,
+                    "dedup_hit": not created,
                 },
             )
 
@@ -139,6 +162,7 @@ class OrderManagementXtIngestService:
                 "buy_lot": buy_lot,
                 "lot_slices": lot_slices,
                 "sell_allocations": sell_allocations,
+                "created": created,
                 "projections": {
                     "raw_fills": build_raw_fills_view([trade_fact]),
                     "open_buy_fills": build_open_buy_fills_view(buy_lots),

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from freshquant.order_management.ids import (
@@ -22,6 +23,14 @@ from freshquant.runtime_observability.failures import (
     mark_exception_emitted,
 )
 from freshquant.runtime_observability.logger import RuntimeEventLogger
+
+
+@dataclass
+class TradeReportReconcileOutcome:
+    handled: bool
+    action: str
+    result: dict | None = None
+    normalized: dict | None = None
 
 
 class ExternalOrderReconcileService:
@@ -94,127 +103,157 @@ class ExternalOrderReconcileService:
             "INFERRED_PENDING"
         )
         for report in trade_reports:
-            current_node = "internal_match"
-            ids = {
-                "trace_id": report.get("trace_id"),
-                "intent_id": report.get("intent_id"),
-                "request_id": report.get("request_id"),
-                "internal_order_id": report.get("internal_order_id"),
-                "symbol": report.get("symbol"),
-            }
-            try:
-                normalized = normalize_xt_trade_report(
-                    report, repository=self.repository
-                )
-                ids["symbol"] = normalized.get("symbol")
-                if self.repository.find_order_by_broker_order_id(
-                    normalized.get("broker_order_id")
-                ):
-                    continue
+            outcome = self.reconcile_trade_report(
+                report,
+                pending_candidates=pending_candidates,
+            )
+            if outcome.result is not None:
+                results.append(outcome.result)
+        return results
 
-                match_status, matched_order = self._match_inflight_internal_order(
-                    normalized
+    def reconcile_trade_report(self, report, pending_candidates=None):
+        current_node = "internal_match"
+        ids = {
+            "trace_id": report.get("trace_id"),
+            "intent_id": report.get("intent_id"),
+            "request_id": report.get("request_id"),
+            "internal_order_id": report.get("internal_order_id"),
+            "symbol": report.get("symbol"),
+        }
+        try:
+            normalized = normalize_xt_trade_report(
+                report,
+                repository=self.repository,
+            )
+            ids["symbol"] = normalized.get("symbol")
+            if self.repository.find_order_by_broker_order_id(
+                normalized.get("broker_order_id")
+            ):
+                return TradeReportReconcileOutcome(
+                    handled=True,
+                    action="already_known_internal_order",
+                    normalized=normalized,
                 )
-                if match_status == "matched":
-                    ids.update(
-                        {
-                            "trace_id": matched_order.get("trace_id"),
-                            "intent_id": matched_order.get("intent_id"),
-                            "request_id": matched_order.get("request_id"),
-                            "internal_order_id": matched_order["internal_order_id"],
-                            "symbol": normalized["symbol"],
-                        }
-                    )
-                    self._emit_runtime(
-                        "internal_match",
-                        ids,
-                        payload={"broker_order_id": normalized.get("broker_order_id")},
-                    )
-                    normalized["internal_order_id"] = matched_order["internal_order_id"]
-                    if normalized.get("broker_order_id") and not matched_order.get(
-                        "broker_order_id"
-                    ):
-                        self.repository.update_order(
-                            matched_order["internal_order_id"],
-                            {
-                                "broker_order_id": normalized.get("broker_order_id"),
-                                "updated_at": datetime.now(timezone.utc).isoformat(),
-                            },
-                        )
-                    current_node = "projection_update"
-                    result = self.ingest_service.ingest_trade_report(
-                        normalized,
-                        lot_amount=_safe_resolve_lot_amount(normalized["symbol"]),
-                        grid_interval_lookup=_safe_grid_interval_lookup,
-                    )
-                    self._emit_runtime(
-                        "projection_update",
-                        ids,
-                        payload={"source": "internal_match"},
-                    )
-                    results.append(result)
-                    continue
-                if match_status == "defer":
-                    continue
 
-                candidate = _find_trade_candidate(pending_candidates, normalized)
-                current_node = "externalize"
-                order = self._create_external_order(
-                    symbol=normalized["symbol"],
-                    side=normalized["side"],
-                    quantity=normalized["quantity"],
-                    price=normalized["price"],
-                    source_type="external_reported",
-                    state="FILLED",
-                    broker_order_id=normalized.get("broker_order_id"),
+            match_status, matched_order = self._match_inflight_internal_order(
+                normalized
+            )
+            if match_status == "matched":
+                ids.update(
+                    {
+                        "trace_id": matched_order.get("trace_id"),
+                        "intent_id": matched_order.get("intent_id"),
+                        "request_id": matched_order.get("request_id"),
+                        "internal_order_id": matched_order["internal_order_id"],
+                        "symbol": normalized["symbol"],
+                    }
                 )
-                ids = {
-                    "request_id": order["request_id"],
-                    "internal_order_id": order["internal_order_id"],
-                    "symbol": normalized["symbol"],
-                }
                 self._emit_runtime(
-                    "externalize",
+                    "internal_match",
                     ids,
-                    payload={"source_type": "external_reported"},
+                    payload={"broker_order_id": normalized.get("broker_order_id")},
                 )
-                normalized["internal_order_id"] = order["internal_order_id"]
-                normalized["source"] = "external_reported"
+                normalized["internal_order_id"] = matched_order["internal_order_id"]
+                if normalized.get("broker_order_id") and not matched_order.get(
+                    "broker_order_id"
+                ):
+                    self.repository.update_order(
+                        matched_order["internal_order_id"],
+                        {
+                            "broker_order_id": normalized.get("broker_order_id"),
+                            "updated_at": datetime.now(timezone.utc).isoformat(),
+                        },
+                    )
                 current_node = "projection_update"
                 result = self.ingest_service.ingest_trade_report(
                     normalized,
                     lot_amount=_safe_resolve_lot_amount(normalized["symbol"]),
                     grid_interval_lookup=_safe_grid_interval_lookup,
                 )
-                if candidate is not None:
-                    candidate_updates = _build_candidate_trade_updates(
-                        candidate,
-                        normalized_trade=normalized,
-                        order=order,
-                        trade_fact=result["trade_fact"],
-                    )
-                    candidate.update(candidate_updates)
-                    self.repository.update_external_candidate(
-                        candidate["candidate_id"],
-                        candidate_updates,
-                    )
                 self._emit_runtime(
                     "projection_update",
                     ids,
-                    payload={"source": "external_reported"},
+                    payload={"source": "internal_match"},
                 )
-                results.append(result)
-            except Exception as exc:
-                self._emit_runtime(
-                    current_node,
-                    ids,
-                    status="error",
-                    reason_code="unexpected_exception",
-                    payload=build_exception_payload(exc),
+                return TradeReportReconcileOutcome(
+                    handled=True,
+                    action="matched_internal_order",
+                    result=result,
+                    normalized=normalized,
                 )
-                mark_exception_emitted(exc)
-                raise
-        return results
+            if match_status == "defer":
+                return TradeReportReconcileOutcome(
+                    handled=True,
+                    action="deferred_ambiguous_internal_match",
+                    normalized=normalized,
+                )
+
+            if pending_candidates is None:
+                pending_candidates = self.repository.list_external_candidates(
+                    "INFERRED_PENDING"
+                )
+            candidate = _find_trade_candidate(pending_candidates, normalized)
+            current_node = "externalize"
+            order = self._create_external_order(
+                symbol=normalized["symbol"],
+                side=normalized["side"],
+                quantity=normalized["quantity"],
+                price=normalized["price"],
+                source_type="external_reported",
+                state="FILLED",
+                broker_order_id=normalized.get("broker_order_id"),
+            )
+            ids = {
+                "request_id": order["request_id"],
+                "internal_order_id": order["internal_order_id"],
+                "symbol": normalized["symbol"],
+            }
+            self._emit_runtime(
+                "externalize",
+                ids,
+                payload={"source_type": "external_reported"},
+            )
+            normalized["internal_order_id"] = order["internal_order_id"]
+            normalized["source"] = "external_reported"
+            current_node = "projection_update"
+            result = self.ingest_service.ingest_trade_report(
+                normalized,
+                lot_amount=_safe_resolve_lot_amount(normalized["symbol"]),
+                grid_interval_lookup=_safe_grid_interval_lookup,
+            )
+            if candidate is not None:
+                candidate_updates = _build_candidate_trade_updates(
+                    candidate,
+                    normalized_trade=normalized,
+                    order=order,
+                    trade_fact=result["trade_fact"],
+                )
+                candidate.update(candidate_updates)
+                self.repository.update_external_candidate(
+                    candidate["candidate_id"],
+                    candidate_updates,
+                )
+            self._emit_runtime(
+                "projection_update",
+                ids,
+                payload={"source": "external_reported"},
+            )
+            return TradeReportReconcileOutcome(
+                handled=True,
+                action="externalized_report",
+                result=result,
+                normalized=normalized,
+            )
+        except Exception as exc:
+            self._emit_runtime(
+                current_node,
+                ids,
+                status="error",
+                reason_code="unexpected_exception",
+                payload=build_exception_payload(exc),
+            )
+            mark_exception_emitted(exc)
+            raise
 
     def _match_inflight_internal_order(self, normalized_trade):
         candidates = []

--- a/freshquant/order_management/tracking/service.py
+++ b/freshquant/order_management/tracking/service.py
@@ -181,6 +181,9 @@ class OrderTrackingService:
         )
 
     def ingest_trade_report(self, report):
+        return self.ingest_trade_report_with_meta(report)["trade_fact"]
+
+    def ingest_trade_report_with_meta(self, report):
         trade_fact = {
             "trade_fact_id": report.get("trade_fact_id") or new_trade_fact_id(),
             "internal_order_id": report["internal_order_id"],
@@ -210,7 +213,10 @@ class OrderTrackingService:
                     "created_at": _utc_now_iso(),
                 }
             )
-        return saved_trade_fact
+        return {
+            "trade_fact": saved_trade_fact,
+            "created": created,
+        }
 
 
 def _utc_now_iso():

--- a/freshquant/runtime_observability/assembler.py
+++ b/freshquant/runtime_observability/assembler.py
@@ -447,13 +447,16 @@ def _normalized_text(value) -> str:
 class _DisjointSet:
     def __init__(self, size: int) -> None:
         self.parent = list(range(size))
+        self.rank = [0] * size
 
     def find(self, index: int) -> int:
-        parent = self.parent[index]
-        if parent == index:
-            return index
-        root = self.find(parent)
-        self.parent[index] = root
+        root = index
+        while self.parent[root] != root:
+            root = self.parent[root]
+        while self.parent[index] != index:
+            parent = self.parent[index]
+            self.parent[index] = root
+            index = parent
         return root
 
     def union(self, left: int, right: int) -> None:
@@ -461,4 +464,8 @@ class _DisjointSet:
         right_root = self.find(right)
         if left_root == right_root:
             return
+        if self.rank[left_root] < self.rank[right_root]:
+            left_root, right_root = right_root, left_root
         self.parent[right_root] = left_root
+        if self.rank[left_root] == self.rank[right_root]:
+            self.rank[left_root] += 1

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -337,6 +337,42 @@ def test_reconcile_matches_inflight_internal_order_before_creating_external_orde
     assert repository.trade_facts[0]["internal_order_id"] == "ord_internal_1"
 
 
+def test_reconcile_trade_report_marks_existing_internal_order_as_handled(monkeypatch):
+    repository, service = _build_service(monkeypatch)
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "000001",
+            "price": 10.5,
+            "quantity": 200,
+            "source": "strategy",
+            "internal_order_id": "ord_internal_known_1",
+        }
+    )
+    repository.update_order(
+        "ord_internal_known_1",
+        {"broker_order_id": "90011", "state": "SUBMITTED"},
+    )
+
+    outcome = service.reconcile_trade_report(
+        {
+            "order_id": 90011,
+            "traded_id": "T90011",
+            "stock_code": "000001.SZ",
+            "order_type": 23,
+            "traded_volume": 200,
+            "traded_price": 10.5,
+            "traded_time": 1_030,
+        }
+    )
+
+    assert outcome.handled is True
+    assert outcome.action == "already_known_internal_order"
+    assert outcome.result is None
+    assert repository.trade_facts == []
+
+
 def test_inferred_pending_auto_confirms_after_120_seconds(monkeypatch):
     marks = []
     repository, service = _build_service(

--- a/freshquant/tests/test_order_management_tracking_service.py
+++ b/freshquant/tests/test_order_management_tracking_service.py
@@ -158,6 +158,38 @@ def test_ingest_trade_report_preserves_date_and_time_fields():
     assert created["time"] == "09:31:00"
 
 
+def test_ingest_trade_report_with_meta_returns_created_flag():
+    repository = InMemoryRepository()
+    service = OrderTrackingService(repository=repository)
+    service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "000001",
+            "price": 12.34,
+            "quantity": 100,
+            "source": "strategy",
+        }
+    )
+    internal_order_id = repository.orders[0]["internal_order_id"]
+    report = {
+        "internal_order_id": internal_order_id,
+        "broker_trade_id": "T-003",
+        "symbol": "000001",
+        "side": "buy",
+        "quantity": 100,
+        "price": 12.30,
+        "trade_time": 1710000000,
+        "source": "xt_trade_callback",
+    }
+
+    first = service.ingest_trade_report_with_meta(report)
+    second = service.ingest_trade_report_with_meta(report)
+
+    assert first["created"] is True
+    assert second["created"] is False
+    assert first["trade_fact"]["trade_fact_id"] == second["trade_fact"]["trade_fact_id"]
+
+
 def test_ingest_order_report_is_idempotent_when_state_is_unchanged():
     repository = InMemoryRepository()
     service = OrderTrackingService(repository=repository)

--- a/freshquant/tests/test_order_management_xt_ingest.py
+++ b/freshquant/tests/test_order_management_xt_ingest.py
@@ -124,6 +124,59 @@ def _bootstrap_service():
     return repository, ingest_service
 
 
+def _stub_ingest_side_effects(monkeypatch):
+    monkeypatch.setattr(
+        xt_reports_module,
+        "_get_tpsl_service",
+        lambda: type(
+            "FakeTpslService",
+            (),
+            {"on_new_buy_trade": lambda self, symbol, buy_price: None},
+        )(),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        xt_reports_module,
+        "_get_guardian_buy_grid_service",
+        lambda: type(
+            "FakeGuardianBuyGridService",
+            (),
+            {"reset_after_sell_trade": lambda self, symbol: None},
+        )(),
+        raising=False,
+    )
+
+
+def _buy_report(broker_trade_id="T-100"):
+    return {
+        "internal_order_id": "ord_test_1",
+        "broker_trade_id": broker_trade_id,
+        "symbol": "000001",
+        "side": "buy",
+        "quantity": 900,
+        "price": 10.0,
+        "trade_time": 1710000000,
+        "date": 20240102,
+        "time": "09:31:00",
+        "source": "xt_trade_callback",
+    }
+
+
+def _sell_report(broker_trade_id="T-101"):
+    return {
+        "internal_order_id": "ord_test_1",
+        "broker_trade_id": broker_trade_id,
+        "symbol": "000001",
+        "side": "sell",
+        "quantity": 500,
+        "price": 10.8,
+        "trade_time": 1710003600,
+        "date": 20240103,
+        "time": "10:00:00",
+        "source": "xt_trade_callback",
+    }
+
+
 def test_normalize_xt_trade_report_extracts_side_symbol_and_timestamp():
     normalized = normalize_xt_trade_report(
         {
@@ -268,18 +321,7 @@ def test_trade_report_creates_trade_fact_buy_lot_and_slices():
     repository, ingest_service = _bootstrap_service()
 
     result = ingest_service.ingest_trade_report(
-        {
-            "internal_order_id": "ord_test_1",
-            "broker_trade_id": "T-100",
-            "symbol": "000001",
-            "side": "buy",
-            "quantity": 900,
-            "price": 10.0,
-            "trade_time": 1710000000,
-            "date": 20240102,
-            "time": "09:31:00",
-            "source": "xt_trade_callback",
-        },
+        _buy_report(),
         lot_amount=3000,
         grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
     )
@@ -301,18 +343,7 @@ def test_trade_report_marks_holding_projection_updated(monkeypatch):
     )
 
     ingest_service.ingest_trade_report(
-        {
-            "internal_order_id": "ord_test_1",
-            "broker_trade_id": "T-100-mark",
-            "symbol": "000001",
-            "side": "buy",
-            "quantity": 900,
-            "price": 10.0,
-            "trade_time": 1710000000,
-            "date": 20240102,
-            "time": "09:31:00",
-            "source": "xt_trade_callback",
-        },
+        _buy_report("T-100-mark"),
         lot_amount=3000,
         grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
     )
@@ -323,35 +354,13 @@ def test_trade_report_marks_holding_projection_updated(monkeypatch):
 def test_sell_trade_report_creates_sell_allocations_and_updates_projection():
     repository, ingest_service = _bootstrap_service()
     ingest_service.ingest_trade_report(
-        {
-            "internal_order_id": "ord_test_1",
-            "broker_trade_id": "T-100",
-            "symbol": "000001",
-            "side": "buy",
-            "quantity": 900,
-            "price": 10.0,
-            "trade_time": 1710000000,
-            "date": 20240102,
-            "time": "09:31:00",
-            "source": "xt_trade_callback",
-        },
+        _buy_report(),
         lot_amount=3000,
         grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
     )
 
     result = ingest_service.ingest_trade_report(
-        {
-            "internal_order_id": "ord_test_1",
-            "broker_trade_id": "T-101",
-            "symbol": "000001",
-            "side": "sell",
-            "quantity": 500,
-            "price": 10.8,
-            "trade_time": 1710003600,
-            "date": 20240103,
-            "time": "10:00:00",
-            "source": "xt_trade_callback",
-        },
+        _sell_report(),
         lot_amount=3000,
         grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
     )
@@ -369,18 +378,7 @@ def test_sell_trade_report_resets_guardian_buy_grid_state(monkeypatch):
     repository, ingest_service = _bootstrap_service()
     resets = []
     ingest_service.ingest_trade_report(
-        {
-            "internal_order_id": "ord_test_1",
-            "broker_trade_id": "T-100-reset",
-            "symbol": "000001",
-            "side": "buy",
-            "quantity": 900,
-            "price": 10.0,
-            "trade_time": 1710000000,
-            "date": 20240102,
-            "time": "09:31:00",
-            "source": "xt_trade_callback",
-        },
+        _buy_report("T-100-reset"),
         lot_amount=3000,
         grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
     )
@@ -395,18 +393,7 @@ def test_sell_trade_report_resets_guardian_buy_grid_state(monkeypatch):
     )
 
     ingest_service.ingest_trade_report(
-        {
-            "internal_order_id": "ord_test_1",
-            "broker_trade_id": "T-101-reset",
-            "symbol": "000001",
-            "side": "sell",
-            "quantity": 500,
-            "price": 10.8,
-            "trade_time": 1710003600,
-            "date": 20240103,
-            "time": "10:00:00",
-            "source": "xt_trade_callback",
-        },
+        _sell_report("T-101-reset"),
         lot_amount=3000,
         grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
     )
@@ -416,18 +403,7 @@ def test_sell_trade_report_resets_guardian_buy_grid_state(monkeypatch):
 
 def test_repeated_callback_does_not_duplicate_trade_fact_or_projection():
     repository, ingest_service = _bootstrap_service()
-    report = {
-        "internal_order_id": "ord_test_1",
-        "broker_trade_id": "T-100",
-        "symbol": "000001",
-        "side": "buy",
-        "quantity": 900,
-        "price": 10.0,
-        "trade_time": 1710000000,
-        "date": 20240102,
-        "time": "09:31:00",
-        "source": "xt_trade_callback",
-    }
+    report = _buy_report()
 
     ingest_service.ingest_trade_report(
         report,
@@ -443,6 +419,38 @@ def test_repeated_callback_does_not_duplicate_trade_fact_or_projection():
     assert len(repository.trade_facts) == 1
     assert len(repository.buy_lots) == 1
     assert len(repository.list_open_slices("000001")) == 4
+
+
+def test_repeated_sell_callback_does_not_duplicate_sell_allocations(monkeypatch):
+    _stub_ingest_side_effects(monkeypatch)
+    repository, ingest_service = _bootstrap_service()
+    ingest_service.ingest_trade_report(
+        _buy_report(),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    report = _sell_report()
+
+    first = ingest_service.ingest_trade_report(
+        report,
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    second = ingest_service.ingest_trade_report(
+        report,
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    arranged_fills = build_arranged_fills_view(repository.list_open_slices("000001"))
+
+    assert len(first["sell_allocations"]) == 2
+    assert second["sell_allocations"] == []
+    assert len(repository.sell_allocations) == 2
+    assert [(item["price"], item["quantity"]) for item in arranged_fills] == [
+        (10.93, 200),
+        (10.61, 200),
+    ]
 
 
 def test_order_report_updates_existing_order_state():

--- a/freshquant/tests/test_runtime_observability_routes.py
+++ b/freshquant/tests/test_runtime_observability_routes.py
@@ -444,6 +444,46 @@ def test_runtime_events_route_keeps_xt_component_heartbeats_visible(
     assert body["events"][-1]["metrics"]["connected"] == 1
 
 
+def test_runtime_traces_route_handles_large_repeated_strong_id_groups(
+    monkeypatch, tmp_path
+):
+    tz = timezone(timedelta(hours=8))
+    base_ts = datetime(2026, 3, 20, 9, 30, tzinfo=tz)
+    repeated_request_id = "req_repeated_depth_guard"
+    repeated_order_id = "ord_repeated_depth_guard"
+    records = [
+        {
+            "event_type": "trace_step",
+            "component": "xt_report_ingest",
+            "runtime_node": "host:xt_report_ingest",
+            "node": "report_receive" if index % 2 == 0 else "order_match",
+            "request_id": repeated_request_id,
+            "internal_order_id": repeated_order_id,
+            "ts": (base_ts + timedelta(milliseconds=index)).isoformat(),
+        }
+        for index in range(1500)
+    ]
+    _write_events(
+        tmp_path,
+        runtime_node_path="host_xt_report_ingest",
+        component="xt_report_ingest",
+        date="2026-03-20",
+        file_name="xt_report_ingest_2026-03-20_1.jsonl",
+        records=records,
+    )
+    monkeypatch.setenv("FQ_RUNTIME_LOG_DIR", str(tmp_path))
+    client = _make_runtime_client()
+
+    resp = client.get("/api/runtime/traces")
+
+    body = resp.get_json()
+    assert resp.status_code == 200
+    assert len(body["traces"]) == 1
+    assert body["traces"][0]["request_ids"] == [repeated_request_id]
+    assert body["traces"][0]["internal_order_ids"] == [repeated_order_id]
+    assert body["traces"][0]["step_count"] == 1500
+
+
 def _write_events(
     root: Path,
     *,

--- a/freshquant/tests/test_xt_reports_runtime_observability.py
+++ b/freshquant/tests/test_xt_reports_runtime_observability.py
@@ -114,7 +114,31 @@ class InMemoryRepository:
         return allocations
 
 
-def test_ingest_trade_report_emits_runtime_events():
+def _stub_ingest_side_effects(monkeypatch):
+    monkeypatch.setattr(
+        xt_reports_module,
+        "_get_tpsl_service",
+        lambda: type(
+            "FakeTpslService",
+            (),
+            {"on_new_buy_trade": lambda self, symbol, buy_price: None},
+        )(),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        xt_reports_module,
+        "_get_guardian_buy_grid_service",
+        lambda: type(
+            "FakeGuardianBuyGridService",
+            (),
+            {"reset_after_sell_trade": lambda self, symbol: None},
+        )(),
+        raising=False,
+    )
+
+
+def test_ingest_trade_report_emits_runtime_events(monkeypatch):
+    _stub_ingest_side_effects(monkeypatch)
     runtime_logger = FakeRuntimeLogger()
     repository = InMemoryRepository()
     tracking_service = OrderTrackingService(repository=repository)
@@ -168,6 +192,68 @@ def test_ingest_trade_report_emits_runtime_events():
     ]
     assert runtime_logger.events[0]["trace_id"] == "trc_xt_1"
     assert runtime_logger.events[1]["internal_order_id"] == "ord_xt_1"
+
+
+def test_duplicate_trade_report_emits_skipped_trade_match_runtime_event(monkeypatch):
+    _stub_ingest_side_effects(monkeypatch)
+    runtime_logger = FakeRuntimeLogger()
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "000001",
+            "price": 10.0,
+            "quantity": 300,
+            "source": "strategy",
+            "internal_order_id": "ord_xt_dup_1",
+            "request_id": "req_xt_dup_1",
+            "trace_id": "trc_xt_dup_1",
+            "intent_id": "int_xt_dup_1",
+        }
+    )
+    repository.update_order(
+        "ord_xt_dup_1",
+        {"broker_order_id": "90003", "state": "SUBMITTED"},
+    )
+    service = OrderManagementXtIngestService(
+        repository=repository,
+        tracking_service=tracking_service,
+        runtime_logger=runtime_logger,
+    )
+    report = {
+        "internal_order_id": "ord_xt_dup_1",
+        "broker_order_id": "90003",
+        "broker_trade_id": "T-90003",
+        "symbol": "000001",
+        "side": "buy",
+        "quantity": 300,
+        "price": 10.0,
+        "trade_time": 1710000000,
+        "date": 20240102,
+        "time": "09:31:00",
+        "source": "xt_trade_callback",
+        "trace_id": "trc_xt_dup_1",
+        "intent_id": "int_xt_dup_1",
+        "request_id": "req_xt_dup_1",
+    }
+
+    service.ingest_trade_report(
+        report,
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    service.ingest_trade_report(
+        report,
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    assert runtime_logger.events[-1]["node"] == "trade_match"
+    assert runtime_logger.events[-1]["status"] == "skipped"
+    assert runtime_logger.events[-1]["reason_code"] == "duplicate_trade_report"
+    assert runtime_logger.events[-1]["payload"]["created"] is False
+    assert runtime_logger.events[-1]["payload"]["dedup_hit"] is True
 
 
 def test_ingest_order_report_emits_runtime_events():

--- a/freshquant/tests/test_xtquant_runtime_observability.py
+++ b/freshquant/tests/test_xtquant_runtime_observability.py
@@ -571,6 +571,42 @@ def test_puppet_sell_keeps_duplicate_check_and_submit_inside_trading_lock(
     assert puppet.sell("600000", 11, 10.0, 300) == 654321
 
 
+def test_puppet_save_trades_skips_direct_ingest_when_reconcile_handles_trade(
+    monkeypatch,
+):
+    _install_puppet_stubs(monkeypatch, xt_trader=types.SimpleNamespace())
+    puppet = _load_module("test_runtime_puppet_save_trades", PUPPET_PATH)
+    observed = {"reconcile": 0, "direct_ingest": 0}
+
+    puppet.external_reconcile_service = types.SimpleNamespace(
+        reconcile_trade_report=lambda report: (
+            observed.__setitem__("reconcile", observed["reconcile"] + 1)
+            or types.SimpleNamespace(
+                handled=True,
+                action="already_known_internal_order",
+                result=None,
+            )
+        )
+    )
+    puppet.try_ingest_xt_trade_dict = lambda payload: observed.__setitem__(
+        "direct_ingest", observed["direct_ingest"] + 1
+    )
+
+    puppet.saveTrades(
+        [
+            types.SimpleNamespace(
+                account_id="acct-1",
+                traded_id="T-1",
+                stock_code="600000.SH",
+                order_type=23,
+                strategy_name=None,
+            )
+        ]
+    )
+
+    assert observed == {"reconcile": 1, "direct_ingest": 0}
+
+
 def test_broker_trade_callback_emits_resolved_runtime_context(monkeypatch):
     _install_broker_stubs(monkeypatch)
     broker = _load_module("test_runtime_broker", BROKER_PATH)

--- a/morningglory/fqxtrade/fqxtrade/xtquant/puppet.py
+++ b/morningglory/fqxtrade/fqxtrade/xtquant/puppet.py
@@ -66,9 +66,16 @@ def saveTrades(trades):
         DBfreshquant["xt_trades"].bulk_write(batch)
     for trade in trades:
         trade_dict = FqXtTrade(trade).to_dict()
-        reconciled = external_reconcile_service.reconcile_trade_reports([trade_dict])
-        if not reconciled:
-            try_ingest_xt_trade_dict(trade_dict)
+        if hasattr(external_reconcile_service, "reconcile_trade_report"):
+            outcome = external_reconcile_service.reconcile_trade_report(trade_dict)
+            if not outcome.handled:
+                try_ingest_xt_trade_dict(trade_dict)
+        else:
+            reconciled = external_reconcile_service.reconcile_trade_reports(
+                [trade_dict]
+            )
+            if not reconciled:
+                try_ingest_xt_trade_dict(trade_dict)
     trades = pydash.filter_(trades, lambda x: x.order_type in BUY_ORDER_TYPES)
     trades = pydash.uniq_by(trades, lambda x: x.stock_code)
     for trade in trades:


### PR DESCRIPTION
## 背景
- `/runtime-observability` 在点击左侧组件后，`/api/runtime/traces` 会间歇性返回 500，前端提示 Trace 列表加载失败。
- `XT 回报接入.trade_match` 在 2026-03-19 等时间窗里按约 3 秒节奏高频重放，污染 runtime 观测并可能重复驱动 sell 侧投影更新。

## 目标
- 修复 runtime trace 聚合在深链强关联 ID 下的 500。
- 修复 XT 成交重复回放被误判为未处理后再次进入 ingest 的问题。
- 让重复回放在 runtime 中可识别且保持幂等，不再重复改写持仓投影或 sell allocations。

## 范围
- 将 runtime assembler 的 union-find `find()` 改为非递归实现，避免深链 `RecursionError`。
- 为 external reconcile 引入显式 `TradeReportReconcileOutcome`，调用方按 `handled` 判断是否继续 direct ingest。
- 为 XT trade ingest 增加 `created` / `dedup_hit` 语义，重复回放输出 `status=skipped`。
- 补充对应单测与文档。

## 非目标
- 不改变 XT SDK / XT 自身的回放行为。
- 不重构 xt_account_sync 的轮询策略。

## 验收标准
- `/api/runtime/traces` 在包含大量重复 strong-id 链的时间窗下返回 200。
- 同一 `broker_trade_id` 重复回放不会重复写 `sell_allocations` 或再次改写持仓投影。
- runtime 中重复回放可见 `status=skipped`、`payload.created=false`、`payload.dedup_hit=true`。
- `docs/current/runtime.md` 与 `docs/current/troubleshooting.md` 同步更新。

## 部署影响
- 需要重部署 `fq_apiserver`。
- 需要重启 `order_management` 相关宿主机进程，至少覆盖 `fqnext_xt_account_sync_worker` 与 `fqnext_xtquant_broker`。

## 测试
- `py -3.12 -m pre_commit run --show-diff-on-failure --color=always --files docs/current/runtime.md docs/current/troubleshooting.md freshquant/order_management/ingest/xt_reports.py freshquant/order_management/reconcile/service.py freshquant/order_management/tracking/service.py freshquant/runtime_observability/assembler.py freshquant/tests/test_order_management_reconcile.py freshquant/tests/test_order_management_tracking_service.py freshquant/tests/test_order_management_xt_ingest.py freshquant/tests/test_runtime_observability_routes.py freshquant/tests/test_xt_reports_runtime_observability.py freshquant/tests/test_xtquant_runtime_observability.py morningglory/fqxtrade/fqxtrade/xtquant/puppet.py`
- `py -3.12 -m pytest -q freshquant/tests/test_runtime_observability_routes.py freshquant/tests/test_order_management_reconcile.py freshquant/tests/test_order_management_tracking_service.py freshquant/tests/test_order_management_xt_ingest.py freshquant/tests/test_xt_reports_runtime_observability.py freshquant/tests/test_xtquant_runtime_observability.py freshquant/tests/test_order_reconcile_runtime_observability.py freshquant/tests/test_xt_account_sync_worker.py`
- `powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -ResumeLatest`
- `Invoke-WebRequest http://127.0.0.1:15000/api/runtime/traces?component=xt_report_ingest&start_time=2026-03-19T00:00:00&end_time=2026-03-19T23:59:59`
- `Invoke-WebRequest http://127.0.0.1:15000/api/runtime/health/summary?start_time=2026-03-19T00:00:00&end_time=2026-03-19T23:59:59`
