### PR TITLE
fix: 关闭 guardian 的 buy_zs_huila 事件响应

### DIFF
--- a/docs/current/modules/strategy-guardian.md
+++ b/docs/current/modules/strategy-guardian.md
@@ -27,6 +27,8 @@ Guardian 是当前 A 股实时策略层。它负责把 XTData consumer 产生的
 
 `bar update -> calculate_guardian_signals_latest -> save_a_stock_signal -> stock_signals -> StrategyGuardian.on_signal -> buy/sell decision -> submit_guardian_order -> OrderSubmitService`
 
+当前正式 Guardian 事件链会在入口直接过滤 `buy_zs_huila`。该信号底层仍可被 `calculate_guardian_signals_latest` 计算，但不会继续写入 `stock_signals`、页面展示或 `guardian_strategy` runtime trace。
+
 买入路径分为两类：
 
 - 持仓加仓

--- a/docs/plans/2026-03-20-guardian-disable-buy-zs-huila-design.md
+++ b/docs/plans/2026-03-20-guardian-disable-buy-zs-huila-design.md
@@ -1,0 +1,79 @@
+# Guardian 关闭 buy_zs_huila 事件响应设计
+
+## 背景
+
+当前 Guardian 正式事件链路会在 1 分钟 bar 更新后计算并保存 `buy_zs_huila`，随后继续进入 `stock_signals`、`StrategyGuardian.on_signal` 和 runtime trace。
+
+本次要求是临时关闭 `buy_zs_huila`：
+
+- 不再响应
+- 页面不再可见
+- runtime trace 也不再保留
+
+## 目标
+
+- `buy_zs_huila` 不再进入 Guardian 正式事件链
+- 不再写入 `stock_signals`
+- 不再触发 `StrategyGuardian.on_signal`
+- 不再产生对应 runtime trace
+
+## 非目标
+
+- 不改动其他 5 类 Guardian 信号
+- 不把该开关做成系统配置
+- 不改动通用信号类型定义或其它非 Guardian 调用方
+
+## 方案比较
+
+### 方案 1：在 `calculate_guardian_signals_latest()` 里删除 `buy_zs_huila`
+
+优点：
+
+- 从源头移除，最彻底
+
+缺点：
+
+- 影响所有调用该 helper 的路径
+- 变更面超出 Guardian 当前正式事件链
+
+### 方案 2：在 `monitor_stock_zh_a_min.py` 里过滤 `buy_zs_huila`
+
+优点：
+
+- 只影响 Guardian 当前正式事件入口
+- `stock_signals`、页面和 runtime trace 会一起消失
+- 其余 5 类信号不受影响
+
+缺点：
+
+- 底层 helper 仍保留 `buy_zs_huila` 计算能力
+
+### 方案 3：在 `save_a_stock_signal()` 或 `StrategyGuardian.on_signal()` 里拦截
+
+优点：
+
+- 代码改动集中
+
+缺点：
+
+- 容易留下部分副作用
+- 如果在 `on_signal()` 拦截，页面和入库仍可能保留
+
+## 结论
+
+采用方案 2。
+
+在 `freshquant/signal/astock/job/monitor_stock_zh_a_min.py` 中对 `calculate_guardian_signals_latest()` 的结果做最小过滤，直接跳过 `buy_zs_huila`，不调用 `save_a_stock_signal()`。
+
+## 测试策略
+
+- 新增 Guardian 事件模式回归测试
+- 先证明当前实现会尝试保存 `buy_zs_huila`
+- 再改实现并验证：
+  - `buy_zs_huila` 被过滤
+  - 其余信号仍继续保存
+
+## 部署影响
+
+- 改动位于 `freshquant/signal/**`
+- 按部署矩阵需要重启 Guardian 运行面

--- a/docs/plans/2026-03-20-guardian-disable-buy-zs-huila.md
+++ b/docs/plans/2026-03-20-guardian-disable-buy-zs-huila.md
@@ -1,0 +1,67 @@
+# Guardian Disable buy_zs_huila Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 让 Guardian 正式事件链不再保存、展示或响应 `buy_zs_huila`，同时保持其他 5 类信号不变。
+
+**Architecture:** 在 `monitor_stock_zh_a_min.py` 的事件入口过滤 `buy_zs_huila`，避免进入 `save_a_stock_signal()`。测试覆盖只验证正式 Guardian 事件链路，不修改通用信号 helper 的返回集合。
+
+**Tech Stack:** Python 3.12、pytest、click CLI、现有 Guardian 事件监控链路
+
+---
+
+### Task 1: 落设计与计划文档
+
+**Files:**
+- Create: `docs/plans/2026-03-20-guardian-disable-buy-zs-huila-design.md`
+- Create: `docs/plans/2026-03-20-guardian-disable-buy-zs-huila.md`
+
+**Step 1: 写设计文档**
+
+记录关闭范围、过滤位置和非目标。
+
+**Step 2: 写实现计划**
+
+把测试、实现、验证拆成独立步骤。
+
+### Task 2: 为 Guardian 事件入口补失败测试
+
+**Files:**
+- Modify: `freshquant/tests/test_guardian_monitor_cli.py`
+
+**Step 1: 写失败测试**
+
+新增测试，直接检查 `monitor_stock_zh_a_min.py` 已声明 Guardian 事件链会过滤 `buy_zs_huila`。
+
+**Step 2: 运行测试确认失败**
+
+Run: `py -3.12 -m pytest freshquant/tests/test_guardian_monitor_cli.py -q`
+
+Expected: FAIL，因为过滤逻辑尚未存在。
+
+**Step 3: 写最小实现**
+
+在 `freshquant/signal/astock/job/monitor_stock_zh_a_min.py` 中过滤 `buy_zs_huila`。
+
+**Step 4: 运行测试确认通过**
+
+Run: `py -3.12 -m pytest freshquant/tests/test_guardian_monitor_cli.py -q`
+
+Expected: PASS
+
+### Task 3: 验证相关 Guardian 回归
+
+**Files:**
+- No file changes required
+
+**Step 1: 运行目标测试**
+
+Run: `py -3.12 -m pytest freshquant/tests/test_guardian_monitor_cli.py -q`
+
+Expected: PASS
+
+**Step 2: 运行一组相关回归**
+
+Run: `py -3.12 -m pytest freshquant/tests/test_guardian_strategy.py -q`
+
+Expected: PASS；如果环境缺依赖，则记录真实阻塞，不虚报通过。

--- a/freshquant/signal/astock/job/monitor_stock_zh_a_min.py
+++ b/freshquant/signal/astock/job/monitor_stock_zh_a_min.py
@@ -22,6 +22,7 @@ from freshquant.util.code import normalize_to_base_code
 from freshquant.util.period import to_backend_period, to_frontend_period
 
 strategy = StrategyGuardian()
+DISABLED_GUARDIAN_SIGNAL_TYPES = {"buy_zs_huila"}
 
 
 def monitor_stock_zh_a_min_event_driven() -> None:
@@ -100,6 +101,8 @@ def monitor_stock_zh_a_min_event_driven() -> None:
                 return
 
             for s in signals:
+                if s.signal_type in DISABLED_GUARDIAN_SIGNAL_TYPES:
+                    continue
                 save_a_stock_signal(
                     code,
                     base_code,

--- a/freshquant/tests/test_guardian_monitor_cli.py
+++ b/freshquant/tests/test_guardian_monitor_cli.py
@@ -17,3 +17,12 @@ def test_guardian_monitor_uses_guardian_capability_instead_of_strict_mode_match(
 
     assert "xtdata_mode_enables_guardian" in content
     assert 'expected guardian_1m. Exiting.' not in content
+
+
+def test_guardian_monitor_disables_buy_zs_huila_signal():
+    content = Path("freshquant/signal/astock/job/monitor_stock_zh_a_min.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'DISABLED_GUARDIAN_SIGNAL_TYPES = {"buy_zs_huila"}' in content
+    assert "if s.signal_type in DISABLED_GUARDIAN_SIGNAL_TYPES:" in content


### PR DESCRIPTION
## 背景
Guardian 当前正式事件链会计算并保存 `buy_zs_huila`，随后进入 `stock_signals`、页面展示和 `guardian_strategy` runtime trace。

## 目标
关闭 `buy_zs_huila` 的正式事件响应：
- 不再写入 `stock_signals`
- 不再进入页面展示
- 不再触发 `guardian_strategy` runtime trace
- 不再触发 Guardian 自动响应

## 范围
- 仅调整 `freshquant.signal.astock.job.monitor_stock_zh_a_min` 的正式事件入口过滤逻辑
- 同步更新 `docs/current/modules/strategy-guardian.md`
- 补充 Guardian 监控入口回归测试

## 非目标
- 不移除底层 `calculate_guardian_signals_latest()` 对 `buy_zs_huila` 的计算能力
- 不影响其他 5 类 Guardian 信号
- 不把该行为做成配置项

## 验收标准
- `buy_zs_huila` 不再进入 Guardian 正式事件链
- 其余 Guardian 信号行为不变
- 相关测试通过

## 部署影响
- 变更位于 `freshquant/signal/**`
- 合并后需按部署矩阵重启 Guardian 运行面

## 测试
- `py -3.12 -m pytest freshquant/tests/test_guardian_monitor_cli.py -q`
- `py -3.12 -m pytest freshquant/tests/test_guardian_strategy.py -q`
- `py -3.12 -m pytest freshquant/tests/test_check_current_docs.py -q`