### PR TITLE
统一运行观测页面标的代码与名称展示

### DIFF
--- a/docs/current/modules/runtime-observability.md
+++ b/docs/current/modules/runtime-observability.md
@@ -134,6 +134,9 @@ Runtime Observability 当前采用“双存储”：
   - 必要时 `/api/runtime/traces/<trace_key>/steps`
 - Event 与 Trace 列表都走分页 cursor
 - 自动刷新只刷新摘要列表，不自动刷新已打开的 Trace detail
+- 页面内所有标的展示统一为 `symbol / symbol_name`
+- 写入 ClickHouse 与查询返回阶段都会优先复用现有 instrument lookup 补全 `symbol_name`
+- 名称最终仍缺失时，前端兜底显示 `symbol / 未知名称`
 - Raw Browser 继续按 `runtime_node/component/date/file` 直接读 JSONL
 
 ## 组件健康

--- a/freshquant/runtime_observability/clickhouse_store.py
+++ b/freshquant/runtime_observability/clickhouse_store.py
@@ -9,13 +9,27 @@ from zoneinfo import ZoneInfo
 
 import requests  # type: ignore[import-untyped]
 
+from freshquant.runtime_observability.assembler import (
+    _find_inline_symbol_name,
+    _lookup_symbol_name,
+)
 from freshquant.runtime_observability.logger import get_runtime_log_root
 from freshquant.runtime_observability.node_catalog import COMPONENTS
 from freshquant.runtime_observability.sessioning import build_session_identity
+from freshquant.util.code import normalize_to_base_code
 
 _ISSUE_STATUSES = {"warning", "failed", "error", "skipped"}
 _HEALTH_EVENT_TYPES = {"heartbeat", "metric_snapshot"}
 _CLICKHOUSE_TIMEZONE = ZoneInfo("Asia/Shanghai")
+_SYMBOL_FIELDS = (
+    "symbol",
+    "code",
+    "stock_code",
+    "security_code",
+    "ticker",
+    "instrument",
+    "instrument_id",
+)
 
 
 class RuntimeObservabilityStoreError(RuntimeError):
@@ -43,6 +57,8 @@ def build_clickhouse_event_row(
     decision_outcome = payload.get("decision_outcome")
     if isinstance(decision_outcome, (dict, list)):
         decision_outcome = _to_json_text(decision_outcome)
+    symbol = resolve_runtime_symbol(payload)
+    symbol_name = resolve_runtime_symbol_name(payload, symbol=symbol)
     return {
         "event_id": event_id,
         "ts": _format_clickhouse_datetime(ts),
@@ -58,8 +74,8 @@ def build_clickhouse_event_row(
         "internal_order_id": _normalized_text(payload.get("internal_order_id")),
         "session_key": session_identity["session_key"],
         "session_type": session_identity["session_type"],
-        "symbol": _normalized_text(payload.get("symbol")),
-        "symbol_name": _normalized_text(payload.get("symbol_name")),
+        "symbol": symbol,
+        "symbol_name": symbol_name,
         "message": _normalized_text(payload.get("message")),
         "reason_code": _normalized_text(payload.get("reason_code")),
         "source": _normalized_text(payload.get("source")),
@@ -576,6 +592,47 @@ def _request_error_message(exc: Exception) -> str:
     return message
 
 
+def _runtime_symbol_lookup_candidates(record: Any) -> list[dict[str, Any]]:
+    if not isinstance(record, dict):
+        return []
+    candidates: list[dict[str, Any]] = [record]
+    for nested in (
+        record.get("payload"),
+        record.get("signal_summary"),
+        record.get("metrics"),
+    ):
+        if isinstance(nested, dict):
+            candidates.append(nested)
+    payload = record.get("payload")
+    if isinstance(payload, dict):
+        nested_signal_summary = payload.get("signal_summary")
+        if isinstance(nested_signal_summary, dict):
+            candidates.append(nested_signal_summary)
+    return candidates
+
+
+def resolve_runtime_symbol(record: Any) -> str:
+    for candidate in _runtime_symbol_lookup_candidates(record):
+        for field in _SYMBOL_FIELDS:
+            value = _normalized_text(candidate.get(field))
+            if not value:
+                continue
+            normalized = normalize_to_base_code(value)
+            return normalized or value
+    return ""
+
+
+def resolve_runtime_symbol_name(record: Any, *, symbol: str = "") -> str:
+    for candidate in _runtime_symbol_lookup_candidates(record):
+        inline_name = _find_inline_symbol_name(candidate)
+        if inline_name:
+            return inline_name
+    normalized_symbol = _normalized_text(symbol) or resolve_runtime_symbol(record)
+    if not normalized_symbol:
+        return ""
+    return _lookup_symbol_name(normalized_symbol) or ""
+
+
 def _normalized_text(value: Any) -> str:
     return str(value or "").strip()
 
@@ -735,6 +792,8 @@ def _serialize_trace_summary_row(row: dict[str, Any]) -> dict[str, Any]:
     affected_components = row.get("affected_components")
     if not isinstance(affected_components, list):
         affected_components = []
+    symbol = resolve_runtime_symbol(row)
+    symbol_name = resolve_runtime_symbol_name(row, symbol=symbol)
     return {
         "trace_key": _normalized_text(row.get("trace_key")),
         "trace_id": _normalized_text(row.get("trace_id")),
@@ -750,8 +809,8 @@ def _serialize_trace_summary_row(row: dict[str, Any]) -> dict[str, Any]:
         "exit_node": _normalized_text(row.get("exit_node")),
         "step_count": int(row.get("step_count") or 0),
         "issue_count": int(row.get("issue_count") or 0),
-        "symbol": _normalized_text(row.get("symbol")),
-        "symbol_name": _normalized_text(row.get("symbol_name")),
+        "symbol": symbol,
+        "symbol_name": symbol_name,
         "intent_ids": list(row.get("intent_ids") or []),
         "request_ids": list(row.get("request_ids") or []),
         "internal_order_ids": list(row.get("internal_order_ids") or []),
@@ -768,6 +827,15 @@ def _serialize_event_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def _serialize_event_row(row: dict[str, Any]) -> dict[str, Any]:
+    payload = _decode_json_text(row.get("payload_json"))
+    metrics = _decode_json_text(row.get("metrics_json"))
+    record = {
+        **row,
+        "payload": payload,
+        "metrics": metrics,
+    }
+    symbol = resolve_runtime_symbol(record)
+    symbol_name = resolve_runtime_symbol_name(record, symbol=symbol)
     return {
         "event_id": _normalized_text(row.get("event_id")),
         "session_key": _normalized_text(row.get("session_key")),
@@ -781,12 +849,12 @@ def _serialize_event_row(row: dict[str, Any]) -> dict[str, Any]:
         "intent_id": _normalized_text(row.get("intent_id")),
         "request_id": _normalized_text(row.get("request_id")),
         "internal_order_id": _normalized_text(row.get("internal_order_id")),
-        "symbol": _normalized_text(row.get("symbol")),
-        "symbol_name": _normalized_text(row.get("symbol_name")),
+        "symbol": symbol,
+        "symbol_name": symbol_name,
         "message": _normalized_text(row.get("message")),
         "reason_code": _normalized_text(row.get("reason_code")),
-        "payload": _decode_json_text(row.get("payload_json")),
-        "metrics": _decode_json_text(row.get("metrics_json")),
+        "payload": payload,
+        "metrics": metrics,
         "raw_file": _normalized_text(row.get("raw_file")),
         "raw_line": int(row.get("raw_line") or 0),
         "error_type": _normalized_text(row.get("error_type")),

--- a/freshquant/tests/test_runtime_observability_clickhouse.py
+++ b/freshquant/tests/test_runtime_observability_clickhouse.py
@@ -86,6 +86,34 @@ def test_build_clickhouse_event_row_extracts_runtime_query_fields():
     assert json.loads(row["metrics_json"]) == {"queue_len": 3}
 
 
+def test_build_clickhouse_event_row_backfills_symbol_name_from_nested_payload():
+    from freshquant.runtime_observability.clickhouse_store import (
+        build_clickhouse_event_row,
+    )
+
+    row = build_clickhouse_event_row(
+        normalize_event(
+            {
+                "trace_id": "trc_symbol_1",
+                "component": "order_submit",
+                "runtime_node": "host:rear",
+                "node": "submit_intent",
+                "status": "info",
+                "symbol": "000001",
+                "payload": {
+                    "symbol_name": "平安银行",
+                    "action": "BUY",
+                },
+                "ts": "2026-03-20T10:17:01+08:00",
+            }
+        ),
+        raw_file="host_rear/order_submit/2026-03-20/order_submit_2026-03-20_1.jsonl",
+        raw_line=8,
+    )
+
+    assert row["symbol_name"] == "平安银行"
+
+
 def test_runtime_jsonl_indexer_reads_incremental_lines(monkeypatch, tmp_path):
     from freshquant.runtime_observability.indexer import RuntimeJsonlIndexer
 
@@ -346,6 +374,55 @@ def test_clickhouse_store_get_trace_detail_combines_summary_and_first_step_page(
         "ts": "2026-03-20T10:00:01+08:00",
         "event_id": "evt_1",
     }
+
+
+def test_clickhouse_store_list_traces_backfills_symbol_name_for_legacy_rows(
+    monkeypatch,
+):
+    import freshquant.runtime_observability.clickhouse_store as store_module
+
+    store = store_module.RuntimeObservabilityClickHouseStore(
+        base_url="http://clickhouse.test"
+    )
+
+    def _fake_select_rows(query: str):
+        return [
+            {
+                "trace_key": "trace__trc_legacy_1",
+                "trace_id": "trc_legacy_1",
+                "trace_kind": "guardian_signal",
+                "trace_status": "failed",
+                "break_reason": "failed@guardian_strategy.finish",
+                "first_ts": "2026-03-20 10:00:00.000",
+                "last_ts": "2026-03-20 10:00:02.000",
+                "duration_ms": 2000,
+                "entry_component": "guardian_strategy",
+                "entry_node": "receive_signal",
+                "exit_component": "guardian_strategy",
+                "exit_node": "finish",
+                "step_count": 2,
+                "issue_count": 1,
+                "symbol": "000001",
+                "symbol_name": "",
+                "intent_ids": ["int_legacy_1"],
+                "request_ids": ["req_legacy_1"],
+                "internal_order_ids": ["ord_legacy_1"],
+                "affected_components": ["guardian_strategy"],
+            }
+        ]
+
+    monkeypatch.setattr(store, "ensure_schema", lambda: None)
+    monkeypatch.setattr(store, "_select_rows", _fake_select_rows)
+    monkeypatch.setattr(
+        store_module,
+        "resolve_runtime_symbol_name",
+        lambda record, **kwargs: "平安银行",
+        raising=False,
+    )
+
+    payload = store.list_traces(limit=1)
+
+    assert payload["items"][0]["symbol_name"] == "平安银行"
 
 
 def test_clickhouse_store_health_summary_preserves_missing_heartbeat_as_null(

--- a/morningglory/fqwebui/src/views/RuntimeObservability.vue
+++ b/morningglory/fqwebui/src/views/RuntimeObservability.vue
@@ -168,8 +168,7 @@
               <div v-if="traceLedgerRows.length" class="runtime-ledger runtime-trace-ledger">
                 <div class="runtime-ledger__header runtime-trace-ledger__grid">
                   <span>最近时间</span>
-                  <span>标的代码</span>
-                  <span>标的名称</span>
+                  <span>标的</span>
                   <span>链路类型</span>
                   <span>链路状态</span>
                   <span>节点路径</span>
@@ -186,8 +185,7 @@
                   @click="handleRecentTraceClick(row)"
                 >
                   <span class="runtime-ledger__cell runtime-ledger__cell--mono">{{ row.last_ts_label || '-' }}</span>
-                  <span class="runtime-ledger__cell runtime-ledger__cell--strong">{{ row.symbol || '-' }}</span>
-                  <span class="runtime-ledger__cell runtime-ledger__cell--strong runtime-ledger__cell--truncate" :title="row.symbol_name || '-'">{{ row.symbol_name || '-' }}</span>
+                  <span class="runtime-ledger__cell runtime-ledger__cell--strong runtime-ledger__cell--truncate" :title="row.symbol_display">{{ row.symbol_display }}</span>
                   <span class="runtime-ledger__cell">{{ row.trace_kind_label }}</span>
                   <span class="runtime-ledger__cell runtime-ledger__cell--status">
                     <span class="runtime-inline-status" :class="statusClass(row.trace_status)">
@@ -1210,15 +1208,8 @@ const traceSummaryRows = computed(() =>
     },
     {
       key: 'symbol',
-      label: '标的代码',
-      value: selectedTraceDetail.value.symbol,
-      mono: true,
-      always: true,
-    },
-    {
-      key: 'name',
-      label: '标的名称',
-      value: selectedTraceDetail.value.symbol_name,
+      label: '标的',
+      value: selectedTraceDetail.value.symbol_display,
       always: true,
     },
     {
@@ -2927,8 +2918,7 @@ onBeforeUnmount(() => {
 .runtime-trace-ledger__grid {
   grid-template-columns:
     152px
-    72px
-    112px
+    minmax(220px, 1.15fr)
     104px
     102px
     minmax(480px, 3.6fr)

--- a/morningglory/fqwebui/src/views/runtime-observability.test.mjs
+++ b/morningglory/fqwebui/src/views/runtime-observability.test.mjs
@@ -619,7 +619,7 @@ test('buildComponentEventFeed hydrates event detail fields and guardian insight 
       ['trace_id', 'trc_guardian_evt'],
       ['intent_id', 'intent_guardian_evt'],
       ['request_id', 'req_guardian_evt'],
-      ['symbol', '000001'],
+      ['symbol', '000001 / Ping An Bank'],
       ['action', 'BUY'],
     ],
   )
@@ -674,7 +674,7 @@ test('buildIdentityStrip preserves all strong ids without dropping symbol and tr
         { key: 'intent_id', label: 'Intent', value: 'intent_dense_1, intent_dense_2', values: ['intent_dense_1', 'intent_dense_2'] },
         { key: 'request_id', label: 'Request', value: 'req_dense_1, req_dense_2', values: ['req_dense_1', 'req_dense_2'] },
         { key: 'internal_order_id', label: 'Order', value: 'ord_dense_1, ord_dense_2', values: ['ord_dense_1', 'ord_dense_2'] },
-        { key: 'symbol', label: 'Symbol', value: '000001', values: ['000001'] },
+        { key: 'symbol', label: 'Symbol', value: '000001 / 未知名称', values: ['000001 / 未知名称'] },
         { key: 'trace_kind', label: 'Kind', value: 'guardian_signal', values: ['guardian_signal'] },
         { key: 'trace_status', label: 'Status', value: 'failed', values: ['failed'] },
       ],
@@ -777,6 +777,7 @@ test('buildTraceLedgerRows returns dense table rows for recent trace list', () =
     trace_id: 'trc_dense_1',
     symbol: '000001',
     symbol_name: '平安银行',
+    symbol_display: '000001 / 平安银行',
     trace_kind: 'guardian_signal',
     trace_kind_label: 'Guardian 信号',
     trace_status: 'failed',
@@ -790,6 +791,46 @@ test('buildTraceLedgerRows returns dense table rows for recent trace list', () =
     break_reason: 'unexpected_exception@guardian_strategy.timing_check:ValueError',
     has_issue: true,
   })
+})
+
+test('buildTraceLedgerRows falls back to unknown name when symbol name is unavailable', () => {
+  const rows = buildTraceLedgerRows([
+    {
+      trace_id: 'trc_symbol_missing_name',
+      trace_key: 'trace:trc_symbol_missing_name',
+      trace_kind: 'guardian_signal',
+      trace_status: 'open',
+      first_ts: '2026-03-09T02:00:00Z',
+      last_ts: '2026-03-09T02:00:01Z',
+      duration_ms: 1000,
+      entry_component: 'guardian_strategy',
+      entry_node: 'receive_signal',
+      exit_component: 'guardian_strategy',
+      exit_node: 'finish',
+      symbol: '000001',
+      steps: [
+        {
+          component: 'guardian_strategy',
+          node: 'receive_signal',
+          status: 'info',
+          ts: '2026-03-09T02:00:00Z',
+          trace_id: 'trc_symbol_missing_name',
+          symbol: '000001',
+        },
+        {
+          component: 'guardian_strategy',
+          node: 'finish',
+          status: 'success',
+          ts: '2026-03-09T02:00:01Z',
+          trace_id: 'trc_symbol_missing_name',
+          symbol: '000001',
+        },
+      ],
+    },
+  ])
+
+  assert.equal(rows.length, 1)
+  assert.equal(rows[0].symbol_display, '000001 / 未知名称')
 })
 
 test('buildTraceStepLedgerRows surfaces branch expr reason outcome context and error columns', () => {
@@ -1037,6 +1078,7 @@ test('RuntimeObservability.vue requests explicit symbol-name enrichment for trac
 
   assert.match(content, /const buildTraceRequestParams = \(\) => \(\{[\s\S]*buildTraceQuery\(query,\s*timeRange\.value\)[\s\S]*include_symbol_name:\s*1[\s\S]*\}\)/)
   assert.match(content, /const buildEventRequestParams = \(\) => \(\{[\s\S]*buildBoardScopedQuery\(query,\s*boardFilter,\s*timeRange\.value\)[\s\S]*include_symbol_name:\s*1[\s\S]*\}\)/)
+  assert.match(content, /value: selectedTraceDetail\.value\.symbol_display/)
   assert.match(content, /value: selectedEvent\.value\?\.symbol_display/)
 })
 
@@ -1966,14 +2008,15 @@ test('runtime observability trace mode uses dense ledger layout instead of trace
   assert.match(content, /v-model="selectedTraceKind"/)
   assert.match(content, /traceKindOptions/)
   assert.match(content, /pickDefaultTraceKind/)
-  assert.match(content, /<span>标的名称<\/span>/)
-  assert.match(content, /row\.symbol_name/)
+  assert.match(content, /<span>标的<\/span>/)
+  assert.match(content, /row\.symbol_display/)
+  assert.match(content, /value: selectedTraceDetail\.value\.symbol_display/)
   assert.match(content, /runtime-ledger__cell--entry-exit/)
   assert.match(content, /runtime-ledger__cell--status/)
   assert.match(content, /component-symbol-list/)
   assert.match(content, /component-symbol-card/)
   assert.match(content, /grid-template-columns:\s*minmax\(200px,\s*0\.58fr\)\s*minmax\(820px,\s*2\.42fr\)\s*minmax\(400px,\s*1\.08fr\)/)
-  assert.match(content, /\.runtime-trace-ledger__grid \{[\s\S]*152px[\s\S]*72px[\s\S]*112px[\s\S]*104px[\s\S]*102px[\s\S]*minmax\(480px,\s*3\.6fr\)[\s\S]*54px[\s\S]*84px[\s\S]*minmax\(160px,\s*0\.9fr\)/)
+  assert.match(content, /\.runtime-trace-ledger__grid \{[\s\S]*152px[\s\S]*minmax\(220px,\s*1\.15fr\)[\s\S]*104px[\s\S]*102px[\s\S]*minmax\(480px,\s*3\.6fr\)[\s\S]*54px[\s\S]*84px[\s\S]*minmax\(160px,\s*0\.9fr\)/)
   assert.match(content, /步骤/)
   assert.match(content, /摘要/)
   assert.match(content, /原始数据/)

--- a/morningglory/fqwebui/src/views/runtimeObservability.mjs
+++ b/morningglory/fqwebui/src/views/runtimeObservability.mjs
@@ -209,7 +209,7 @@ const buildSymbolDisplay = (symbol, symbolName) => {
   const normalizedSymbolName = toText(symbolName)
   if (!normalizedSymbol && !normalizedSymbolName) return '-'
   if (!normalizedSymbol) return normalizedSymbolName
-  if (!normalizedSymbolName) return normalizedSymbol
+  if (!normalizedSymbolName) return `${normalizedSymbol} / 未知名称`
   return `${normalizedSymbol} / ${normalizedSymbolName}`
 }
 
@@ -489,7 +489,7 @@ const findTraceSymbol = (trace = {}, steps = []) => {
     const symbol = toText(step?.symbol)
     if (symbol) return symbol
   }
-  return '-'
+  return ''
 }
 
 const findTraceSymbolName = (trace = {}, steps = []) => {
@@ -507,7 +507,7 @@ const findTraceSymbolName = (trace = {}, steps = []) => {
     const nestedSignalName = toText(step?.signal_summary?.name)
     if (nestedSignalName) return nestedSignalName
   }
-  return '-'
+  return ''
 }
 
 const findTraceNode = (steps = [], mode = 'last') => {
@@ -602,7 +602,12 @@ const buildEventBadges = (event = {}) => {
 }
 
 const resolveDetailFieldValue = (record = {}, key) => {
-  if (key === 'symbol') return resolveSymbolFromRecord(record)
+  if (key === 'symbol') {
+    return buildSymbolDisplay(
+      resolveSymbolFromRecord(record),
+      resolveSymbolNameFromRecord(record),
+    )
+  }
   if (key === 'action') return toText(record?.action) || toText(record?.payload?.action)
   return toText(record?.[key])
 }
@@ -967,7 +972,11 @@ export const buildIdentityStrip = (record = {}) => {
   pushItem('intent_id', 'Intent', record?.intent_ids, record?.intent_id)
   pushItem('request_id', 'Request', record?.request_ids, record?.request_id)
   pushItem('internal_order_id', 'Order', record?.internal_order_ids, record?.internal_order_id)
-  pushItem('symbol', 'Symbol', record?.symbol)
+  const symbolDisplay = buildSymbolDisplay(
+    resolveSymbolFromRecord(record),
+    resolveSymbolNameFromRecord(record),
+  )
+  if (symbolDisplay !== '-') pushItem('symbol', 'Symbol', symbolDisplay)
   pushItem('trace_kind', 'Kind', record?.trace_kind)
   pushItem('trace_status', 'Status', record?.trace_status)
   return {
@@ -999,7 +1008,8 @@ export const buildTraceLedgerRows = (traces = [], options = {}) => {
         trace_key: toText(detail?.trace_key) || null,
         trace_id: toText(detail?.trace_id) || null,
         symbol: toText(detail?.symbol),
-        symbol_name: toText(detail?.symbol_name) || '-',
+        symbol_name: toText(detail?.symbol_name),
+        symbol_display: buildSymbolDisplay(detail?.symbol, detail?.symbol_name),
         trace_kind: toText(detail?.trace_kind) || 'unknown',
         trace_kind_label: TRACE_KIND_LABELS[toText(detail?.trace_kind)] || toText(detail?.trace_kind) || '未知链路',
         trace_status: toText(detail?.trace_status) || 'open',


### PR DESCRIPTION
## 背景
/runtime-observability 页面里部分位置只显示标的代码，不显示标的名称，且历史 ClickHouse 行在缺少 `symbol_name` 时没有查询期兜底。

## 目标
统一页面内所有标的展示为 `代码 / 名称`，并确保名称缺失时仍然有稳定兜底。

## 范围
- 复用现有 instrument lookup 能力，在 ClickHouse 写入和查询返回阶段补全 `symbol_name`
- 统一 Trace/Event/detail/identity helper 的标的显示格式
- 补充后端与前端回归测试
- 同步 `docs/current` 文档

## 非目标
- 不改 runtime-observability 的查询架构和页面布局以外的功能
- 不改其他页面的标的展示策略

## 验收标准
- `/runtime-observability` 中所有标的展示点统一为 `代码 / 名称`
- 新写入和历史已入库的 runtime 记录都尽量补全 `symbol_name`
- 名称最终仍缺失时，前端显示 `代码 / 未知名称`
- 相关 Python / Node 测试通过

## 部署影响
需要重新部署 `fq_apiserver` 和 `fq_webui`。

## Summary
- 复用现有 instrument lookup，为 ClickHouse 写入与查询阶段补全 symbol_name
- 统一 runtime-observability 页面里的标的显示为 `代码 / 名称`，名称缺失时兜底 `未知名称`
- 补充后端与前端测试，并更新当前文档

## Test Plan
- [x] `py -3.12 -m pre_commit run --files docs/current/modules/runtime-observability.md freshquant/runtime_observability/clickhouse_store.py freshquant/tests/test_runtime_observability_clickhouse.py morningglory/fqwebui/src/views/runtimeObservability.mjs morningglory/fqwebui/src/views/RuntimeObservability.vue morningglory/fqwebui/src/views/runtime-observability.test.mjs`
- [x] `py -3.12 -m pytest freshquant/tests/test_runtime_observability_clickhouse.py freshquant/tests/test_runtime_observability_routes.py freshquant/tests/test_runtime_observability_docs.py freshquant/tests/test_check_current_docs.py -q`
- [x] `node --test morningglory/fqwebui/src/views/runtime-observability.test.mjs`