### PR TITLE
fix: reload runtime observability traces by kind

### DIFF
--- a/docs/current/modules/runtime-observability.md
+++ b/docs/current/modules/runtime-observability.md
@@ -34,6 +34,7 @@ Runtime Observability 当前采用“双存储”：
 - `intent_id`
 - `request_id`
 - `internal_order_id`
+- `trace_kind`
 - `symbol`
 - `component`
 - `runtime_node`
@@ -133,6 +134,7 @@ Runtime Observability 当前采用“双存储”：
   - `/api/runtime/traces/<trace_key>`
   - 必要时 `/api/runtime/traces/<trace_key>/steps`
 - Event 与 Trace 列表都走分页 cursor
+- 全局 Trace 顶部的类型按钮会带 `trace_kind` 重新请求最新 Trace；不是在当前已加载列表上做本地筛选
 - 自动刷新只刷新摘要列表，不自动刷新已打开的 Trace detail
 - 页面内所有标的展示统一为 `symbol / symbol_name`
 - 写入 ClickHouse 与查询返回阶段都会优先复用现有 instrument lookup 补全 `symbol_name`

--- a/freshquant/rear/runtime/routes.py
+++ b/freshquant/rear/runtime/routes.py
@@ -223,6 +223,7 @@ def _request_filters() -> dict:
         "request_id",
         "internal_order_id",
         "intent_id",
+        "trace_kind",
         "symbol",
         "component",
         "event_type",

--- a/freshquant/runtime_observability/clickhouse_store.py
+++ b/freshquant/runtime_observability/clickhouse_store.py
@@ -650,6 +650,7 @@ def _build_trace_summary_query(
     trace_key: str = "",
 ) -> str:
     matched_filters = dict(filters or {})
+    trace_kind_filter = _normalized_text(matched_filters.pop("trace_kind", ""))
     if trace_key:
         matched_filters["session_key"] = trace_key
     matched_conditions = _build_where_conditions(
@@ -662,6 +663,11 @@ def _build_trace_summary_query(
         start_time=start_time,
         end_time=end_time,
         include_session_key=True,
+    )
+    having_clause = (
+        f"\n    HAVING trace_kind = {_sql_string(trace_kind_filter)}"
+        if trace_kind_filter
+        else ""
     )
     return f"""
     SELECT
@@ -715,6 +721,7 @@ def _build_trace_summary_query(
     )
       AND {outer_conditions}
     GROUP BY session_key
+    {having_clause}
     """
 
 

--- a/freshquant/tests/test_runtime_observability_clickhouse.py
+++ b/freshquant/tests/test_runtime_observability_clickhouse.py
@@ -425,6 +425,27 @@ def test_clickhouse_store_list_traces_backfills_symbol_name_for_legacy_rows(
     assert payload["items"][0]["symbol_name"] == "平安银行"
 
 
+def test_clickhouse_store_list_traces_accepts_trace_kind_filter(monkeypatch):
+    from freshquant.runtime_observability.clickhouse_store import (
+        RuntimeObservabilityClickHouseStore,
+    )
+
+    store = RuntimeObservabilityClickHouseStore(base_url="http://clickhouse.test")
+    queries = []
+
+    def _fake_select_rows(query: str):
+        queries.append(query)
+        return []
+
+    monkeypatch.setattr(store, "ensure_schema", lambda: None)
+    monkeypatch.setattr(store, "_select_rows", _fake_select_rows)
+
+    payload = store.list_traces(filters={"trace_kind": "takeprofit"}, limit=1)
+
+    assert payload["items"] == []
+    assert "trace_kind = 'takeprofit'" in queries[0]
+
+
 def test_clickhouse_store_health_summary_preserves_missing_heartbeat_as_null(
     monkeypatch,
 ):

--- a/freshquant/tests/test_runtime_observability_routes.py
+++ b/freshquant/tests/test_runtime_observability_routes.py
@@ -216,6 +216,49 @@ def test_runtime_traces_route_returns_summary_page(monkeypatch):
     assert body["next_cursor"]["trace_key"] == "trace__trc_0"
 
 
+def test_runtime_traces_route_passes_trace_kind_filter(monkeypatch):
+    class _TraceKindService(_FakeRuntimeQueryService):
+        def list_traces(self, **kwargs):
+            assert kwargs["filters"]["trace_kind"] == "takeprofit"
+            assert kwargs["limit"] == 1
+            return {
+                "items": [
+                    {
+                        "trace_key": "trace__tp_1",
+                        "trace_id": "tp_1",
+                        "trace_kind": "takeprofit",
+                        "trace_status": "completed",
+                        "break_reason": "",
+                        "first_ts": "2026-03-20T10:00:00+08:00",
+                        "last_ts": "2026-03-20T10:00:01+08:00",
+                        "duration_ms": 1000,
+                        "entry_component": "tpsl_worker",
+                        "entry_node": "submit_intent",
+                        "exit_component": "broker_gateway",
+                        "exit_node": "submit_result",
+                        "step_count": 2,
+                        "issue_count": 0,
+                        "symbol": "000001",
+                        "symbol_name": "平安银行",
+                        "intent_ids": [],
+                        "request_ids": [],
+                        "internal_order_ids": [],
+                    }
+                ],
+                "next_cursor": None,
+            }
+
+    service = _TraceKindService()
+    _patch_runtime_query_service(monkeypatch, service)
+    client = _make_runtime_client()
+
+    resp = client.get("/api/runtime/traces?trace_kind=takeprofit&limit=1")
+
+    body = resp.get_json()
+    assert resp.status_code == 200
+    assert body["items"][0]["trace_kind"] == "takeprofit"
+
+
 def test_runtime_trace_detail_route_returns_summary_and_first_step_page(monkeypatch):
     service = _FakeRuntimeQueryService()
     _patch_runtime_query_service(monkeypatch, service)

--- a/morningglory/fqwebui/src/views/RuntimeObservability.vue
+++ b/morningglory/fqwebui/src/views/RuntimeObservability.vue
@@ -33,6 +33,18 @@
                 active-text="仅异常"
                 inactive-text="全部"
               />
+              <div v-if="activeView === 'traces'" class="runtime-trace-kind-actions">
+                <el-button
+                  v-for="option in traceKindOptions"
+                  :key="option.value"
+                  size="small"
+                  :type="selectedTraceKind === option.value ? 'primary' : 'default'"
+                  :plain="selectedTraceKind !== option.value"
+                  @click="handleTraceKindClick(option.value)"
+                >
+                  {{ option.label }}
+                </el-button>
+              </div>
               <el-button @click="openAdvancedFilter">高级筛选</el-button>
               <el-button type="primary" :loading="loading.overview" @click="loadOverview">刷新</el-button>
             </div>
@@ -137,17 +149,9 @@
               <div class="runtime-home-head">
                 <div>
                   <h2>全局 Trace</h2>
-                  <p>主表直接展示链路类型、中文节点路径和断裂原因，并支持按 kind 快速筛选。</p>
+                  <p>主表直接展示链路类型、中文节点路径和断裂原因，并支持按类型重新加载最新 Trace。</p>
                 </div>
                 <div class="runtime-home-actions">
-                  <el-select v-model="selectedTraceKind" size="small" class="runtime-kind-filter">
-                    <el-option
-                      v-for="option in traceKindOptions"
-                      :key="option.value"
-                      :label="option.label"
-                      :value="option.value"
-                    />
-                  </el-select>
                   <span class="runtime-home-meta">当前显示 {{ traceLedgerRows.length }} 条</span>
                 </div>
               </div>
@@ -906,11 +910,9 @@ import {
   createTraceQueryState,
   findTraceByRow,
   findRawRecordIndex,
-  filterTracesByKind,
   filterTraceSteps,
   hasMatchingRawSelection,
   pickDefaultSidebarComponent,
-  pickDefaultTraceKind,
   pickDefaultTraceStep,
   readApiPayload,
   stopPollingTimer,
@@ -951,7 +953,7 @@ const activeView = ref('traces')
 const onlyIssues = ref(false)
 const autoRefresh = ref(true)
 const advancedFilterVisible = ref(false)
-const selectedTraceKind = ref('')
+const selectedTraceKind = ref('all')
 const activeTraceDetailTab = ref('steps')
 const activeEventDetailTab = ref('event')
 const rawDrawerVisible = ref(false)
@@ -1108,6 +1110,9 @@ const normalizeTimeRangeState = (value) => {
 
 const buildTraceRequestParams = () => ({
   ...buildTraceQuery(query, timeRange.value),
+  ...(selectedTraceKind.value && selectedTraceKind.value !== 'all'
+    ? { trace_kind: selectedTraceKind.value }
+    : {}),
   include_symbol_name: 1,
   limit: TRACE_PAGE_SIZE,
 })
@@ -1123,9 +1128,8 @@ const timeRangeDisplayLabel = computed(() => formatTimeRangeLabel(timeRange.valu
 
 const hydratedTraces = computed(() => traces.value.map((trace) => buildTraceDetail(trace)))
 const visibleTraces = computed(() => {
-  const kindFiltered = filterTracesByKind(hydratedTraces.value, selectedTraceKind.value)
-  if (!onlyIssues.value) return kindFiltered
-  return kindFiltered.filter((trace) => trace.issue_count > 0)
+  if (!onlyIssues.value) return hydratedTraces.value
+  return hydratedTraces.value.filter((trace) => trace.issue_count > 0)
 })
 const traceKindOptions = computed(() => buildTraceKindOptions(hydratedTraces.value))
 const traceListSummary = computed(() => buildTraceListSummary(visibleTraces.value))
@@ -1992,6 +1996,12 @@ const handleTimeRangeChange = async (value) => {
   await loadOverview()
 }
 
+const handleTraceKindClick = async (kind) => {
+  const normalizedKind = String(kind || '').trim() || 'all'
+  selectedTraceKind.value = normalizedKind
+  await loadTraces()
+}
+
 const handleComponentFilter = (target) => {
   const normalizedComponent =
     typeof target === 'string'
@@ -2010,7 +2020,7 @@ const clearFilterChip = async (chip) => {
     return
   }
   if (chip.kind === 'trace-kind') {
-    selectedTraceKind.value = 'all'
+    await handleTraceKindClick('all')
     return
   }
   if (chip.kind === 'query' && chip.field) {
@@ -2237,10 +2247,6 @@ watch(componentEventFeed, (items) => {
   selectedEvent.value = items.find((item) => item.key === currentKey) || items[0] || null
 }, { immediate: true })
 
-watch(hydratedTraces, (items) => {
-  selectedTraceKind.value = pickDefaultTraceKind(items, selectedTraceKind.value)
-}, { immediate: true })
-
 watch(componentSidebarItems, (items) => {
   if (items.length === 0) {
     boardFilter.component = ''
@@ -2376,6 +2382,13 @@ onBeforeUnmount(() => {
   margin-right: 4px;
 }
 
+.runtime-trace-kind-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
 .runtime-summary-row {
   justify-content: space-between;
 }
@@ -2451,10 +2464,6 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   gap: 10px;
-}
-
-.runtime-kind-filter {
-  width: 160px;
 }
 
 .runtime-browse-layout {

--- a/morningglory/fqwebui/src/views/runtime-observability.test.mjs
+++ b/morningglory/fqwebui/src/views/runtime-observability.test.mjs
@@ -993,24 +993,53 @@ test('buildTraceKindOptions returns chinese labels for available trace kinds', (
     { value: 'all', label: '全部链路' },
     { value: 'guardian_signal', label: 'Guardian 信号' },
     { value: 'takeprofit', label: '止盈链路' },
+    { value: 'stoploss', label: '止损链路' },
+    { value: 'external_reported', label: '外部上报' },
+    { value: 'external_inferred', label: '外部推断' },
+    { value: 'manual_api_order', label: '手动下单' },
+    { value: 'unknown', label: '未知链路' },
   ])
 })
 
-test('pickDefaultTraceKind prefers guardian traces and falls back to all when unavailable', () => {
+test('pickDefaultTraceKind keeps a valid current kind and otherwise falls back to all', () => {
+  assert.equal(
+    pickDefaultTraceKind([
+      { trace_id: 'trc_guardian', trace_kind: 'guardian_signal', steps: [] },
+      { trace_id: 'trc_takeprofit', trace_kind: 'takeprofit', steps: [] },
+    ], 'takeprofit'),
+    'takeprofit',
+  )
+
   assert.equal(
     pickDefaultTraceKind([
       { trace_id: 'trc_guardian', trace_kind: 'guardian_signal', steps: [] },
       { trace_id: 'trc_takeprofit', trace_kind: 'takeprofit', steps: [] },
     ]),
-    'guardian_signal',
+    'all',
   )
 
   assert.equal(
     pickDefaultTraceKind([
       { trace_id: 'trc_takeprofit', trace_kind: 'takeprofit', steps: [] },
-    ]),
-    'all',
+    ], 'stoploss'),
+    'stoploss',
   )
+})
+
+test('RuntimeObservability.vue reloads traces from the server when a trace-kind button is clicked', async () => {
+  const content = await readFile(new URL('./RuntimeObservability.vue', import.meta.url), 'utf8')
+
+  assert.match(content, /<div v-if="activeView === 'traces'" class="runtime-trace-kind-actions">[\s\S]*v-for="option in traceKindOptions"[\s\S]*@click="handleTraceKindClick\(option.value\)"/)
+  assert.match(content, /const buildTraceRequestParams = \(\) => \(\{[\s\S]*buildTraceQuery\(query,\s*timeRange\.value\)[\s\S]*selectedTraceKind\.value && selectedTraceKind\.value !== 'all'[\s\S]*trace_kind:\s*selectedTraceKind\.value[\s\S]*\}\)/)
+  assert.match(content, /const handleTraceKindClick = async \(kind\) => \{[\s\S]*selectedTraceKind\.value = normalizedKind[\s\S]*await loadTraces\(\)/)
+  assert.match(content, /if \(chip\.kind === 'trace-kind'\) \{[\s\S]*await handleTraceKindClick\('all'\)/)
+})
+
+test('RuntimeObservability.vue uses trace-kind buttons instead of a trace-kind select dropdown', async () => {
+  const content = await readFile(new URL('./RuntimeObservability.vue', import.meta.url), 'utf8')
+
+  assert.doesNotMatch(content, /<el-select v-model="selectedTraceKind"/)
+  assert.doesNotMatch(content, /pickDefaultTraceKind/)
 })
 
 test('RuntimeObservability.vue scopes event reloads with the active sidebar component', async () => {
@@ -2005,9 +2034,7 @@ test('runtime observability trace mode uses dense ledger layout instead of trace
   assert.match(content, /<section v-show="activeTraceDetailTab === 'steps'" class="runtime-detail-panel runtime-detail-panel--steps">/)
   assert.match(content, /buildTraceLedgerRows/)
   assert.match(content, /buildTraceStepLedgerRows/)
-  assert.match(content, /v-model="selectedTraceKind"/)
   assert.match(content, /traceKindOptions/)
-  assert.match(content, /pickDefaultTraceKind/)
   assert.match(content, /<span>标的<\/span>/)
   assert.match(content, /row\.symbol_display/)
   assert.match(content, /value: selectedTraceDetail\.value\.symbol_display/)

--- a/morningglory/fqwebui/src/views/runtimeObservability.mjs
+++ b/morningglory/fqwebui/src/views/runtimeObservability.mjs
@@ -796,11 +796,12 @@ export const filterTracesByKind = (traces = [], kind = 'all') => {
 
 export const buildTraceKindOptions = (traces = []) => {
   const options = [{ value: 'all', label: '全部链路' }]
-  const kinds = [...new Set(
-    normalizeTraces(traces)
+  const kinds = [...new Set([
+    ...Object.keys(TRACE_KIND_LABELS),
+    ...normalizeTraces(traces)
       .map((trace) => toText(trace?.trace_kind))
       .filter(Boolean),
-  )].sort((left, right) => left.localeCompare(right))
+  ])]
   for (const kind of kinds) {
     options.push({
       value: kind,
@@ -813,17 +814,11 @@ export const buildTraceKindOptions = (traces = []) => {
 export const pickDefaultTraceKind = (
   traces = [],
   currentKind = '',
-  preferredKind = 'guardian_signal',
 ) => {
   const normalizedCurrent = toText(currentKind)
-  const availableKinds = new Set(
-    normalizeTraces(traces)
-      .map((trace) => toText(trace?.trace_kind))
-      .filter(Boolean),
-  )
+  const availableKinds = new Set(buildTraceKindOptions(traces).map((item) => toText(item?.value)).filter(Boolean))
   if (normalizedCurrent === 'all') return 'all'
   if (normalizedCurrent && availableKinds.has(normalizedCurrent)) return normalizedCurrent
-  if (availableKinds.has(preferredKind)) return preferredKind
   return 'all'
 }
 


### PR DESCRIPTION
## 背景
runtime-observability 的“全局 Trace”当前按已加载列表做本地 trace kind 筛选。遇到某一类 trace 风暴时，当前页可能完全没有加载到其他类型 trace，导致切换 kind 后仍然看不到该类型的最新链路。

## 目标
让 runtime-observability 在切换 trace 类型时，重新拉取该类型的最新 Trace，而不是在当前已加载结果上做本地筛选。

## 范围
- 在 `/runtime-observability` 顶部“仅异常”后追加全量 trace 类型按钮
- 点击类型按钮后，`/api/runtime/traces` 带 `trace_kind` 重新请求最新 Trace
- 后端 trace summary 查询支持 `trace_kind` 过滤
- 更新相关前后端测试和 `docs/current/modules/runtime-observability.md`

## 非目标
- 不调整 Trace detail / Event detail 布局语义
- 不变更 trace kind 推断规则
- 不处理 formal deploy 之外的运行面重启逻辑

## 验收标准
- 点击任一 trace 类型按钮，会重新加载该类型最新 Trace
- 不再依赖当前页已加载 Trace 集合是否包含该类型
- `trace_kind=all` 时恢复全局最新 Trace 列表
- 前后端相关测试通过，文档事实同步

## 部署影响
- `freshquant/rear/**`：需要重部署 API server
- `morningglory/fqwebui/**`：需要重新构建并部署 Web UI

## 验证
- `node --test src/views/runtime-observability.test.mjs`
- `py -3.12 script/ci/check_current_docs.py --base-ref github/main --head-ref HEAD`
- `py -3.12 -m uv tool run pre-commit run --show-diff-on-failure --color=always --from-ref github/main --to-ref HEAD`
- `py -3.12 -m uv run pytest -q freshquant/tests -n auto --dist loadfile`