### PR TITLE
fix: close runtime observability anomaly gaps

### DIFF
--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -49,6 +49,8 @@
 
 `submit / ingest / reconcile` 当前要求在 unexpected exception 时，直接在当前 runtime node 发 `status=error`、`reason_code=unexpected_exception` 的 trace step，而不是只记日志或靠下游兜底。这样全局 Trace 会停在真实失败节点，并保留 `payload.error_type/error_message`。
 
+策略单若在下单前被仓位管理门禁拒绝，`OrderSubmitService` 当前会在 `credit_mode_resolve` 发出 `status=failed`、`reason_code=position_management_rejected` 的 runtime step，并继续向上抛 `PositionManagementRejectedError`。
+
 ### 撤单
 
 `cancel_order -> internal_order_id 校验 -> cancel queue payload -> broker`
@@ -66,6 +68,8 @@
 `om_trade_facts` 当前会保留 `trade_time` 以及同一笔成交对应的 `date/time`；旧的 `external_inferred` 历史 lot / slice 如果缺少 `date/time`，投影读取时会按已有 `trade_time` 回填，避免 Guardian 和持仓视图在消费投影时拿到 `None/None`。
 
 如果 XT callback 在进入标准 ingest 前就抛异常，`try_ingest_xt_trade_dict` / `try_ingest_xt_order_dict` 现在也会在 `xt_report_ingest.report_receive` 发出异常 step，不再只留下普通日志后直接吞掉。
+
+XT `order callback` 若只带 `broker_order_id` 且无法命中内部订单，当前会在归一化阶段直接忽略；外部单仍通过 `reconcile_trade_report` 或 `reconcile_account -> externalize` 正式落账。
 
 ### 对账
 

--- a/freshquant/order_management/ingest/xt_reports.py
+++ b/freshquant/order_management/ingest/xt_reports.py
@@ -335,6 +335,8 @@ def normalize_xt_order_report(report, repository=None):
             repository.find_order(internal_order_id) if repository is not None else None
         )
     if internal_order_id is None:
+        if repository is not None:
+            return None
         internal_order_id = str(broker_order_id)
         order = None
 

--- a/freshquant/order_management/submit/service.py
+++ b/freshquant/order_management/submit/service.py
@@ -122,9 +122,30 @@ class OrderSubmitService:
                     )
                 )
                 if not position_decision.allowed:
-                    raise PositionManagementRejectedError(
+                    rejection_reason = (
                         f"position management rejected: {position_decision.reason_code}"
                     )
+                    self._emit_runtime(
+                        current_node,
+                        payload=payload,
+                        action=action,
+                        symbol=symbol,
+                        status="failed",
+                        reason_code="position_management_rejected",
+                        extra_payload={
+                            "reason": rejection_reason,
+                            "position_management_state": position_decision.state,
+                            "position_management_reason_code": (
+                                position_decision.reason_code
+                            ),
+                            "position_management_decision_id": (
+                                position_decision.decision_id
+                            ),
+                        },
+                    )
+                    exc = PositionManagementRejectedError(rejection_reason)
+                    mark_exception_emitted(exc)
+                    raise exc
 
             current_node = "tracking_create"
             request_id = self.tracking_service.submit_order(

--- a/freshquant/tests/test_order_management_xt_ingest.py
+++ b/freshquant/tests/test_order_management_xt_ingest.py
@@ -303,6 +303,22 @@ def test_normalize_xt_order_report_maps_broker_order_back_to_internal_order():
     assert normalized["state"] == "CANCELED"
 
 
+def test_normalize_xt_order_report_returns_none_for_unknown_broker_order():
+    repository = InMemoryRepository()
+
+    normalized = normalize_xt_order_report(
+        {
+            "order_id": 89991,
+            "stock_code": "000001.SZ",
+            "order_time": 1710000000,
+            "order_status": 54,
+        },
+        repository=repository,
+    )
+
+    assert normalized is None
+
+
 def test_normalize_xt_order_report_keeps_cancel_requested_state_for_pending_cancel():
     normalized = normalize_xt_order_report(
         {

--- a/freshquant/tests/test_order_submit_runtime_observability.py
+++ b/freshquant/tests/test_order_submit_runtime_observability.py
@@ -2,6 +2,7 @@ import pytest
 
 from freshquant.order_management.submit.service import OrderSubmitService
 from freshquant.order_management.tracking.service import OrderTrackingService
+from freshquant.position_management.errors import PositionManagementRejectedError
 from freshquant.position_management.models import PositionDecision
 
 
@@ -91,6 +92,18 @@ class AllowingPositionService:
         )
 
 
+class RejectingPositionService:
+    def evaluate_strategy_order(self, payload, is_profitable=False):
+        return PositionDecision(
+            allowed=False,
+            state="HOLDING_ONLY",
+            reason_code="new_position_blocked",
+            reason_text="当前状态禁止策略开新仓",
+            decision_id="pmd_reject_1",
+            meta={"force_profit_reduce": False},
+        )
+
+
 def test_submit_order_emits_runtime_trace_steps():
     runtime_logger = FakeRuntimeLogger()
     repository = InMemoryRepository()
@@ -163,6 +176,49 @@ def test_submit_order_emits_runtime_error_when_queue_push_fails():
     assert error_event["intent_id"] == "int_queue_error"
     assert error_event["payload"]["error_type"] == "RuntimeError"
     assert error_event["payload"]["error_message"] == "queue unavailable"
+
+
+def test_submit_order_emits_failed_runtime_event_for_position_management_rejection():
+    runtime_logger = FakeRuntimeLogger()
+    repository = InMemoryRepository()
+    service = OrderSubmitService(
+        repository=repository,
+        queue_client=FakeQueueClient(),
+        position_management_service=RejectingPositionService(),
+        account_type_loader=lambda: "STOCK",
+        runtime_logger=runtime_logger,
+    )
+
+    with pytest.raises(
+        PositionManagementRejectedError,
+        match="position management rejected: new_position_blocked",
+    ):
+        service.submit_order(
+            {
+                "action": "buy",
+                "symbol": "000001",
+                "price": 10.0,
+                "quantity": 100,
+                "source": "strategy",
+                "strategy_name": "Guardian",
+                "trace_id": "trc_pm_reject",
+                "intent_id": "int_pm_reject",
+            }
+        )
+
+    assert [event["node"] for event in runtime_logger.events] == [
+        "intent_normalize",
+        "credit_mode_resolve",
+        "credit_mode_resolve",
+    ]
+    rejection_event = runtime_logger.events[-1]
+    assert rejection_event["status"] == "failed"
+    assert rejection_event["reason_code"] == "position_management_rejected"
+    assert rejection_event["trace_id"] == "trc_pm_reject"
+    assert rejection_event["intent_id"] == "int_pm_reject"
+    assert rejection_event["payload"]["reason"] == (
+        "position management rejected: new_position_blocked"
+    )
 
 
 def test_cancel_order_emits_runtime_trace_steps():

--- a/freshquant/tests/test_xt_reports_runtime_observability.py
+++ b/freshquant/tests/test_xt_reports_runtime_observability.py
@@ -339,6 +339,28 @@ def test_duplicate_order_snapshot_is_silent_in_runtime_observability():
     assert len(runtime_logger.events) == first_event_count
 
 
+def test_unknown_order_snapshot_is_ignored_in_runtime_observability():
+    runtime_logger = FakeRuntimeLogger()
+    repository = InMemoryRepository()
+    service = OrderManagementXtIngestService(
+        repository=repository,
+        tracking_service=OrderTrackingService(repository=repository),
+        runtime_logger=runtime_logger,
+    )
+
+    result = service.ingest_order_report(
+        {
+            "order_id": 99901,
+            "stock_code": "000001.SZ",
+            "order_time": 1710000000,
+            "order_status": 54,
+        }
+    )
+
+    assert result is None
+    assert runtime_logger.events == []
+
+
 def test_try_ingest_xt_trade_dict_emits_runtime_error_when_wrapper_catches_exception(
     monkeypatch,
 ):


### PR DESCRIPTION
## 背景
- runtime-observability 已记录两类仍未收敛的真实代码异常：
  - XT order callback 命中不到内部订单时，`xt_report_ingest.order_match` 会因伪造 `internal_order_id` 继续下沉而触发 `TypeError`
  - `OrderSubmitService` 在仓位管理拒单时把业务拒绝误记为 `unexpected_exception`

## 目标
- 修复上述两个未完成异常
- 保持外部单仍通过 reconcile 正式落账
- 让 runtime 语义与当前业务语义一致

## 范围
- `freshquant/order_management/ingest/xt_reports.py`
- `freshquant/order_management/submit/service.py`
- 相关 runtime / ingest 测试
- `docs/current/modules/order-management.md` 当前事实同步

## 非目标
- 不调整 runtime-observability 将 `skipped` 计入 issue 的统计口径
- 不处理 `broker_gateway.watchdog` 运行环境告警

## 验收标准
- 未知 `broker_order_id` 的 XT order snapshot 被 ingest 边界忽略，不再触发 `TypeError`
- 策略单被仓位管理拒绝时，`credit_mode_resolve` 写入 `status=failed` / `reason_code=position_management_rejected`，并继续抛出 `PositionManagementRejectedError`
- 相关回归测试通过

## 验证
- `py -3.12 -m pytest freshquant/tests/test_order_management_xt_ingest.py freshquant/tests/test_xt_reports_runtime_observability.py freshquant/tests/test_order_management_tracking_service.py freshquant/tests/test_order_submit_runtime_observability.py freshquant/tests/test_order_management_reconcile.py freshquant/tests/test_order_reconcile_runtime_observability.py freshquant/tests/test_guardian_runtime_observability.py freshquant/tests/test_guardian_strategy.py -q`
- 结果：`59 passed in 2.48s`

## 部署影响
- 受影响模块在 `freshquant/order_management/**`，按当前部署矩阵需要重部署后端/API，必要时重启相关 worker
- submit / ingest / reconcile 逻辑改动后，需同步重启 `fqnext_xtquant_broker` 与 `fqnext_xt_account_sync_worker`
