### PR TITLE
Document no-op formal deploy evidence

### DIFF
--- a/.claude/skills/fq-deploy/SKILL.md
+++ b/.claude/skills/fq-deploy/SKILL.md
@@ -44,9 +44,11 @@ py -3.12 script/ci/run_formal_deploy.py --repo-root . --format summary
 
 - `D:/fqpack/runtime/formal-deploy/production-state.json`
 - `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/plan.json`
-- `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/runtime-baseline.json`
-- `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/runtime-verify.json`
 - `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/result.json`
+- 当 `plan.json` / `result.json` 显示 `deployment_required=true` 时，再要求：
+  - `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/runtime-baseline.json`
+  - `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/runtime-verify.json`
+- 当 `plan.json` / `result.json` 显示 `deployment_required=false` 时，把这轮当成 `no-op deploy`；`runtime-verify.json 可以不存在`，但必须确认 `result.json` 为 `ok=true`，并且 `production-state.json` 的 `last_success_sha` 已更新到目标 SHA
 
 ## Runtime Verification
 
@@ -81,6 +83,13 @@ print(inspect.signature(resolve_stock_account))
 ```
 
 - 如果源文件落在 `.venv\Lib\site-packages\fqxtrade\xtquant\account.py`，说明宿主机运行时仍在使用已安装包；先确认正式 deploy 是否已经切到包含最新兼容修复的远程 `main`
+
+### formal deploy 判定为 no-op deploy
+
+- 如果当前 run_dir 只有 `plan.json` 和 `result.json`，先不要把它直接判成失败
+- 先读 `result.json` 和 `plan.json`；如果其中明确写了 `deployment_required=false`，说明这轮没有命中任何真实 deploy surface
+- 这种情况下 `runtime-verify.json 可以不存在`；收口依据是 `result.json` 的 `ok=true`，以及 `production-state.json` 的 `last_success_sha` 已更新到目标 SHA
+- 只有当你预期本轮应该触发运行面变更，但 deploy plan 仍然给出 `deployment_required=false` 时，才继续回查 changed paths 或 deploy plan 规则
 
 ### Docker 构建阶段 fqchan04 编译器崩溃
 

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -74,7 +74,9 @@ py -3.12 script/ci/run_formal_deploy.py --repo-root <deploy-mirror> --format sum
 - 先确认当前代码真值是最新远程 `origin/main`；如果为了修 deploy 问题需要改代码，必须先走 `feature branch -> PR -> merge remote main`，再回到本地 `main` 与 `origin/main` 对齐。
 - 正式 deploy 统一从 `D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production` 执行，不要直接把开发 worktree 当成正式来源。
 - 在 deploy mirror 中先执行 `py -3.12 -m uv sync --frozen`，再执行 `py -3.12 script/ci/run_formal_deploy.py --repo-root . --format summary`。
-- 读取 `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/plan.json`、`runtime-baseline.json`、`runtime-verify.json` 与 `result.json` 作为正式 deploy 证据，不要只凭终端退出码判断成功。
+- 读取 `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/plan.json`、`result.json` 与 `D:/fqpack/runtime/formal-deploy/production-state.json` 作为正式 deploy 基础证据；不要只凭终端退出码判断成功。
+- 如果 `plan.json` / `result.json` 显示 `deployment_required=false`，把这轮判定为 `no-op deploy`：`runtime-verify.json 可以不存在`，但仍要确认 `result.json` 为 `ok=true`，并且 `production-state.json` 里的 `last_success_sha` 已更新到目标 SHA。
+- 如果 `plan.json` / `result.json` 显示 `deployment_required=true`，再额外读取 `runtime-baseline.json`、`runtime-verify.json`，并保留 `CaptureBaseline -> deploy -> health check -> Verify` 的完整顺序。
 - Dagster 容器必须在容器内固定使用 `DAGSTER_HOME=/opt/dagster/home` 与 `FRESHQUANT_DAGSTER__HOME=/opt/dagster/home`；不要让主工作树 `.env` 里的 Windows 路径 `D:/fqpack/dagster` 直接透传进 Linux 容器。
 - 命中宿主机 deployment surface 时，把 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode Status` 与对应 stderr 日志一起当作正式证据；不要只看 `fqnext-supervisord` service 是否仍是 `Running`。
 - 如果宿主机 traceback 指向 vendored 包 API 不匹配，例如 `resolve_stock_account() got an unexpected keyword argument 'settings_provider'`，先确认实际 import 源文件是否落在 `.venv\\Lib\\site-packages\\fqxtrade\\xtquant\\account.py`，不要假设仓库里的 vendored 源码一定覆盖了宿主机 Python 环境。

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -223,6 +223,27 @@ print(inspect.signature(resolve_stock_account))
 - 只有当第二次仍在相同位置稳定复现时，才继续进入代码修复、Dockerfile 调整或编译环境隔离
 - 如果重跑成功，把这次失败判定为构建过程瞬时失败；继续以新 run_dir 的 `result.json` 与 `runtime-verify.json` 作为正式交付证据
 
+## formal deploy 判定为 no-op deploy
+
+现象：
+
+- `run_formal_deploy.py` 成功退出，但当前 run_dir 只有 `plan.json` 和 `result.json`
+- `runtime-baseline.json`、`runtime-verify.json` 没有生成
+- `result.json` / `plan.json` 里明确显示 `deployment_required=false`
+
+先检查：
+
+- `Get-Content D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/result.json`
+- `Get-Content D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/plan.json`
+- `Get-Content D:/fqpack/runtime/formal-deploy/production-state.json`
+
+处理：
+
+- 先确认这轮 changed paths 只命中文档、skill、测试或其他不需要部署的路径，而不是误漏了 deploy surface
+- 如果 `deployment_required=false`，把这轮判定为正常的 `no-op deploy`，不是失败
+- 在这种情况下，`runtime-verify.json 可以不存在`；正式收口依据改为 `result.json` 的 `ok=true` 和 `production-state.json` 的 `last_success_sha` 已更新到目标 SHA
+- 只有当你预期本轮应该命中运行面，但 plan 仍然给出 `deployment_required=false` 时，才继续回查 deploy plan 规则或 changed paths 计算
+
 ## API 无响应
 
 现象：

--- a/freshquant/tests/test_deploy_guidance_assets.py
+++ b/freshquant/tests/test_deploy_guidance_assets.py
@@ -38,6 +38,18 @@ def test_current_docs_cover_transient_fqchan04_build_failure() -> None:
     assert "原样重跑 1 次" in troubleshooting_text
 
 
+def test_current_docs_cover_noop_formal_deploy_evidence() -> None:
+    deployment_text = Path("docs/current/deployment.md").read_text(encoding="utf-8")
+    troubleshooting_text = Path("docs/current/troubleshooting.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "deployment_required=false" in deployment_text
+    assert "runtime-verify.json 可以不存在" in deployment_text
+    assert "no-op deploy" in troubleshooting_text
+    assert "last_success_sha" in troubleshooting_text
+
+
 def test_project_deploy_skill_exists_and_covers_formal_flow() -> None:
     skill_text = Path(".claude/skills/fq-deploy/SKILL.md").read_text(encoding="utf-8")
 
@@ -50,3 +62,5 @@ def test_project_deploy_skill_exists_and_covers_formal_flow() -> None:
     assert "site-packages" in skill_text
     assert "fqchan04" in skill_text
     assert "原样重跑 1 次" in skill_text
+    assert "deployment_required=false" in skill_text
+    assert "runtime-verify.json 可以不存在" in skill_text


### PR DESCRIPTION
## 背景\n- 这轮部署经验新增了 no-op formal deploy 判定：当 changed paths 不命中 deploy surface 时，formal deploy 会成功收口，但不会生成 runtime-verify.json\n- 现有 docs/current 和 fq-deploy skill 还没有把这条规则写清，自动部署 prompt 容易把它误判为失败\n\n## 目标\n- 把 no-op formal deploy 的完成判据补进当前部署文档、排障文档和 fq-deploy skill\n- 用资产测试锁定该规则，避免后续回退\n\n## 范围\n- docs/current/deployment.md\n- docs/current/troubleshooting.md\n- .claude/skills/fq-deploy/SKILL.md\n- freshquant/tests/test_deploy_guidance_assets.py\n\n## 非目标\n- 不修改 formal deploy 脚本行为\n- 不调整 deployment surface 判定逻辑\n\n## 验证\n- py -3.12 -m pytest freshquant/tests/test_deploy_guidance_assets.py -q\n- py -3.12 -m pre_commit run --show-diff-on-failure --color=always --files .claude/skills/fq-deploy/SKILL.md docs/current/deployment.md docs/current/troubleshooting.md freshquant/tests/test_deploy_guidance_assets.py\n- powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure\n\n## 部署影响\n- 仅文档、skill 与测试更新\n- merge 后仍按正式流程执行一次 formal deploy 收口到最新远程 main SHA