### PR TITLE
fix: resolve production deploy entrypoint path

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,7 +25,11 @@ jobs:
         shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
         run: |
           $ErrorActionPreference = 'Stop'
-          powershell -NoProfile -ExecutionPolicy Bypass -File script/ci/run_production_deploy.ps1 `
+          $entrypoint = Join-Path $env:FQ_DEPLOY_CANONICAL_REPO_ROOT 'script/ci/run_production_deploy.ps1'
+          if (-not (Test-Path $entrypoint)) {
+            throw "production deploy entrypoint not found: $entrypoint"
+          }
+          powershell -NoProfile -ExecutionPolicy Bypass -File $entrypoint `
             -CanonicalRoot $env:FQ_DEPLOY_CANONICAL_REPO_ROOT `
             -MirrorRoot $env:FQ_DEPLOY_MIRROR_ROOT `
             -MirrorBranch $env:FQ_DEPLOY_MIRROR_BRANCH `

--- a/freshquant/tests/test_deploy_production_workflow.py
+++ b/freshquant/tests/test_deploy_production_workflow.py
@@ -16,6 +16,17 @@ def test_deploy_workflow_uses_single_production_entrypoint() -> None:
     assert "py -3.12 script/ci/run_formal_deploy.py" not in text
 
 
+def test_deploy_workflow_resolves_entrypoint_from_canonical_root() -> None:
+    text = Path(".github/workflows/deploy-production.yml").read_text(encoding="utf-8")
+
+    assert (
+        "$entrypoint = Join-Path $env:FQ_DEPLOY_CANONICAL_REPO_ROOT "
+        "'script/ci/run_production_deploy.ps1'"
+    ) in text
+    assert "-File $entrypoint" in text
+    assert "-File script/ci/run_production_deploy.ps1" not in text
+
+
 def _powershell_executable() -> str:
     executable = shutil.which("powershell") or shutil.which("pwsh")
     if executable is None:


### PR DESCRIPTION
## Summary
- resolve the production deploy entrypoint path from the canonical repo root before invoking PowerShell
- fail fast with a clearer error if the entrypoint script is missing on the production runner
- add a regression test that locks the workflow to canonical-root path resolution

## Test Plan
- [x] python -m pytest freshquant/tests/test_deploy_production_workflow.py freshquant/tests/test_deploy_build_cache_policy.py -q
- [x] python -m pre_commit run --files .github/workflows/deploy-production.yml freshquant/tests/test_deploy_production_workflow.py
- [x] powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure
