### PR TITLE
fix: tolerate py launcher fallback failures

### DIFF
--- a/freshquant/tests/test_deploy_production_workflow.py
+++ b/freshquant/tests/test_deploy_production_workflow.py
@@ -27,6 +27,21 @@ def test_deploy_workflow_resolves_entrypoint_from_canonical_root() -> None:
     assert "-File script/ci/run_production_deploy.ps1" not in text
 
 
+def test_run_production_deploy_catches_py_launcher_failures_before_fallback() -> None:
+    text = Path("script/ci/run_production_deploy.ps1").read_text(encoding="utf-8")
+    start = text.index("function Get-PyLauncherPython312")
+    end = text.index("function Get-RegisteredPython312Candidates")
+    py_launcher_block = text[start:end]
+
+    assert (
+        '$pythonExe = & $pyCommand.Source -3.12 -c "import sys; print(sys.executable)" 2>$null'
+        in py_launcher_block
+    )
+    assert "try {" in py_launcher_block
+    assert "catch {" in py_launcher_block
+    assert "return $null" in py_launcher_block
+
+
 def _powershell_executable() -> str:
     executable = shutil.which("powershell") or shutil.which("pwsh")
     if executable is None:

--- a/script/ci/run_production_deploy.ps1
+++ b/script/ci/run_production_deploy.ps1
@@ -50,7 +50,11 @@ function Get-PyLauncherPython312 {
         return $null
     }
 
-    $pythonExe = & $pyCommand.Source -3.12 -c "import sys; print(sys.executable)" 2>$null
+    try {
+        $pythonExe = & $pyCommand.Source -3.12 -c "import sys; print(sys.executable)" 2>$null
+    } catch {
+        return $null
+    }
     if ($LASTEXITCODE -ne 0) {
         return $null
     }


### PR DESCRIPTION
## Summary
- catch py -3.12 launcher failures inside un_production_deploy.ps1 so the script can continue to registry-based Python 3.12 fallback
- add a regression test that locks the py-launcher failure path into the deploy entrypoint contract

## Test Plan
- [x] python -m pytest freshquant/tests/test_deploy_production_workflow.py -q
- [x] python -m pre_commit run --files freshquant/tests/test_deploy_production_workflow.py script/ci/run_production_deploy.ps1
- [x] powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure
