### PR TITLE
fix: sync canonical deploy repo before entrypoint

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,6 +25,28 @@ jobs:
         shell: powershell -NoProfile -ExecutionPolicy Bypass -File {0}
         run: |
           $ErrorActionPreference = 'Stop'
+          git -C $env:FQ_DEPLOY_CANONICAL_REPO_ROOT fetch origin main
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to fetch origin/main for production deploy"
+          }
+          $currentBranch = (git -C $env:FQ_DEPLOY_CANONICAL_REPO_ROOT rev-parse --abbrev-ref HEAD).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to resolve canonical repo root branch"
+          }
+          if ($currentBranch -ne 'main') {
+            throw "canonical repo root must be on main before deploy: $currentBranch"
+          }
+          $remoteMainSha = (git -C $env:FQ_DEPLOY_CANONICAL_REPO_ROOT rev-parse origin/main).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to resolve latest origin/main sha"
+          }
+          if ($remoteMainSha -ne "${{ github.sha }}") {
+            throw "stale push deploy trigger: target_sha=${{ github.sha }} current_main=$remoteMainSha"
+          }
+          git -C $env:FQ_DEPLOY_CANONICAL_REPO_ROOT pull --ff-only origin main
+          if ($LASTEXITCODE -ne 0) {
+            throw "failed to fast-forward canonical repo root to origin/main"
+          }
           $entrypoint = Join-Path $env:FQ_DEPLOY_CANONICAL_REPO_ROOT 'script/ci/run_production_deploy.ps1'
           if (-not (Test-Path $entrypoint)) {
             throw "production deploy entrypoint not found: $entrypoint"

--- a/freshquant/tests/test_deploy_production_workflow.py
+++ b/freshquant/tests/test_deploy_production_workflow.py
@@ -27,6 +27,20 @@ def test_deploy_workflow_resolves_entrypoint_from_canonical_root() -> None:
     assert "-File script/ci/run_production_deploy.ps1" not in text
 
 
+def test_deploy_workflow_fast_forwards_canonical_root_before_entrypoint() -> None:
+    text = Path(".github/workflows/deploy-production.yml").read_text(encoding="utf-8")
+
+    assert "git -C $env:FQ_DEPLOY_CANONICAL_REPO_ROOT fetch origin main" in text
+    assert (
+        '$remoteMainSha = (git -C $env:FQ_DEPLOY_CANONICAL_REPO_ROOT rev-parse '
+        'origin/main).Trim()'
+    ) in text
+    assert 'if ($remoteMainSha -ne "${{ github.sha }}") {' in text
+    assert (
+        "git -C $env:FQ_DEPLOY_CANONICAL_REPO_ROOT pull --ff-only origin main" in text
+    )
+
+
 def test_run_production_deploy_catches_py_launcher_failures_before_fallback() -> None:
     text = Path("script/ci/run_production_deploy.ps1").read_text(encoding="utf-8")
     start = text.index("function Get-PyLauncherPython312")


### PR DESCRIPTION
## Summary
- fast-forward the canonical production repo root to the current github.sha before invoking the deploy entrypoint script
- fail fast if the canonical repo root is not on main or if origin/main drifts from the workflow SHA
- add a regression test that locks the workflow bootstrap sync contract in place

## Test Plan
- [x] python -m pytest freshquant/tests/test_deploy_production_workflow.py freshquant/tests/test_deploy_build_cache_policy.py -q
- [x] python -m pre_commit run --files .github/workflows/deploy-production.yml freshquant/tests/test_deploy_production_workflow.py
- [x] powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure
