### PR TITLE
fix runtime observability freeze and deploy mirror cleanup

### DIFF
--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -35,6 +35,7 @@ docker compose -f docker/compose.parallel.yaml up -d --build
 - `deploy-production.yml` 由 `push main` 直接触发，不需要额外审批。
 - `deploy-production.yml` 现在只调用 `script/ci/run_production_deploy.ps1`，不再在 workflow YAML 内手工展开 mirror sync、`uv sync` 和 `run_formal_deploy.py`。
 - `script/ci/run_production_deploy.ps1` 会先校验 `github.sha == latest origin/main`，再负责 mirror bootstrap / fast-forward、runner Python 3.12 / `uv` 自愈、mirror `.venv` 同步和 formal deploy 调用。
+- `script/ci/sync_local_deploy_mirror.py` 在 fast-forward 前会先执行 `git clean -ffdX` 清掉 mirror 内的 ignored 产物，避免历史 `build/`、`*.egg-info/`、生成的 `fqchan*.cpp` 一类文件混入后续 Docker 构建。
 - `script/ci/run_formal_deploy.py` 会读取 `production-state.json` 中的上一次成功部署 SHA，计算 `last_success_sha -> current main HEAD` 的 changed paths，再调用 `script/freshquant_deploy_plan.py` 得到本轮 deploy plan。
 - `script/ci/run_production_deploy.ps1` 会显式把 canonical repo root 与本机 deploy mirror 加入 git `safe.directory`，避免 runner 在多 worktree 场景下拒绝执行 git。
 - 正式 deploy 要求 production runner 至少存在一个可用的 Python 3.12；若 `py -3.12` 因旧注册失效，入口脚本会回退到已注册的 per-user / system Python 3.12，并回补 `HKCU\Software\Python\PythonCore\3.12\InstallPath`。
@@ -76,6 +77,7 @@ powershell -ExecutionPolicy Bypass -File script/ci/run_production_deploy.ps1 -Ca
 - 正式 deploy 统一从 `D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production` 执行，不要直接把开发 worktree 当成正式来源。
 - workflow 与人工正式 deploy 都应优先调用 `script/ci/run_production_deploy.ps1`；不要再把 mirror sync、`uv sync`、`run_formal_deploy.py` 手工拆开执行。
 - `script/ci/run_production_deploy.ps1` 会先用 runner Python 3.12 做 `uv sync`，再切换到 deploy mirror `.venv\Scripts\python.exe` 运行 `run_formal_deploy.py`；formal deploy 内部 health check 也跟随 mirror `.venv` 解释器。
+- 如果 formal deploy 命中 `fq_apiserver` / `fq_webui` 后仍出现“像是旧代码”的症状，先检查 deploy mirror 是否残留过往 ignored 构建产物；当前正式入口会在 mirror sync 阶段主动清掉这类文件。
 - 读取 `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/plan.json`、`result.json` 与 `D:/fqpack/runtime/formal-deploy/production-state.json` 作为正式 deploy 基础证据；不要只凭终端退出码判断成功。
 - 如果 `plan.json` / `result.json` 显示 `deployment_required=false`，把这轮判定为 `no-op deploy`：`runtime-verify.json 可以不存在`，但仍要确认 `result.json` 为 `ok=true`，并且 `production-state.json` 里的 `last_success_sha` 已更新到目标 SHA。
 - 如果 `plan.json` / `result.json` 显示 `deployment_required=true`，再额外读取 `runtime-baseline.json`、`runtime-verify.json`，并保留 `CaptureBaseline -> deploy -> health check -> Verify` 的完整顺序。

--- a/freshquant/tests/test_sync_local_deploy_mirror.py
+++ b/freshquant/tests/test_sync_local_deploy_mirror.py
@@ -225,3 +225,24 @@ def test_sync_local_deploy_mirror_rejects_non_fast_forward_main(tmp_path: Path) 
 
     with pytest.raises(RuntimeError, match="failed to fast-forward main"):
         module.sync_local_deploy_mirror(repo_root=mirror, target_sha=target_sha)
+
+
+def test_sync_local_deploy_mirror_removes_ignored_artifacts(tmp_path: Path) -> None:
+    module = load_module()
+    remote = init_bare_remote(tmp_path)
+    seed, _ = init_seed_repo(tmp_path, remote)
+    (seed / ".gitignore").write_text("build/\n", encoding="utf-8")
+    git(["add", ".gitignore"], seed)
+    git(["commit", "-m", "ignore build artifacts"], seed)
+    target_sha = push_main(seed)
+    mirror = clone_mirror(tmp_path, remote)
+
+    ignored_dir = mirror / "build"
+    ignored_dir.mkdir()
+    (ignored_dir / "stale.txt").write_text("stale\n", encoding="utf-8")
+
+    result = module.sync_local_deploy_mirror(repo_root=mirror, target_sha=target_sha)
+
+    assert result["ok"] is True
+    assert result["head_sha"] == target_sha
+    assert not ignored_dir.exists()

--- a/morningglory/fqwebui/src/views/RuntimeObservability.vue
+++ b/morningglory/fqwebui/src/views/RuntimeObservability.vue
@@ -995,8 +995,8 @@ const rawFiles = ref([])
 const rawRecords = ref([])
 const rawFocusedIndex = ref(-1)
 const rawSelectionKey = ref('')
-const rawRecordRefs = ref({})
-const stepRowRefs = ref({})
+const rawRecordRefs = new Map()
+const stepRowRefs = new Map()
 const pageError = ref('')
 const boardFilter = reactive({
   component: '',
@@ -2251,17 +2251,15 @@ const isSlowestStep = (step) => {
 }
 
 const setStepRowRef = (element, key) => {
-  stepRowRefs.value = {
-    ...stepRowRefs.value,
-    [key]: element || null,
-  }
+  if (!key) return
+  stepRowRefs.set(key, element || null)
 }
 
 const scrollToSelectedStep = async () => {
   const key = stepKey(selectedStep.value)
   if (!key) return
   await nextTick()
-  stepRowRefs.value[key]?.scrollIntoView({
+  stepRowRefs.get(key)?.scrollIntoView({
     block: 'nearest',
     behavior: 'smooth',
   })
@@ -2356,16 +2354,13 @@ const syncSelectedStep = () => {
 }
 
 const setRawRecordRef = (element, index) => {
-  rawRecordRefs.value = {
-    ...rawRecordRefs.value,
-    [index]: element || null,
-  }
+  rawRecordRefs.set(index, element || null)
 }
 
 const scrollToFocusedRawRecord = async () => {
   if (rawFocusedIndex.value < 0) return
   await nextTick()
-  rawRecordRefs.value[rawFocusedIndex.value]?.scrollIntoView({
+  rawRecordRefs.get(rawFocusedIndex.value)?.scrollIntoView({
     block: 'nearest',
     behavior: 'smooth',
   })
@@ -2444,11 +2439,11 @@ watch(
 )
 
 watch(rawRecords, () => {
-  rawRecordRefs.value = {}
+  rawRecordRefs.clear()
 })
 
 watch(traceStepLedgerRows, () => {
-  stepRowRefs.value = {}
+  stepRowRefs.clear()
 })
 
 watch(selectedStep, () => {

--- a/morningglory/fqwebui/src/views/runtime-observability.test.mjs
+++ b/morningglory/fqwebui/src/views/runtime-observability.test.mjs
@@ -2187,3 +2187,16 @@ test('RuntimeObservability.vue lets zero-issue chips pass clicks through to the 
 
   assert.match(content, /\.component-symbol-card__action\.is-disabled\s*\{[\s\S]*pointer-events:\s*none;/)
 })
+
+test('RuntimeObservability.vue keeps step and raw DOM registries outside Vue reactivity to avoid render-time update loops', async () => {
+  const content = await readFile(new URL('./RuntimeObservability.vue', import.meta.url), 'utf8')
+
+  assert.match(content, /const stepRowRefs = new Map\(\)/)
+  assert.match(content, /const rawRecordRefs = new Map\(\)/)
+  assert.match(content, /const setStepRowRef = \(element, key\) => \{[\s\S]*stepRowRefs\.set\(key, element \|\| null\)/)
+  assert.match(content, /const setRawRecordRef = \(element, index\) => \{[\s\S]*rawRecordRefs\.set\(index, element \|\| null\)/)
+  assert.match(content, /stepRowRefs\.get\(key\)\?\.scrollIntoView/)
+  assert.match(content, /rawRecordRefs\.get\(rawFocusedIndex\.value\)\?\.scrollIntoView/)
+  assert.doesNotMatch(content, /stepRowRefs\.value = \{/)
+  assert.doesNotMatch(content, /rawRecordRefs\.value = \{/)
+})

--- a/script/ci/sync_local_deploy_mirror.py
+++ b/script/ci/sync_local_deploy_mirror.py
@@ -40,6 +40,16 @@ def ensure_clean_worktree(repo_root: Path) -> None:
         raise RuntimeError(f"deploy mirror has a dirty working tree: {repo_root}")
 
 
+def clean_ignored_artifacts(repo_root: Path) -> None:
+    subprocess.run(
+        ["git", "clean", "-ffdX"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 def current_head_sha(repo_root: Path) -> str:
     return run_git(repo_root, "rev-parse", "HEAD")
 
@@ -113,6 +123,7 @@ def sync_local_deploy_mirror(
     repo_root = repo_root.resolve()
     ensure_git_repo(repo_root)
     ensure_safe_directory(repo_root)
+    clean_ignored_artifacts(repo_root)
     ensure_clean_worktree(repo_root)
 
     resolved_checkout_branch = checkout_branch or branch


### PR DESCRIPTION
## 背景\n- Runtime Observability 页面进入后主线程卡死，刷新后浏览器 target crash。\n- formal deploy 使用的 local deploy mirror 会保留 ignored 构建产物，导致后续 Docker 构建可能混入历史生成文件。\n\n## 目标\n- 修复 Runtime Observability 首屏加载即卡死的问题。\n- 让正式 deploy 在 mirror sync 阶段主动清掉 ignored 历史产物，避免遗留旧代码。\n\n## 范围\n- morningglory/fqwebui/src/views/RuntimeObservability.vue\n- morningglory/fqwebui/src/views/runtime-observability.test.mjs\n- script/ci/sync_local_deploy_mirror.py\n- reshquant/tests/test_sync_local_deploy_mirror.py\n- docs/current/deployment.md\n\n## 非目标\n- 不改 Runtime Observability 的交互设计和数据口径。\n- 不改 formal deploy 之外的整体发布流程。\n\n## 验收\n- 
ode --test src/views/runtime-observability.test.mjs 通过。\n- .venv\\Scripts\\python.exe -m pytest -q freshquant/tests/test_sync_local_deploy_mirror.py freshquant/tests/test_check_current_docs.py 通过。\n- Playwright 复现旧 bundle 页面卡死，并在修复后本地 dev server 上验证页面可点击、可刷新。\n\n## 部署影响\n- 命中 morningglory/fqwebui/**，需要重建并部署 q_webui。\n- script/ci/sync_local_deploy_mirror.py 变更会在正式 deploy 前清理 deploy mirror 的 ignored 产物，下一次正式 deploy 会重建 mirror .venv / build cache。