### PR TITLE
Runtime observability guardian trace preview and signal remark

### DIFF
--- a/docs/current/modules/runtime-observability.md
+++ b/docs/current/modules/runtime-observability.md
@@ -42,6 +42,14 @@ Runtime Observability 当前采用“双存储”：
 - `cursor_trace_key`
 - `limit`
 
+`/api/runtime/traces` 当前返回 Trace 摘要字段之外，还会附带：
+
+- `steps_preview`
+  - 每条 Trace 最多 12 个按时间正序排列的步骤预览
+  - 直接复用 runtime event 的 `signal_summary`、`decision_context`、`decision_outcome`
+  - 同时保留 `decision_branch`、`decision_expr`、`error_type`、`error_message`
+  - 用途是让全局 Trace 列表在不额外发 detail 请求的情况下直接渲染节点 hover
+
 `/api/runtime/traces/<trace_key>/steps` 与 `/api/runtime/events` 额外支持：
 
 - `cursor_ts`
@@ -135,6 +143,30 @@ Runtime Observability 当前采用“双存储”：
   - 必要时 `/api/runtime/traces/<trace_key>/steps`
 - Event 与 Trace 列表都走分页 cursor
 - 全局 Trace 顶部的类型按钮会带 `trace_kind` 重新请求最新 Trace；不是在当前已加载列表上做本地筛选
+- 全局 Trace 主表当前新增 `信号备注` 列，优先显示 Guardian `signal_summary.remark`
+- 全局 Trace 主表的 `节点路径` 当前不再是纯文本；Guardian 会直接渲染中文判断节点 pill，并在 hover 时展示该节点判断上下文
+- Guardian 的全局 Trace 节点 hover 当前重点展开：
+  - `receive_signal`：标的、方向、周期、信号价格、触发时间、发现时间、信号备注、信号标签
+  - `holding_scope_resolve`：仓位状态、是否持仓内、是否必选池内、成交次数
+  - `timing_check`：触发时间、发现时间、截止时间、最大时长、最近成交时间
+  - `price_threshold_check`：当前价、最近成交价、底河价格、顶河价格
+  - `signal_structure_check`：成交次数、中枢数量、最近成交时间、最近成交价、候选中枢、是否分离
+  - `cooldown_check`：冷却键、是否命中冷却、上次值、冷却分钟
+  - `quantity_check`：下单数量、路径、网格层级、来源价格、盈利成交数
+  - `position_management_check`：动作、下单数量、拒绝原因
+  - `submit_intent`：动作、下单数量、盈利减仓标记
+  - `finish`：最终结果、最终原因，以及最后一次判断上下文
+- Guardian 节点名当前统一显示为：
+  - `信号接收`
+  - `范围判断`
+  - `时间条件判断`
+  - `价格阈值判断`
+  - `中枢分离判断`
+  - `冷却判断`
+  - `下单数量判断`
+  - `仓位门禁判断`
+  - `策略下单意图`
+  - `最终结论`
 - 自动刷新只刷新摘要列表，不自动刷新已打开的 Trace detail
 - 页面内所有标的展示统一为 `symbol / symbol_name`
 - 写入 ClickHouse 与查询返回阶段都会优先复用现有 instrument lookup 补全 `symbol_name`

--- a/freshquant/runtime_observability/clickhouse_store.py
+++ b/freshquant/runtime_observability/clickhouse_store.py
@@ -21,6 +21,7 @@ from freshquant.util.code import normalize_to_base_code
 _ISSUE_STATUSES = {"warning", "failed", "error", "skipped"}
 _HEALTH_EVENT_TYPES = {"heartbeat", "metric_snapshot"}
 _CLICKHOUSE_TIMEZONE = ZoneInfo("Asia/Shanghai")
+_TRACE_PREVIEW_STEP_LIMIT = 12
 _SYMBOL_FIELDS = (
     "symbol",
     "code",
@@ -363,8 +364,19 @@ class RuntimeObservabilityClickHouseStore:
                 "trace_key": _normalized_text(cursor_row.get("trace_key")),
             }
             rows = rows[:safe_limit]
+        items = [_serialize_trace_summary_row(row) for row in rows]
+        preview_by_trace = self._list_trace_preview_steps(
+            [item.get("trace_key") for item in items],
+            start_time=start_time,
+            end_time=end_time,
+            limit_per_trace=_TRACE_PREVIEW_STEP_LIMIT,
+        )
+        for item in items:
+            item["steps_preview"] = preview_by_trace.get(
+                _normalized_text(item.get("trace_key")), []
+            )
         return {
-            "items": [_serialize_trace_summary_row(row) for row in rows],
+            "items": items,
             "next_cursor": next_cursor,
         }
 
@@ -441,8 +453,12 @@ class RuntimeObservabilityClickHouseStore:
                 symbol_name,
                 message,
                 reason_code,
+                decision_branch,
+                decision_expr,
+                decision_outcome,
                 payload_json,
                 metrics_json,
+                raw_json,
                 raw_file,
                 raw_line,
                 error_type,
@@ -463,6 +479,106 @@ class RuntimeObservabilityClickHouseStore:
             rows = rows[:safe_limit]
         items = list(reversed(_serialize_event_rows(rows)))
         return {"items": items, "next_cursor": next_cursor}
+
+    def _list_trace_preview_steps(
+        self,
+        trace_keys: list[Any] | tuple[Any, ...],
+        *,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        limit_per_trace: int = _TRACE_PREVIEW_STEP_LIMIT,
+    ) -> dict[str, list[dict[str, Any]]]:
+        normalized_trace_keys = [
+            _normalized_text(item)
+            for item in (trace_keys or [])
+            if _normalized_text(item)
+        ]
+        if not normalized_trace_keys:
+            return {}
+        key_list = ", ".join(_sql_string(item) for item in normalized_trace_keys)
+        time_conditions = _build_where_conditions(
+            start_time=start_time,
+            end_time=end_time,
+        )
+        visibility_condition = _build_tpsl_event_visibility_condition()
+        safe_limit = max(int(limit_per_trace or 1), 1)
+        rows = self._select_rows(
+            f"""
+            SELECT
+                event_id,
+                session_key,
+                ts,
+                runtime_node,
+                component,
+                node,
+                status,
+                event_type,
+                trace_id,
+                intent_id,
+                request_id,
+                internal_order_id,
+                symbol,
+                symbol_name,
+                message,
+                reason_code,
+                decision_branch,
+                decision_expr,
+                decision_outcome,
+                payload_json,
+                metrics_json,
+                raw_json,
+                raw_file,
+                raw_line,
+                error_type,
+                error_message
+            FROM (
+                SELECT
+                    event_id,
+                    session_key,
+                    ts,
+                    runtime_node,
+                    component,
+                    node,
+                    status,
+                    event_type,
+                    trace_id,
+                    intent_id,
+                    request_id,
+                    internal_order_id,
+                    symbol,
+                    symbol_name,
+                    message,
+                    reason_code,
+                    decision_branch,
+                    decision_expr,
+                    decision_outcome,
+                    payload_json,
+                    metrics_json,
+                    raw_json,
+                    raw_file,
+                    raw_line,
+                    error_type,
+                    error_message,
+                    row_number() OVER (
+                        PARTITION BY session_key
+                        ORDER BY ts ASC, event_id ASC
+                    ) AS step_rank
+                FROM runtime_events
+                WHERE session_key IN ({key_list})
+                  AND {time_conditions}
+                  AND {visibility_condition}
+            )
+            WHERE step_rank <= {safe_limit}
+            ORDER BY session_key ASC, ts ASC, event_id ASC
+            """
+        )
+        preview_by_trace: dict[str, list[dict[str, Any]]] = {}
+        for row in _serialize_event_rows(rows):
+            preview_by_trace.setdefault(
+                _normalized_text(row.get("session_key")),
+                [],
+            ).append(row)
+        return preview_by_trace
 
     def list_events(
         self,
@@ -864,10 +980,20 @@ def _serialize_event_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def _serialize_event_row(row: dict[str, Any]) -> dict[str, Any]:
     payload = _decode_json_text(row.get("payload_json"))
     metrics = _decode_json_text(row.get("metrics_json"))
+    raw_record = _decode_json_text(row.get("raw_json"))
+    signal_summary = _coerce_dict(raw_record.get("signal_summary"))
+    decision_context = _coerce_dict(raw_record.get("decision_context"))
+    decision_outcome = _decode_json_text(row.get("decision_outcome"))
+    if not decision_outcome:
+        decision_outcome = _coerce_dict(raw_record.get("decision_outcome"))
     record = {
         **row,
+        **raw_record,
         "payload": payload,
         "metrics": metrics,
+        "signal_summary": signal_summary,
+        "decision_context": decision_context,
+        "decision_outcome": decision_outcome,
     }
     symbol = resolve_runtime_symbol(record)
     symbol_name = resolve_runtime_symbol_name(record, symbol=symbol)
@@ -884,10 +1010,18 @@ def _serialize_event_row(row: dict[str, Any]) -> dict[str, Any]:
         "intent_id": _normalized_text(row.get("intent_id")),
         "request_id": _normalized_text(row.get("request_id")),
         "internal_order_id": _normalized_text(row.get("internal_order_id")),
+        "action": _normalized_text(raw_record.get("action")),
         "symbol": symbol,
         "symbol_name": symbol_name,
         "message": _normalized_text(row.get("message")),
         "reason_code": _normalized_text(row.get("reason_code")),
+        "decision_branch": _normalized_text(row.get("decision_branch"))
+        or _normalized_text(raw_record.get("decision_branch")),
+        "decision_expr": _normalized_text(row.get("decision_expr"))
+        or _normalized_text(raw_record.get("decision_expr")),
+        "signal_summary": signal_summary,
+        "decision_context": decision_context,
+        "decision_outcome": decision_outcome,
         "payload": payload,
         "metrics": metrics,
         "raw_file": _normalized_text(row.get("raw_file")),
@@ -906,6 +1040,10 @@ def _decode_json_text(raw: Any) -> dict[str, Any]:
     except ValueError:
         return {}
     return payload if isinstance(payload, dict) else {}
+
+
+def _coerce_dict(raw: Any) -> dict[str, Any]:
+    return raw if isinstance(raw, dict) else {}
 
 
 def _clickhouse_ts_to_iso(raw: Any) -> str:

--- a/freshquant/tests/test_runtime_observability_clickhouse.py
+++ b/freshquant/tests/test_runtime_observability_clickhouse.py
@@ -412,32 +412,36 @@ def test_clickhouse_store_list_traces_backfills_symbol_name_for_legacy_rows(
     store = store_module.RuntimeObservabilityClickHouseStore(
         base_url="http://clickhouse.test"
     )
+    queries = []
 
     def _fake_select_rows(query: str):
-        return [
-            {
-                "trace_key": "trace__trc_legacy_1",
-                "trace_id": "trc_legacy_1",
-                "trace_kind": "guardian_signal",
-                "trace_status": "failed",
-                "break_reason": "failed@guardian_strategy.finish",
-                "first_ts": "2026-03-20 10:00:00.000",
-                "last_ts": "2026-03-20 10:00:02.000",
-                "duration_ms": 2000,
-                "entry_component": "guardian_strategy",
-                "entry_node": "receive_signal",
-                "exit_component": "guardian_strategy",
-                "exit_node": "finish",
-                "step_count": 2,
-                "issue_count": 1,
-                "symbol": "000001",
-                "symbol_name": "",
-                "intent_ids": ["int_legacy_1"],
-                "request_ids": ["req_legacy_1"],
-                "internal_order_ids": ["ord_legacy_1"],
-                "affected_components": ["guardian_strategy"],
-            }
-        ]
+        queries.append(query)
+        if len(queries) == 1:
+            return [
+                {
+                    "trace_key": "trace__trc_legacy_1",
+                    "trace_id": "trc_legacy_1",
+                    "trace_kind": "guardian_signal",
+                    "trace_status": "failed",
+                    "break_reason": "failed@guardian_strategy.finish",
+                    "first_ts": "2026-03-20 10:00:00.000",
+                    "last_ts": "2026-03-20 10:00:02.000",
+                    "duration_ms": 2000,
+                    "entry_component": "guardian_strategy",
+                    "entry_node": "receive_signal",
+                    "exit_component": "guardian_strategy",
+                    "exit_node": "finish",
+                    "step_count": 2,
+                    "issue_count": 1,
+                    "symbol": "000001",
+                    "symbol_name": "",
+                    "intent_ids": ["int_legacy_1"],
+                    "request_ids": ["req_legacy_1"],
+                    "internal_order_ids": ["ord_legacy_1"],
+                    "affected_components": ["guardian_strategy"],
+                }
+            ]
+        return []
 
     monkeypatch.setattr(store, "ensure_schema", lambda: None)
     monkeypatch.setattr(store, "_select_rows", _fake_select_rows)
@@ -451,6 +455,155 @@ def test_clickhouse_store_list_traces_backfills_symbol_name_for_legacy_rows(
     payload = store.list_traces(limit=1)
 
     assert payload["items"][0]["symbol_name"] == "平安银行"
+    assert payload["items"][0]["steps_preview"] == []
+
+
+def test_clickhouse_store_list_traces_includes_steps_preview(monkeypatch):
+    from freshquant.runtime_observability.clickhouse_store import (
+        RuntimeObservabilityClickHouseStore,
+    )
+
+    store = RuntimeObservabilityClickHouseStore(base_url="http://clickhouse.test")
+    queries = []
+
+    def _fake_select_rows(query: str):
+        queries.append(query)
+        if len(queries) == 1:
+            return [
+                {
+                    "trace_key": "trace__trc_preview_1",
+                    "trace_id": "trc_preview_1",
+                    "trace_kind": "guardian_signal",
+                    "trace_status": "failed",
+                    "break_reason": "skipped@guardian_strategy.price_threshold_check:price_threshold_not_met",
+                    "first_ts": "2026-03-20 10:00:00.000",
+                    "last_ts": "2026-03-20 10:00:02.000",
+                    "duration_ms": 2000,
+                    "entry_component": "guardian_strategy",
+                    "entry_node": "receive_signal",
+                    "exit_component": "guardian_strategy",
+                    "exit_node": "finish",
+                    "step_count": 3,
+                    "issue_count": 1,
+                    "symbol": "000001",
+                    "symbol_name": "平安银行",
+                    "intent_ids": ["int_preview_1"],
+                    "request_ids": ["req_preview_1"],
+                    "internal_order_ids": ["ord_preview_1"],
+                    "affected_components": ["guardian_strategy"],
+                }
+            ]
+        return [
+            {
+                "event_id": "evt_preview_1",
+                "session_key": "trace__trc_preview_1",
+                "ts": "2026-03-20 10:00:00.000",
+                "runtime_node": "host:guardian",
+                "component": "guardian_strategy",
+                "node": "receive_signal",
+                "status": "info",
+                "event_type": "trace_step",
+                "trace_id": "trc_preview_1",
+                "intent_id": "int_preview_1",
+                "request_id": "req_preview_1",
+                "internal_order_id": "ord_preview_1",
+                "symbol": "000001",
+                "symbol_name": "平安银行",
+                "message": "",
+                "reason_code": "",
+                "decision_branch": "signal_received",
+                "decision_expr": "",
+                "decision_outcome": '{"outcome":"continue"}',
+                "payload_json": "{}",
+                "metrics_json": "{}",
+                "raw_json": json.dumps(
+                    {
+                        "signal_summary": {
+                            "code": "000001",
+                            "name": "平安银行",
+                            "price": 9.8,
+                            "remark": "首板回封",
+                        }
+                    },
+                    ensure_ascii=False,
+                ),
+                "raw_file": "host_guardian/guardian_strategy/2026-03-20/file.jsonl",
+                "raw_line": 1,
+                "error_type": "",
+                "error_message": "",
+            },
+            {
+                "event_id": "evt_preview_2",
+                "session_key": "trace__trc_preview_1",
+                "ts": "2026-03-20 10:00:01.000",
+                "runtime_node": "host:guardian",
+                "component": "guardian_strategy",
+                "node": "price_threshold_check",
+                "status": "skipped",
+                "event_type": "trace_step",
+                "trace_id": "trc_preview_1",
+                "intent_id": "int_preview_1",
+                "request_id": "req_preview_1",
+                "internal_order_id": "ord_preview_1",
+                "symbol": "000001",
+                "symbol_name": "平安银行",
+                "message": "",
+                "reason_code": "price_threshold_not_met",
+                "decision_branch": "holding_add_threshold",
+                "decision_expr": "current_price <= bot_river_price",
+                "decision_outcome": '{"outcome":"skip","reason_code":"price_threshold_not_met"}',
+                "payload_json": "{}",
+                "metrics_json": "{}",
+                "raw_json": json.dumps(
+                    {
+                        "signal_summary": {
+                            "code": "000001",
+                            "name": "平安银行",
+                            "remark": "首板回封",
+                        },
+                        "decision_context": {
+                            "threshold": {
+                                "current_price": 9.8,
+                                "last_fill_price": 10.0,
+                                "bot_river_price": 9.5,
+                            }
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                "raw_file": "host_guardian/guardian_strategy/2026-03-20/file.jsonl",
+                "raw_line": 2,
+                "error_type": "",
+                "error_message": "",
+            },
+        ]
+
+    monkeypatch.setattr(store, "ensure_schema", lambda: None)
+    monkeypatch.setattr(store, "_select_rows", _fake_select_rows)
+
+    payload = store.list_traces(limit=1)
+
+    assert len(queries) == 2
+    assert payload["items"][0]["trace_key"] == "trace__trc_preview_1"
+    assert [item["node"] for item in payload["items"][0]["steps_preview"]] == [
+        "receive_signal",
+        "price_threshold_check",
+    ]
+    assert (
+        payload["items"][0]["steps_preview"][0]["signal_summary"]["remark"]
+        == "首板回封"
+    )
+    assert payload["items"][0]["steps_preview"][1]["decision_context"] == {
+        "threshold": {
+            "current_price": 9.8,
+            "last_fill_price": 10.0,
+            "bot_river_price": 9.5,
+        }
+    }
+    assert payload["items"][0]["steps_preview"][1]["decision_outcome"] == {
+        "outcome": "skip",
+        "reason_code": "price_threshold_not_met",
+    }
 
 
 def test_clickhouse_store_list_traces_accepts_trace_kind_filter(monkeypatch):
@@ -472,6 +625,7 @@ def test_clickhouse_store_list_traces_accepts_trace_kind_filter(monkeypatch):
 
     assert payload["items"] == []
     assert "trace_kind = 'takeprofit'" in queries[0]
+    assert len(queries) == 1
 
 
 def test_clickhouse_store_health_summary_preserves_missing_heartbeat_as_null(

--- a/freshquant/tests/test_runtime_observability_routes.py
+++ b/freshquant/tests/test_runtime_observability_routes.py
@@ -60,6 +60,50 @@ class _FakeRuntimeQueryService:
                     "intent_ids": ["int_1"],
                     "request_ids": ["req_1"],
                     "internal_order_ids": ["ord_1"],
+                    "steps_preview": [
+                        {
+                            "event_id": "evt_1",
+                            "ts": "2026-03-20T10:00:00+08:00",
+                            "runtime_node": "host:guardian",
+                            "component": "guardian_strategy",
+                            "node": "receive_signal",
+                            "status": "info",
+                            "event_type": "trace_step",
+                            "trace_id": "trc_1",
+                            "symbol": "000001",
+                            "symbol_name": "平安银行",
+                            "signal_summary": {
+                                "code": "000001",
+                                "name": "平安银行",
+                                "remark": "首板回封",
+                            },
+                            "decision_outcome": {"outcome": "continue"},
+                        },
+                        {
+                            "event_id": "evt_2",
+                            "ts": "2026-03-20T10:00:01+08:00",
+                            "runtime_node": "host:guardian",
+                            "component": "guardian_strategy",
+                            "node": "price_threshold_check",
+                            "status": "skipped",
+                            "event_type": "trace_step",
+                            "trace_id": "trc_1",
+                            "symbol": "000001",
+                            "symbol_name": "平安银行",
+                            "reason_code": "price_threshold_not_met",
+                            "decision_expr": "current_price <= bot_river_price",
+                            "decision_context": {
+                                "threshold": {
+                                    "current_price": 9.8,
+                                    "bot_river_price": 9.5,
+                                }
+                            },
+                            "decision_outcome": {
+                                "outcome": "skip",
+                                "reason_code": "price_threshold_not_met",
+                            },
+                        },
+                    ],
                 }
             ],
             "next_cursor": {
@@ -213,6 +257,10 @@ def test_runtime_traces_route_returns_summary_page(monkeypatch):
     assert resp.status_code == 200
     assert body["items"][0]["trace_key"] == "trace__trc_1"
     assert body["items"][0]["trace_status"] == "failed"
+    assert (
+        body["items"][0]["steps_preview"][0]["signal_summary"]["remark"] == "首板回封"
+    )
+    assert body["items"][0]["steps_preview"][1]["node"] == "price_threshold_check"
     assert body["next_cursor"]["trace_key"] == "trace__trc_0"
 
 

--- a/morningglory/fqwebui/src/views/RuntimeObservability.vue
+++ b/morningglory/fqwebui/src/views/RuntimeObservability.vue
@@ -197,6 +197,7 @@
                   <span>标的</span>
                   <span>链路类型</span>
                   <span>链路状态</span>
+                  <span>信号备注</span>
                   <span>节点路径</span>
                   <span>节点数</span>
                   <span>总耗时</span>
@@ -218,7 +219,38 @@
                       {{ row.trace_status_label }}
                     </span>
                   </span>
-                  <span class="runtime-ledger__cell runtime-ledger__cell--truncate runtime-ledger__cell--entry-exit" :title="row.entry_exit_label">{{ row.entry_exit_label }}</span>
+                  <span class="runtime-ledger__cell runtime-ledger__cell--truncate runtime-ledger__cell--signal-remark" :title="row.signal_remark || '-'">
+                    {{ row.signal_remark || '-' }}
+                  </span>
+                  <span class="runtime-ledger__cell runtime-ledger__cell--entry-exit" :title="row.entry_exit_label">
+                    <span class="trace-flow-strip">
+                      <template v-for="(node, nodeIndex) in row.flow_nodes" :key="node.key || `${row.trace_key || row.trace_id}-${nodeIndex}`">
+                        <el-popover
+                          trigger="hover"
+                          placement="top"
+                          :width="320"
+                          :teleported="false"
+                        >
+                          <template #reference>
+                            <span class="trace-flow-pill" :class="`is-${node.status}`">
+                              {{ node.label }}
+                            </span>
+                          </template>
+                          <div class="trace-flow-popover">
+                            <div
+                              v-for="item in node.hover_items"
+                              :key="`${node.key || node.label}-${item.label}`"
+                              class="trace-flow-popover-item"
+                            >
+                              <span>{{ item.label }}</span>
+                              <strong :title="item.value">{{ item.value }}</strong>
+                            </div>
+                          </div>
+                        </el-popover>
+                        <span v-if="nodeIndex < row.flow_nodes.length - 1" class="trace-flow-arrow">→</span>
+                      </template>
+                    </span>
+                  </span>
                   <span class="runtime-ledger__cell runtime-ledger__cell--number">{{ row.step_count }}</span>
                   <span class="runtime-ledger__cell">{{ row.duration_label }}</span>
                   <span class="runtime-ledger__cell runtime-ledger__cell--truncate" :title="row.break_reason || '-'">{{ row.break_reason || '-' }}</span>
@@ -3133,13 +3165,14 @@ onBeforeUnmount(() => {
 .runtime-trace-ledger__grid {
   grid-template-columns:
     152px
-    minmax(220px, 1.15fr)
+    minmax(220px, 1.1fr)
     104px
     102px
-    minmax(480px, 3.6fr)
+    minmax(180px, 0.95fr)
+    minmax(480px, 3.1fr)
     54px
     84px
-    minmax(160px, 0.9fr);
+    minmax(160px, 0.85fr);
 }
 
 .runtime-event-ledger__grid {
@@ -3183,6 +3216,74 @@ onBeforeUnmount(() => {
 .runtime-ledger__cell--entry-exit {
   color: #21405e;
   font-weight: 600;
+  overflow: visible;
+}
+
+.runtime-ledger__cell--signal-remark {
+  color: #5a728b;
+}
+
+.trace-flow-strip {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.trace-flow-pill {
+  display: inline-flex;
+  align-items: center;
+  max-width: 220px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #edf4fb;
+  color: #21405e;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
+.trace-flow-pill.is-success {
+  background: #eefaf3;
+  color: #17784b;
+}
+
+.trace-flow-pill.is-warning,
+.trace-flow-pill.is-skipped {
+  background: #fff4e3;
+  color: #a45d08;
+}
+
+.trace-flow-pill.is-failed,
+.trace-flow-pill.is-error {
+  background: #fff1f0;
+  color: #b6382c;
+}
+
+.trace-flow-arrow {
+  color: #88a0b7;
+  font-size: 12px;
+}
+
+.trace-flow-popover {
+  display: grid;
+  gap: 8px;
+}
+
+.trace-flow-popover-item {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  font-size: 12px;
+}
+
+.trace-flow-popover-item span {
+  color: #68839d;
+}
+
+.trace-flow-popover-item strong {
+  color: #21405e;
+  word-break: break-word;
 }
 
 .runtime-inline-status,

--- a/morningglory/fqwebui/src/views/runtime-observability.test.mjs
+++ b/morningglory/fqwebui/src/views/runtime-observability.test.mjs
@@ -856,7 +856,7 @@ test('buildTraceLedgerRows returns dense table rows for recent trace list', () =
       internal_order_ids: ['ord_dense_1'],
       intent_ids: ['intent_dense_1'],
       symbol: '000001',
-      steps: [
+      steps_preview: [
         {
           component: 'guardian_strategy',
           node: 'receive_signal',
@@ -867,19 +867,38 @@ test('buildTraceLedgerRows returns dense table rows for recent trace list', () =
           signal_summary: {
             code: '000001',
             name: '平安银行',
+            price: 9.8,
+            remark: '首板回封',
+          },
+          decision_outcome: {
+            outcome: 'continue',
           },
         },
         {
           component: 'guardian_strategy',
-          node: 'timing_check',
-          status: 'error',
-          ts: '2026-03-09T02:00:02Z',
+          node: 'price_threshold_check',
+          status: 'skipped',
+          ts: '2026-03-09T02:00:01Z',
           trace_id: 'trc_dense_1',
           symbol: '000001',
-          reason_code: 'unexpected_exception',
-          payload: {
-            error_type: 'ValueError',
-            error_message: 'invalid fill time',
+          signal_summary: {
+            code: '000001',
+            name: '平安银行',
+            price: 9.8,
+            remark: '首板回封',
+          },
+          reason_code: 'price_threshold_not_met',
+          decision_expr: 'current_price <= bot_river_price',
+          decision_context: {
+            threshold: {
+              current_price: 9.8,
+              bot_river_price: 9.5,
+              last_fill_price: 10,
+            },
+          },
+          decision_outcome: {
+            outcome: 'skip',
+            reason_code: 'price_threshold_not_met',
           },
         },
       ],
@@ -887,25 +906,32 @@ test('buildTraceLedgerRows returns dense table rows for recent trace list', () =
   ])
 
   assert.equal(rows.length, 1)
-  assert.deepEqual(rows[0], {
-    trace_key: 'trace:trc_dense_1',
-    trace_id: 'trc_dense_1',
-    symbol: '000001',
-    symbol_name: '平安银行',
-    symbol_display: '000001 / 平安银行',
-    trace_kind: 'guardian_signal',
-    trace_kind_label: 'Guardian 信号',
-    trace_status: 'failed',
-    trace_status_label: '失败',
-    last_ts: '2026-03-09T02:00:02Z',
-    last_ts_label: '2026-03-09 10:00:02',
-    duration_ms: 2000,
-    duration_label: '2s',
-    step_count: 2,
-    entry_exit_label: '信号接收 -> 时效判断',
-    break_reason: 'unexpected_exception@guardian_strategy.timing_check:ValueError',
-    has_issue: true,
-  })
+  assert.equal(rows[0].trace_key, 'trace:trc_dense_1')
+  assert.equal(rows[0].trace_status, 'failed')
+  assert.equal(rows[0].symbol_display, '000001 / 平安银行')
+  assert.equal(rows[0].duration_label, '2s')
+  assert.equal(rows[0].step_count, 2)
+  assert.equal(rows[0].signal_remark, '首板回封')
+  assert.equal(rows[0].entry_exit_label, '信号接收 -> 价格阈值判断')
+  assert.equal(rows[0].break_reason, 'unexpected_exception@guardian_strategy.timing_check:ValueError')
+  assert.equal(rows[0].has_issue, true)
+  assert.deepEqual(rows[0].flow_nodes.map((item) => item.label), ['信号接收', '价格阈值判断'])
+  assert.equal(
+    rows[0].flow_nodes[0].hover_items.find((item) => item.label === '信号备注')?.value,
+    '首板回封',
+  )
+  assert.equal(
+    rows[0].flow_nodes[1].hover_items.find((item) => item.label === '当前价')?.value,
+    '9.8',
+  )
+  assert.equal(
+    rows[0].flow_nodes[1].hover_items.find((item) => item.label === '最近成交价')?.value,
+    '10',
+  )
+  assert.equal(
+    rows[0].flow_nodes[1].hover_items.find((item) => item.label === '结果')?.value,
+    '跳过',
+  )
 })
 
 test('buildTraceLedgerRows falls back to unknown name when symbol name is unavailable', () => {
@@ -994,7 +1020,7 @@ test('buildTraceStepLedgerRows surfaces branch expr reason outcome context and e
     ts: '2026-03-09T10:00:01.300+08:00',
     ts_label: '2026-03-09 10:00:01',
     delta_label: '1.3s',
-    component_node: '时效判断',
+    component_node: '时间条件判断',
     status: 'error',
     branch: 'holding_sell_timing',
     expr: 'fill_time >= signal_time',
@@ -1069,7 +1095,7 @@ test('buildEventLedgerRows keeps heartbeat events and extracts summary and metri
       component: 'guardian_strategy',
       component_label: 'Guardian 策略',
       node: 'timing_check',
-      node_label: '时效判断',
+      node_label: '时间条件判断',
       status: 'error',
       symbol: '000001',
       symbol_name: '平安银行',
@@ -1482,6 +1508,14 @@ test('buildRecentTraceFeed exposes flow nodes with guardian decision detail and 
     guardianRow.flow_nodes[1].hover_items.find((item) => item.label === '原因')?.value,
     'price_threshold_not_met',
   )
+  assert.equal(
+    guardianRow.flow_nodes[1].hover_items.find((item) => item.label === '当前价')?.value,
+    '9.8',
+  )
+  assert.equal(
+    guardianRow.flow_nodes[0].hover_items.find((item) => item.label === '信号备注')?.value,
+    'runtime-test',
+  )
 
   const genericRow = feed.find((item) => item.trace_id === 'trc_generic_flow')
   assert.ok(genericRow)
@@ -1502,7 +1536,7 @@ test('buildGuardianTraceSummary and buildGuardianStepInsight expose structured g
   const stepInsight = buildGuardianStepInsight(detail.steps[1])
 
   assert.equal(summary.signal.title, '000001 Ping An Bank')
-  assert.equal(summary.conclusion.node_label, '结束结论')
+  assert.equal(summary.conclusion.node_label, '最终结论')
   assert.equal(summary.conclusion.label, '跳过')
   assert.equal(summary.conclusion.reason_code, 'price_threshold_not_met')
 
@@ -2432,12 +2466,18 @@ test('runtime observability trace mode uses dense ledger layout instead of trace
   assert.match(content, /<span>标的<\/span>/)
   assert.match(content, /row\.symbol_display/)
   assert.match(content, /value: selectedTraceDetail\.value\.symbol_display/)
+  assert.match(content, /<span>信号备注<\/span>/)
+  assert.match(content, /row\.signal_remark \|\| '-'/)
   assert.match(content, /runtime-ledger__cell--entry-exit/)
   assert.match(content, /runtime-ledger__cell--status/)
+  assert.match(content, /v-for="\(node,\s*nodeIndex\) in row\.flow_nodes"/)
+  assert.match(content, /<el-popover[\s\S]*class="trace-flow-pill"/)
+  assert.match(content, /trace-flow-popover/)
+  assert.match(content, /trace-flow-arrow/)
   assert.match(content, /component-symbol-list/)
   assert.match(content, /component-symbol-card/)
   assert.match(content, /grid-template-columns:\s*minmax\(200px,\s*0\.58fr\)\s*minmax\(820px,\s*2\.42fr\)\s*minmax\(400px,\s*1\.08fr\)/)
-  assert.match(content, /\.runtime-trace-ledger__grid \{[\s\S]*152px[\s\S]*minmax\(220px,\s*1\.15fr\)[\s\S]*104px[\s\S]*102px[\s\S]*minmax\(480px,\s*3\.6fr\)[\s\S]*54px[\s\S]*84px[\s\S]*minmax\(160px,\s*0\.9fr\)/)
+  assert.match(content, /\.runtime-trace-ledger__grid \{[\s\S]*152px[\s\S]*minmax\(220px,\s*1\.1fr\)[\s\S]*104px[\s\S]*102px[\s\S]*minmax\(180px,\s*0\.95fr\)[\s\S]*minmax\(480px,\s*3\.1fr\)[\s\S]*54px[\s\S]*84px[\s\S]*minmax\(160px,\s*0\.85fr\)/)
   assert.match(content, /步骤/)
   assert.match(content, /摘要/)
   assert.match(content, /原始数据/)
@@ -2446,7 +2486,6 @@ test('runtime observability trace mode uses dense ledger layout instead of trace
   assert.match(content, /\.trace-step-ledger__header,\s*\.trace-step-ledger__row \{[\s\S]*min-height:\s*var\(--trace-step-ledger-row-height\);/)
   assert.match(content, /\.step-inspector \{[\s\S]*flex:\s*1 1 auto;[\s\S]*overflow:\s*auto;/)
   assert.doesNotMatch(content, /trace-feed-row/)
-  assert.doesNotMatch(content, /trace-flow-strip/)
   assert.doesNotMatch(content, /trace-group-card/)
   assert.doesNotMatch(content, /trace-summary-card/)
   assert.doesNotMatch(content, /guardian-trace-card/)

--- a/morningglory/fqwebui/src/views/runtimeObservability.mjs
+++ b/morningglory/fqwebui/src/views/runtimeObservability.mjs
@@ -97,15 +97,15 @@ const COMMON_NODE_LABELS = {
 const GUARDIAN_COMPONENT = 'guardian_strategy'
 const GUARDIAN_NODE_LABELS = {
   receive_signal: '信号接收',
-  holding_scope_resolve: '持仓范围判断',
-  timing_check: '时效判断',
+  holding_scope_resolve: '范围判断',
+  timing_check: '时间条件判断',
   price_threshold_check: '价格阈值判断',
-  signal_structure_check: '中枢/分离判断',
+  signal_structure_check: '中枢分离判断',
   cooldown_check: '冷却判断',
-  quantity_check: '数量有效性判断',
-  position_management_check: '仓位管理判断',
-  submit_intent: '提交意图',
-  finish: '结束结论',
+  quantity_check: '下单数量判断',
+  position_management_check: '仓位门禁判断',
+  submit_intent: '策略下单意图',
+  finish: '最终结论',
 }
 const GUARDIAN_OUTCOME_LABELS = {
   continue: '继续',
@@ -886,8 +886,198 @@ const buildFlowNodeLabel = (step = {}) => {
   return [componentLabel, nodeLabel].filter(Boolean).join('.') || '运行事件'
 }
 
+const appendHoverItem = (items, label, value, options = {}) => {
+  const display = options?.formatter
+    ? options.formatter(value)
+    : formatValueText(value)
+  if (!toText(display)) return
+  items.push({
+    label,
+    value: display,
+  })
+}
+
+const formatBooleanLikeLabel = (value) => {
+  const parsed = parseBooleanLike(value)
+  if (parsed === null) return formatValueText(value)
+  return parsed ? '是' : '否'
+}
+
+const appendGuardianSignalHoverItems = (items, step = {}, options = {}) => {
+  const signalSummary = step?.signal_summary || {}
+  const signalDisplay = buildSymbolDisplay(
+    resolveSymbolFromRecord(step),
+    resolveSymbolNameFromRecord(step),
+  )
+  if (!options?.skipSymbol && signalDisplay !== '-') appendHoverItem(items, '标的', signalDisplay)
+  appendHoverItem(items, '方向', signalSummary?.position)
+  appendHoverItem(items, '周期', signalSummary?.period)
+  appendHoverItem(items, '信号价格', signalSummary?.price)
+  appendHoverItem(items, '触发时间', signalSummary?.fire_time, { formatter: formatTimestampLabel })
+  appendHoverItem(items, '发现时间', signalSummary?.discover_time, { formatter: formatTimestampLabel })
+  appendHoverItem(items, '信号备注', signalSummary?.remark)
+  appendHoverItem(items, '信号标签', signalSummary?.tags)
+}
+
+const appendGuardianContextItemsByType = (items, context = {}, type = '') => {
+  const normalizedType = toText(type)
+  if (normalizedType === 'scope') {
+    appendHoverItem(items, '仓位状态', context?.position)
+    appendHoverItem(items, '持仓内', context?.in_holding, { formatter: formatBooleanLikeLabel })
+    appendHoverItem(items, '必选池内', context?.in_must_pool, { formatter: formatBooleanLikeLabel })
+    appendHoverItem(items, '成交次数', context?.fill_count)
+    return
+  }
+  if (normalizedType === 'timing') {
+    appendHoverItem(items, '触发时间', context?.fire_time, { formatter: formatTimestampLabel })
+    appendHoverItem(items, '发现时间', context?.discover_time, { formatter: formatTimestampLabel })
+    appendHoverItem(items, '截止时间', context?.cutoff_time, { formatter: formatTimestampLabel })
+    appendHoverItem(items, '最大时长(分钟)', context?.max_age_minutes)
+    appendHoverItem(items, '最近成交时间', context?.last_fill_time, { formatter: formatTimestampLabel })
+    return
+  }
+  if (normalizedType === 'threshold') {
+    appendHoverItem(items, '当前价', context?.current_price)
+    appendHoverItem(items, '最近成交价', context?.last_fill_price)
+    appendHoverItem(items, '底河价格', context?.bot_river_price)
+    appendHoverItem(items, '顶河价格', context?.top_river_price)
+    return
+  }
+  if (normalizedType === 'signal_structure') {
+    appendHoverItem(items, '成交次数', context?.fill_count)
+    appendHoverItem(items, '中枢数量', context?.zs_count)
+    appendHoverItem(items, '最近成交时间', context?.fill_time, { formatter: formatTimestampLabel })
+    appendHoverItem(items, '最近成交价', context?.fill_price)
+    appendHoverItem(items, '要求中枢', context?.requires_zs, { formatter: formatBooleanLikeLabel })
+    appendHoverItem(items, '候选中枢开始', context?.candidate_zs?.start, { formatter: formatTimestampLabel })
+    appendHoverItem(items, '候选中枢结束', context?.candidate_zs?.end, { formatter: formatTimestampLabel })
+    appendHoverItem(items, '候选中枢低点1', context?.candidate_zs?.low_1)
+    appendHoverItem(items, '候选中枢低点2', context?.candidate_zs?.low_2)
+    appendHoverItem(items, '是否分离', context?.separating, { formatter: formatBooleanLikeLabel })
+    return
+  }
+  if (normalizedType === 'cooldown') {
+    appendHoverItem(items, '冷却键', context?.key)
+    appendHoverItem(items, '命中冷却', context?.active, { formatter: formatBooleanLikeLabel })
+    appendHoverItem(items, '上次值', context?.last_value)
+    appendHoverItem(items, '冷却分钟', context?.cooldown_minutes)
+    return
+  }
+  if (normalizedType === 'quantity') {
+    appendHoverItem(items, '下单数量', context?.quantity)
+    appendHoverItem(items, '路径', context?.path)
+    appendHoverItem(items, '网格层级', context?.grid_level)
+    appendHoverItem(items, '来源价格', context?.source_price)
+    appendHoverItem(items, '设置开仓冷却', context?.set_new_open_cooldown, { formatter: formatBooleanLikeLabel })
+    appendHoverItem(items, '盈利成交数', context?.profitable_fill_count)
+    appendHoverItem(items, '成交次数', context?.fill_count)
+    return
+  }
+  if (normalizedType === 'position_management') {
+    appendHoverItem(items, '动作', context?.action)
+    appendHoverItem(items, '下单数量', context?.quantity)
+    appendHoverItem(items, '拒绝原因', context?.reason)
+  }
+}
+
+const appendGuardianNodeContextItems = (items, step = {}) => {
+  const node = toText(step?.node)
+  const decisionContext = step?.decision_context && typeof step.decision_context === 'object'
+    ? step.decision_context
+    : {}
+  const payload = step?.payload && typeof step.payload === 'object' ? step.payload : {}
+  if (node === 'receive_signal') {
+    appendGuardianSignalHoverItems(items, step)
+    return
+  }
+  if (node === 'holding_scope_resolve') {
+    appendGuardianContextItemsByType(items, decisionContext?.scope, 'scope')
+    return
+  }
+  if (node === 'timing_check') {
+    appendGuardianContextItemsByType(items, decisionContext?.timing, 'timing')
+    return
+  }
+  if (node === 'price_threshold_check') {
+    appendGuardianContextItemsByType(items, decisionContext?.threshold, 'threshold')
+    return
+  }
+  if (node === 'signal_structure_check') {
+    appendGuardianContextItemsByType(items, decisionContext?.signal_structure, 'signal_structure')
+    return
+  }
+  if (node === 'cooldown_check') {
+    appendGuardianContextItemsByType(items, decisionContext?.cooldown, 'cooldown')
+    return
+  }
+  if (node === 'quantity_check') {
+    appendGuardianContextItemsByType(items, decisionContext?.quantity, 'quantity')
+    return
+  }
+  if (node === 'position_management_check') {
+    appendGuardianContextItemsByType(items, decisionContext?.position_management, 'position_management')
+    appendHoverItem(items, '拒绝原因', payload?.reason || decisionContext?.position_management?.reason)
+    return
+  }
+  if (node === 'submit_intent') {
+    appendGuardianContextItemsByType(items, decisionContext?.quantity, 'quantity')
+    appendHoverItem(items, '动作', step?.action)
+    appendHoverItem(items, '盈利减仓', payload?.is_profitable, { formatter: formatBooleanLikeLabel })
+    return
+  }
+  if (node === 'finish') {
+    for (const [key, value] of Object.entries(decisionContext)) {
+      appendGuardianContextItemsByType(items, value, key)
+    }
+  }
+}
+
+const buildGuardianFlowNodeHoverItems = (step = {}, guardianStep = null) => {
+  const items = [
+    {
+      label: '阶段',
+      value: buildFlowNodeLabel(step),
+    },
+    {
+      label: '状态',
+      value: toText(step?.status) || 'info',
+    },
+  ]
+  const condition =
+    guardianStep?.outcome?.expr ||
+    toText(step?.decision_expr) ||
+    ''
+  if (condition) {
+    items.push({
+      label: '条件',
+      value: condition,
+    })
+  }
+  items.push({
+    label: '结果',
+    value: buildStepOutcomeLabel(step),
+  })
+  const reasonCode =
+    guardianStep?.outcome?.reason_code ||
+    toText(step?.reason_code) ||
+    toText(step?.decision_outcome?.reason_code)
+  if (reasonCode) {
+    items.push({
+      label: '原因',
+      value: reasonCode,
+    })
+  }
+  appendGuardianNodeContextItems(items, step)
+  appendHoverItem(items, '异常类型', step?.error_type || step?.payload?.error_type)
+  appendHoverItem(items, '异常信息', step?.error_message || step?.payload?.error_message)
+  return items.filter((item) => toText(item?.value))
+}
+
 const buildFlowNodeHoverItems = (step = {}) => {
   const guardianStep = step?.guardian_step || buildGuardianStepInsight(step)
+  if (guardianStep) {
+    return buildGuardianFlowNodeHoverItems(step, guardianStep)
+  }
   const items = [
     {
       label: '阶段',
@@ -977,6 +1167,29 @@ export const buildTraceFlowNodes = (steps = []) => {
   })
 }
 
+const buildTraceFallbackFlowNodes = (detail = {}) => {
+  const fallbackSteps = [
+    detail?.entry_component && detail?.entry_node
+      ? {
+          component: detail.entry_component,
+          node: detail.entry_node,
+          status: 'info',
+          ts: detail?.first_ts || '',
+        }
+      : null,
+    detail?.exit_component && detail?.exit_node
+      ? {
+          component: detail.exit_component,
+          node: detail.exit_node,
+          status: toText(detail?.trace_status) || 'info',
+          ts: detail?.last_ts || '',
+          reason_code: detail?.break_reason || '',
+        }
+      : null,
+  ].filter(Boolean)
+  return buildTraceFlowNodes(fallbackSteps)
+}
+
 export const filterTracesByKind = (traces = [], kind = 'all') => {
   const normalizedKind = toText(kind) || 'all'
   if (normalizedKind === 'all') return normalizeTraces(traces)
@@ -1043,18 +1256,7 @@ export const summarizeTrace = (trace = {}) => {
   const lastStep = detail.steps[detail.steps.length - 1] || {}
   const flowNodes = detail.steps.length > 0
     ? buildTraceFlowNodes(detail.steps)
-    : [
-        {
-          component: detail.entry_component,
-          label: `${resolveComponentLabel(detail.entry_component)}.${resolveNodeLabel(detail.entry_component, detail.entry_node)}`,
-        },
-        detail.exit_component && detail.exit_node
-          ? {
-              component: detail.exit_component,
-              label: `${resolveComponentLabel(detail.exit_component)}.${resolveNodeLabel(detail.exit_component, detail.exit_node)}`,
-            }
-          : null,
-      ].filter(Boolean)
+    : buildTraceFallbackFlowNodes(detail)
   const traceKind = toText(trace?.trace_kind) || 'unknown'
   const traceStatus = toText(trace?.trace_status) || (detail.issue_count > 0 ? 'broken' : 'open')
   return {
@@ -1169,6 +1371,17 @@ export const buildIdentityStrip = (record = {}) => {
   }
 }
 
+const findGuardianSignalRemark = (detail = {}) => {
+  const guardianSteps = Array.isArray(detail?.steps)
+    ? detail.steps.filter((step) => toText(step?.component) === GUARDIAN_COMPONENT)
+    : []
+  for (const step of guardianSteps) {
+    const remark = toText(step?.signal_summary?.remark)
+    if (remark) return remark
+  }
+  return ''
+}
+
 export const buildTraceLedgerRows = (traces = [], options = {}) => {
   const limit = Number(options?.limit || 0)
   const rows = normalizeTraces(traces)
@@ -1176,18 +1389,7 @@ export const buildTraceLedgerRows = (traces = [], options = {}) => {
       const detail = buildTraceDetail(trace)
       const flowNodes = detail.steps.length > 0
         ? buildTraceFlowNodes(detail.steps)
-        : [
-            {
-              component: detail.entry_component,
-              label: `${resolveComponentLabel(detail.entry_component)}.${resolveNodeLabel(detail.entry_component, detail.entry_node)}`,
-            },
-            detail.exit_component && detail.exit_node
-              ? {
-                  component: detail.exit_component,
-                  label: `${resolveComponentLabel(detail.exit_component)}.${resolveNodeLabel(detail.exit_component, detail.exit_node)}`,
-                }
-              : null,
-          ].filter(Boolean)
+        : buildTraceFallbackFlowNodes(detail)
       return {
         trace_key: toText(detail?.trace_key) || null,
         trace_id: toText(detail?.trace_id) || null,
@@ -1203,6 +1405,8 @@ export const buildTraceLedgerRows = (traces = [], options = {}) => {
         duration_ms: Number.isFinite(detail?.duration_ms) ? Number(detail.duration_ms) : null,
         duration_label: toText(detail?.duration_label) || '-',
         step_count: Number(detail?.step_count || 0),
+        signal_remark: findGuardianSignalRemark(detail),
+        flow_nodes: flowNodes,
         entry_exit_label: flowNodes.map((item) => item.label).join(' -> ') || '-',
         break_reason: toText(detail?.break_reason),
         has_issue: Number(detail?.issue_count || 0) > 0,
@@ -1486,7 +1690,9 @@ const isHydratedTraceDetail = (trace = {}) => {
 
 export const buildTraceDetail = (trace = {}) => {
   if (isHydratedTraceDetail(trace)) return trace
-  const sourceSteps = Array.isArray(trace.steps) ? trace.steps : []
+  const sourceSteps = Array.isArray(trace.steps) && trace.steps.length > 0
+    ? trace.steps
+    : Array.isArray(trace.steps_preview) ? trace.steps_preview : []
   let previousTsMs = null
   const steps = sourceSteps.map((step, index) => {
     const tsMs = parseTimestampMs(step?.ts)
@@ -1567,8 +1773,8 @@ export const buildTraceDetail = (trace = {}) => {
     symbol_name: symbolName,
     symbol_display: buildSymbolDisplay(symbol, symbolName),
     steps,
-    step_count: steps.length > 0 ? steps.length : summaryStepCount,
-    issue_count: issueSteps.length > 0 || steps.length > 0 ? issueSteps.length : summaryIssueCount,
+    step_count: summaryStepCount,
+    issue_count: summaryIssueCount,
     first_issue: issueSteps[0] || null,
     total_duration_ms: totalDurationMs,
     total_duration_label: totalDurationMs === null ? '-' : formatDurationMs(totalDurationMs),


### PR DESCRIPTION
## 变更摘要

- 为 `/api/runtime/traces` 增加 `steps_preview`，让全局 trace 列表直接拿到 Guardian 节点预览与判断上下文
- 将 runtime-observability 的 Guardian 节点路径改为可悬浮的判断摘要节点，并新增 `信号备注` 列
- 补充 ClickHouse / 路由 / 前端视图测试，并同步更新 `docs/current/modules/runtime-observability.md`

## 关联任务

- GitHub Issue：无
- Draft PR / Design Review（如适用）：无

## 当前文档同步（强制）

- [x] 若当前系统事实有变化：已同步更新 `docs/current/**`
- [ ] 若不涉及当前系统事实变化：已确认无需更新 `docs/current/**`

## 验收与测试（强制）

- [x] `pre-commit` 已通过（CI 会校验）
- [ ] `pytest -q freshquant/tests -n auto --dist loadfile` 已通过（CI 会校验）
- [x] 已明确受影响模块的部署动作
- [x] 已明确健康检查方式

## 部署与健康检查

- 部署模块：`freshquant/runtime_observability/**` 对应 API server；`morningglory/fqwebui/**` 对应 Web UI
- 健康检查：调用 `/api/runtime/traces` 确认返回 `steps_preview` 与 `signal_summary.remark`；打开 runtime-observability 页面确认 Guardian 全局 trace 展示节点摘要、悬浮上下文和 `信号备注`

## 风险与说明（如有）

- Design Review 要点：后端新增的是向后兼容字段，旧前端不会受影响；新前端优先消费 `steps_preview`，详情接口仍保留完整 steps 懒加载
- 配置 / 接口 / 存储 / 运行面变化：`/api/runtime/traces` 返回新增 `steps_preview`
- 回滚说明：回滚本 PR，并同时回退 API server 与 Web UI 到上一版