### PR TITLE
fix: audit suspicious etf xdxr sync results

### DIFF
--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -193,11 +193,17 @@ print(sync_etf_xdxr_all(codes=['512800']))
 
 - 当前实现会对 ETF xdxr 首次空结果做 fresh connection retry，并在全量同步时周期性重建 TDX 连接
 - retry 仍超时或为空时，优先核对该 code 在不同 TDX host 上是否一致为空；对确实为空但库里已有历史回填的 ETF，允许保留旧文档
+- Dagster `etf_xdxr` 资产会对本次同步中 `empty/preserved` 的可疑 code 追加一次近期覆盖审计；如果近窗口内源侧有事件但库里没有，asset 会直接 fail，不再把 run 记成成功
 - 对单券立即修复可执行：
   - `@'
 from freshquant.data.etf_adj_sync import sync_etf_adj_all, sync_etf_xdxr_all
 print(sync_etf_xdxr_all(codes=['512800']))
 print(sync_etf_adj_all(codes=['512800']))
+'@ | py -3.12 -m uv run -`
+- 对近期覆盖审计可手工执行：
+  - `@'
+from freshquant.data.etf_adj_sync import audit_recent_etf_xdxr_coverage
+print(audit_recent_etf_xdxr_coverage(codes=['512800'], recent_days=365))
 '@ | py -3.12 -m uv run -`
 - 正式修复后，重新部署 Dagster，并再跑一次 formal deploy health check / runtime verify
 

--- a/freshquant/data/etf_adj_sync.py
+++ b/freshquant/data/etf_adj_sync.py
@@ -150,6 +150,74 @@ def _fetch_xdxr_df_with_fresh_connection(
         return _fetch_xdxr_df(api, market=market, code=code)
 
 
+def _normalize_xdxr_df_to_docs(df: pd.DataFrame, *, code: str) -> list[dict]:
+    for col in ["year", "month", "day", "category"]:
+        if col not in df.columns:
+            raise ValueError(f"TDX xdxr missing column: {col}")
+
+    normalized = df.copy()
+    normalized["date"] = pd.to_datetime(
+        normalized[["year", "month", "day"]], errors="coerce"
+    ).dt.strftime("%Y-%m-%d")
+    normalized = normalized.drop(
+        columns=[c for c in ["year", "month", "day"] if c in normalized.columns]
+    )
+    normalized["code"] = code
+    normalized["category_meaning"] = normalized["category"].map(
+        lambda x: _CATEGORY_MEANING.get(int(x))
+    )
+    if "name" in normalized.columns:
+        normalized["category_meaning"] = normalized["category_meaning"].fillna(
+            normalized["name"]
+        )
+    normalized["category_meaning"] = normalized["category_meaning"].fillna(
+        normalized["category"].astype(str)
+    )
+    normalized = normalized.rename(
+        columns={
+            "panhouliutong": "liquidity_after",
+            "panqianliutong": "liquidity_before",
+            "houzongguben": "shares_after",
+            "qianzongguben": "shares_before",
+        }
+    )
+    normalized = normalized.where(pd.notnull(normalized), None)
+    return normalized.to_dict(orient="records")
+
+
+def _normalize_xdxr_signature_value(value):
+    if value is None or pd.isna(value):
+        return None
+    if isinstance(value, (int, float)):
+        return round(float(value), 6)
+    try:
+        return round(float(value), 6)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _build_xdxr_signature_set(
+    documents: Iterable[dict], *, cutoff_date: str, as_of_date: str
+) -> set[tuple]:
+    signatures = set()
+    for document in documents or []:
+        trade_date = str(document.get("date") or "")
+        if not trade_date or trade_date < cutoff_date or trade_date > as_of_date:
+            continue
+        signatures.add(
+            (
+                trade_date,
+                _normalize_xdxr_signature_value(document.get("category")),
+                _normalize_xdxr_signature_value(document.get("fenhong")),
+                _normalize_xdxr_signature_value(document.get("peigu")),
+                _normalize_xdxr_signature_value(document.get("peigujia")),
+                _normalize_xdxr_signature_value(document.get("songzhuangu")),
+                _normalize_xdxr_signature_value(document.get("suogu")),
+            )
+        )
+    return signatures
+
+
 def sync_etf_xdxr_all(
     *,
     db=DBQuantAxis,
@@ -193,6 +261,8 @@ def sync_etf_xdxr_all(
     retried_empty = 0
     recovered_after_retry = 0
     retry_failed = 0
+    empty_codes: list[str] = []
+    preserved_codes: list[str] = []
     reconnect_every = max(int(reconnect_every), 1)
 
     for batch_start in range(0, len(code_list), reconnect_every):
@@ -255,6 +325,7 @@ def sync_etf_xdxr_all(
                             df = retry_df
                         elif existing_docs and preserve_on_empty:
                             preserved += 1
+                            preserved_codes.append(code)
                             logger.warning(
                                 "sync etf_xdxr empty after retry, preserving existing docs: "
                                 f"{code} market={market} latest_existing={existing_docs[0].get('date')}"
@@ -263,40 +334,10 @@ def sync_etf_xdxr_all(
                         else:
                             coll.delete_many({"code": code})
                             empty += 1
+                            empty_codes.append(code)
                             continue
 
-                    for col in ["year", "month", "day", "category"]:
-                        if col not in df.columns:
-                            raise ValueError(f"TDX xdxr missing column: {col}")
-
-                    df["date"] = pd.to_datetime(
-                        df[["year", "month", "day"]], errors="coerce"
-                    ).dt.strftime("%Y-%m-%d")
-                    df = df.drop(
-                        columns=[c for c in ["year", "month", "day"] if c in df.columns]
-                    )
-                    df["code"] = code
-                    df["category_meaning"] = df["category"].map(
-                        lambda x: _CATEGORY_MEANING.get(int(x))
-                    )
-                    if "name" in df.columns:
-                        df["category_meaning"] = df["category_meaning"].fillna(
-                            df["name"]
-                        )
-                    df["category_meaning"] = df["category_meaning"].fillna(
-                        df["category"].astype(str)
-                    )
-                    df = df.rename(
-                        columns={
-                            "panhouliutong": "liquidity_after",
-                            "panqianliutong": "liquidity_before",
-                            "houzongguben": "shares_after",
-                            "qianzongguben": "shares_before",
-                        }
-                    )
-
-                    df = df.where(pd.notnull(df), None)
-                    docs = df.to_dict(orient="records")
+                    docs = _normalize_xdxr_df_to_docs(df, code=code)
 
                     coll.delete_many({"code": code})
                     if docs:
@@ -326,6 +367,169 @@ def sync_etf_xdxr_all(
         "retried_empty": retried_empty,
         "recovered_after_retry": recovered_after_retry,
         "retry_failed": retry_failed,
+        "empty_codes": empty_codes,
+        "preserved_codes": preserved_codes,
+    }
+
+
+def audit_recent_etf_xdxr_coverage(
+    *,
+    db=DBQuantAxis,
+    codes: Optional[Iterable[str]] = None,
+    timeout: float = 0.7,
+    reconnect_every: int = 200,
+    recent_days: int = 120,
+    as_of_date: str | None = None,
+) -> dict:
+    """
+    校验近期 ETF xdxr 事件是否已经从 TDX 同步到 quantaxis.etf_xdxr。
+
+    只校验近窗口内源侧存在的事件是否落库，避免历史缺口导致的误报。
+    """
+    _ensure_indexes(db)
+
+    code_list = _normalize_code_list(codes)
+    etf_map = {}
+    if not code_list:
+        cursor = db.etf_list.find({}, {"_id": 0, "code": 1, "sse": 1})
+        for doc in cursor:
+            c = str(doc.get("code", "")).zfill(6)
+            if c and c.isdigit():
+                etf_map[c] = doc.get("sse")
+        code_list = sorted(etf_map.keys())
+    else:
+        for c in code_list:
+            etf_map[c] = None
+
+    window_days = max(int(recent_days), 1)
+    as_of_ts = (
+        pd.Timestamp(as_of_date).normalize()
+        if as_of_date
+        else pd.Timestamp.utcnow().normalize()
+    )
+    as_of_date_str = as_of_ts.strftime("%Y-%m-%d")
+    cutoff_date = (as_of_ts - pd.Timedelta(days=window_days)).strftime("%Y-%m-%d")
+
+    TdxHq_API, _ = _import_pytdx()
+    current_host = _pick_hq_host(timeout=timeout)
+    logger.info(
+        f"TDX HQ host selected for ETF xdxr audit: {current_host.name} {current_host.ip}:{current_host.port}"
+    )
+
+    coll = db.etf_xdxr
+    reconnect_every = max(int(reconnect_every), 1)
+    checked = 0
+    matching = 0
+    mismatched = 0
+    source_empty = 0
+    failed = 0
+    mismatch_codes: list[str] = []
+
+    for batch_start in range(0, len(code_list), reconnect_every):
+        batch_codes = code_list[batch_start : batch_start + reconnect_every]
+        if batch_start > 0:
+            try:
+                current_host = _pick_hq_host(
+                    timeout=timeout,
+                    exclude_hosts={(current_host.ip, current_host.port)},
+                )
+            except RuntimeError:
+                pass
+        api = TdxHq_API()
+        with api.connect(current_host.ip, current_host.port, time_out=timeout):
+            for batch_offset, code in enumerate(batch_codes, 1):
+                i = batch_start + batch_offset
+                market = _market_from_sse_or_code(sse=etf_map.get(code), code=code)
+                try:
+                    df = _fetch_xdxr_df(api, market=market, code=code)
+                    if df is None or len(df) == 0:
+                        retry_host = current_host
+                        try:
+                            retry_host = _pick_hq_host(
+                                timeout=timeout,
+                                exclude_hosts={(current_host.ip, current_host.port)},
+                            )
+                        except RuntimeError:
+                            retry_host = current_host
+                        df = _fetch_xdxr_df_with_fresh_connection(
+                            TdxHq_API,
+                            host=retry_host,
+                            timeout=timeout,
+                            market=market,
+                            code=code,
+                        )
+
+                    if df is None or len(df) == 0:
+                        source_empty += 1
+                        continue
+
+                    source_docs = _normalize_xdxr_df_to_docs(df, code=code)
+                    source_signatures = _build_xdxr_signature_set(
+                        source_docs,
+                        cutoff_date=cutoff_date,
+                        as_of_date=as_of_date_str,
+                    )
+                    if not source_signatures:
+                        source_empty += 1
+                        continue
+
+                    checked += 1
+                    db_docs = list(
+                        coll.find(
+                            {
+                                "code": code,
+                                "date": {"$gte": cutoff_date, "$lte": as_of_date_str},
+                            },
+                            {
+                                "_id": 0,
+                                "date": 1,
+                                "category": 1,
+                                "fenhong": 1,
+                                "peigu": 1,
+                                "peigujia": 1,
+                                "songzhuangu": 1,
+                                "suogu": 1,
+                            },
+                        )
+                    )
+                    db_signatures = _build_xdxr_signature_set(
+                        db_docs,
+                        cutoff_date=cutoff_date,
+                        as_of_date=as_of_date_str,
+                    )
+                    if source_signatures.issubset(db_signatures):
+                        matching += 1
+                    else:
+                        mismatched += 1
+                        mismatch_codes.append(code)
+                        missing = sorted(source_signatures - db_signatures)
+                        logger.warning(
+                            "ETF xdxr recent audit mismatch: "
+                            f"{code} missing_recent_signatures={missing[:3]} cutoff_date={cutoff_date}"
+                        )
+                except Exception as e:
+                    failed += 1
+                    logger.warning(
+                        f"audit etf_xdxr failed: {code} market={market} err={e}"
+                    )
+                    continue
+
+                if i % 200 == 0:
+                    logger.info(
+                        "etf_xdxr audit progress: "
+                        f"{i}/{len(code_list)} checked={checked} matching={matching} "
+                        f"mismatched={mismatched} source_empty={source_empty} failed={failed}"
+                    )
+
+    return {
+        "total": len(code_list),
+        "checked": checked,
+        "matching": matching,
+        "mismatched": mismatched,
+        "source_empty": source_empty,
+        "failed": failed,
+        "cutoff_date": cutoff_date,
+        "mismatch_codes": mismatch_codes,
     }
 
 

--- a/freshquant/tests/test_etf_adj_sync.py
+++ b/freshquant/tests/test_etf_adj_sync.py
@@ -166,6 +166,8 @@ def test_sync_etf_xdxr_all_preserves_existing_docs_when_source_returns_empty(
         "retried_empty": 1,
         "recovered_after_retry": 0,
         "retry_failed": 0,
+        "empty_codes": [],
+        "preserved_codes": ["512000"],
     }
     assert db.etf_xdxr.documents == [
         {
@@ -221,6 +223,8 @@ def test_sync_etf_xdxr_all_replaces_docs_when_source_returns_events(monkeypatch)
         "retried_empty": 0,
         "recovered_after_retry": 0,
         "retry_failed": 0,
+        "empty_codes": [],
+        "preserved_codes": [],
     }
     assert db.etf_xdxr.documents == [
         {
@@ -283,6 +287,8 @@ def test_sync_etf_xdxr_all_retries_empty_result_before_preserving_docs(monkeypat
         "retried_empty": 1,
         "recovered_after_retry": 1,
         "retry_failed": 0,
+        "empty_codes": [],
+        "preserved_codes": [],
     }
     assert db.etf_xdxr.documents == [
         {
@@ -346,5 +352,115 @@ def test_sync_etf_xdxr_all_reconnects_between_batches(monkeypatch):
         "retried_empty": 0,
         "recovered_after_retry": 0,
         "retry_failed": 0,
+        "empty_codes": [],
+        "preserved_codes": [],
     }
     assert FakeTdxApi.instance_count == 2
+
+
+def test_audit_recent_etf_xdxr_coverage_reports_missing_recent_source_event(
+    monkeypatch,
+):
+    db = FakeDb(
+        etf_list=[{"code": "512800", "sse": "sh"}],
+        etf_xdxr=[
+            {
+                "code": "512800",
+                "date": "2023-12-25",
+                "category": 1,
+                "fenhong": 0.48,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(etf_adj_sync, "_ensure_indexes", lambda db: None)
+    monkeypatch.setattr(
+        etf_adj_sync,
+        "_pick_hq_host",
+        lambda timeout=0.7, **kwargs: etf_adj_sync.TdxHqHost("fake", "127.0.0.1", 7709),
+    )
+    FakeTdxApi.instance_count = 0
+    FakeTdxApi.payload_by_code = {
+        "512800": [
+            {
+                "year": 2025,
+                "month": 7,
+                "day": 7,
+                "category": 11,
+                "name": "扩缩股",
+                "suogu": 2.0,
+            }
+        ]
+    }
+    monkeypatch.setattr(etf_adj_sync, "_import_pytdx", lambda: (FakeTdxApi, []))
+
+    stats = etf_adj_sync.audit_recent_etf_xdxr_coverage(
+        db=db,
+        as_of_date="2025-07-10",
+        recent_days=30,
+    )
+
+    assert stats == {
+        "total": 1,
+        "checked": 1,
+        "matching": 0,
+        "mismatched": 1,
+        "source_empty": 0,
+        "failed": 0,
+        "cutoff_date": "2025-06-10",
+        "mismatch_codes": ["512800"],
+    }
+
+
+def test_audit_recent_etf_xdxr_coverage_accepts_matching_recent_source_event(
+    monkeypatch,
+):
+    db = FakeDb(
+        etf_list=[{"code": "512800", "sse": "sh"}],
+        etf_xdxr=[
+            {
+                "code": "512800",
+                "date": "2025-07-07",
+                "category": 11,
+                "suogu": 2.0,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(etf_adj_sync, "_ensure_indexes", lambda db: None)
+    monkeypatch.setattr(
+        etf_adj_sync,
+        "_pick_hq_host",
+        lambda timeout=0.7, **kwargs: etf_adj_sync.TdxHqHost("fake", "127.0.0.1", 7709),
+    )
+    FakeTdxApi.instance_count = 0
+    FakeTdxApi.payload_by_code = {
+        "512800": [
+            {
+                "year": 2025,
+                "month": 7,
+                "day": 7,
+                "category": 11,
+                "name": "扩缩股",
+                "suogu": 2.0,
+            }
+        ]
+    }
+    monkeypatch.setattr(etf_adj_sync, "_import_pytdx", lambda: (FakeTdxApi, []))
+
+    stats = etf_adj_sync.audit_recent_etf_xdxr_coverage(
+        db=db,
+        as_of_date="2025-07-10",
+        recent_days=30,
+    )
+
+    assert stats == {
+        "total": 1,
+        "checked": 1,
+        "matching": 1,
+        "mismatched": 0,
+        "source_empty": 0,
+        "failed": 0,
+        "cutoff_date": "2025-06-10",
+        "mismatch_codes": [],
+    }

--- a/freshquant/tests/test_market_data_assets.py
+++ b/freshquant/tests/test_market_data_assets.py
@@ -3,6 +3,8 @@ import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
+import pytest
+
 
 def _build_dagster_stub():
     module = ModuleType("dagster")
@@ -77,6 +79,7 @@ def _build_etf_adj_sync_stub():
     module = ModuleType("freshquant.data.etf_adj_sync")
     module.sync_etf_adj_all = lambda *args, **kwargs: None
     module.sync_etf_xdxr_all = lambda *args, **kwargs: None
+    module.audit_recent_etf_xdxr_coverage = lambda *args, **kwargs: None
     return module
 
 
@@ -413,7 +416,14 @@ def test_etf_xdxr_asset_calls_sync_function(monkeypatch):
     monkeypatch.setattr(
         module,
         "sync_etf_xdxr_all",
-        lambda: captured.setdefault("etf_xdxr", True) and {"ok": 1},
+        lambda: captured.setdefault("etf_xdxr", True)
+        and {"ok": 1, "empty_codes": [], "preserved_codes": []},
+    )
+    monkeypatch.setattr(
+        module,
+        "audit_recent_etf_xdxr_coverage",
+        lambda **kwargs: captured.setdefault("etf_xdxr_audit", kwargs)
+        or {"mismatched": 0, "failed": 0},
     )
 
     context = SimpleNamespace(log=log)
@@ -421,6 +431,31 @@ def test_etf_xdxr_asset_calls_sync_function(monkeypatch):
 
     assert captured == {"etf_xdxr": True}
     assert isinstance(result, str)
+
+
+def test_etf_xdxr_asset_raises_when_recent_audit_finds_mismatch(monkeypatch):
+    module = _import_market_data_module(monkeypatch)
+    log = FakeLog()
+    captured = {}
+
+    monkeypatch.setattr(
+        module,
+        "sync_etf_xdxr_all",
+        lambda: {"ok": 1, "empty_codes": ["512800"], "preserved_codes": []},
+    )
+    monkeypatch.setattr(
+        module,
+        "audit_recent_etf_xdxr_coverage",
+        lambda **kwargs: (
+            captured.setdefault("audit_kwargs", kwargs),
+            {"mismatched": 1, "failed": 0, "mismatch_codes": ["512800"]},
+        )[1],
+    )
+
+    context = SimpleNamespace(log=log)
+    with pytest.raises(RuntimeError, match="512800"):
+        module.etf_xdxr(context, "2026-03-17 16:00:00")
+    assert captured == {"audit_kwargs": {"codes": ["512800"]}}
 
 
 def test_etf_adj_asset_calls_sync_function(monkeypatch):

--- a/morningglory/fqdagster/src/fqdagster/defs/assets/market_data.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/assets/market_data.py
@@ -31,7 +31,11 @@ from QUANTAXIS.QASU.main import (
 )
 from QUANTAXIS.QAUtil import QA_util_to_json_from_pandas
 
-from freshquant.data.etf_adj_sync import sync_etf_adj_all, sync_etf_xdxr_all
+from freshquant.data.etf_adj_sync import (
+    audit_recent_etf_xdxr_coverage,
+    sync_etf_adj_all,
+    sync_etf_xdxr_all,
+)
 from freshquant.db import DBQuantAxis
 
 from ..postclose_markers import (
@@ -553,6 +557,28 @@ def etf_xdxr(context: AssetExecutionContext, etf_list: str) -> str:
     context.log.info(f"Saving ETF xdxr data, triggered after etf_list at {etf_list}")
     stats = sync_etf_xdxr_all()
     context.log.info(f"ETF xdxr sync stats: {stats}")
+    suspicious_codes = list(
+        dict.fromkeys(
+            [
+                *list(stats.get("empty_codes") or []),
+                *list(stats.get("preserved_codes") or []),
+            ]
+        )
+    )
+    if suspicious_codes:
+        audit_stats = audit_recent_etf_xdxr_coverage(codes=suspicious_codes)
+        context.log.info(f"ETF xdxr recent audit stats: {audit_stats}")
+        if audit_stats.get("mismatched") or audit_stats.get("failed"):
+            mismatch_codes = audit_stats.get("mismatch_codes") or []
+            mismatch_suffix = (
+                f" mismatch_codes={mismatch_codes[:10]}" if mismatch_codes else ""
+            )
+            raise RuntimeError(
+                "ETF xdxr recent audit failed: "
+                f"mismatched={audit_stats.get('mismatched', 0)} "
+                f"failed={audit_stats.get('failed', 0)}"
+                f"{mismatch_suffix}"
+            )
     market_data_alert.send(
         "dagster-asset",
         payload={


### PR DESCRIPTION
## 背景
- 512800 在前复权问题修复后，已经恢复正确，但 Dagster 之前仍存在一种静默风险：ETF xdxr 同步如果把某些 code 记成 `empty/preserved`，run 依旧可能显示成功。
- 这会导致前端直到用户看到价格断层时才暴露问题。

## 目标
- 让 ETF xdxr 同步对可疑结果追加近期覆盖审计。
- 如果近窗口内源侧有事件但库里没有，Dagster asset 直接 fail，避免静默漏同步。
- 保持审计范围只覆盖本次同步中的可疑 code，避免把 nightly 任务拖慢一倍。

## 范围
- `freshquant.data.etf_adj_sync`：新增近期 xdxr 覆盖审计函数，并在同步统计中回传 `empty_codes/preserved_codes`
- `fqdagster` ETF xdxr asset：仅对本次 `empty/preserved` 的 code 执行审计并在 mismatch/failed 时失败
- `docs/current/troubleshooting.md`：补当前排障口径
- 测试：补同步审计与 Dagster asset 行为用例

## 非目标
- 不修改前端 UI 逻辑
- 不改动 ETF qfq 公式
- 不做全市场二次全量审计

## 验收标准
- 新增测试覆盖：近期源事件缺库会被识别，Dagster asset 在审计失配时 fail
- `pytest freshquant/tests/test_etf_adj_sync.py freshquant/tests/test_market_data_assets.py -q` 通过
- `pytest freshquant/tests -q -k etf` 通过
- 浏览器侧继续能通过 `/kline-big?symbol=sh512800&period=1d&endDate=2025-07-10` 验证 `512800` 的日线前复权数据

## 部署影响
- 影响面为 Dagster
- merge 后需要 formal deploy，命中 Dagster surface
