### PR TITLE
fix: harden ETF xdxr host fallback

### DIFF
--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -187,13 +187,15 @@ print(sync_etf_xdxr_all(codes=['512800']))
 常见根因：
 
 - pytdx 长连接在 ETF xdxr 全量批量同步后段返回空结果
+- pytdx `connect()` 失败时会直接返回 `False`；旧实现把它放进 `with api.connect(...)`，会把 retry host / batch host 故障误打成 `bool` context manager 错误
 - 部分 ETF 的旧 `etf_xdxr` 文档来自 TDX 之外的历史回填，TDX 当前返回为空时会走 `preserve_on_empty=True` 保留旧文档；如果某只 ETF 在长连接退化场景下误返回空，也会被保留成旧状态
 
 处理：
 
 - 当前实现会对 ETF xdxr 首次空结果做 fresh connection retry，并在全量同步时周期性重建 TDX 连接
+- 当前实现会在 batch host 连接失败时自动切到下一个可用 HQ host；fresh connection retry 的目标 host 若连不上，也会继续轮转其他 HQ host，而不是把 run 记成成功或打成 `bool` context manager 异常
 - retry 仍超时或为空时，优先核对该 code 在不同 TDX host 上是否一致为空；对确实为空但库里已有历史回填的 ETF，允许保留旧文档
-- Dagster `etf_xdxr` 资产会对本次同步中 `empty/preserved` 的可疑 code 追加一次近期覆盖审计；如果近窗口内源侧有事件但库里没有，asset 会直接 fail，不再把 run 记成成功
+- Dagster `etf_xdxr` 资产会对本次同步中 `empty/preserved` 的可疑 code 追加一次近期覆盖审计；如果近窗口内源侧有事件但库里没有，或者所有 HQ host 都不可达，asset 会直接 fail，不再把 run 记成成功
 - 对单券立即修复可执行：
   - `@'
 from freshquant.data.etf_adj_sync import sync_etf_adj_all, sync_etf_xdxr_all
@@ -204,6 +206,11 @@ print(sync_etf_adj_all(codes=['512800']))
   - `@'
 from freshquant.data.etf_adj_sync import audit_recent_etf_xdxr_coverage
 print(audit_recent_etf_xdxr_coverage(codes=['512800'], recent_days=365))
+'@ | py -3.12 -m uv run -`
+- 对全量 ETF 近期覆盖审计可手工执行：
+  - `@'
+from freshquant.data.etf_adj_sync import audit_recent_etf_xdxr_coverage
+print(audit_recent_etf_xdxr_coverage(recent_days=365))
 '@ | py -3.12 -m uv run -`
 - 正式修复后，重新部署 Dagster，并再跑一次 formal deploy health check / runtime verify
 

--- a/freshquant/data/etf_adj_sync.py
+++ b/freshquant/data/etf_adj_sync.py
@@ -137,6 +137,60 @@ def _fetch_xdxr_df(api, *, market: int, code: str) -> pd.DataFrame:
     return df
 
 
+def _disconnect_tdx_api_safely(api) -> None:
+    try:
+        api.disconnect()
+    except Exception:
+        pass
+
+
+def _connect_tdx_api_or_raise(api, *, host: TdxHqHost, timeout: float):
+    try:
+        conn = api.connect(host.ip, host.port, time_out=timeout)
+    except Exception as exc:
+        raise RuntimeError(
+            f"TDX HQ connect failed: {host.name} {host.ip}:{host.port}: {exc}"
+        ) from exc
+    if not conn:
+        raise RuntimeError(f"TDX HQ connect failed: {host.name} {host.ip}:{host.port}")
+    return conn
+
+
+def _open_tdx_api_with_host_fallback(
+    tdx_api_cls,
+    *,
+    preferred_host: TdxHqHost,
+    timeout: float,
+    log_prefix: str,
+    max_attempts: int = 3,
+) -> tuple[object, TdxHqHost]:
+    host = preferred_host
+    tried_hosts: set[tuple[str, int]] = set()
+    last_error: Exception | None = None
+
+    for _ in range(max(int(max_attempts), 1)):
+        api = tdx_api_cls()
+        try:
+            _connect_tdx_api_or_raise(api, host=host, timeout=timeout)
+            return api, host
+        except Exception as exc:
+            last_error = exc
+            logger.warning(
+                f"{log_prefix} host connect failed: "
+                f"{host.name} {host.ip}:{host.port} err={exc}"
+            )
+            _disconnect_tdx_api_safely(api)
+            tried_hosts.add((host.ip, host.port))
+            try:
+                host = _pick_hq_host(timeout=timeout, exclude_hosts=tried_hosts)
+            except RuntimeError:
+                break
+
+    if last_error is not None:
+        raise RuntimeError(f"{log_prefix} no reachable TDX HQ host") from last_error
+    raise RuntimeError(f"{log_prefix} no reachable TDX HQ host")
+
+
 def _fetch_xdxr_df_with_fresh_connection(
     tdx_api_cls,
     *,
@@ -144,10 +198,37 @@ def _fetch_xdxr_df_with_fresh_connection(
     timeout: float,
     market: int,
     code: str,
+    exclude_hosts: Optional[set[tuple[str, int]]] = None,
 ) -> pd.DataFrame:
-    api = tdx_api_cls()
-    with api.connect(host.ip, host.port, time_out=timeout):
-        return _fetch_xdxr_df(api, market=market, code=code)
+    current_host = host
+    tried_hosts = set(exclude_hosts or set())
+    last_error: Exception | None = None
+
+    while True:
+        api = tdx_api_cls()
+        try:
+            _connect_tdx_api_or_raise(api, host=current_host, timeout=timeout)
+            return _fetch_xdxr_df(api, market=market, code=code)
+        except Exception as exc:
+            last_error = exc
+            logger.warning(
+                "fresh ETF xdxr connection failed: "
+                f"{code} market={market} host={current_host.name} "
+                f"{current_host.ip}:{current_host.port} err={exc}"
+            )
+            tried_hosts.add((current_host.ip, current_host.port))
+            try:
+                current_host = _pick_hq_host(timeout=timeout, exclude_hosts=tried_hosts)
+            except RuntimeError:
+                break
+        finally:
+            _disconnect_tdx_api_safely(api)
+
+    if last_error is not None:
+        raise RuntimeError(
+            f"fresh ETF xdxr connection exhausted all hosts for {code}"
+        ) from last_error
+    raise RuntimeError(f"fresh ETF xdxr connection exhausted all hosts for {code}")
 
 
 def _normalize_xdxr_df_to_docs(df: pd.DataFrame, *, code: str) -> list[dict]:
@@ -275,8 +356,13 @@ def sync_etf_xdxr_all(
                 )
             except RuntimeError:
                 pass
-        api = TdxHq_API()
-        with api.connect(current_host.ip, current_host.port, time_out=timeout):
+        api, current_host = _open_tdx_api_with_host_fallback(
+            TdxHq_API,
+            preferred_host=current_host,
+            timeout=timeout,
+            log_prefix="sync etf_xdxr batch",
+        )
+        try:
             for batch_offset, code in enumerate(batch_codes, 1):
                 i = batch_start + batch_offset
                 market = _market_from_sse_or_code(sse=etf_map.get(code), code=code)
@@ -292,13 +378,16 @@ def sync_etf_xdxr_all(
                         )
                         retry_df = pd.DataFrame()
                         retry_host = current_host
+                        retry_exclude_hosts: set[tuple[str, int]] = set()
                         try:
+                            retry_exclude_hosts = {(current_host.ip, current_host.port)}
                             retry_host = _pick_hq_host(
                                 timeout=timeout,
-                                exclude_hosts={(current_host.ip, current_host.port)},
+                                exclude_hosts=retry_exclude_hosts,
                             )
                         except RuntimeError:
                             retry_host = current_host
+                            retry_exclude_hosts = set()
                         try:
                             retry_df = _fetch_xdxr_df_with_fresh_connection(
                                 TdxHq_API,
@@ -306,6 +395,7 @@ def sync_etf_xdxr_all(
                                 timeout=timeout,
                                 market=market,
                                 code=code,
+                                exclude_hosts=retry_exclude_hosts,
                             )
                         except Exception as retry_error:
                             retry_failed += 1
@@ -357,6 +447,8 @@ def sync_etf_xdxr_all(
                         f"failed={failed} retried_empty={retried_empty} "
                         f"recovered_after_retry={recovered_after_retry} retry_failed={retry_failed}"
                     )
+        finally:
+            _disconnect_tdx_api_safely(api)
 
     return {
         "total": len(code_list),
@@ -435,8 +527,13 @@ def audit_recent_etf_xdxr_coverage(
                 )
             except RuntimeError:
                 pass
-        api = TdxHq_API()
-        with api.connect(current_host.ip, current_host.port, time_out=timeout):
+        api, current_host = _open_tdx_api_with_host_fallback(
+            TdxHq_API,
+            preferred_host=current_host,
+            timeout=timeout,
+            log_prefix="audit etf_xdxr batch",
+        )
+        try:
             for batch_offset, code in enumerate(batch_codes, 1):
                 i = batch_start + batch_offset
                 market = _market_from_sse_or_code(sse=etf_map.get(code), code=code)
@@ -444,19 +541,23 @@ def audit_recent_etf_xdxr_coverage(
                     df = _fetch_xdxr_df(api, market=market, code=code)
                     if df is None or len(df) == 0:
                         retry_host = current_host
+                        retry_exclude_hosts: set[tuple[str, int]] = set()
                         try:
+                            retry_exclude_hosts = {(current_host.ip, current_host.port)}
                             retry_host = _pick_hq_host(
                                 timeout=timeout,
-                                exclude_hosts={(current_host.ip, current_host.port)},
+                                exclude_hosts=retry_exclude_hosts,
                             )
                         except RuntimeError:
                             retry_host = current_host
+                            retry_exclude_hosts = set()
                         df = _fetch_xdxr_df_with_fresh_connection(
                             TdxHq_API,
                             host=retry_host,
                             timeout=timeout,
                             market=market,
                             code=code,
+                            exclude_hosts=retry_exclude_hosts,
                         )
 
                     if df is None or len(df) == 0:
@@ -520,6 +621,8 @@ def audit_recent_etf_xdxr_coverage(
                         f"{i}/{len(code_list)} checked={checked} matching={matching} "
                         f"mismatched={mismatched} source_empty={source_empty} failed={failed}"
                     )
+        finally:
+            _disconnect_tdx_api_safely(api)
 
     return {
         "total": len(code_list),

--- a/freshquant/tests/test_etf_adj_sync.py
+++ b/freshquant/tests/test_etf_adj_sync.py
@@ -97,15 +97,29 @@ class FakeDb:
 
 class FakeTdxApi:
     payload_by_code: dict[str, list[dict[str, Any]]] = {}
+    payload_by_endpoint_and_code: dict[tuple[str, int, str], Any] = {}
+    connect_outcome_by_endpoint: dict[tuple[str, int], Any] = {}
     instance_count = 0
 
     def __init__(self):
         type(self).instance_count += 1
         self.instance_no = type(self).instance_count
         self.call_count_by_code: dict[str, int] = {}
+        self.connected_endpoint: tuple[str, int] | None = None
 
     def connect(self, ip, port, time_out=0.7):
-        return self
+        endpoint = (str(ip), int(port))
+        self.connected_endpoint = endpoint
+        outcome = type(self).connect_outcome_by_endpoint.get(endpoint, self)
+        if callable(outcome):
+            outcome = outcome(
+                api=self,
+                ip=str(ip),
+                port=int(port),
+                instance_no=self.instance_no,
+                time_out=time_out,
+            )
+        return outcome
 
     def __enter__(self):
         return self
@@ -115,7 +129,18 @@ class FakeTdxApi:
 
     def get_xdxr_info(self, market, code):
         self.call_count_by_code[code] = self.call_count_by_code.get(code, 0) + 1
-        payload = self.payload_by_code.get(code, [])
+        payload = []
+        if self.connected_endpoint is not None:
+            payload = self.payload_by_endpoint_and_code.get(
+                (
+                    self.connected_endpoint[0],
+                    self.connected_endpoint[1],
+                    code,
+                ),
+                [],
+            )
+        if not payload:
+            payload = self.payload_by_code.get(code, [])
         if callable(payload):
             return payload(
                 code=code,
@@ -358,6 +383,70 @@ def test_sync_etf_xdxr_all_reconnects_between_batches(monkeypatch):
     assert FakeTdxApi.instance_count == 2
 
 
+def test_sync_etf_xdxr_all_falls_back_when_batch_host_connect_fails(monkeypatch):
+    db = FakeDb(etf_list=[{"code": "512800", "sse": "sh"}])
+
+    monkeypatch.setattr(etf_adj_sync, "_ensure_indexes", lambda db: None)
+    hosts = [
+        etf_adj_sync.TdxHqHost("bad", "10.0.0.1", 7709),
+        etf_adj_sync.TdxHqHost("good", "10.0.0.2", 7709),
+    ]
+
+    def pick_host(timeout=0.7, exclude_hosts=None):
+        exclude_hosts = exclude_hosts or set()
+        for host in hosts:
+            if (host.ip, host.port) not in exclude_hosts:
+                return host
+        raise RuntimeError("no host")
+
+    monkeypatch.setattr(etf_adj_sync, "_pick_hq_host", pick_host)
+    FakeTdxApi.instance_count = 0
+    FakeTdxApi.connect_outcome_by_endpoint = {("10.0.0.1", 7709): False}
+    FakeTdxApi.payload_by_code = {}
+    FakeTdxApi.payload_by_endpoint_and_code = {
+        (
+            "10.0.0.2",
+            7709,
+            "512800",
+        ): [
+            {
+                "year": 2025,
+                "month": 7,
+                "day": 7,
+                "category": 11,
+                "name": "扩缩股",
+                "suogu": 2.0,
+            }
+        ]
+    }
+    monkeypatch.setattr(etf_adj_sync, "_import_pytdx", lambda: (FakeTdxApi, []))
+
+    stats = etf_adj_sync.sync_etf_xdxr_all(db=db, reconnect_every=1)
+
+    assert stats == {
+        "total": 1,
+        "ok": 1,
+        "empty": 0,
+        "preserved": 0,
+        "failed": 0,
+        "retried_empty": 0,
+        "recovered_after_retry": 0,
+        "retry_failed": 0,
+        "empty_codes": [],
+        "preserved_codes": [],
+    }
+    assert db.etf_xdxr.documents == [
+        {
+            "code": "512800",
+            "date": "2025-07-07",
+            "category": 11,
+            "name": "扩缩股",
+            "suogu": 2.0,
+            "category_meaning": "扩缩股",
+        }
+    ]
+
+
 def test_audit_recent_etf_xdxr_coverage_reports_missing_recent_source_event(
     monkeypatch,
 ):
@@ -445,6 +534,76 @@ def test_audit_recent_etf_xdxr_coverage_accepts_matching_recent_source_event(
                 "suogu": 2.0,
             }
         ]
+    }
+    monkeypatch.setattr(etf_adj_sync, "_import_pytdx", lambda: (FakeTdxApi, []))
+
+    stats = etf_adj_sync.audit_recent_etf_xdxr_coverage(
+        db=db,
+        as_of_date="2025-07-10",
+        recent_days=30,
+    )
+
+    assert stats == {
+        "total": 1,
+        "checked": 1,
+        "matching": 1,
+        "mismatched": 0,
+        "source_empty": 0,
+        "failed": 0,
+        "cutoff_date": "2025-06-10",
+        "mismatch_codes": [],
+    }
+
+
+def test_audit_recent_etf_xdxr_coverage_falls_back_when_retry_host_connect_fails(
+    monkeypatch,
+):
+    db = FakeDb(
+        etf_list=[{"code": "512800", "sse": "sh"}],
+        etf_xdxr=[
+            {
+                "code": "512800",
+                "date": "2025-07-07",
+                "category": 11,
+                "suogu": 2.0,
+            }
+        ],
+    )
+
+    monkeypatch.setattr(etf_adj_sync, "_ensure_indexes", lambda db: None)
+    hosts = [
+        etf_adj_sync.TdxHqHost("current", "10.0.1.1", 7709),
+        etf_adj_sync.TdxHqHost("bad-retry", "10.0.1.2", 7709),
+        etf_adj_sync.TdxHqHost("good-retry", "10.0.1.3", 7709),
+    ]
+
+    def pick_host(timeout=0.7, exclude_hosts=None):
+        exclude_hosts = exclude_hosts or set()
+        for host in hosts:
+            if (host.ip, host.port) not in exclude_hosts:
+                return host
+        raise RuntimeError("no host")
+
+    monkeypatch.setattr(etf_adj_sync, "_pick_hq_host", pick_host)
+    FakeTdxApi.instance_count = 0
+    FakeTdxApi.connect_outcome_by_endpoint = {("10.0.1.2", 7709): False}
+    FakeTdxApi.payload_by_code = {}
+    FakeTdxApi.payload_by_endpoint_and_code = {
+        ("10.0.1.1", 7709, "512800"): [],
+        (
+            "10.0.1.3",
+            7709,
+            "512800",
+        ): [
+            {
+                "year": 2025,
+                "month": 7,
+                "day": 7,
+                "category": 11,
+                "name": "扩缩股",
+                "suogu": 2.0,
+            }
+        ],
     }
     monkeypatch.setattr(etf_adj_sync, "_import_pytdx", lambda: (FakeTdxApi, []))
 


### PR DESCRIPTION
## 背景\n- 512800 的 ETF 前复权问题已经定位到 Dagster 的 tf_xdxr -> etf_adj 同步链。\n- 上一轮修复后，512800 和一批历史缺失 ETF 已经可以手工回填，但全量审计又暴露出另一个剩余缺口：当 pytdx connect() 失败返回 False 时，with api.connect(...) 会把 batch host / retry host 故障误打成 ool context manager 异常。\n- 这会让 ETF 历史同步和近期覆盖审计在部分 host 故障下出现误失败，影响 Dagster 对漏同步的兜底判定。\n\n## 目标\n- 让 ETF tf_xdxr 同步和近期覆盖审计在 HQ host 连接失败时自动 fallback 到其他可用 host。\n- 把 connect=False 的错误从 Python 运行时异常收口为显式的 host 轮转 / 显式失败。\n- 保持 docs/current/** 与当前排障事实同步。\n\n## 范围\n- reshquant/data/etf_adj_sync.py\n- reshquant/tests/test_etf_adj_sync.py\n- docs/current/troubleshooting.md\n\n## 非目标\n- 不改 ETF 前复权计算公式。\n- 不改 KlineSlim / API 读取逻辑。\n- 不在这条 PR 里引入新的 Dagster asset 或调度。\n\n## 验收标准\n- batch host 连接失败时，ETF tf_xdxr 同步仍可切到可用 host 并继续。\n- retry host 连接失败时，ETF 近期覆盖审计仍可切到可用 host 并避免误报 ool context manager 异常。\n- 相关测试通过。\n\n## 本地验证\n- py -3.12 -m uv run pytest freshquant/tests/test_etf_adj_sync.py -q\n- py -3.12 -m uv run pytest freshquant/tests/test_market_data_assets.py -q\n- py -3.12 -m uv run pytest freshquant/tests -q -k etf\n- powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure\n\n## 部署影响\n- 命中 reshquant/data/etf_adj_sync.py，需要重部署 Dagster。\n- merge 后会补跑 ETF 全量近期覆盖审计，并做前端验收。