### PR TITLE
fix: redeploy docker runtime on compose changes

### DIFF
--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -76,6 +76,7 @@ powershell -ExecutionPolicy Bypass -File script/ci/run_production_deploy.ps1 -Ca
 - 先确认当前代码真值是最新远程 `origin/main`；如果为了修 deploy 问题需要改代码，必须先走 `feature branch -> PR -> merge remote main`，再回到本地 `main` 与 `origin/main` 对齐。
 - 正式 deploy 统一从 `D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production` 执行，不要直接把开发 worktree 当成正式来源。
 - workflow 与人工正式 deploy 都应优先调用 `script/ci/run_production_deploy.ps1`；不要再把 mirror sync、`uv sync`、`run_formal_deploy.py` 手工拆开执行。
+- `docker/compose.parallel.yaml` 变更现在按完整 Docker 并行环境运行时变更处理；`freshquant_deploy_plan.py` 必须把它解析成实际 deploy，而不是 `deployment_required=false` 的 no-op。
 - `script/ci/run_production_deploy.ps1` 会先用 runner Python 3.12 做 `uv sync`，再切换到 deploy mirror `.venv\Scripts\python.exe` 运行 `run_formal_deploy.py`；formal deploy 内部 health check 也跟随 mirror `.venv` 解释器。
 - 如果 formal deploy 命中 `fq_apiserver` / `fq_webui` 后仍出现“像是旧代码”的症状，先检查 deploy mirror 是否残留过往 ignored 构建产物；当前正式入口会在 mirror sync 阶段主动清掉这类文件。
 - 读取 `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/plan.json`、`result.json` 与 `D:/fqpack/runtime/formal-deploy/production-state.json` 作为正式 deploy 基础证据；不要只凭终端退出码判断成功。

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -116,6 +116,7 @@
 - Docker 容器内部 Mongo 继续使用服务名 `fq_mongodb:27017`
 - Docker 容器内部 Redis 继续使用服务名 `fq_redis:6379`
 - `docker/compose.parallel.yaml` 会为核心容器显式注入 `FRESHQUANT_MONGODB__HOST=fq_mongodb`、`FRESHQUANT_MONGODB__PORT=27017`、`FRESHQUANT_REDIS__HOST=fq_redis` 与 `FRESHQUANT_REDIS__PORT=6379`
+- `docker/compose.parallel.yaml` 只要变更，正式 deploy plan 就按全量受管 Docker 并行环境容器重建/重启处理，避免 merge 后漏掉运行时配置更新。
 - Web UI 默认访问并行 API `http://127.0.0.1:15000`
 
 ### 跑本地预检并开 PR

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -197,6 +197,7 @@ print(sync_etf_xdxr_all(codes=['512800']))
 - retry 仍超时或为空时，优先核对该 code 在不同 TDX host 上是否一致为空；对确实为空但库里已有历史回填的 ETF，允许保留旧文档
 - Dagster `etf_xdxr` 资产会对本次同步中 `empty/preserved` 的可疑 code 追加一次近期覆盖审计；如果近窗口内源侧有事件但库里没有，或者所有 HQ host 都不可达，asset 会直接 fail，不再把 run 记成成功
 - 如果 API / KlineSlim 在 `/api/stock_data` 上直接报 `redis.exceptions.ConnectionError: Error 111 connecting to 127.0.0.1:6379`，优先检查 Docker compose 是否把宿主机 `.env` 里的 Redis 地址误透传进容器；正式口径应由 `docker/compose.parallel.yaml` 显式覆盖为 `FRESHQUANT_REDIS__HOST=fq_redis`、`FRESHQUANT_REDIS__PORT=6379`
+- 如果 compose Redis 覆盖修复已经 merge，但 formal deploy 的 `plan.json` 仍显示 `deployment_required=false`，优先检查 changed paths 是否包含 `docker/compose.parallel.yaml`；当前正式口径要求这类 compose 运行时变更必须触发全量受管 Docker 并行环境容器重建/重启。
 - 对单券立即修复可执行：
   - `@'
 from freshquant.data.etf_adj_sync import sync_etf_adj_all, sync_etf_xdxr_all

--- a/freshquant/tests/test_freshquant_deploy_plan.py
+++ b/freshquant/tests/test_freshquant_deploy_plan.py
@@ -137,6 +137,42 @@ def test_etf_adj_sync_path_requires_dagster_redeploy() -> None:
     ]
 
 
+def test_compose_parallel_changes_require_full_docker_runtime_redeploy() -> None:
+    module = load_module()
+
+    plan = module.build_deploy_plan(changed_paths=["docker/compose.parallel.yaml"])
+
+    assert plan["deployment_required"] is True
+    assert plan["deployment_surfaces"] == [
+        "api",
+        "web",
+        "dagster",
+        "qa",
+        "tradingagents",
+    ]
+    assert plan["docker_build_targets"] == [
+        "fq_apiserver",
+        "fq_webui",
+        "ta_backend",
+        "ta_frontend",
+    ]
+    assert plan["docker_services"] == [
+        "fq_mongodb",
+        "fq_redis",
+        "fq_runtime_clickhouse",
+        "fq_apiserver",
+        "fq_runtime_indexer",
+        "fq_tdxhq",
+        "fq_dagster_webserver",
+        "fq_dagster_daemon",
+        "fq_qawebserver",
+        "fq_webui",
+        "ta_backend",
+        "ta_frontend",
+    ]
+    assert any("compose.parallel.yaml" in note for note in plan["notes"])
+
+
 def test_qa_surface_requires_shared_rear_build_target() -> None:
     module = load_module()
 

--- a/freshquant/tests/test_freshquant_health_check.py
+++ b/freshquant/tests/test_freshquant_health_check.py
@@ -39,6 +39,7 @@ def test_resolve_check_urls_uses_surface_targets_and_deduplicates() -> None:
         "http://127.0.0.1:18080/",
         "http://127.0.0.1:18080/gantt/shouban30",
         "http://127.0.0.1:18080/runtime-observability",
+        "http://127.0.0.1:18080/api/stock_data?period=1d&symbol=sh512800&endDate=2025-07-10&barCount=2",
         "http://127.0.0.1:9999/custom",
     ]
 

--- a/script/freshquant_deploy_plan.py
+++ b/script/freshquant_deploy_plan.py
@@ -84,6 +84,7 @@ HEALTH_CHECK_MAP = {
         "http://127.0.0.1:18080/",
         "http://127.0.0.1:18080/gantt/shouban30",
         "http://127.0.0.1:18080/runtime-observability",
+        "http://127.0.0.1:18080/api/stock_data?period=1d&symbol=sh512800&endDate=2025-07-10&barCount=2",
     ],
     "tradingagents": [
         "http://127.0.0.1:13000/api/health",
@@ -107,6 +108,22 @@ FRESHQUANT_MESSAGE_SURFACES = ("market_data", "guardian")
 FRESHQUANT_TRADING_SURFACES = ("api", "dagster", "market_data", "guardian")
 FRESHQUANT_LEGACY_CONFIG_SURFACES = ("dagster", "market_data", "guardian")
 FQXTRADE_RUNTIME_SURFACES = ("order_management",)
+DOCKER_PARALLEL_ALL_SURFACES = ("api", "web", "dagster", "qa", "tradingagents")
+DOCKER_PARALLEL_ALL_SERVICES = (
+    "fq_mongodb",
+    "fq_redis",
+    "fq_runtime_clickhouse",
+    "fq_apiserver",
+    "fq_runtime_indexer",
+    "fq_tdxhq",
+    "fq_dagster_webserver",
+    "fq_dagster_daemon",
+    "fq_qawebserver",
+    "fq_webui",
+    "ta_backend",
+    "ta_frontend",
+)
+DOCKER_PARALLEL_COMPOSE_PATH = "docker/compose.parallel.yaml"
 
 
 @dataclass(frozen=True)
@@ -321,9 +338,16 @@ def build_deploy_plan(
 ) -> dict[str, object]:
     changed_paths = changed_paths or []
     explicit_surfaces = explicit_surfaces or []
+    normalized_changed_paths = [normalize_path(path) for path in changed_paths]
+    compose_parallel_changed = DOCKER_PARALLEL_COMPOSE_PATH in normalized_changed_paths
 
-    surfaces_from_paths, notes = resolve_surfaces_from_paths(changed_paths)
+    surfaces_from_paths, notes = resolve_surfaces_from_paths(normalized_changed_paths)
     surfaces = set(surfaces_from_paths)
+    if compose_parallel_changed:
+        surfaces.update(DOCKER_PARALLEL_ALL_SURFACES)
+        notes.append(
+            "`docker/compose.parallel.yaml` 变更会直接影响 Docker 并行环境；正式 deploy 统一重建/重启全部受管容器。"
+        )
     for value in explicit_surfaces:
         surfaces.add(normalize_surface(value))
 
@@ -343,6 +367,10 @@ def build_deploy_plan(
         ]
     )
     docker_services = unique_in_order(docker_build_targets + docker_up_services)
+    if compose_parallel_changed:
+        docker_services = unique_in_order(
+            [*DOCKER_PARALLEL_ALL_SERVICES, *docker_services]
+        )
     host_surfaces = [surface for surface in ordered if surface in HOST_SURFACE_PROGRAMS]
     host_programs = unique_in_order(
         [
@@ -407,7 +435,7 @@ def build_deploy_plan(
     )
 
     return {
-        "changed_paths": [normalize_path(path) for path in changed_paths],
+        "changed_paths": normalized_changed_paths,
         "deployment_required": bool(ordered),
         "deployment_surfaces": ordered,
         "docker_build_targets": docker_build_targets,


### PR DESCRIPTION
## 背景
- `docker/compose.parallel.yaml` 的 Redis 覆盖修复虽然已经 merge，但 formal deploy plan 会把纯 compose 变更判成 `deployment_required=false`
- 结果是 merge 后线上没有重建到新容器配置，KlineSlim 同源 `/api/stock_data` 仍然返回 500

## 目标
- 让 `docker/compose.parallel.yaml` 变更稳定触发正式 deploy
- 让 `web` surface 健康检查覆盖真实同源行情接口，避免页面 200 但前端核心数据链路仍损坏

## 范围
- 更新 `freshquant_deploy_plan.py` 对 compose 变更的部署判定
- 补充 deploy / health check 回归测试
- 同步 `docs/current/**` 正式口径

## 非目标
- 不修改 ETF 前复权同步逻辑本身
- 不引入新的 deployment surface

## 验收标准
- `py -3.12 script/freshquant_deploy_plan.py --changed-path docker/compose.parallel.yaml --format summary` 返回 `deployment_required: true`
- 输出的 `docker_services` 包含 Docker 并行环境受管服务集合
- `script/freshquant_health_check.py --surface web` 包含同源 `/api/stock_data` 检查
- 相关 deploy / health / orchestrator 回归测试通过

## 部署影响
- formal deploy 会把 `docker/compose.parallel.yaml` 变更按实际 Docker runtime 变更处理
- 本轮合并后需要基于最新远程 `main` 执行正式 deploy，并复核 KlineSlim 同源行情接口

## 验证
- `py -3.12 -m pytest freshquant/tests/test_freshquant_deploy_plan.py freshquant/tests/test_freshquant_health_check.py freshquant/tests/test_formal_deploy_orchestrator.py freshquant/tests/test_fq_apply_deploy_plan.py freshquant/tests/test_docker_runtime_policy.py freshquant/tests/test_docker_parallel_compose.py freshquant/tests/test_deploy_build_cache_policy.py -q`
- `powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure`