### PR TITLE
fix: reduce runtime indexer progress write amplification

### DIFF
--- a/docs/current/modules/runtime-observability.md
+++ b/docs/current/modules/runtime-observability.md
@@ -70,6 +70,11 @@ Runtime Observability 当前采用“双存储”：
 
 `fq_runtime_indexer` 维护文件 offset 状态，只做增量读取，不改写原始 JSONL。
 
+当前 indexer 会把 `runtime_ingest_progress` 作为文件 offset snapshot：
+
+- 只有当某个 JSONL 的 `offset / file_size / mtime` 发生变化时，才会写新的 progress
+- 单轮扫描内多个文件的 progress 会合并成一次批量写入，避免为每个文件单独生成 ClickHouse insert part
+
 ### 查询链
 
 `ClickHouse -> Flask runtime routes -> RuntimeObservability.vue`
@@ -129,6 +134,12 @@ Runtime Observability 当前采用“双存储”：
 - `file_size`
 - `mtime`
 - `updated_at`
+
+恢复口径：
+
+- 不要通过“删除 progress 后全量重扫 JSONL”来恢复已存在的 `runtime_events`
+- 正式恢复入口是 `script/rebuild_runtime_ingest_progress.py`
+- 该脚本会先从 `runtime_events` 读取每个 `raw_file` 已入库的最大 `raw_line`，再反推当前 JSONL 的 byte offset，重建 `runtime_ingest_progress`
 
 ## 页面信息架构
 
@@ -276,6 +287,7 @@ Runtime Observability 当前采用“双存储”：
 - 先查 `fq_runtime_indexer` 是否在跑
 - 再查 `runtime_ingest_progress` 是否推进
 - 再查 `fq_runtime_clickhouse` 健康
+- 如果 `runtime_ingest_progress` 因 broken parts 无法 attach，先重建这张进度表，再恢复 indexer；不要直接让 indexer 从 0 重扫所有 JSONL
 
 ### Raw Browser 正常但 summary/detail 为空
 

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -78,6 +78,12 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
 - 确认 `fq_runtime_clickhouse` 与 `fq_runtime_indexer` 都已恢复。
 - 核对 `FQ_RUNTIME_CLICKHOUSE_USER` / `FQ_RUNTIME_CLICKHOUSE_PASSWORD` 是否与 API / indexer 使用的一致。
 - 若 ClickHouse 已恢复但页面仍无数据，优先排查 indexer backlog 与 runtime event 写入链路。
+- 如果 `fq_runtime_indexer` 持续重启，且 ClickHouse stderr 报 `runtime_ingest_progress` 的 `TOO_MANY_UNEXPECTED_DATA_PARTS`：
+  - 先停止 indexer，避免继续重试
+  - 修复或重建 `runtime_ingest_progress`
+  - 再执行 `py -3.12 script/rebuild_runtime_ingest_progress.py --apply --truncate-existing`
+  - 最后再恢复 indexer
+- 不要直接删除 progress 后让 indexer 从 0 全量重扫；`runtime_events` 当前不是去重表，这样会把历史事件重复写入 ClickHouse。
 
 ## Memory context 缺失或过期
 

--- a/freshquant/runtime_observability/clickhouse_store.py
+++ b/freshquant/runtime_observability/clickhouse_store.py
@@ -198,12 +198,26 @@ class RuntimeObservabilityClickHouseStore:
         self._schema_ready = True
 
     def load_progress(self, raw_file: str) -> int:
+        snapshot = self.load_progress_snapshot(raw_file)
+        return int(snapshot.get("offset_bytes") or 0)
+
+    def load_progress_snapshot(self, raw_file: str) -> dict[str, Any]:
         self.ensure_schema()
         rows = self._select_rows(
-            "SELECT argMax(offset_bytes, updated_at) AS offset_bytes "
+            "SELECT "
+            "argMax(offset_bytes, updated_at) AS offset_bytes, "
+            "argMax(file_size, updated_at) AS file_size, "
+            "argMax(mtime, updated_at) AS mtime "
             f"FROM runtime_ingest_progress WHERE raw_file = {_sql_string(raw_file)}"
         )
-        return int(rows[0].get("offset_bytes") or 0) if rows else 0
+        if not rows:
+            return {}
+        row = rows[0]
+        return {
+            "offset_bytes": int(row.get("offset_bytes") or 0),
+            "file_size": int(row.get("file_size") or 0),
+            "mtime": float(row.get("mtime") or 0.0),
+        }
 
     def record_progress(
         self,
@@ -213,21 +227,66 @@ class RuntimeObservabilityClickHouseStore:
         file_size: int | None = None,
         mtime: float | None = None,
     ) -> None:
-        self.ensure_schema()
-        self._insert_json_each_row(
-            "runtime_ingest_progress",
+        self.record_progress_rows(
             [
                 {
                     "raw_file": raw_file,
                     "offset_bytes": int(offset_bytes),
                     "file_size": int(file_size or 0),
                     "mtime": float(mtime or 0.0),
-                    "updated_at": _format_clickhouse_datetime(
-                        datetime.now().astimezone()
-                    ),
                 }
-            ],
+            ]
         )
+
+    def record_progress_rows(
+        self, rows: list[dict[str, Any]] | tuple[dict[str, Any], ...]
+    ) -> None:
+        self.ensure_schema()
+        payload = []
+        now = _format_clickhouse_datetime(datetime.now().astimezone())
+        for row in rows or []:
+            raw_file = (
+                _normalized_text(row.get("raw_file")) if isinstance(row, dict) else ""
+            )
+            if not raw_file:
+                continue
+            payload.append(
+                {
+                    "raw_file": raw_file,
+                    "offset_bytes": int(row.get("offset_bytes") or 0),
+                    "file_size": int(row.get("file_size") or 0),
+                    "mtime": float(row.get("mtime") or 0.0),
+                    "updated_at": _normalized_text(row.get("updated_at")) or now,
+                }
+            )
+        if payload:
+            self._insert_json_each_row("runtime_ingest_progress", payload)
+
+    def list_runtime_event_checkpoints(self) -> list[dict[str, Any]]:
+        self.ensure_schema()
+        rows = self._select_rows(
+            """
+            SELECT
+                raw_file,
+                max(raw_line) AS raw_line
+            FROM runtime_events
+            WHERE raw_file != ''
+            GROUP BY raw_file
+            ORDER BY raw_file ASC
+            """
+        )
+        return [
+            {
+                "raw_file": _normalized_text(row.get("raw_file")),
+                "raw_line": int(row.get("raw_line") or 0),
+            }
+            for row in rows
+            if _normalized_text(row.get("raw_file"))
+        ]
+
+    def truncate_progress(self) -> None:
+        self.ensure_schema()
+        self._execute_command("TRUNCATE TABLE runtime_ingest_progress")
 
     def insert_events(
         self, events: list[dict[str, Any]] | tuple[dict[str, Any], ...]

--- a/freshquant/runtime_observability/indexer.py
+++ b/freshquant/runtime_observability/indexer.py
@@ -25,19 +25,32 @@ class RuntimeJsonlIndexer:
 
     def sync_once(self) -> None:
         self.store.ensure_schema()
+        progress_rows: list[dict[str, Any]] = []
         for path in sorted(self.runtime_root.rglob("*.jsonl")):
             if path.is_file():
-                self._sync_file(path)
+                progress_row = self._sync_file(path)
+                if progress_row:
+                    progress_rows.append(progress_row)
+        self._record_progress_rows(progress_rows)
 
     def sync_forever(self, *, poll_interval_s: float = 2.0) -> None:
         while True:
             self.sync_once()
             time.sleep(max(float(poll_interval_s or 0.5), 0.5))
 
-    def _sync_file(self, path: Path) -> None:
+    def _sync_file(self, path: Path) -> dict[str, Any] | None:
         raw_file = path.relative_to(self.runtime_root).as_posix()
-        offset = int(self.store.load_progress(raw_file) or 0)
-        file_size = path.stat().st_size
+        snapshot = self._load_progress_snapshot(raw_file)
+        offset = int(snapshot.get("offset_bytes") or 0)
+        stat = path.stat()
+        file_size = int(stat.st_size)
+        mtime = float(stat.st_mtime)
+        if (
+            file_size == offset
+            and file_size == int(snapshot.get("file_size") or 0)
+            and self._same_mtime(snapshot.get("mtime"), mtime)
+        ):
+            return None
         if file_size < offset:
             offset = 0
         line_no = self._count_lines_until_offset(path, offset)
@@ -67,11 +80,43 @@ class RuntimeJsonlIndexer:
                     batch = []
             if batch:
                 self.store.insert_events(batch)
+            final_offset = int(handle.tell())
+        if (
+            final_offset == int(snapshot.get("offset_bytes") or 0)
+            and file_size == int(snapshot.get("file_size") or 0)
+            and self._same_mtime(snapshot.get("mtime"), mtime)
+        ):
+            return None
+        return {
+            "raw_file": raw_file,
+            "offset_bytes": final_offset,
+            "file_size": file_size,
+            "mtime": mtime,
+        }
+
+    def _load_progress_snapshot(self, raw_file: str) -> dict[str, Any]:
+        loader = getattr(self.store, "load_progress_snapshot", None)
+        if callable(loader):
+            snapshot = loader(raw_file) or {}
+            if isinstance(snapshot, dict):
+                return snapshot
+        return {"offset_bytes": int(self.store.load_progress(raw_file) or 0)}
+
+    def _record_progress_rows(
+        self, rows: list[dict[str, Any]] | tuple[dict[str, Any], ...]
+    ) -> None:
+        if not rows:
+            return
+        writer = getattr(self.store, "record_progress_rows", None)
+        if callable(writer):
+            writer(rows)
+            return
+        for row in rows:
             self.store.record_progress(
-                raw_file,
-                handle.tell(),
-                file_size=file_size,
-                mtime=path.stat().st_mtime,
+                row["raw_file"],
+                row["offset_bytes"],
+                file_size=row.get("file_size"),
+                mtime=row.get("mtime"),
             )
 
     def _count_lines_until_offset(self, path: Path, offset: int) -> int:
@@ -87,6 +132,13 @@ class RuntimeJsonlIndexer:
                 count += chunk.count(b"\n")
                 remaining -= len(chunk)
         return count
+
+    @staticmethod
+    def _same_mtime(left: Any, right: float, *, tolerance: float = 1e-6) -> bool:
+        try:
+            return abs(float(left) - float(right)) <= tolerance
+        except (TypeError, ValueError):
+            return False
 
 
 __all__ = ["RuntimeJsonlIndexer"]

--- a/freshquant/runtime_observability/progress_rebuild.py
+++ b/freshquant/runtime_observability/progress_rebuild.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from freshquant.runtime_observability.logger import get_runtime_log_root
+
+
+def resolve_raw_line_offset(path: str | Path, *, raw_line: int) -> int:
+    file_path = Path(path)
+    target_line = max(int(raw_line or 0), 0)
+    if target_line <= 0 or not file_path.exists():
+        return 0
+    line_no = 0
+    with file_path.open("rb") as handle:
+        while True:
+            line = handle.readline()
+            if not line:
+                return int(handle.tell())
+            line_no += 1
+            if line_no >= target_line:
+                return int(handle.tell())
+
+
+def build_progress_rows_from_runtime_events(
+    runtime_root: str | Path,
+    checkpoints: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+) -> list[dict[str, Any]]:
+    root = Path(runtime_root)
+    rows = []
+    for checkpoint in checkpoints or []:
+        raw_file = str(checkpoint.get("raw_file") or "").strip()
+        if not raw_file:
+            continue
+        path = root.joinpath(*Path(raw_file).parts)
+        if not path.exists() or not path.is_file():
+            continue
+        stat = path.stat()
+        rows.append(
+            {
+                "raw_file": raw_file,
+                "offset_bytes": min(
+                    resolve_raw_line_offset(
+                        path, raw_line=int(checkpoint.get("raw_line") or 0)
+                    ),
+                    int(stat.st_size),
+                ),
+                "file_size": int(stat.st_size),
+                "mtime": float(stat.st_mtime),
+            }
+        )
+    return rows
+
+
+def rebuild_progress_rows(
+    store,
+    *,
+    runtime_root: str | Path | None = None,
+    truncate_existing: bool = False,
+) -> list[dict[str, Any]]:
+    root = Path(runtime_root) if runtime_root is not None else get_runtime_log_root()
+    rows = build_progress_rows_from_runtime_events(
+        root,
+        store.list_runtime_event_checkpoints(),
+    )
+    if truncate_existing:
+        store.truncate_progress()
+    if rows:
+        store.record_progress_rows(rows)
+    return rows
+
+
+__all__ = [
+    "build_progress_rows_from_runtime_events",
+    "rebuild_progress_rows",
+    "resolve_raw_line_offset",
+]

--- a/freshquant/tests/test_runtime_observability_clickhouse.py
+++ b/freshquant/tests/test_runtime_observability_clickhouse.py
@@ -189,6 +189,203 @@ def test_runtime_jsonl_indexer_reads_incremental_lines(monkeypatch, tmp_path):
     assert inserted_batches[1][0]["trace_id"] == "trc_2"
 
 
+def test_runtime_jsonl_indexer_skips_unchanged_file_without_progress_write(tmp_path):
+    from freshquant.runtime_observability.indexer import RuntimeJsonlIndexer
+
+    inserted_batches = []
+    legacy_progress_calls = []
+    batch_progress_calls = []
+    runtime_root = tmp_path / "runtime"
+    path = (
+        runtime_root
+        / "host_guardian"
+        / "guardian_strategy"
+        / "2026-03-20"
+        / "guardian_strategy_2026-03-20_1.jsonl"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            normalize_event(
+                {
+                    "trace_id": "trc_static",
+                    "component": "guardian_strategy",
+                    "runtime_node": "host:guardian",
+                    "node": "receive_signal",
+                    "ts": "2026-03-20T10:00:00+08:00",
+                }
+            ),
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    stat = path.stat()
+    snapshots = {
+        path.relative_to(runtime_root).as_posix(): {
+            "offset_bytes": stat.st_size,
+            "file_size": stat.st_size,
+            "mtime": stat.st_mtime,
+        }
+    }
+
+    class _FakeStore:
+        def ensure_schema(self):
+            return None
+
+        def load_progress(self, raw_file: str) -> int:
+            return int(snapshots.get(raw_file, {}).get("offset_bytes", 0))
+
+        def load_progress_snapshot(self, raw_file: str) -> dict:
+            return dict(snapshots.get(raw_file, {}))
+
+        def record_progress(self, raw_file: str, offset_bytes: int, **kwargs):
+            legacy_progress_calls.append((raw_file, offset_bytes, dict(kwargs)))
+
+        def record_progress_rows(self, rows):
+            batch_progress_calls.append(list(rows))
+
+        def insert_events(self, events):
+            inserted_batches.append(list(events))
+
+    indexer = RuntimeJsonlIndexer(_FakeStore(), runtime_root=runtime_root)
+
+    indexer.sync_once()
+
+    assert inserted_batches == []
+    assert batch_progress_calls == []
+    assert legacy_progress_calls == []
+
+
+def test_runtime_jsonl_indexer_batches_progress_updates_for_changed_files(tmp_path):
+    from freshquant.runtime_observability.indexer import RuntimeJsonlIndexer
+
+    inserted_batches = []
+    legacy_progress_calls = []
+    batch_progress_calls = []
+    runtime_root = tmp_path / "runtime"
+    paths = [
+        runtime_root
+        / "host_guardian"
+        / "guardian_strategy"
+        / "2026-03-20"
+        / "guardian_strategy_2026-03-20_1.jsonl",
+        runtime_root
+        / "host_xt_consumer"
+        / "xt_consumer"
+        / "2026-03-20"
+        / "xt_consumer_2026-03-20_1.jsonl",
+    ]
+    for index, path in enumerate(paths, start=1):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                normalize_event(
+                    {
+                        "trace_id": f"trc_{index}",
+                        "component": (
+                            "guardian_strategy" if index == 1 else "xt_consumer"
+                        ),
+                        "runtime_node": (
+                            "host:guardian" if index == 1 else "host:xt_consumer"
+                        ),
+                        "node": "receive_signal" if index == 1 else "heartbeat",
+                        "ts": f"2026-03-20T10:00:0{index}+08:00",
+                    }
+                ),
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    snapshots = {}
+
+    class _FakeStore:
+        def ensure_schema(self):
+            return None
+
+        def load_progress(self, raw_file: str) -> int:
+            return int(snapshots.get(raw_file, {}).get("offset_bytes", 0))
+
+        def load_progress_snapshot(self, raw_file: str) -> dict:
+            return dict(snapshots.get(raw_file, {}))
+
+        def record_progress(self, raw_file: str, offset_bytes: int, **kwargs):
+            legacy_progress_calls.append((raw_file, offset_bytes, dict(kwargs)))
+
+        def record_progress_rows(self, rows):
+            batch_progress_calls.append(list(rows))
+
+        def insert_events(self, events):
+            inserted_batches.append(list(events))
+
+    indexer = RuntimeJsonlIndexer(_FakeStore(), runtime_root=runtime_root)
+
+    indexer.sync_once()
+
+    assert len(inserted_batches) == 2
+    assert legacy_progress_calls == []
+    assert len(batch_progress_calls) == 1
+    assert sorted(row["raw_file"] for row in batch_progress_calls[0]) == sorted(
+        path.relative_to(runtime_root).as_posix() for path in paths
+    )
+
+
+def test_resolve_raw_line_offset_returns_byte_offset_after_target_line(tmp_path):
+    from freshquant.runtime_observability.progress_rebuild import (
+        resolve_raw_line_offset,
+    )
+
+    path = tmp_path / "sample.jsonl"
+    payload = b'{"a":1}\n{"b":2}\n{"c":3}\n'
+    path.write_bytes(payload)
+
+    assert resolve_raw_line_offset(path, raw_line=0) == 0
+    assert resolve_raw_line_offset(path, raw_line=1) == len('{"a":1}\n'.encode("utf-8"))
+    assert resolve_raw_line_offset(path, raw_line=2) == len(
+        '{"a":1}\n{"b":2}\n'.encode("utf-8")
+    )
+    assert resolve_raw_line_offset(path, raw_line=99) == path.stat().st_size
+
+
+def test_build_progress_rows_from_runtime_events_uses_existing_files_only(tmp_path):
+    from freshquant.runtime_observability.progress_rebuild import (
+        build_progress_rows_from_runtime_events,
+    )
+
+    runtime_root = tmp_path / "runtime"
+    existing_path = (
+        runtime_root
+        / "host_xt_producer"
+        / "xt_producer"
+        / "2026-03-26"
+        / "xt_producer_2026-03-26_1.jsonl"
+    )
+    existing_path.parent.mkdir(parents=True, exist_ok=True)
+    existing_path.write_bytes(b'{"a":1}\n{"b":2}\n{"c":3}\n')
+
+    rows = build_progress_rows_from_runtime_events(
+        runtime_root,
+        [
+            {
+                "raw_file": "host_xt_producer/xt_producer/2026-03-26/xt_producer_2026-03-26_1.jsonl",
+                "raw_line": 2,
+            },
+            {
+                "raw_file": "host_xt_producer/xt_producer/2026-03-26/missing.jsonl",
+                "raw_line": 5,
+            },
+        ],
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["raw_file"].endswith("xt_producer_2026-03-26_1.jsonl")
+    assert rows[0]["offset_bytes"] == len('{"a":1}\n{"b":2}\n'.encode("utf-8"))
+    assert rows[0]["file_size"] == existing_path.stat().st_size
+    assert rows[0]["mtime"] == existing_path.stat().st_mtime
+
+
 def test_clickhouse_store_list_events_decodes_payloads_and_builds_cursor(monkeypatch):
     from freshquant.runtime_observability.clickhouse_store import (
         RuntimeObservabilityClickHouseStore,
@@ -217,8 +414,8 @@ def test_clickhouse_store_list_events_decodes_payloads_and_builds_cursor(monkeyp
                 "symbol_name": "平安银行",
                 "message": "payload rejected",
                 "reason_code": "bad_payload",
-                "payload_json": "{\"error_type\":\"ValueError\"}",
-                "metrics_json": "{\"queue_len\":3}",
+                "payload_json": '{"error_type":"ValueError"}',
+                "metrics_json": '{"queue_len":3}',
                 "raw_file": "host_rear/order_submit/2026-03-20/file.jsonl",
                 "raw_line": 2,
                 "error_type": "ValueError",
@@ -289,9 +486,9 @@ def test_clickhouse_store_list_events_hides_non_triggered_tpsl_info_noise(
     assert "component = 'tpsl_worker'" in queries[0]
     assert "node IN ('tick_match', 'profile_load')" in queries[0]
     assert 'payload_json LIKE \'%"kind": "takeprofit"%\'' in queries[0]
-    assert 'payload_json LIKE \'%"triggered": false%\'' in queries[0]
+    assert "payload_json LIKE '%\"triggered\": false%'" in queries[0]
     assert 'payload_json LIKE \'%"kind": "stoploss"%\'' in queries[0]
-    assert 'payload_json LIKE \'%"triggered_bindings": 0%\'' in queries[0]
+    assert "payload_json LIKE '%\"triggered_bindings\": 0%'" in queries[0]
 
 
 def test_clickhouse_store_get_trace_detail_combines_summary_and_first_step_page(
@@ -349,7 +546,7 @@ def test_clickhouse_store_get_trace_detail_combines_summary_and_first_step_page(
                 "symbol_name": "平安银行",
                 "message": "",
                 "reason_code": "bad_payload",
-                "payload_json": "{\"error_type\":\"ValueError\",\"error_message\":\"bad payload\"}",
+                "payload_json": '{"error_type":"ValueError","error_message":"bad payload"}',
                 "metrics_json": "{}",
                 "raw_file": "host_rear/order_submit/2026-03-20/file.jsonl",
                 "raw_line": 2,

--- a/script/rebuild_runtime_ingest_progress.py
+++ b/script/rebuild_runtime_ingest_progress.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from freshquant.runtime_observability.clickhouse_store import (
+    RuntimeObservabilityClickHouseStore,
+)
+from freshquant.runtime_observability.logger import get_runtime_log_root
+from freshquant.runtime_observability.progress_rebuild import (
+    build_progress_rows_from_runtime_events,
+    rebuild_progress_rows,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Rebuild runtime_ingest_progress from runtime_events/raw JSONL.",
+    )
+    parser.add_argument(
+        "--runtime-log-root",
+        type=Path,
+        default=None,
+        help="Runtime JSONL root. Defaults to FQ_RUNTIME_LOG_DIR.",
+    )
+    parser.add_argument(
+        "--truncate-existing",
+        action="store_true",
+        help="Truncate runtime_ingest_progress before writing rebuilt rows.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write rebuilt rows back to ClickHouse. Default is dry-run summary only.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    store = RuntimeObservabilityClickHouseStore()
+    runtime_root = args.runtime_log_root or get_runtime_log_root()
+    checkpoints = store.list_runtime_event_checkpoints()
+    rows = build_progress_rows_from_runtime_events(
+        runtime_root,
+        checkpoints,
+    )
+    if args.apply:
+        rebuild_progress_rows(
+            store,
+            runtime_root=runtime_root,
+            truncate_existing=args.truncate_existing,
+        )
+    summary = {
+        "mode": "apply" if args.apply else "dry-run",
+        "runtime_log_root": str(runtime_root) if runtime_root else None,
+        "checkpoint_count": len(checkpoints),
+        "rebuilt_row_count": len(rows),
+        "sample_rows": rows[:5],
+    }
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- stop `runtime_jsonl_indexer` from writing `runtime_ingest_progress` when the JSONL file state has not changed, and batch progress writes per scan
- add `progress_rebuild` plus `script/rebuild_runtime_ingest_progress.py` to rebuild ClickHouse progress from indexed runtime events and raw JSONL offsets
- document the new recovery path and add regression coverage for unchanged-file scans and progress rebuild offsets

## Test Plan
- `py -3.12 -m uv run pytest freshquant/tests/test_runtime_observability_clickhouse.py freshquant/tests/test_runtime_observability_docs.py -q`
- `py -3.12 -m uv run python script/rebuild_runtime_ingest_progress.py --help`

## Deploy
- not deployed in this change set
