### PR TITLE
fix: restore runtime observability heartbeat labels

### DIFF
--- a/docs/current/modules/runtime-observability.md
+++ b/docs/current/modules/runtime-observability.md
@@ -239,6 +239,8 @@ Runtime Observability 当前采用“双存储”：
 - `issue_trace_count`
 - `issue_step_count`
 - `last_issue_ts`
+- 左侧组件卡片的 `主心跳` 优先复用 API 已返回的 `heartbeat_label`；若接口当前只返回 `heartbeat_age_s`，前端会直接按秒龄格式化，不依赖 Trace steps 才显示心跳
+- 左侧组件卡片的指标摘要优先复用 health summary 已带的 `highlights`；若接口当前只返回原始 `metrics`，前端会在卡片层按既定规则回填核心指标
 
 左侧组件导航仍固定展示核心组件全集：
 

--- a/morningglory/fqwebui/src/views/runtime-observability.test.mjs
+++ b/morningglory/fqwebui/src/views/runtime-observability.test.mjs
@@ -2298,6 +2298,7 @@ test('buildComponentSidebarItems uses health summary counters without requiring 
   assert.equal(card.issue_trace_count, 3)
   assert.equal(card.issue_step_count, 4)
   assert.equal(card.trace_count, 7)
+  assert.equal(card.heartbeat_label, '5s')
   assert.equal(card.runtime_details[0].runtime_node, 'host:rear')
 })
 

--- a/morningglory/fqwebui/src/views/runtimeObservability.mjs
+++ b/morningglory/fqwebui/src/views/runtimeObservability.mjs
@@ -1633,6 +1633,20 @@ export const buildHealthCards = (components = []) => {
   })
 }
 
+const buildHealthCardHeartbeatLabel = (item = {}) => {
+  const explicit = toText(item?.heartbeat_label)
+  if (explicit) return explicit
+  if (item?.heartbeat_age_s === null || item?.heartbeat_age_s === undefined) return 'no data'
+  return formatDurationMs(Number(item.heartbeat_age_s) * 1000)
+}
+
+const buildHealthCardHighlights = (item = {}) => {
+  if (Array.isArray(item?.highlights) && item.highlights.length > 0) {
+    return item.highlights
+  }
+  return buildHealthHighlights(item?.metrics || {})
+}
+
 export const buildRawLookupFromStep = (step = {}) => {
   const ts = toText(step?.ts)
   const date = ts.slice(0, 10)
@@ -2179,13 +2193,13 @@ export const buildComponentBoard = (traces = [], components = []) => {
         runtime_node: runtimeNode,
         status: toText(healthCard?.status) || (issueTraceCount > 0 ? 'warning' : 'unknown'),
         heartbeat_age_s: healthCard?.heartbeat_age_s ?? null,
-        heartbeat_label: healthCard?.heartbeat_label || 'no data',
+        heartbeat_label: buildHealthCardHeartbeatLabel(healthCard),
         issue_trace_count: issueTraceCount,
         issue_step_count: issueStepCount,
         last_issue_ts: toText(healthCard?.last_issue_ts) || toText(lastIssueTrace?.last_ts) || '',
         trace_count: traceCount,
         is_placeholder: Boolean(healthCard?.is_placeholder),
-        highlights: Array.isArray(healthCard?.highlights) ? healthCard.highlights : [],
+        highlights: buildHealthCardHighlights(healthCard),
       })
     }
   }


### PR DESCRIPTION
## 背景
- `runtime-observability` 的 ClickHouse/API 数据已经恢复，但页面左侧组件卡片仍把 `xt_producer` / `xt_consumer` 等组件显示成 `主心跳 no data`。
- 实际接口 `/api/runtime/health/summary` 已返回 `heartbeat_age_s`，所以问题在前端状态映射，不在后端或 indexer。

## 目标
- 恢复运行观测组件卡片的主心跳展示。
- 用前端回归测试锁住这个渲染缺陷。

## 范围
- 修复 `runtimeObservability.mjs` 中组件卡片对 health summary 原始数据的心跳/高亮推导。
- 补充 `runtime-observability.test.mjs` 回归断言。

## 非目标
- 不修改 runtime API。
- 不修改 ClickHouse/indexer。
- 不处理无关的 web 构建产物。

## 根因
- `RuntimeObservability.vue` 把原始 `healthSummaryItems` 传给了 `buildComponentSidebarItems()`。
- 该链路读取 `heartbeat_age_s` 是对的，但组件卡片展示依赖 `heartbeat_label`，而原始 API 项没有这个字段，只在 `buildHealthCards()` 规范化后才有。
- 结果组件卡片统一回退到 `no data`，即使接口已经返回了真实心跳年龄。

## 验收标准
- `buildComponentSidebarItems` 在接收原始 health summary 项时，能正确显示 `heartbeat_label`。
- 组件卡片不再把 `xt_producer` 等有心跳的组件显示成 `no data`。
- 前端测试覆盖这个原始 health summary 场景。

## 测试
- `node --test src/views/runtime-observability.test.mjs`
- `npm run build`
- `py -3.12 -m uv tool run pre-commit run --files morningglory/fqwebui/src/views/runtimeObservability.mjs morningglory/fqwebui/src/views/runtime-observability.test.mjs`
