### PR TITLE
fix: avoid bouncing web deps during deploy

### DIFF
--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -95,7 +95,7 @@ powershell -ExecutionPolicy Bypass -File script/ci/run_production_deploy.ps1 -Ca
 - Dagster 容器必须在容器内固定使用 `DAGSTER_HOME=/opt/dagster/home` 与 `FRESHQUANT_DAGSTER__HOME=/opt/dagster/home`；不要让主工作树 `.env` 里的 Windows 路径 `D:/fqpack/dagster` 直接透传进 Linux 容器。
 - 命中宿主机 deployment surface 时，把 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode Status` 与对应 stderr 日志一起当作正式证据；不要只看 `fqnext-supervisord` service 是否仍是 `Running`。
 - 如果宿主机 traceback 指向 vendored 包 API 不匹配，例如 `resolve_stock_account() got an unexpected keyword argument 'settings_provider'`，先确认实际 import 源文件是否落在 `.venv\\Lib\\site-packages\\fqxtrade\\xtquant\\account.py`，不要假设仓库里的 vendored 源码一定覆盖了宿主机 Python 环境。
-- `fq_webui` 的 compose 依赖当前仍会带出 `fq_apiserver` / `fq_qawebserver` 启动路径；因此即使本轮 deploy plan 只命中 Web，也要预期 rear image 构建链路可能被触发，不能把 Docker 构建失败简单当成纯前端问题。
+- `fq_webui` 的 compose 依赖当前仍声明了 `fq_apiserver` / `fq_qawebserver`；但正式 deploy 在“仅命中 Web surface”时会固定追加 `--no-deps`，避免把未改动的 API / QA 容器一起重建。只有显式命中 `api` / `qa` / compose 全量变更时，才会把这些依赖一并纳入 deploy。
 - 如果 Docker 构建阶段在 `fq_apiserver` 里编译 `fqchan04` 时出现 `g++ internal compiler error`、`Segmentation fault` 一类编译器崩溃，先保留失败 run_dir artifacts，再对同一 SHA 原样重跑 1 次 formal deploy；只有稳定复现后才进入代码修复或 Dockerfile 调整。
 - 只要本轮有实际 deploy，就必须保留 `CaptureBaseline -> deploy -> health check -> Verify` 的顺序；不能跳过 baseline，也不能把 runtime verify 替换成手工肉眼检查。
 

--- a/freshquant/tests/test_freshquant_deploy_plan.py
+++ b/freshquant/tests/test_freshquant_deploy_plan.py
@@ -49,6 +49,7 @@ def test_webui_paths_use_web_surface_and_correct_port() -> None:
     assert plan["deployment_surfaces"] == ["web"]
     assert plan["docker_services"] == ["fq_webui"]
     assert plan["host_surfaces"] == []
+    assert "--no-deps" in plan["docker_command"]
     assert "http://127.0.0.1:18080/" in plan["health_checks"]
 
 
@@ -170,6 +171,7 @@ def test_compose_parallel_changes_require_full_docker_runtime_redeploy() -> None
         "ta_backend",
         "ta_frontend",
     ]
+    assert "--no-deps" not in plan["docker_command"]
     assert any("compose.parallel.yaml" in note for note in plan["notes"])
 
 

--- a/script/freshquant_deploy_plan.py
+++ b/script/freshquant_deploy_plan.py
@@ -402,8 +402,9 @@ def build_deploy_plan(
             }
         )
 
-    docker_command = (
-        [
+    docker_command: list[str] = []
+    if docker_services:
+        docker_command = [
             "powershell",
             "-ExecutionPolicy",
             "Bypass",
@@ -412,11 +413,11 @@ def build_deploy_plan(
             "up",
             "-d",
             "--build",
-            *docker_services,
         ]
-        if docker_services
-        else []
-    )
+        # Web-only deploy should not bounce unchanged API/QA dependencies.
+        if ordered == ["web"] and docker_services == ["fq_webui"]:
+            docker_command.append("--no-deps")
+        docker_command.extend(docker_services)
     host_command = (
         [
             "powershell",


### PR DESCRIPTION
## 背景
- 本轮 workbench dense ledger 重构已经合并到 `main` 并进入 formal deploy。
- deploy 过程中，`web` 单面发布会因为 `fq_webui` 的 compose 依赖把 `fq_apiserver` / `fq_qawebserver` 一起重建；健康检查窗口较短时，`/api/stock_data` 会在 API 尚未恢复时返回 `502`，导致 formal deploy 假失败。

## 目标
- 保持 `web` 单面部署只发布 `fq_webui`，不抖动未改动的 API / QA 依赖。
- 给 deploy plan 增加明确测试，避免后续回归。

## 范围
- `script/freshquant_deploy_plan.py`
- `freshquant/tests/test_freshquant_deploy_plan.py`
- `docs/current/deployment.md`

## 非目标
- 不修改业务页面代码。
- 不扩大为通用 health retry 策略调整。

## 实现摘要
- `web` 且仅 `fq_webui` 命中时，deploy plan 生成 `docker compose up -d --build --no-deps fq_webui`。
- 保留 compose 全量变更和 `api` / `qa` 命中时的原有依赖行为。
- 单测断言 `web` 单面 deploy 带 `--no-deps`，compose 全量 redeploy 不带该参数。
- 同步更新当前部署文档。

## 验证
- `py -3.12 -m pytest freshquant/tests/test_freshquant_deploy_plan.py`
- `py -3.12 script/freshquant_deploy_plan.py --changed-path morningglory/fqwebui/src/views/DailyScreening.vue --format json`

## 部署影响
- 影响 formal deploy 计划生成逻辑
- 合并后需要重新从最新远程 `main` 跑一遍 production deploy 收口上一轮 Web UI 发布
