### PR TITLE
Fix Kline entry price guide rendering

### DIFF
--- a/docs/current/modules/kline-webui.md
+++ b/docs/current/modules/kline-webui.md
@@ -25,6 +25,7 @@
 - 标的设置浮层中的止损对象已经是 open `entries`
 - 保存止损时只提交 `entry_id`
 - 浮层详情返回 `entries`，不再依赖 `buy_lots`
+- 图表价格引导里的持仓参考线已经改成 `entry` 语义，对外文案是“持仓入口线”
 - 持仓股侧边栏排序与 SubjectManagement、PositionManagement 保持一致，按持仓金额从大到小排序
 
 ## 当前页面结构
@@ -70,7 +71,7 @@
 - 查返回的持仓金额字段
 - 当前排序口径是 `position_amount -> market_value -> amount`
 
-### 浮层仍出现 `buy_lot` 文案
+### 图表未显示持仓入口线
 
-- 查 `subjectManagement` / `kline-slim-subject-panel` 的 detail 归一逻辑
-- 当前页面只应使用 `entryDisplayLabel / entryMetaLabel / entryIdLabel`
+- 查 `/api/subject-management/<symbol>` 是否返回 `entries`
+- 查 `subject-price-guides` 是否从 `entry_price / remaining_quantity` 生成价格线

--- a/morningglory/fqwebui/src/views/js/kline-slim-chart-controller.mjs
+++ b/morningglory/fqwebui/src/views/js/kline-slim-chart-controller.mjs
@@ -182,7 +182,7 @@ function isPriceGuideVisible(scene, group) {
 
 function shouldAlwaysIncludePriceGuideInAutoYRange(line) {
   const group = String(line?.group || '').trim()
-  return group === 'cost_basis' || group === 'buy_lot'
+  return group === 'cost_basis' || group === 'entry'
 }
 
 function shouldIncludePriceGuideInYRange(scene, line, { includeAllPriceGuides = false } = {}) {

--- a/morningglory/fqwebui/src/views/js/kline-slim-chart-price-guides.test.mjs
+++ b/morningglory/fqwebui/src/views/js/kline-slim-chart-price-guides.test.mjs
@@ -173,7 +173,7 @@ test('buildKlineSlimChartOption renders price lines without background bands and
   assert.equal(option.legend.selected['止盈价格线'], true)
 })
 
-test('buildKlineSlimChartOption exposes cost basis and buy lot legend toggles', () => {
+test('buildKlineSlimChartOption exposes cost basis and entry legend toggles', () => {
   const scene = buildKlineSlimChartScene({
     mainData: makeMainData(),
     currentPeriod: '30m',
@@ -190,13 +190,13 @@ test('buildKlineSlimChartOption exposes cost basis and buy lot legend toggles', 
           group: 'cost_basis',
         },
         {
-          id: 'buy-lot-lot_1',
-          key: 'lot_1',
+          id: 'entry-entry_1',
+          key: 'entry_1',
           price: 10.02,
           color: '#06b6d4',
-          label: '买1 10.020 / 200股',
+          label: '入口1 10.020 / 200股',
           lineStyle: 'dotted',
-          group: 'buy_lot',
+          group: 'entry',
         },
       ],
       bands: [],
@@ -219,12 +219,12 @@ test('buildKlineSlimChartOption exposes cost basis and buy lot legend toggles', 
 
   assert.deepEqual(
     option.legend.data.slice(-2),
-    ['成本价线', '买入订单线'],
+    ['成本价线', '持仓入口线'],
   )
   assert.equal(option.legend.selected['成本价线'], true)
-  assert.equal(option.legend.selected['买入订单线'], true)
+  assert.equal(option.legend.selected['持仓入口线'], true)
   assert.equal(option.series.find((item) => item.id === 'cost-basis')?.lineStyle.type, 'solid')
-  assert.equal(option.series.find((item) => item.id === 'buy-lot-lot_1')?.lineStyle.type, 'dotted')
+  assert.equal(option.series.find((item) => item.id === 'entry-entry_1')?.lineStyle.type, 'dotted')
 })
 
 test('buildChartPriceGuides does not mark guardian lines active when runtime state is missing', () => {
@@ -270,14 +270,14 @@ test('deriveViewportStateForScene keeps low-price auto y range tight', () => {
   assert.equal(viewport.yRange.max - viewport.yRange.min < 0.05, true)
 })
 
-test('deriveViewportStateForScene includes visible cost basis and buy lot guides in auto y range', () => {
+test('deriveViewportStateForScene includes visible cost basis and entry guides in auto y range', () => {
   const scene = buildKlineSlimChartScene({
     mainData: makeMainData(),
     currentPeriod: '30m',
     visiblePeriods: ['30m'],
     legendSelected: {
       '成本价线': true,
-      '买入订单线': true,
+      '持仓入口线': true,
     },
     priceGuides: {
       lines: [
@@ -293,13 +293,13 @@ test('deriveViewportStateForScene includes visible cost basis and buy lot guides
           manual_enabled: false,
         },
         {
-          id: 'buy-lot-lot_1',
-          key: 'lot_1',
+          id: 'entry-entry_1',
+          key: 'entry_1',
           price: 8.2,
           color: '#06b6d4',
-          label: '买1 8.200 / 200股',
+          label: '入口1 8.200 / 200股',
           lineStyle: 'dotted',
-          group: 'buy_lot',
+          group: 'entry',
           active: false,
           manual_enabled: false,
         },
@@ -320,14 +320,14 @@ test('deriveViewportStateForScene includes visible cost basis and buy lot guides
   assert.equal(viewport.yRange.min < 9, true)
 })
 
-test('deriveViewportStateForScene excludes hidden cost basis and buy lot guides from auto y range', () => {
+test('deriveViewportStateForScene excludes hidden cost basis and entry guides from auto y range', () => {
   const scene = buildKlineSlimChartScene({
     mainData: makeMainData(),
     currentPeriod: '30m',
     visiblePeriods: ['30m'],
     legendSelected: {
       '成本价线': false,
-      '买入订单线': false,
+      '持仓入口线': false,
     },
     priceGuides: {
       lines: [
@@ -343,13 +343,13 @@ test('deriveViewportStateForScene excludes hidden cost basis and buy lot guides 
           manual_enabled: false,
         },
         {
-          id: 'buy-lot-lot_1',
-          key: 'lot_1',
+          id: 'entry-entry_1',
+          key: 'entry_1',
           price: 8.2,
           color: '#06b6d4',
-          label: '买1 8.200 / 200股',
+          label: '入口1 8.200 / 200股',
           lineStyle: 'dotted',
-          group: 'buy_lot',
+          group: 'entry',
           active: false,
           manual_enabled: false,
         },

--- a/morningglory/fqwebui/src/views/js/kline-slim.js
+++ b/morningglory/fqwebui/src/views/js/kline-slim.js
@@ -433,7 +433,7 @@ export default {
         takeprofitDrafts: this.takeprofitDrafts,
         takeprofitState: this.takeprofitState,
         costBasisPrice: this.subjectPriceDetail?.costBasisPrice ?? null,
-        buyLots: this.subjectPriceDetail?.openBuyLots ?? []
+        entries: this.subjectPriceDetail?.openEntries ?? []
       })
     },
     editablePriceGuides() {

--- a/morningglory/fqwebui/src/views/js/subject-price-guides.mjs
+++ b/morningglory/fqwebui/src/views/js/subject-price-guides.mjs
@@ -24,7 +24,7 @@ export const PRICE_GUIDE_LEGEND_GROUPS = [
   { key: 'guardian', legendName: 'Guardian 价格线', color: GUIDE_COLORS[0] },
   { key: 'takeprofit', legendName: '止盈价格线', color: GUIDE_COLORS[2] },
   { key: 'cost_basis', legendName: '成本价线', color: '#f59e0b' },
-  { key: 'buy_lot', legendName: '买入订单线', color: '#06b6d4' },
+  { key: 'entry', legendName: '持仓入口线', color: '#06b6d4' },
 ]
 
 const toText = (value) => String(value ?? '').trim()
@@ -238,24 +238,24 @@ export const buildCostBasisPriceGuide = (avgPrice = null) => {
   }
 }
 
-export const buildBuyLotPriceGuides = (buyLots = []) => {
-  return (Array.isArray(buyLots) ? buyLots : [])
+export const buildEntryPriceGuides = (entries = []) => {
+  return (Array.isArray(entries) ? entries : [])
     .map((row, index) => {
-      const price = toPositiveGuidePrice(row?.buy_price_real)
+      const price = toPositiveGuidePrice(row?.entry_price ?? row?.buy_price_real)
       const remainingQuantity = toNullableNumber(row?.remaining_quantity)
-      const buyLotId = toText(row?.buy_lot_id)
+      const entryId = toText(row?.entry_id || row?.buy_lot_id)
       if (price === null) {
         return null
       }
       const quantityLabel = remainingQuantity !== null ? ` / ${Math.trunc(remainingQuantity)}股` : ''
       return {
-        id: `buy-lot-${buyLotId || index + 1}`,
-        key: buyLotId || `lot_${index + 1}`,
+        id: `entry-${entryId || index + 1}`,
+        key: entryId || `entry_${index + 1}`,
         level: index + 1,
-        group: 'buy_lot',
+        group: 'entry',
         price,
         color: '#06b6d4',
-        label: `买${index + 1} ${formatGuidePrice(price)}${quantityLabel}`,
+        label: `入口${index + 1} ${formatGuidePrice(price)}${quantityLabel}`,
         active: true,
         manual_enabled: true,
         lineStyle: 'dotted',
@@ -291,18 +291,18 @@ export const buildChartPriceGuides = ({
   takeprofitDrafts = [],
   takeprofitState = {},
   costBasisPrice = null,
-  buyLots = [],
+  entries = [],
 } = {}) => {
   const guardianLines = buildGuardianPriceGuides(guardianDraft, guardianState)
   const takeprofitLines = buildTakeprofitPriceGuides(takeprofitDrafts, takeprofitState)
   const costBasisLine = buildCostBasisPriceGuide(costBasisPrice)
-  const buyLotLines = buildBuyLotPriceGuides(buyLots)
+  const entryLines = buildEntryPriceGuides(entries)
 
   return {
     lines: guardianLines
       .concat(takeprofitLines)
       .concat(costBasisLine ? [costBasisLine] : [])
-      .concat(buyLotLines),
+      .concat(entryLines),
     bands: [],
   }
 }
@@ -418,11 +418,13 @@ export const buildKlineSubjectPriceDetail = (detail = {}) => {
   const takeprofitDrafts = buildTakeprofitDrafts(takeprofitTiers)
   const takeprofitState = detail?.takeprofit?.state || { armed_levels: {} }
   const costBasisPrice = toPositiveGuidePrice(detail?.runtime_summary?.avg_price)
-  const openBuyLots = Array.isArray(detail?.buy_lots)
-    ? detail.buy_lots.filter((row) => toPositiveGuidePrice(row?.buy_price_real) !== null)
+  const openEntries = Array.isArray(detail?.entries)
+    ? detail.entries.filter((row) => toPositiveGuidePrice(row?.entry_price ?? row?.buy_price_real) !== null)
+    : Array.isArray(detail?.buy_lots)
+      ? detail.buy_lots.filter((row) => toPositiveGuidePrice(row?.entry_price ?? row?.buy_price_real) !== null)
     : []
   const costBasisPriceGuide = buildCostBasisPriceGuide(costBasisPrice)
-  const buyLotPriceGuides = buildBuyLotPriceGuides(openBuyLots)
+  const entryPriceGuides = buildEntryPriceGuides(openEntries)
 
   return {
     guardianDraft,
@@ -433,15 +435,15 @@ export const buildKlineSubjectPriceDetail = (detail = {}) => {
     takeprofitPriceGuides: buildTakeprofitPriceGuides(takeprofitDrafts, takeprofitState),
     costBasisPrice,
     costBasisPriceGuide,
-    openBuyLots,
-    buyLotPriceGuides,
+    openEntries,
+    entryPriceGuides,
     chartPriceGuides: buildChartPriceGuides({
       guardianDraft,
       guardianState,
       takeprofitDrafts,
       takeprofitState,
       costBasisPrice,
-      buyLots: openBuyLots,
+      entries: openEntries,
     }),
   }
 }

--- a/morningglory/fqwebui/src/views/js/subject-price-guides.test.mjs
+++ b/morningglory/fqwebui/src/views/js/subject-price-guides.test.mjs
@@ -42,53 +42,53 @@ test('buildKlineSubjectPriceDetail keeps guardian, takeprofit and runtime state'
   assert.equal(detail.chartPriceGuides.bands.length, 0)
 })
 
-test('buildKlineSubjectPriceDetail adds cost basis and open buy lot guides', () => {
+test('buildKlineSubjectPriceDetail adds cost basis and open entry guides', () => {
   const detail = buildKlineSubjectPriceDetail({
     runtime_summary: {
       avg_price: 10.0234,
     },
-    buy_lots: [
+    entries: [
       {
-        buy_lot_id: 'lot_1',
-        buy_price_real: 10.02,
+        entry_id: 'entry_1',
+        entry_price: 10.02,
         remaining_quantity: 200,
       },
       {
-        buy_lot_id: 'lot_2',
-        buy_price_real: 9.88,
+        entry_id: 'entry_2',
+        entry_price: 9.88,
         remaining_quantity: 100,
       },
       {
-        buy_lot_id: 'lot_3',
-        buy_price_real: null,
+        entry_id: 'entry_3',
+        entry_price: null,
         remaining_quantity: 50,
       },
     ],
   })
 
   const costBasisLine = detail.chartPriceGuides.lines.find((row) => row.group === 'cost_basis')
-  const buyLotLines = detail.chartPriceGuides.lines.filter((row) => row.group === 'buy_lot')
+  const entryLines = detail.chartPriceGuides.lines.filter((row) => row.group === 'entry')
 
   assert.equal(costBasisLine?.price, 10.023)
   assert.equal(costBasisLine?.label, '成本 10.023')
   assert.equal(costBasisLine?.lineStyle, 'solid')
   assert.deepEqual(
-    buyLotLines.map((row) => ({
+    entryLines.map((row) => ({
       id: row.id,
       price: row.price,
       label: row.label,
       lineStyle: row.lineStyle,
     })),
     [
-      { id: 'buy-lot-lot_1', price: 10.02, label: '买1 10.020 / 200股', lineStyle: 'dotted' },
-      { id: 'buy-lot-lot_2', price: 9.88, label: '买2 9.880 / 100股', lineStyle: 'dotted' },
+      { id: 'entry-entry_1', price: 10.02, label: '入口1 10.020 / 200股', lineStyle: 'dotted' },
+      { id: 'entry-entry_2', price: 9.88, label: '入口2 9.880 / 100股', lineStyle: 'dotted' },
     ],
   )
 })
 
-test('getPriceGuideLegendName exposes cost basis and buy lot legend labels', () => {
+test('getPriceGuideLegendName exposes cost basis and entry legend labels', () => {
   assert.equal(getPriceGuideLegendName('cost_basis'), '成本价线')
-  assert.equal(getPriceGuideLegendName('buy_lot'), '买入订单线')
+  assert.equal(getPriceGuideLegendName('entry'), '持仓入口线')
 })
 
 test('buildGuardianPriceGuides keeps blue red green order from high to low', () => {


### PR DESCRIPTION
## 背景
- 订单账本 v2 重建后，`SubjectManagement` / `KlineSlim` 主表已经切到 `entry` 语义
- 但 K 线价格引导仍然从 `detail.buy_lots` 读取，导致实际图上的持仓参考线缺失，并继续暴露旧的“买入订单线”文案

## 目标
- 让 K 线价格引导直接读取 `entries`
- 统一图例与价格线文案到 `entry` / “持仓入口线`
- 保持自动 y 轴、Subject/Kline 价格面板和当前文档口径一致

## 范围
- `subject-price-guides.mjs`
- `kline-slim.js`
- `kline-slim-chart-controller.mjs`
- 对应前端测试与 `docs/current/modules/kline-webui.md`

## 非目标
- 不改订单账本数据结构
- 不重跑订单数据 rebuild
- 不调整 `/api/stock_fills` 兼容接口契约

## 验收标准
- `buildKlineSubjectPriceDetail` 在 `detail.entries` 下能生成 entry 价格线
- Kline 图例显示“持仓入口线”，不再显示“买入订单线”
- entry 价格线仍参与自动 y 轴范围计算
- 相关前端单测、lint、browser smoke、build 全部通过

## 部署影响
- 仅影响 Web UI，需要重新构建并部署前端静态资源

## Test Plan
- [x] `node --test morningglory/fqwebui/src/views/js/subject-price-guides.test.mjs morningglory/fqwebui/src/views/js/kline-slim-chart-price-guides.test.mjs`
- [x] `node --test morningglory/fqwebui/src/views/subjectManagement.test.mjs morningglory/fqwebui/src/views/tpslManagement.test.mjs morningglory/fqwebui/src/views/positionManagement.test.mjs morningglory/fqwebui/src/views/orderManagement.test.mjs morningglory/fqwebui/src/views/js/kline-slim-price-panel.test.mjs morningglory/fqwebui/src/views/js/kline-slim-subject-panel.test.mjs morningglory/fqwebui/src/views/js/kline-slim-chart-controller.test.mjs morningglory/fqwebui/src/views/js/subject-price-guides.test.mjs morningglory/fqwebui/src/views/js/kline-slim-chart-price-guides.test.mjs`
- [x] `npm run test:unit`
- [x] `npm run lint`
- [x] `npm run test:browser-smoke`
- [x] `npm run build`
- [x] `py -3.12 -m pre_commit run --files docs/current/modules/kline-webui.md morningglory/fqwebui/src/views/js/kline-slim-chart-controller.mjs morningglory/fqwebui/src/views/js/kline-slim-chart-price-guides.test.mjs morningglory/fqwebui/src/views/js/kline-slim.js morningglory/fqwebui/src/views/js/subject-price-guides.mjs morningglory/fqwebui/src/views/js/subject-price-guides.test.mjs`
