### PR TITLE
Fix runtime verify repo root detection

### DIFF
--- a/freshquant/tests/test_runtime_post_deploy_check.py
+++ b/freshquant/tests/test_runtime_post_deploy_check.py
@@ -11,6 +11,13 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "script" / "check_freshquant_runtime_post_deploy.ps1"
 
 
+def test_runtime_post_deploy_check_resolves_repo_root_from_script_parent() -> None:
+    script_text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "Join-Path $PSScriptRoot '..')).Path" in script_text
+    assert "Join-Path $PSScriptRoot '..\\..\\..')).Path" not in script_text
+
+
 def _run_powershell(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
     executable = shutil.which("powershell") or shutil.which("pwsh")
     if executable is None:

--- a/script/check_freshquant_runtime_post_deploy.ps1
+++ b/script/check_freshquant_runtime_post_deploy.ps1
@@ -14,7 +14,8 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+# Script lives under repo_root/script in both the canonical repo and deploy worktrees.
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 
 function Write-Utf8NoBomFile {
     param(


### PR DESCRIPTION
## 背景
- 订单数据重建和前端 entry 语义补丁已经落地，但在收尾阶段发现 `script/check_freshquant_runtime_post_deploy.ps1` 从主仓目录运行时会把 `repoRoot` 解析错到 `D:\`。
- 这会让脚本拿不到 `script/fqnext_host_runtime.py`，退回到 `Win32_Process.CommandLine` 匹配；而当前机器上该字段为空，结果把所有 supervisor worker 误判成未运行。

## 目标
- 让 runtime verify 在主仓目录和 deploy worktree 两种路径下都能正确解析 repo root。
- 为这次回归补一个稳定测试，防止以后再次把路径写回去。

## 范围
- 修改 `script/check_freshquant_runtime_post_deploy.ps1` 的 repo root 解析。
- 新增对应回归测试到 `freshquant/tests/test_runtime_post_deploy_check.py`。

## 非目标
- 不改 deploy 语义。
- 不改任何线上业务模块或 Mongo 数据。

## 验收标准
- `py -3.12 -m pytest freshquant/tests/test_runtime_post_deploy_check.py -q` 通过。
- `py -3.12 -m pre_commit run --files script/check_freshquant_runtime_post_deploy.ps1 freshquant/tests/test_runtime_post_deploy_check.py` 通过。
- 从 repo root 运行 `check_freshquant_runtime_post_deploy.ps1 -Mode Verify ...` 能正确识别 supervisor worker，不再误报全挂。

## 部署影响
- 无运行面部署；这是运维核验脚本修复。
