### PR TITLE
fix: unify reconciliation and Beijing time semantics

### DIFF
--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -125,6 +125,8 @@
 - `board_lot_rejected`
 - `matched_execution_fill`
 
+自动平账与 XT 回报补录路径里，凡是由 `trade_time / confirmed_at` 回填 `date/time` 的订单域记录，当前统一按北京时间（`Asia/Shanghai`）落地，避免同一笔成交在不同读模型里出现跨日漂移。
+
 ### 手工导入
 
 `manual import/reset -> om_trade_facts -> om_position_entries / om_entry_slices -> stock_fills_compat mirror sync`

--- a/docs/current/modules/position-management.md
+++ b/docs/current/modules/position-management.md
@@ -85,6 +85,12 @@
 
 这里的正式对照语义是：`券商真值 / 账本仓位 / reconciliation`。页面展示文案对应为 `券商仓位 / 账本仓位 / 对账状态`，不再返回三套并列仓位真值。
 
+`reconciliation.signed_gap_quantity` 当前表示同一 symbol 所有未闭合 gap 的净差额：
+
+- `buy` gap 记正
+- `sell` gap 记负
+- 多条 OPEN / REJECTED gap 需要做净额累计，不能只取最后一条
+
 ## tracked scope
 
 单标的仓位上限摘要行只保留 tracked scope 内的 symbol：

--- a/docs/current/modules/subject-management.md
+++ b/docs/current/modules/subject-management.md
@@ -49,6 +49,8 @@
 - entry 级止损摘要
 - 单标的仓位上限摘要
 
+overview 里的“单标的仓位上限摘要”当前按批量 PM dashboard 结果一次性装载，不再按 symbol 重复调用单标的 limit 读路径。
+
 左表 symbol 集合来自这些来源的并集，不再单独把孤儿 `guardian_buy_grid_states` 带进页面。
 
 ### detail

--- a/freshquant/order_management/guardian/arranger.py
+++ b/freshquant/order_management/guardian/arranger.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
-
 from freshquant.order_management.ids import (
     new_buy_lot_id,
     new_entry_slice_id,
     new_lot_slice_id,
     new_position_entry_id,
 )
+from freshquant.order_management.time_helpers import beijing_date_time_from_epoch
 
 
 def build_position_entry_from_trade_fact(
@@ -328,10 +327,9 @@ def _resolve_trade_date_time(trade_fact):
     if trade_time in {None, ""}:
         return date_value, time_value
     try:
-        trade_dt = datetime.fromtimestamp(int(trade_time))
+        return beijing_date_time_from_epoch(trade_time)
     except (OSError, OverflowError, TypeError, ValueError):
         return date_value, time_value
-    return int(trade_dt.strftime("%Y%m%d")), trade_dt.strftime("%H:%M:%S")
 
 
 def _has_date_time(date_value, time_value):

--- a/freshquant/order_management/ingest/xt_reports.py
+++ b/freshquant/order_management/ingest/xt_reports.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime, timezone
 from uuid import uuid4
-from zoneinfo import ZoneInfo
 
 from loguru import logger
 
@@ -30,6 +29,10 @@ from freshquant.order_management.projection.stock_fills import (
     build_raw_fills_view,
 )
 from freshquant.order_management.repository import OrderManagementRepository
+from freshquant.order_management.time_helpers import (
+    beijing_date_time_from_epoch,
+    beijing_datetime_from_epoch,
+)
 from freshquant.order_management.tracking.service import OrderTrackingService
 from freshquant.runtime_observability.failures import (
     build_exception_payload,
@@ -60,7 +63,6 @@ _SELL_ORDER_TYPES = {
     "sell",
     "SELL",
 }
-_XT_REPORT_TIMEZONE = ZoneInfo("Asia/Shanghai")
 
 
 class OrderManagementXtIngestService:
@@ -615,9 +617,9 @@ def _upsert_broker_position_entry(
     if trade_payload.get("trade_time") and not (
         trade_payload.get("date") and trade_payload.get("time")
     ):
-        trade_dt = datetime.fromtimestamp(int(trade_payload["trade_time"]))
-        trade_payload["date"] = int(trade_dt.strftime("%Y%m%d"))
-        trade_payload["time"] = trade_dt.strftime("%H:%M:%S")
+        trade_payload["date"], trade_payload["time"] = beijing_date_time_from_epoch(
+            trade_payload["trade_time"]
+        )
     if existing_entry is not None:
         trade_payload["date"] = existing_entry.get("date") or trade_payload.get("date")
         trade_payload["time"] = existing_entry.get("time") or trade_payload.get("time")
@@ -702,7 +704,7 @@ def _map_xt_order_type_to_side(order_type):
 
 
 def _xt_timestamp_to_datetime(timestamp):
-    return datetime.fromtimestamp(timestamp, _XT_REPORT_TIMEZONE).replace(tzinfo=None)
+    return beijing_datetime_from_epoch(timestamp).replace(tzinfo=None)
 
 
 def _get_tpsl_service():

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -25,6 +25,10 @@ from freshquant.order_management.ingest.xt_reports import (
 )
 from freshquant.order_management.reconcile.matcher import match_candidate_to_trade
 from freshquant.order_management.repository import OrderManagementRepository
+from freshquant.order_management.time_helpers import (
+    beijing_date_time_from_epoch,
+    beijing_day_start_from_epoch,
+)
 from freshquant.order_management.tracking.service import OrderTrackingService
 from freshquant.runtime_observability.failures import (
     build_exception_payload,
@@ -793,7 +797,7 @@ def _pending_until_for_observation(
 
 def _build_inferred_trade_report(candidate, internal_order_id):
     trade_time = int(candidate["pending_until"])
-    trade_datetime = datetime.fromtimestamp(trade_time)
+    date_value, time_value = beijing_date_time_from_epoch(trade_time)
     return {
         "internal_order_id": internal_order_id,
         "broker_order_id": None,
@@ -803,8 +807,8 @@ def _build_inferred_trade_report(candidate, internal_order_id):
         "quantity": candidate["quantity_delta"],
         "price": candidate.get("price_estimate") or 0.0,
         "trade_time": trade_time,
-        "date": int(trade_datetime.strftime("%Y%m%d")),
-        "time": trade_datetime.strftime("%H:%M:%S"),
+        "date": date_value,
+        "time": time_value,
         "source": "external_inferred",
         "provisional": True,
     }
@@ -948,12 +952,7 @@ def _load_previous_close_from_realtime(symbol, detected_at):
         if not code:
             return None
 
-        day_start = datetime.fromtimestamp(int(detected_at)).replace(
-            hour=0,
-            minute=0,
-            second=0,
-            microsecond=0,
-        )
+        day_start = beijing_day_start_from_epoch(detected_at)
         for collection_name in ("stock_realtime", "index_realtime"):
             document = DBfreshquant[collection_name].find_one(
                 {
@@ -1102,9 +1101,7 @@ def _safe_grid_interval_lookup(symbol, trade_fact):
 
 
 def _build_auto_open_entry(gap, *, resolution_id, confirmed_at):
-    trade_datetime = datetime.fromtimestamp(int(confirmed_at), tz=timezone.utc)
-    date_value = int(trade_datetime.strftime("%Y%m%d"))
-    time_value = trade_datetime.strftime("%H:%M:%S")
+    date_value, time_value = beijing_date_time_from_epoch(confirmed_at)
     quantity = int(gap.get("quantity_delta") or 0)
     price = float(gap.get("price_estimate") or 0.0)
     return {

--- a/freshquant/order_management/reconcile/summary.py
+++ b/freshquant/order_management/reconcile/summary.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+
+def build_reconciliation_summary_map(
+    gap_rows,
+    *,
+    rejection_rows=None,
+    normalize_symbol=None,
+):
+    symbol_normalizer = normalize_symbol or (lambda value: value)
+    grouped = {}
+
+    for gap in list(gap_rows or []):
+        symbol = symbol_normalizer(gap.get("symbol"))
+        if not symbol:
+            continue
+        grouped.setdefault(symbol, {"gap_rows": [], "rejection_count": 0})[
+            "gap_rows"
+        ].append(dict(gap))
+
+    for rejection in list(rejection_rows or []):
+        symbol = symbol_normalizer(rejection.get("symbol"))
+        if not symbol:
+            continue
+        grouped.setdefault(symbol, {"gap_rows": [], "rejection_count": 0})[
+            "rejection_count"
+        ] += 1
+
+    return {
+        symbol: summarize_symbol_reconciliation(
+            symbol=symbol,
+            gap_rows=payload["gap_rows"],
+            rejection_count=payload["rejection_count"],
+        )
+        for symbol, payload in grouped.items()
+    }
+
+
+def summarize_symbol_reconciliation(
+    *,
+    symbol,
+    gap_rows,
+    rejection_count=0,
+    broker_quantity=None,
+    ledger_quantity=None,
+    include_rows=False,
+):
+    normalized_rows = list(gap_rows or [])
+    signed_gap_quantity = 0
+    open_gap_count = 0
+    rejected_gap_count = 0
+    latest_gap_state = ""
+    latest_resolution_type = None
+    latest_sort_value = -1
+    rows = []
+
+    for item in normalized_rows:
+        side = str(item.get("side") or "").strip().lower()
+        state = str(item.get("state") or "").strip().upper()
+        quantity_delta = int(item.get("quantity_delta") or 0)
+        if state in {"OPEN", "REJECTED"}:
+            open_gap_count += 1
+            signed_gap_quantity += quantity_delta if side == "buy" else -quantity_delta
+        if state == "REJECTED":
+            rejected_gap_count += 1
+        sort_value = int(
+            item.get("confirmed_at")
+            or item.get("dismissed_at")
+            or item.get("pending_until")
+            or item.get("detected_at")
+            or 0
+        )
+        if sort_value >= latest_sort_value:
+            latest_sort_value = sort_value
+            latest_gap_state = state
+            latest_resolution_type = _normalize_optional_text(
+                item.get("resolution_type")
+            )
+        if include_rows:
+            rows.append(
+                {
+                    "gap_id": item.get("gap_id"),
+                    "side": side,
+                    "state": str(item.get("state") or ""),
+                    "quantity_delta": quantity_delta,
+                    "pending_until": item.get("pending_until"),
+                    "resolution_type": item.get("resolution_type"),
+                }
+            )
+
+    derived_signed_gap = None
+    if broker_quantity is not None or ledger_quantity is not None:
+        derived_signed_gap = int(broker_quantity or 0) - int(ledger_quantity or 0)
+    effective_signed_gap = (
+        signed_gap_quantity
+        if normalized_rows
+        else (derived_signed_gap if derived_signed_gap is not None else 0)
+    )
+
+    if open_gap_count > 0:
+        summary_state = (
+            "BROKEN"
+            if latest_gap_state == "REJECTED" or int(rejection_count or 0) > 0
+            else "OBSERVING"
+        )
+    elif latest_gap_state in {"AUTO_OPENED", "AUTO_CLOSED", "MATCHED"}:
+        summary_state = "AUTO_RECONCILED"
+    elif effective_signed_gap == 0:
+        summary_state = "ALIGNED"
+    else:
+        summary_state = "DRIFT"
+
+    result = {
+        "symbol": symbol,
+        "state": summary_state,
+        "latest_gap_state": latest_gap_state or summary_state,
+        "signed_gap_quantity": effective_signed_gap,
+        "open_gap_count": open_gap_count,
+        "latest_resolution_type": latest_resolution_type,
+        "ingest_rejection_count": int(rejection_count or 0),
+    }
+    if broker_quantity is not None or ledger_quantity is not None:
+        result.update(
+            {
+                "broker_quantity": int(broker_quantity or 0),
+                "ledger_quantity": int(ledger_quantity or 0),
+                "rejected_gap_count": rejected_gap_count,
+            }
+        )
+    if include_rows:
+        result["rows"] = rows
+    return result
+
+
+def _normalize_optional_text(value):
+    text = str(value or "").strip()
+    return text or None

--- a/freshquant/order_management/time_helpers.py
+++ b/freshquant/order_management/time_helpers.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+_BEIJING_TIMEZONE = ZoneInfo("Asia/Shanghai")
+
+
+def beijing_datetime_from_epoch(timestamp):
+    return datetime.fromtimestamp(int(timestamp), tz=_BEIJING_TIMEZONE)
+
+
+def beijing_date_time_from_epoch(timestamp):
+    dt = beijing_datetime_from_epoch(timestamp)
+    return int(dt.strftime("%Y%m%d")), dt.strftime("%H:%M:%S")
+
+
+def beijing_day_start_from_epoch(timestamp):
+    dt = beijing_datetime_from_epoch(timestamp)
+    return dt.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/freshquant/position_management/dashboard_service.py
+++ b/freshquant/position_management/dashboard_service.py
@@ -4,6 +4,9 @@ import math
 from datetime import datetime, timezone
 
 from freshquant.instrument.general import query_instrument_info
+from freshquant.order_management.reconcile.summary import (
+    build_reconciliation_summary_map,
+)
 from freshquant.position_management.models import (
     ALLOW_OPEN,
     FORCE_PROFIT_REDUCE,
@@ -1312,78 +1315,11 @@ def _default_reconciliation_loader():
     from freshquant.order_management.repository import OrderManagementRepository
 
     repository = OrderManagementRepository()
-    summaries = {}
-
-    for gap in repository.list_reconciliation_gaps():
-        symbol = normalize_to_base_code(gap.get("symbol"))
-        if not symbol:
-            continue
-        current = summaries.setdefault(
-            symbol,
-            {
-                "state": "ALIGNED",
-                "latest_gap_state": "",
-                "signed_gap_quantity": 0,
-                "open_gap_count": 0,
-                "latest_resolution_type": None,
-                "ingest_rejection_count": 0,
-                "_latest_sort_value": -1,
-            },
-        )
-        latest_sort_value = _coerce_int(
-            gap.get("confirmed_at")
-            or gap.get("dismissed_at")
-            or gap.get("pending_until")
-            or gap.get("detected_at"),
-            0,
-        )
-        gap_state = _normalize_optional_text(gap.get("state")) or ""
-        if gap_state in {"OPEN", "REJECTED"}:
-            current["open_gap_count"] += 1
-            current["signed_gap_quantity"] = _coerce_int(
-                gap.get("quantity_delta"), current["signed_gap_quantity"]
-            )
-        if latest_sort_value >= current["_latest_sort_value"]:
-            current["_latest_sort_value"] = latest_sort_value
-            current["latest_gap_state"] = gap_state
-            current["latest_resolution_type"] = _normalize_optional_text(
-                gap.get("resolution_type")
-            )
-
-    for rejection in repository.list_ingest_rejections():
-        symbol = normalize_to_base_code(rejection.get("symbol"))
-        if not symbol:
-            continue
-        current = summaries.setdefault(
-            symbol,
-            {
-                "state": "ALIGNED",
-                "latest_gap_state": "",
-                "signed_gap_quantity": 0,
-                "open_gap_count": 0,
-                "latest_resolution_type": None,
-                "ingest_rejection_count": 0,
-                "_latest_sort_value": -1,
-            },
-        )
-        current["ingest_rejection_count"] += 1
-
-    for current in summaries.values():
-        latest_gap_state = current.get("latest_gap_state") or ""
-        if current["open_gap_count"] > 0:
-            current["state"] = (
-                "BROKEN"
-                if latest_gap_state == "REJECTED"
-                or current["ingest_rejection_count"] > 0
-                else "OBSERVING"
-            )
-        elif latest_gap_state in {"AUTO_OPENED", "AUTO_CLOSED", "MATCHED"}:
-            current["state"] = "AUTO_RECONCILED"
-        else:
-            current["state"] = "ALIGNED"
-        current.pop("_latest_sort_value", None)
-
-    return summaries
+    return build_reconciliation_summary_map(
+        repository.list_reconciliation_gaps(),
+        rejection_rows=repository.list_ingest_rejections(),
+        normalize_symbol=normalize_to_base_code,
+    )
 
 
 def _resolve_settings_provider(query_param_loader=None):

--- a/freshquant/subject_management/dashboard_service.py
+++ b/freshquant/subject_management/dashboard_service.py
@@ -24,6 +24,7 @@ class SubjectManagementDashboardService:
         symbol_position_loader=None,
         pm_summary_loader=None,
         symbol_limit_loader=None,
+        symbol_limit_map_loader=None,
     ):
         if database is None:
             from freshquant.db import DBfreshquant
@@ -38,6 +39,15 @@ class SubjectManagementDashboardService:
         )
         self.pm_summary_loader = pm_summary_loader or _default_pm_summary_loader
         self.symbol_limit_loader = symbol_limit_loader or _default_symbol_limit_loader
+        self.symbol_limit_map_loader = (
+            symbol_limit_map_loader
+            if symbol_limit_map_loader is not None
+            else (
+                _default_symbol_limit_map_loader
+                if symbol_limit_loader is None
+                else None
+            )
+        )
 
     def get_overview(self):
         must_pool_rows = self._must_pool_map()
@@ -52,6 +62,7 @@ class SubjectManagementDashboardService:
         symbols.update(takeprofit_profiles)
         symbols.update(positions)
         symbols.update(stoploss_summary)
+        position_limit_summary_map = self._load_overview_position_limit_summary_map()
 
         latest_events = self._latest_trigger_map(symbols)
         rows = []
@@ -71,7 +82,9 @@ class SubjectManagementDashboardService:
                 },
             )
             latest_event = latest_events.get(symbol) or {}
-            position_limit_summary = self._load_position_limit_summary(symbol)
+            position_limit_summary = position_limit_summary_map.get(symbol)
+            if position_limit_summary is None:
+                position_limit_summary = self._load_position_limit_summary(symbol)
 
             rows.append(
                 {
@@ -243,6 +256,24 @@ class SubjectManagementDashboardService:
             "available": bool(summary),
             **summary,
         }
+
+    def _load_overview_position_limit_summary_map(self):
+        if self.symbol_limit_map_loader is None:
+            return {}
+        try:
+            rows = dict(self.symbol_limit_map_loader() or {})
+        except Exception:
+            return {}
+        normalized = {}
+        for symbol, summary in rows.items():
+            normalized_symbol = _normalize_symbol(symbol)
+            if not normalized_symbol:
+                continue
+            payload = dict(summary or {})
+            payload["symbol"] = normalized_symbol
+            payload["available"] = bool(payload)
+            normalized[normalized_symbol] = payload
+        return normalized
 
     def _must_pool_map(self):
         rows = {}
@@ -505,6 +536,32 @@ def _default_symbol_limit_loader(symbol):
     )
 
     return PositionManagementDashboardService().get_symbol_limit(symbol)
+
+
+def _default_symbol_limit_map_loader():
+    from freshquant.position_management.dashboard_service import (
+        PositionManagementDashboardService,
+    )
+
+    payload = PositionManagementDashboardService().get_dashboard()
+    rows = (payload or {}).get("rows") or []
+    summary_map = {}
+    for item in rows:
+        symbol = _normalize_symbol((item or {}).get("symbol"))
+        if not symbol:
+            continue
+        summary_map[symbol] = {
+            "symbol": symbol,
+            "default_limit": item.get("default_limit"),
+            "override_limit": item.get("override_limit"),
+            "effective_limit": item.get("effective_limit"),
+            "using_override": bool(item.get("using_override")),
+            "blocked": bool(item.get("blocked")),
+            "blocked_reason": item.get("blocked_reason"),
+            "market_value": item.get("market_value"),
+            "market_value_source": item.get("market_value_source"),
+        }
+    return summary_map
 
 
 def _default_position_loader():

--- a/freshquant/tests/test_order_management_guardian_semantics.py
+++ b/freshquant/tests/test_order_management_guardian_semantics.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import freshquant.order_management.guardian.arranger as arranger_module
 from freshquant.order_management.guardian.allocation_policy import (
     allocate_sell_to_entry_slices,
     allocate_sell_to_slices,
@@ -162,6 +163,39 @@ def test_build_buy_lot_from_trade_fact_backfills_date_and_time_from_trade_time()
 
     assert buy_lot["date"] == int(expected_dt.strftime("%Y%m%d"))
     assert buy_lot["time"] == expected_dt.strftime("%H:%M:%S")
+
+
+def test_build_buy_lot_from_trade_fact_uses_beijing_time_even_if_local_fromtimestamp_differs(
+    monkeypatch,
+):
+    observed = {}
+
+    def _fake_beijing_date_time_from_epoch(timestamp):
+        observed["timestamp"] = timestamp
+        return 20240310, "00:00:00"
+
+    monkeypatch.setattr(
+        arranger_module,
+        "beijing_date_time_from_epoch",
+        _fake_beijing_date_time_from_epoch,
+    )
+
+    buy_lot = arranger_module.build_buy_lot_from_trade_fact(
+        {
+            "trade_fact_id": "trade_buy_missing_date_time_local_drift",
+            "symbol": "000001",
+            "side": "buy",
+            "quantity": 300,
+            "price": 10.0,
+            "trade_time": 1710000000,
+            "date": None,
+            "time": None,
+        }
+    )
+
+    assert buy_lot["date"] == 20240310
+    assert buy_lot["time"] == "00:00:00"
+    assert observed["timestamp"] == 1710000000
 
 
 def test_list_arranged_fills_backfills_date_and_time_from_buy_lot_trade_time():

--- a/freshquant/tests/test_order_management_guardian_semantics.py
+++ b/freshquant/tests/test_order_management_guardian_semantics.py
@@ -146,7 +146,10 @@ def test_guardian_read_model_matches_legacy_sell_quantity_cases():
 
 def test_build_buy_lot_from_trade_fact_backfills_date_and_time_from_trade_time():
     trade_time = 1710000000
-    expected_dt = datetime.fromtimestamp(trade_time)
+    expected_dt = datetime.fromtimestamp(
+        trade_time,
+        tz=timezone(timedelta(hours=8)),
+    )
 
     buy_lot = build_buy_lot_from_trade_fact(
         {

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -1,3 +1,5 @@
+from zoneinfo import ZoneInfo
+
 import pytest
 
 import freshquant.order_management.ingest.xt_reports as xt_reports_module
@@ -613,7 +615,84 @@ def test_confirmed_gap_is_not_recreated_for_same_position_delta(monkeypatch):
 
     assert recreated == []
     assert len(repository.reconciliation_gaps) == 1
-    assert len(repository.position_entries) == 1
+
+
+def test_build_auto_open_entry_uses_beijing_date_time():
+    entry = reconcile_service_module._build_auto_open_entry(
+        {
+            "symbol": "000001",
+            "quantity_delta": 100,
+            "price_estimate": 10.0,
+        },
+        resolution_id="resolution_1",
+        confirmed_at=1710000000,
+    )
+
+    assert entry["date"] == 20240310
+    assert entry["time"] == "00:00:00"
+
+
+def test_load_previous_close_from_realtime_uses_beijing_midnight_when_local_fromtimestamp_differs(
+    monkeypatch,
+):
+    import sys
+    import types
+    from datetime import datetime, timezone
+
+    captured = {}
+
+    class FakeDateTime(datetime):
+        @classmethod
+        def fromtimestamp(cls, timestamp, tz=None):
+            if tz is None:
+                return datetime.fromtimestamp(timestamp, timezone.utc).replace(
+                    tzinfo=None
+                )
+            return datetime.fromtimestamp(timestamp, tz=tz)
+
+    class FakeCollection:
+        def find_one(self, query, sort=None):
+            captured["datetime_lt"] = query["datetime"]["$lt"]
+            return None
+
+    class FakeMongo:
+        client = object()
+
+        def __getitem__(self, name):
+            return FakeCollection()
+
+    pymongo_module = types.ModuleType("pymongo")
+    pymongo_module.DESCENDING = -1
+    mongodb_module = types.ModuleType("fqxtrade.database.mongodb")
+    mongodb_module.DBfreshquant = FakeMongo()
+    schema_module = types.ModuleType("freshquant.market_data.xtdata.schema")
+    schema_module.normalize_prefixed_code = lambda value: str(value or "").strip()
+
+    monkeypatch.setitem(sys.modules, "pymongo", pymongo_module)
+    monkeypatch.setitem(sys.modules, "fqxtrade.database.mongodb", mongodb_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "freshquant.market_data.xtdata.schema",
+        schema_module,
+    )
+    monkeypatch.setattr(reconcile_service_module, "datetime", FakeDateTime)
+    monkeypatch.setattr(
+        reconcile_service_module, "_can_query_mongo", lambda client: True
+    )
+
+    reconcile_service_module._load_previous_close_from_realtime(
+        "000001.SZ",
+        1710000000,
+    )
+
+    assert captured["datetime_lt"] == datetime(
+        2024,
+        3,
+        10,
+        0,
+        0,
+        tzinfo=ZoneInfo("Asia/Shanghai"),
+    )
 
 
 def test_non_board_lot_gap_is_rejected_without_creating_entry(monkeypatch):

--- a/freshquant/tests/test_order_management_xt_ingest.py
+++ b/freshquant/tests/test_order_management_xt_ingest.py
@@ -351,6 +351,53 @@ def test_normalize_xt_trade_report_prefers_order_domain_broker_order_type():
     assert normalized["side"] == "buy"
 
 
+def test_upsert_broker_position_entry_uses_beijing_time_when_local_fromtimestamp_differs(
+    monkeypatch,
+):
+    from datetime import datetime, timezone
+
+    class FakeDateTime(datetime):
+        @classmethod
+        def fromtimestamp(cls, timestamp, tz=None):
+            if tz is None:
+                return datetime.fromtimestamp(timestamp, timezone.utc).replace(
+                    tzinfo=None
+                )
+            return datetime.fromtimestamp(timestamp, tz=tz)
+
+    monkeypatch.setattr(xt_reports_module, "datetime", FakeDateTime)
+
+    repository = InMemoryRepository()
+    repository.broker_orders.append(
+        {
+            "broker_order_key": "ord_test_fill_time_backfill",
+            "filled_quantity": 100,
+            "first_fill_time": 1710000000,
+            "avg_filled_price": 10.0,
+        }
+    )
+
+    entry, _ = xt_reports_module._upsert_broker_position_entry(
+        repository=repository,
+        trade_fact={
+            "internal_order_id": "ord_test_fill_time_backfill",
+            "symbol": "000001",
+            "side": "buy",
+            "quantity": 100,
+            "price": 10.0,
+            "trade_time": None,
+            "date": None,
+            "time": None,
+            "source": "xt_trade_callback",
+        },
+        lot_amount=50000,
+        grid_interval=1.03,
+    )
+
+    assert entry["date"] == 20240310
+    assert entry["time"] == "00:00:00"
+
+
 def test_normalize_xt_order_report_maps_broker_order_back_to_internal_order():
     repository = InMemoryRepository()
     tracking_service = OrderTrackingService(repository=repository)

--- a/freshquant/tests/test_position_management_dashboard.py
+++ b/freshquant/tests/test_position_management_dashboard.py
@@ -857,12 +857,62 @@ def test_dashboard_reconciliation_loader_summarizes_gap_and_rejection_state(
 
     assert dashboard_service._default_reconciliation_loader() == {
         "000001": {
+            "symbol": "000001",
             "state": "BROKEN",
             "latest_gap_state": "OPEN",
             "signed_gap_quantity": 200,
             "open_gap_count": 1,
             "latest_resolution_type": None,
             "ingest_rejection_count": 1,
+        }
+    }
+
+
+def test_dashboard_reconciliation_loader_sums_multiple_gap_deltas_by_side(
+    monkeypatch,
+):
+    import freshquant.order_management.repository as order_repository_module
+    from freshquant.position_management import dashboard_service
+
+    class FakeOrderRepository:
+        def list_reconciliation_gaps(self):
+            return [
+                {
+                    "symbol": "600000.SH",
+                    "state": "OPEN",
+                    "quantity_delta": 200,
+                    "side": "buy",
+                    "detected_at": 10,
+                    "resolution_type": "",
+                },
+                {
+                    "symbol": "600000.SH",
+                    "state": "OPEN",
+                    "quantity_delta": 50,
+                    "side": "sell",
+                    "detected_at": 20,
+                    "resolution_type": "",
+                },
+            ]
+
+        def list_ingest_rejections(self):
+            return []
+
+    monkeypatch.setattr(
+        order_repository_module,
+        "OrderManagementRepository",
+        lambda: FakeOrderRepository(),
+    )
+
+    assert dashboard_service._default_reconciliation_loader() == {
+        "600000": {
+            "symbol": "600000",
+            "state": "OBSERVING",
+            "latest_gap_state": "OPEN",
+            "signed_gap_quantity": 150,
+            "open_gap_count": 2,
+            "latest_resolution_type": None,
+            "ingest_rejection_count": 0,
         }
     }
 

--- a/freshquant/tests/test_subject_management_service.py
+++ b/freshquant/tests/test_subject_management_service.py
@@ -419,6 +419,73 @@ def test_subject_management_overview_prefers_symbol_snapshot_market_value():
     assert rows[0]["runtime"]["position_amount"] == 123456.0
 
 
+def test_subject_management_overview_uses_default_symbol_limit_batch_loader_once(
+    monkeypatch,
+):
+    import freshquant.position_management.dashboard_service as pm_dashboard_module
+
+    call_counts = {"dashboard": 0, "symbol": 0}
+
+    class FakePositionManagementDashboardService:
+        def get_dashboard(self):
+            call_counts["dashboard"] += 1
+            return {
+                "rows": [
+                    {
+                        "symbol": "600000",
+                        "default_limit": 800000.0,
+                        "override_limit": 500000.0,
+                        "effective_limit": 500000.0,
+                        "using_override": True,
+                        "blocked": False,
+                    },
+                    {
+                        "symbol": "000001",
+                        "default_limit": 800000.0,
+                        "override_limit": None,
+                        "effective_limit": 800000.0,
+                        "using_override": False,
+                        "blocked": False,
+                    },
+                ]
+            }
+
+        def get_symbol_limit(self, symbol):
+            call_counts["symbol"] += 1
+            return {
+                "symbol": symbol,
+                "default_limit": 800000.0,
+                "override_limit": None,
+                "effective_limit": 800000.0,
+                "using_override": False,
+                "blocked": False,
+            }
+
+    monkeypatch.setattr(
+        pm_dashboard_module,
+        "PositionManagementDashboardService",
+        FakePositionManagementDashboardService,
+    )
+
+    service = SubjectManagementDashboardService(
+        database=FakeDatabase(),
+        tpsl_repository=InMemoryTpslRepository(),
+        order_repository=InMemoryOrderManagementRepository(),
+        position_loader=lambda: [
+            {"symbol": "600000.SH", "name": "浦发银行", "quantity": 500},
+            {"symbol": "000001.SZ", "name": "平安银行", "quantity": 300},
+        ],
+        symbol_position_loader=lambda symbol: None,
+        pm_summary_loader=lambda: {},
+    )
+
+    rows = service.get_overview()
+
+    assert len(rows) == 2
+    assert call_counts == {"dashboard": 1, "symbol": 0}
+    assert rows[0]["position_limit_summary"]["effective_limit"] in {500000.0, 800000.0}
+
+
 def test_subject_management_overview_keeps_rows_when_symbol_limit_loader_rejects_untracked_symbol():
     service = SubjectManagementDashboardService(
         database=FakeDatabase(

--- a/freshquant/tpsl/management_service.py
+++ b/freshquant/tpsl/management_service.py
@@ -9,6 +9,9 @@ from freshquant.order_management.entry_adapter import (
     list_open_entry_slices_compat,
     list_open_entry_views,
 )
+from freshquant.order_management.reconcile.summary import (
+    summarize_symbol_reconciliation,
+)
 from freshquant.order_management.repository import OrderManagementRepository
 from freshquant.tpsl.repository import TpslRepository
 from freshquant.tpsl.takeprofit_service import TakeprofitService
@@ -436,66 +439,17 @@ def _build_reconciliation_view(symbol, *, repository, broker_quantity, ledger_qu
             "rows": [],
         }
 
-    rows = []
-    gap_rows = list(repository.list_reconciliation_gaps(symbol=symbol) or [])
-    gap_ids = [item.get("gap_id") for item in gap_rows if item.get("gap_id")]
-    resolution_rows = []
-    if gap_ids and hasattr(repository, "list_reconciliation_resolutions"):
-        resolution_rows = list(
-            repository.list_reconciliation_resolutions(gap_ids=gap_ids) or []
-        )
-    latest_resolution = None
-    for item in resolution_rows:
-        resolved_at = str(item.get("resolved_at") or "")
-        if latest_resolution is None or resolved_at > str(
-            latest_resolution.get("resolved_at") or ""
-        ):
-            latest_resolution = item
-
-    signed_gap_quantity = 0
-    open_gap_count = 0
-    rejected_gap_count = 0
-    for item in gap_rows:
-        side = str(item.get("side") or "").strip().lower()
-        quantity_delta = int(item.get("quantity_delta") or 0)
-        signed_gap_quantity += quantity_delta if side == "buy" else -quantity_delta
-        state = str(item.get("state") or "").strip().upper()
-        if state in {"OPEN", "REJECTED"}:
-            open_gap_count += 1
-        if state == "REJECTED":
-            rejected_gap_count += 1
-        rows.append(
-            {
-                "gap_id": item.get("gap_id"),
-                "side": side,
-                "state": str(item.get("state") or ""),
-                "quantity_delta": quantity_delta,
-                "pending_until": item.get("pending_until"),
-                "resolution_type": item.get("resolution_type"),
-            }
-        )
-    derived_signed_gap = int(broker_quantity or 0) - int(ledger_quantity or 0)
-    effective_signed_gap = signed_gap_quantity if gap_rows else derived_signed_gap
-    if open_gap_count > 0:
-        state = "observing" if rejected_gap_count == 0 else "rejected"
-    elif effective_signed_gap == 0:
-        state = "aligned"
-    elif latest_resolution is not None:
-        state = "auto_reconciled"
-    else:
-        state = "drift"
+    summary = summarize_symbol_reconciliation(
+        symbol=symbol,
+        gap_rows=list(repository.list_reconciliation_gaps(symbol=symbol) or []),
+        broker_quantity=broker_quantity,
+        ledger_quantity=ledger_quantity,
+        include_rows=True,
+    )
     return {
-        "symbol": symbol,
-        "broker_quantity": int(broker_quantity or 0),
-        "ledger_quantity": int(ledger_quantity or 0),
-        "signed_gap_quantity": effective_signed_gap,
-        "open_gap_count": open_gap_count,
-        "rejected_gap_count": rejected_gap_count,
-        "latest_resolution_type": str(
-            (latest_resolution or {}).get("resolution_type") or ""
-        ),
-        "state": state,
-        "rows": rows,
+        **summary,
+        "latest_resolution_type": str(summary.get("latest_resolution_type") or ""),
+        "state": str(summary.get("state") or "ALIGNED").lower(),
     }
 
 


### PR DESCRIPTION
## 背景

本次修复来自全库 review 中确认度最高的 5 个问题，主要集中在订单域时间语义、reconciliation 汇总一致性，以及 Subject overview 的重复计算路径。

## 目标

- 统一订单域 `trade_time / confirmed_at` 回填 `date/time` 的北京时间语义
- 统一 `position_management` 与 `tpsl` 的 reconciliation 汇总算法
- 去掉 Subject overview 按 symbol 重跑整套 PM limit 读取的热点路径
- 同步补齐对应测试与当前文档

## 范围

- 新增共享时间 helper 与共享 reconciliation summary helper
- 修复 `guardian.arranger`、`xt_reports`、`reconcile.service` 的时间回填与 previous close 日界
- 修复 `position_management` 的多 gap reconciliation 净额计算
- 让 `tpsl` 与 `position_management` 共享同一 reconciliation summary 规则
- 让 `subject_management` overview 默认走批量 symbol-limit 读取
- 更新 `docs/current/**` 中相关当前事实说明

## 非目标

- 不做更大范围的 order-management 重构
- 不改动前端展示逻辑
- 不处理本次 review 之外的其他潜在问题

## 验收标准

- 相关回归测试通过
- 自动补开的 entry 与 XT 回报补录路径按北京时间回填 `date/time`
- `position_management` 多 gap symbol 的 `signed_gap_quantity` 为净额而非最后一条 gap
- `subject_management/overview` 默认不再按 symbol 重跑单标的 PM limit 路径

## 验证

```powershell
..\..\.venv\Scripts\python.exe script/ci/check_current_docs.py
..\..\.venv\Scripts\python.exe -m pre_commit run --files docs/current/modules/order-management.md docs/current/modules/position-management.md docs/current/modules/subject-management.md freshquant/order_management/time_helpers.py freshquant/order_management/reconcile/summary.py freshquant/order_management/guardian/arranger.py freshquant/order_management/ingest/xt_reports.py freshquant/order_management/reconcile/service.py freshquant/position_management/dashboard_service.py freshquant/subject_management/dashboard_service.py freshquant/tpsl/management_service.py freshquant/tests/test_order_management_guardian_semantics.py freshquant/tests/test_order_management_reconcile.py freshquant/tests/test_order_management_xt_ingest.py freshquant/tests/test_position_management_dashboard.py freshquant/tests/test_subject_management_service.py
..\..\.venv\Scripts\python.exe -m pytest freshquant/tests/test_order_management_xt_ingest.py freshquant/tests/test_order_management_reconcile.py freshquant/tests/test_order_management_guardian_semantics.py freshquant/tests/test_position_management_dashboard.py freshquant/tests/test_subject_management_service.py freshquant/tests/test_tpsl_management_service.py -q
```

## 部署影响

- `freshquant/order_management/**`：重部署后端/API，必要时重启相关 worker
- `freshquant/position_management/**`：重部署后端并重启 `xt_account_sync.worker`
- `freshquant/tpsl/**`：重部署后端并重启 `tpsl.tick_listener`
- `freshquant/subject_management/**`：随 API 一并部署
