### PR TITLE
fix: unify cli time semantics to Beijing

### DIFF
--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -127,6 +127,8 @@
 
 自动平账与 XT 回报补录路径里，凡是由 `trade_time / confirmed_at` 回填 `date/time` 的订单域记录，当前统一按北京时间（`Asia/Shanghai`）落地，避免同一笔成交在不同读模型里出现跨日漂移。
 
+排障查看口径也保持同一套时间语义：`xt-order list`、`xt-trade list` 以及依赖成交 epoch 时间的 fill 查看命令，当前统一按北京时间展示；其中 `--date` 过滤使用北京时间自然日边界，而不是宿主机本地时区。
+
 ### 手工导入
 
 `manual import/reset -> om_trade_facts -> om_position_entries / om_entry_slices -> stock_fills_compat mirror sync`

--- a/freshquant/command/order.py
+++ b/freshquant/command/order.py
@@ -1,27 +1,52 @@
 import click
 from bson import ObjectId
-from freshquant.db import DBfreshquant
-from rich.table import Table
 from rich.console import Console
 from rich.padding import Padding
-from datetime import datetime, timedelta
-from freshquant.util.xtquant import translate_order_type, translate_broker_price_type  # 导入 translate_broker_price_type 函数
+from rich.table import Table
+
+from freshquant.db import DBfreshquant
 from freshquant.instrument.general import query_instrument_info
+from freshquant.order_management.time_helpers import (
+    beijing_datetime_from_epoch,
+    beijing_epoch_range_for_date,
+    normalize_cli_date_input,
+)
+from freshquant.util.xtquant import (  # 导入 translate_broker_price_type 函数
+    translate_broker_price_type,
+    translate_order_type,
+)
+
 
 @click.group(name="xt-order")
 def xt_order_command_group():
     pass
 
+
 @xt_order_command_group.command(name="list")
-@click.option("--code", required=False, help="Filter by stock code (e.g., 300888 or 300888.SZ)")
-@click.option("--date", required=False, help="Filter by date (e.g., YYYYMMDD, YYYY.MM.DD, or YYYY-MM-DD)")
-@click.option("--fields", required=False, help="Comma-separated list of fields to display (e.g., id,stock_code,traded_price)")
+@click.option(
+    "--code", required=False, help="Filter by stock code (e.g., 300888 or 300888.SZ)"
+)
+@click.option(
+    "--date",
+    required=False,
+    help="Filter by date (e.g., YYYYMMDD, YYYY.MM.DD, or YYYY-MM-DD)",
+)
+@click.option(
+    "--fields",
+    required=False,
+    help="Comma-separated list of fields to display (e.g., id,stock_code,traded_price)",
+)
 def xt_order_list_command(code: str, date: str, fields: str):
     list_xt_order(code, date, fields)
 
+
 @xt_order_command_group.command(name="rm")
 @click.option("--id", required=False, help="The ID of the record to delete")
-@click.option("--code", required=False, help="Delete records by stock code (e.g., 300888 or 300888.SZ)")
+@click.option(
+    "--code",
+    required=False,
+    help="Delete records by stock code (e.g., 300888 or 300888.SZ)",
+)
 def xt_order_rm_command(id: str, code: str):
     """Delete a record by its ID or stock code and display the remaining records."""
     query = {}
@@ -38,7 +63,10 @@ def xt_order_rm_command(id: str, code: str):
     if code:
         # Normalize the code by removing the suffix (e.g., ".SZ" or ".SH") if present
         normalized_code = code.split(".")[0]
-        query["stock_code"] = {"$regex": f"^{normalized_code}(\\..*)?$", "$options": "i"}
+        query["stock_code"] = {
+            "$regex": f"^{normalized_code}(\\..*)?$",
+            "$options": "i",
+        }
 
     if not query:
         click.echo("Either --id or --code must be provided.")
@@ -56,46 +84,57 @@ def list_xt_order(code: str = None, date: str = None, fields: str = None):
     if code:
         # Normalize the code by removing the suffix (e.g., ".SZ" or ".SH") if present
         normalized_code = code.split(".")[0]
-        query["stock_code"] = {"$regex": f"^{normalized_code}(\\..*)?$", "$options": "i"}
-    
+        query["stock_code"] = {
+            "$regex": f"^{normalized_code}(\\..*)?$",
+            "$options": "i",
+        }
+
     if date:
         # Normalize the date format to YYYY-MM-DD
         try:
-            if len(date) == 8 and date.isdigit():  # YYYYMMDD format
-                normalized_date = f"{date[:4]}-{date[4:6]}-{date[6:]}"
-            elif "." in date:  # YYYY.MM.DD format
-                parts = date.split(".")
-                normalized_date = f"{parts[0]}-{parts[1]}-{parts[2]}"
-            elif "-" in date:  # YYYY-MM-DD format
-                parts = date.split("-")
-                normalized_date = f"{parts[0]}-{parts[1]}-{parts[2]}"
-            else:
-                raise ValueError("Invalid date format")
-            
+            normalized_date = normalize_cli_date_input(date)
+            start_ts, end_ts = beijing_epoch_range_for_date(normalized_date)
             # Add the date filter to the query
             query["order_time"] = {
-                "$gte": int(datetime.strptime(normalized_date, "%Y-%m-%d").timestamp()),
-                "$lt": int((datetime.strptime(normalized_date, "%Y-%m-%d") + timedelta(days=1)).timestamp())
+                "$gte": start_ts,
+                "$lt": end_ts,
             }
         except Exception as e:
             click.echo(f"Error parsing date: {e}")
             return
-    
+
     records = list(DBfreshquant["xt_orders"].find(query).sort([('order_time', 1)]))
-    
+
     # Default fields to display if not specified
     default_fields = [
-        "id", "account_id", "stock_code", "name", "order_id", "order_type",
-        "price", "order_volume", "traded_price", "traded_volume",
-        "order_time", "strategy_name", "source", "price_type"  # 添加 price_type 字段
+        "id",
+        "account_id",
+        "stock_code",
+        "name",
+        "order_id",
+        "order_type",
+        "price",
+        "order_volume",
+        "traded_price",
+        "traded_volume",
+        "order_time",
+        "strategy_name",
+        "source",
+        "price_type",  # 添加 price_type 字段
     ]
-    
+
     # Parse the fields option
     selected_fields = fields.split(",") if fields else default_fields
-    
+
     # Create a Rich Table with borders
-    table = Table(show_header=True, header_style="bold magenta", show_lines=True, title="委托记录", title_style="bold")
-    
+    table = Table(
+        show_header=True,
+        header_style="bold magenta",
+        show_lines=True,
+        title="委托记录",
+        title_style="bold",
+    )
+
     # Define all possible columns with their styles
     column_definitions = {
         "id": {"style": "dim", "overflow": "fold"},
@@ -111,23 +150,34 @@ def list_xt_order(code: str = None, date: str = None, fields: str = None):
         "order_time": {"overflow": "fold"},
         "strategy_name": {"overflow": "fold"},
         "source": {"overflow": "fold"},
-        "price_type": {"justify": "right", "overflow": "fold"}  # 新增 price_type 列定义
+        "price_type": {
+            "justify": "right",
+            "overflow": "fold",
+        },  # 新增 price_type 列定义
     }
-    
+
     # Add only the selected fields as columns
     for field in selected_fields:
         if field in column_definitions:
             table.add_column(field, **column_definitions[field])
-    
+
     for record in records:
         row_data = []
-        
+
         for field in selected_fields:
             if field == "id":
                 row_data.append(str(record.get('_id', "")))
             elif field == "account_id":
                 account_id = str(record.get('account_id'))
-                masked_account_id = (lambda x: x[:len(x)//3] + '*'*(len(x)//3) + x[-(len(x)-2*(len(x)//3)):] if len(x) >= 3 else x)(str(account_id))
+                masked_account_id = (
+                    lambda x: (
+                        x[: len(x) // 3]
+                        + '*' * (len(x) // 3)
+                        + x[-(len(x) - 2 * (len(x) // 3)) :]
+                        if len(x) >= 3
+                        else x
+                    )
+                )(str(account_id))
                 row_data.append(masked_account_id)
             elif field == "order_type":
                 order_type = record.get('order_type')
@@ -144,7 +194,9 @@ def list_xt_order(code: str = None, date: str = None, fields: str = None):
             elif field == "order_time":
                 order_time = record.get('order_time')
                 if order_time:
-                    order_time = datetime.fromtimestamp(order_time).strftime('%Y-%m-%d %H:%M:%S')
+                    order_time = beijing_datetime_from_epoch(order_time).strftime(
+                        '%Y-%m-%d %H:%M:%S'
+                    )
                 else:
                     order_time = "N/A"
                 row_data.append(order_time)
@@ -154,7 +206,9 @@ def list_xt_order(code: str = None, date: str = None, fields: str = None):
                 stock_code = record.get('stock_code')
                 if stock_code:
                     stock_info = query_instrument_info(stock_code)
-                    stock_name = stock_info.get('name', 'Unknown') if stock_info else 'Unknown'
+                    stock_name = (
+                        stock_info.get('name', 'Unknown') if stock_info else 'Unknown'
+                    )
                 else:
                     stock_name = 'Unknown'
                 row_data.append(stock_name)
@@ -164,15 +218,14 @@ def list_xt_order(code: str = None, date: str = None, fields: str = None):
                 row_data.append(price_type_desc)
             else:
                 row_data.append("")  # For fields that don't exist
-        
+
         # Add rows to the table
         table.add_row(*row_data)
-    
+
     # Print the table using Rich Console with expanded width
     console = Console()  # Set a wider console width
     t = Padding(table, (1, 0, 0, 0))
     console.print(t)
-
 
 
 # Entry point to run tests

--- a/freshquant/command/trade.py
+++ b/freshquant/command/trade.py
@@ -1,28 +1,52 @@
 import click
 from bson import ObjectId
-from freshquant.db import DBfreshquant
-from rich.table import Table
-from rich.padding import Padding
 from rich.console import Console
-from datetime import datetime, timedelta
-from freshquant.util.xtquant import translate_order_type  # 导入 translate_order_type 函数
-from freshquant.util.mask_helper import mask
+from rich.padding import Padding
+from rich.table import Table
+
+from freshquant.db import DBfreshquant
 from freshquant.instrument.general import query_instrument_info
+from freshquant.order_management.time_helpers import (
+    beijing_datetime_from_epoch,
+    beijing_epoch_range_for_date,
+    normalize_cli_date_input,
+)
+from freshquant.util.mask_helper import mask
+from freshquant.util.xtquant import (  # 导入 translate_order_type 函数
+    translate_order_type,
+)
+
 
 @click.group(name="xt-trade")
 def xt_trade_command_group():
     pass
 
+
 @xt_trade_command_group.command(name="list")
-@click.option("--code", required=False, help="Filter by stock code (e.g., 300888 or 300888.SZ)")
-@click.option("--date", required=False, help="Filter by date (e.g., YYYYMMDD, YYYY.MM.DD, or YYYY-MM-DD)")
-@click.option("--fields", required=False, help="Comma-separated list of fields to display (e.g., id,stock_code,traded_price)")
+@click.option(
+    "--code", required=False, help="Filter by stock code (e.g., 300888 or 300888.SZ)"
+)
+@click.option(
+    "--date",
+    required=False,
+    help="Filter by date (e.g., YYYYMMDD, YYYY.MM.DD, or YYYY-MM-DD)",
+)
+@click.option(
+    "--fields",
+    required=False,
+    help="Comma-separated list of fields to display (e.g., id,stock_code,traded_price)",
+)
 def xt_trade_list_command(code: str, date: str, fields: str):
     list_xt_trade(code, date, fields)
 
+
 @xt_trade_command_group.command(name="rm")
 @click.option("--id", required=False, help="The ID of the record to delete")
-@click.option("--code", required=False, help="Delete records by stock code (e.g., 300888 or 300888.SZ)")
+@click.option(
+    "--code",
+    required=False,
+    help="Delete records by stock code (e.g., 300888 or 300888.SZ)",
+)
 def xt_trade_rm_command(id: str, code: str):
     """Delete a record by its ID or stock code and display the remaining records."""
     query = {}
@@ -39,7 +63,10 @@ def xt_trade_rm_command(id: str, code: str):
     if code:
         # Normalize the code by removing the suffix (e.g., ".SZ" or ".SH") if present
         normalized_code = code.split(".")[0]
-        query["stock_code"] = {"$regex": f"^{normalized_code}(\\..*)?$", "$options": "i"}
+        query["stock_code"] = {
+            "$regex": f"^{normalized_code}(\\..*)?$",
+            "$options": "i",
+        }
 
     if not query:
         click.echo("Either --id or --code must be provided.")
@@ -57,46 +84,55 @@ def list_xt_trade(code: str = None, date: str = None, fields: str = None):
     if code:
         # Normalize the code by removing the suffix (e.g., ".SZ" or ".SH") if present
         normalized_code = code.split(".")[0]
-        query["stock_code"] = {"$regex": f"^{normalized_code}(\\..*)?$", "$options": "i"}
-    
+        query["stock_code"] = {
+            "$regex": f"^{normalized_code}(\\..*)?$",
+            "$options": "i",
+        }
+
     if date:
         # Normalize the date format to YYYY-MM-DD
         try:
-            if len(date) == 8 and date.isdigit():  # YYYYMMDD format
-                normalized_date = f"{date[:4]}-{date[4:6]}-{date[6:]}"
-            elif "." in date:  # YYYY.MM.DD format
-                parts = date.split(".")
-                normalized_date = f"{parts[0]}-{parts[1]}-{parts[2]}"
-            elif "-" in date:  # YYYY-MM-DD format
-                parts = date.split("-")
-                normalized_date = f"{parts[0]}-{parts[1]}-{parts[2]}"
-            else:
-                raise ValueError("Invalid date format")
-            
+            normalized_date = normalize_cli_date_input(date)
+            start_ts, end_ts = beijing_epoch_range_for_date(normalized_date)
             # Add the date filter to the query
             query["traded_time"] = {
-                "$gte": int(datetime.strptime(normalized_date, "%Y-%m-%d").timestamp()),
-                "$lt": int((datetime.strptime(normalized_date, "%Y-%m-%d") + timedelta(days=1)).timestamp())
+                "$gte": start_ts,
+                "$lt": end_ts,
             }
         except Exception as e:
             click.echo(f"Error parsing date: {e}")
             return
-    
+
     records = list(DBfreshquant["xt_trades"].find(query).sort([('traded_time', 1)]))
-    
+
     # Default fields to display if not specified
     default_fields = [
-        "id", "account_id", "stock_code", "name", "order_id", "order_type",
-        "traded_price", "traded_volume", "traded_amount",
-        "traded_time", "strategy_name", "source"
+        "id",
+        "account_id",
+        "stock_code",
+        "name",
+        "order_id",
+        "order_type",
+        "traded_price",
+        "traded_volume",
+        "traded_amount",
+        "traded_time",
+        "strategy_name",
+        "source",
     ]
-    
+
     # Parse the fields option
     selected_fields = fields.split(",") if fields else default_fields
-    
+
     # Create a Rich Table with borders
-    table = Table(show_header=True, header_style="bold magenta", show_lines=True, title="成交记录", title_style="bold")
-    
+    table = Table(
+        show_header=True,
+        header_style="bold magenta",
+        show_lines=True,
+        title="成交记录",
+        title_style="bold",
+    )
+
     # Define all possible columns with their styles
     column_definitions = {
         "id": {"style": "dim", "overflow": "fold"},
@@ -110,9 +146,9 @@ def list_xt_trade(code: str = None, date: str = None, fields: str = None):
         "traded_amount": {"justify": "right", "overflow": "fold"},
         "traded_time": {"overflow": "fold"},
         "strategy_name": {"overflow": "fold"},
-        "source": {"overflow": "fold"}
+        "source": {"overflow": "fold"},
     }
-    
+
     # 字段名到中文的映射
     field_to_chinese = {
         "id": "ID",
@@ -126,17 +162,17 @@ def list_xt_trade(code: str = None, date: str = None, fields: str = None):
         "traded_amount": "成交金额",
         "traded_time": "成交时间",
         "strategy_name": "策略名称",
-        "source": "来源"
+        "source": "来源",
     }
-    
+
     # Add only the selected fields as columns
     for field in selected_fields:
         if field in column_definitions:
             table.add_column(field_to_chinese[field], **column_definitions[field])
-    
+
     for record in records:
         row_data = []
-        
+
         for field in selected_fields:
             if field == "id":
                 row_data.append(str(record.get('_id', "")))
@@ -155,7 +191,9 @@ def list_xt_trade(code: str = None, date: str = None, fields: str = None):
             elif field == "traded_time":
                 traded_time = record.get('traded_time')
                 if traded_time:
-                    traded_time = datetime.fromtimestamp(traded_time).strftime('%Y-%m-%d %H:%M:%S')
+                    traded_time = beijing_datetime_from_epoch(traded_time).strftime(
+                        '%Y-%m-%d %H:%M:%S'
+                    )
                 else:
                     traded_time = "N/A"
                 row_data.append(traded_time)
@@ -167,21 +205,22 @@ def list_xt_trade(code: str = None, date: str = None, fields: str = None):
                 stock_code = record.get('stock_code')
                 if stock_code:
                     stock_info = query_instrument_info(stock_code)
-                    stock_name = stock_info.get('name', 'Unknown') if stock_info else 'Unknown'
+                    stock_name = (
+                        stock_info.get('name', 'Unknown') if stock_info else 'Unknown'
+                    )
                 else:
                     stock_name = 'Unknown'
                 row_data.append(stock_name)
             else:
                 row_data.append("")  # For fields that don't exist
-        
+
         # Add rows to the table
         table.add_row(*row_data)
-    
+
     # Print the table using Rich Console with expanded width
     console = Console()  # Set a wider console width
     t = Padding(table, (1, 0, 0, 0))
     console.print(t)
-
 
 
 # Entry point to run tests

--- a/freshquant/data/digital/fill.py
+++ b/freshquant/data/digital/fill.py
@@ -1,9 +1,9 @@
 from bson import ObjectId
-from datetime import datetime
 from rich.console import Console
 from rich.table import Table
 
 from freshquant.db import DBfreshquant
+from freshquant.order_management.time_helpers import beijing_datetime_from_epoch
 
 
 def list_fill(instrument_id: str = None, dt: str = None):
@@ -21,7 +21,7 @@ def list_fill(instrument_id: str = None, dt: str = None):
         'instrument_id': 1,
         'volume': 1,
         'price': 1,
-        'trade_date_time': 1
+        'trade_date_time': 1,
     }
 
     results = list(collection.find(query, fields))
@@ -38,7 +38,9 @@ def list_fill(instrument_id: str = None, dt: str = None):
 
     for result in results:
         # 将时间戳转换为可读的日期时间格式
-        readable_time = datetime.fromtimestamp(result['trade_date_time']).strftime('%Y-%m-%d %H:%M:%S')
+        readable_time = beijing_datetime_from_epoch(result['trade_date_time']).strftime(
+            '%Y-%m-%d %H:%M:%S'
+        )
         table.add_row(
             str(result['_id']),
             result['direction'],
@@ -46,7 +48,7 @@ def list_fill(instrument_id: str = None, dt: str = None):
             result['instrument_id'],
             f"{result['volume']:.8f}".rstrip('0').rstrip('.'),
             f"{float(result['price']):.8f}".rstrip('0').rstrip('.'),
-            readable_time
+            readable_time,
         )
 
     # 创建控制台实例并打印表格
@@ -77,21 +79,41 @@ def list_fill(instrument_id: str = None, dt: str = None):
 
         if total_long_quantity > 0:
             avg_long_price = total_long_cost / total_long_quantity
-            print(f"当前多头持仓数量: {total_long_quantity:.8f}".rstrip('0').rstrip('.') + f", 占用资金: {total_long_cost:.8f}".rstrip('0').rstrip('.') + f", 成本价: {avg_long_price:.8f}".rstrip('0').rstrip('.'))
+            print(
+                f"当前多头持仓数量: {total_long_quantity:.8f}".rstrip('0').rstrip('.')
+                + f", 占用资金: {total_long_cost:.8f}".rstrip('0').rstrip('.')
+                + f", 成本价: {avg_long_price:.8f}".rstrip('0').rstrip('.')
+            )
             profit_ratio = (last_trade_price - avg_long_price) / avg_long_price
             profit_amount = (last_trade_price - avg_long_price) * total_long_quantity
-            print(f"盈亏比率: {profit_ratio * 100:.8f}".rstrip('0').rstrip('.') + f"%, 盈亏金额: {profit_amount:.8f}".rstrip('0').rstrip('.'))
+            print(
+                f"盈亏比率: {profit_ratio * 100:.8f}".rstrip('0').rstrip('.')
+                + f"%, 盈亏金额: {profit_amount:.8f}".rstrip('0').rstrip('.')
+            )
         else:
-            print(f"当前多头持仓数量: {total_long_quantity:.8f}".rstrip('0').rstrip('.') + f", 盈亏金额: {-total_long_cost:.8f}".rstrip('0').rstrip('.'))
+            print(
+                f"当前多头持仓数量: {total_long_quantity:.8f}".rstrip('0').rstrip('.')
+                + f", 盈亏金额: {-total_long_cost:.8f}".rstrip('0').rstrip('.')
+            )
 
         if total_short_quantity > 0:
             avg_short_price = total_short_cost / total_short_quantity
-            print(f"当前空头持仓数量: {total_short_quantity:.8f}".rstrip('0').rstrip('.') + f", 占用资金: {total_short_cost:.8f}".rstrip('0').rstrip('.') + f", 成本价: {avg_short_price:.8f}".rstrip('0').rstrip('.'))
+            print(
+                f"当前空头持仓数量: {total_short_quantity:.8f}".rstrip('0').rstrip('.')
+                + f", 占用资金: {total_short_cost:.8f}".rstrip('0').rstrip('.')
+                + f", 成本价: {avg_short_price:.8f}".rstrip('0').rstrip('.')
+            )
             profit_ratio = (avg_short_price - last_trade_price) / avg_short_price
             profit_amount = (avg_short_price - last_trade_price) * total_short_quantity
-            print(f"盈亏比率: {profit_ratio * 100:.8f}".rstrip('0').rstrip('.') + f"%, 盈亏金额: {profit_amount:.8f}".rstrip('0').rstrip('.'))
+            print(
+                f"盈亏比率: {profit_ratio * 100:.8f}".rstrip('0').rstrip('.')
+                + f"%, 盈亏金额: {profit_amount:.8f}".rstrip('0').rstrip('.')
+            )
         else:
-            print(f"当前空头持仓数量: {total_short_quantity:.8f}".rstrip('0').rstrip('.') + f", 盈亏金额: {-total_short_cost:.8f}".rstrip('0').rstrip('.'))
+            print(
+                f"当前空头持仓数量: {total_short_quantity:.8f}".rstrip('0').rstrip('.')
+                + f", 盈亏金额: {-total_short_cost:.8f}".rstrip('0').rstrip('.')
+            )
 
 
 def remove_fill(id=None, instrument_id=None):
@@ -131,7 +153,7 @@ def import_fill(op: str, instrument_id: str, volume: float, price: float, dt: st
         'offset': offset,
         'volume': volume,
         'price': price,
-        'trade_date_time': trade_date_time
+        'trade_date_time': trade_date_time,
     }
 
     # 插入数据库

--- a/freshquant/data/future/fill.py
+++ b/freshquant/data/future/fill.py
@@ -1,23 +1,25 @@
-from freshquant.db import DBfreshquant
-from rich.table import Table
+from bson import ObjectId
 from rich.console import Console
-from datetime import datetime
+from rich.table import Table
+
+from freshquant.db import DBfreshquant
+from freshquant.instrument.code import convert_code_to_tdx, convert_code_to_tq
+from freshquant.instrument.general import query_instrument_info
 from freshquant.KlineDataTool import (
     get_future_data_v2,
 )
-from freshquant.instrument.code import convert_code_to_tdx, convert_code_to_tq
-from bson import ObjectId
-from freshquant.instrument.general import query_instrument_info
+from freshquant.order_management.time_helpers import beijing_datetime_from_epoch
+
 
 def list_fill(instrument_id: str = None, dt: str = None):
-    collection = DBfreshquant.future_fills    
+    collection = DBfreshquant.future_fills
     query = {}
     if instrument_id:
         instrument_id = convert_code_to_tq(instrument_id)
         query['instrument_id'] = instrument_id
     if dt:
         query['date'] = int(dt.replace('-', '').replace('.', ''))
-        
+
     fields = {
         '_id': 1,
         'direction': 1,
@@ -25,11 +27,11 @@ def list_fill(instrument_id: str = None, dt: str = None):
         'instrument_id': 1,
         'volume': 1,
         'price': 1,
-        'trade_date_time': 1
+        'trade_date_time': 1,
     }
-    
+
     results = list(collection.find(query, fields))
-    
+
     # 创建Rich表格
     table = Table(show_header=True, header_style="bold magenta")
     table.add_column("ID", style="dim")
@@ -39,10 +41,12 @@ def list_fill(instrument_id: str = None, dt: str = None):
     table.add_column("数量")
     table.add_column("价格")
     table.add_column("时间")
-    
+
     for result in results:
         # 将时间戳转换为可读的日期时间格式
-        readable_time = datetime.fromtimestamp(result['trade_date_time']).strftime('%Y-%m-%d %H:%M:%S')
+        readable_time = beijing_datetime_from_epoch(result['trade_date_time']).strftime(
+            '%Y-%m-%d %H:%M:%S'
+        )
         table.add_row(
             str(result['_id']),
             result['direction'],
@@ -50,9 +54,9 @@ def list_fill(instrument_id: str = None, dt: str = None):
             result['instrument_id'],
             str(result['volume']),
             f"{float(result['price']):.3f}",
-            readable_time  # 使用转换后的时间
+            readable_time,  # 使用转换后的时间
         )
-    
+
     # 创建控制台实例并打印表格
     console = Console()
     console.print(table)
@@ -63,7 +67,7 @@ def list_fill(instrument_id: str = None, dt: str = None):
         total_long_cost = 0.0
         total_short_cost = 0.0
         last_trade_price = 0.0
-        
+
         for result in results:
             last_trade_price = result['price']
             if result['direction'] == 'BUY' and result['offset'] == 'OPEN':
@@ -78,54 +82,81 @@ def list_fill(instrument_id: str = None, dt: str = None):
             elif result['direction'] == 'BUY' and result['offset'] == 'CLOSE':
                 total_short_quantity -= result['volume']
                 total_short_cost -= result['volume'] * result['price']
-        
+
         if total_long_quantity > 0:
             avg_long_price = total_long_cost / total_long_quantity
-            print(f"当前多头持仓数量: {total_long_quantity}, 占用资金: {round(total_long_cost, 2)}, 成本价: {round(avg_long_price, 3)}")
+            print(
+                f"当前多头持仓数量: {total_long_quantity}, 占用资金: {round(total_long_cost, 2)}, 成本价: {round(avg_long_price, 3)}"
+            )
             kline_data = get_future_data_v2(convert_code_to_tdx(instrument_id), "1m")
             if len(kline_data) > 0:
-                change_ratio = (kline_data.close[-1] - last_trade_price) / last_trade_price
-                print(f"当前价格: {kline_data.close[-1]}, 涨跌比率: {round(change_ratio * 100, 2)}%")
+                change_ratio = (
+                    kline_data.close[-1] - last_trade_price
+                ) / last_trade_price
+                print(
+                    f"当前价格: {kline_data.close[-1]}, 涨跌比率: {round(change_ratio * 100, 2)}%"
+                )
                 profit_ratio = (kline_data.close[-1] - avg_long_price) / avg_long_price
-                profit_amount = (kline_data.close[-1] - avg_long_price) * total_long_quantity
-                print(f"盈亏比率: {round(profit_ratio * 100, 2)}%, 盈亏金额: {round(profit_amount, 2)}")
+                profit_amount = (
+                    kline_data.close[-1] - avg_long_price
+                ) * total_long_quantity
+                print(
+                    f"盈亏比率: {round(profit_ratio * 100, 2)}%, 盈亏金额: {round(profit_amount, 2)}"
+                )
         else:
-            print(f"当前多头持仓数量: {total_long_quantity}, 盈亏金额: {round(-total_long_cost, 2)}")
+            print(
+                f"当前多头持仓数量: {total_long_quantity}, 盈亏金额: {round(-total_long_cost, 2)}"
+            )
 
         if total_short_quantity > 0:
             avg_short_price = total_short_cost / total_short_quantity
-            print(f"当前空头持仓数量: {total_short_quantity}, 占用资金: {round(total_short_cost, 2)}, 成本价: {round(avg_short_price, 3)}")
+            print(
+                f"当前空头持仓数量: {total_short_quantity}, 占用资金: {round(total_short_cost, 2)}, 成本价: {round(avg_short_price, 3)}"
+            )
             kline_data = get_future_data_v2(convert_code_to_tdx(instrument_id), "1m")
             if len(kline_data) > 0:
-                change_ratio = (kline_data.close[-1] - last_trade_price) / last_trade_price
-                print(f"当前价格: {kline_data.close[-1]}, 涨跌比率: {round(change_ratio * 100, 2)}%")
-                profit_ratio = (avg_short_price - kline_data.close[-1]) / avg_short_price
-                profit_amount = (avg_short_price - kline_data.close[-1]) * total_short_quantity
-                print(f"盈亏比率: {round(profit_ratio * 100, 2)}%, 盈亏金额: {round(profit_amount, 2)}")
+                change_ratio = (
+                    kline_data.close[-1] - last_trade_price
+                ) / last_trade_price
+                print(
+                    f"当前价格: {kline_data.close[-1]}, 涨跌比率: {round(change_ratio * 100, 2)}%"
+                )
+                profit_ratio = (
+                    avg_short_price - kline_data.close[-1]
+                ) / avg_short_price
+                profit_amount = (
+                    avg_short_price - kline_data.close[-1]
+                ) * total_short_quantity
+                print(
+                    f"盈亏比率: {round(profit_ratio * 100, 2)}%, 盈亏金额: {round(profit_amount, 2)}"
+                )
         else:
-            print(f"当前空头持仓数量: {total_short_quantity}, 盈亏金额: {round(-total_short_cost, 2)}")
+            print(
+                f"当前空头持仓数量: {total_short_quantity}, 盈亏金额: {round(-total_short_cost, 2)}"
+            )
         print("这是没有考虑杠杆的情况，只做参考，以后会考虑算入杠杆的情况")
+
 
 def remove_fill(id=None, instrument_id=None):
     if id is None and instrument_id is None:
         raise ValueError("必须提供id或instrument_id参数")
-        
+
     collection = DBfreshquant.future_fills
     query = {}
-    
+
     if id is not None:
         query['_id'] = ObjectId(id)
     elif instrument_id is not None:
         instrument_id = convert_code_to_tq(instrument_id)
         query['instrument_id'] = instrument_id
-        
+
     result = collection.delete_many(query)
-    
+
     if result.deleted_count == 0:
         print("未找到匹配的记录")
     else:
         print(f"成功删除{result.deleted_count}条记录")
-        
+
 
 def import_fill(op: str, instrument_id: str, volume: float, price: float, dt: str):
     instrument = query_instrument_info(convert_code_to_tdx(instrument_id))
@@ -137,10 +168,10 @@ def import_fill(op: str, instrument_id: str, volume: float, price: float, dt: st
     direction, offset = op.split("_")
     direction = direction.upper()
     offset = offset.upper()
-    
+
     # 把dt转成时间戳timestamp，保存在trade_date_time字段
     trade_date_time = datetime.strptime(dt, '%Y-%m-%d %H:%M:%S').timestamp()
-    
+
     # 构建插入文档
     document = {
         'instrument_id': instrument_id,
@@ -149,9 +180,9 @@ def import_fill(op: str, instrument_id: str, volume: float, price: float, dt: st
         'name': instrument.get("name"),
         'volume': volume,
         'price': price,
-        'trade_date_time': trade_date_time
+        'trade_date_time': trade_date_time,
     }
-    
+
     # 插入数据库
     DBfreshquant.future_fills.insert_one(document)
     print(f"成功导入{instrument_id}的{op}操作记录")

--- a/freshquant/order_management/time_helpers.py
+++ b/freshquant/order_management/time_helpers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 _BEIJING_TIMEZONE = ZoneInfo("Asia/Shanghai")
@@ -18,3 +18,26 @@ def beijing_date_time_from_epoch(timestamp):
 def beijing_day_start_from_epoch(timestamp):
     dt = beijing_datetime_from_epoch(timestamp)
     return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def normalize_cli_date_input(value):
+    text = str(value or "").strip()
+    if len(text) == 8 and text.isdigit():
+        return f"{text[:4]}-{text[4:6]}-{text[6:]}"
+    if "." in text:
+        parts = text.split(".")
+        if len(parts) == 3 and all(parts):
+            return f"{parts[0]}-{parts[1]}-{parts[2]}"
+    if "-" in text:
+        parts = text.split("-")
+        if len(parts) == 3 and all(parts):
+            return f"{parts[0]}-{parts[1]}-{parts[2]}"
+    raise ValueError("Invalid date format")
+
+
+def beijing_epoch_range_for_date(date_text):
+    day_start = datetime.strptime(date_text, "%Y-%m-%d").replace(
+        tzinfo=_BEIJING_TIMEZONE
+    )
+    next_day_start = day_start + timedelta(days=1)
+    return int(day_start.timestamp()), int(next_day_start.timestamp())

--- a/freshquant/tests/test_cli_time_semantics.py
+++ b/freshquant/tests/test_cli_time_semantics.py
@@ -1,0 +1,207 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+import freshquant.command.order as order_module
+import freshquant.command.trade as trade_module
+import freshquant.data.digital.fill as digital_fill_module
+import freshquant.data.future.fill as future_fill_module
+
+
+class _FakeSortedCursor:
+    def __init__(self, rows):
+        self._rows = [dict(item) for item in rows]
+
+    def sort(self, *_args, **_kwargs):
+        return [dict(item) for item in self._rows]
+
+
+class _FakeCollection:
+    def __init__(self, rows=None):
+        self.rows = [dict(item) for item in rows or []]
+        self.find_calls = []
+
+    def find(self, query=None, fields=None):
+        self.find_calls.append(
+            {
+                "query": dict(query or {}),
+                "fields": dict(fields or {}) if fields else None,
+            }
+        )
+        if fields is None:
+            return _FakeSortedCursor(self.rows)
+        return [dict(item) for item in self.rows]
+
+
+def _install_rich_spies(module, monkeypatch):
+    captured_rows = []
+
+    class _FakeTable:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def add_column(self, *args, **kwargs):
+            pass
+
+        def add_row(self, *values):
+            captured_rows.append(values)
+
+    monkeypatch.setattr(module, "Table", _FakeTable)
+    monkeypatch.setattr(
+        module,
+        "Console",
+        lambda *args, **kwargs: SimpleNamespace(
+            print=lambda *print_args, **print_kwargs: None
+        ),
+    )
+    monkeypatch.setattr(module, "Padding", lambda value, padding: value, raising=False)
+    return captured_rows
+
+
+def test_xt_order_list_uses_beijing_day_range_helper(monkeypatch):
+    observed = {}
+    collection = _FakeCollection([])
+    _install_rich_spies(order_module, monkeypatch)
+    monkeypatch.setattr(order_module, "DBfreshquant", {"xt_orders": collection})
+
+    def _fake_beijing_epoch_range_for_date(normalized_date):
+        observed["normalized_date"] = normalized_date
+        return 101, 202
+
+    monkeypatch.setattr(
+        order_module,
+        "beijing_epoch_range_for_date",
+        _fake_beijing_epoch_range_for_date,
+        raising=False,
+    )
+
+    order_module.list_xt_order(date="20240310", fields="order_time")
+
+    assert observed["normalized_date"] == "2024-03-10"
+    assert collection.find_calls[0]["query"]["order_time"] == {"$gte": 101, "$lt": 202}
+
+
+def test_xt_order_list_formats_order_time_with_beijing_helper(monkeypatch):
+    observed = {}
+    collection = _FakeCollection([{"_id": "row1", "order_time": 1710000000}])
+    captured_rows = _install_rich_spies(order_module, monkeypatch)
+    monkeypatch.setattr(order_module, "DBfreshquant", {"xt_orders": collection})
+
+    def _fake_beijing_datetime_from_epoch(timestamp):
+        observed["timestamp"] = timestamp
+        return datetime(2024, 3, 10, 0, 0, 0)
+
+    monkeypatch.setattr(
+        order_module,
+        "beijing_datetime_from_epoch",
+        _fake_beijing_datetime_from_epoch,
+        raising=False,
+    )
+
+    order_module.list_xt_order(fields="order_time")
+
+    assert observed["timestamp"] == 1710000000
+    assert captured_rows == [("2024-03-10 00:00:00",)]
+
+
+def test_xt_trade_list_uses_beijing_day_range_helper(monkeypatch):
+    observed = {}
+    collection = _FakeCollection([])
+    _install_rich_spies(trade_module, monkeypatch)
+    monkeypatch.setattr(trade_module, "DBfreshquant", {"xt_trades": collection})
+
+    def _fake_beijing_epoch_range_for_date(normalized_date):
+        observed["normalized_date"] = normalized_date
+        return 303, 404
+
+    monkeypatch.setattr(
+        trade_module,
+        "beijing_epoch_range_for_date",
+        _fake_beijing_epoch_range_for_date,
+        raising=False,
+    )
+
+    trade_module.list_xt_trade(date="2024.03.10", fields="traded_time")
+
+    assert observed["normalized_date"] == "2024-03-10"
+    assert collection.find_calls[0]["query"]["traded_time"] == {
+        "$gte": 303,
+        "$lt": 404,
+    }
+
+
+def test_digital_fill_list_formats_trade_time_with_beijing_helper(monkeypatch):
+    observed = {}
+    collection = _FakeCollection(
+        [
+            {
+                "_id": "fill1",
+                "direction": "BUY",
+                "offset": "OPEN",
+                "instrument_id": "BTCUSDT",
+                "volume": 1.0,
+                "price": 10.0,
+                "trade_date_time": 1710000000,
+            }
+        ]
+    )
+    captured_rows = _install_rich_spies(digital_fill_module, monkeypatch)
+    monkeypatch.setattr(
+        digital_fill_module,
+        "DBfreshquant",
+        SimpleNamespace(digital_fills=collection),
+    )
+
+    def _fake_beijing_datetime_from_epoch(timestamp):
+        observed["timestamp"] = timestamp
+        return datetime(2024, 3, 10, 0, 0, 0)
+
+    monkeypatch.setattr(
+        digital_fill_module,
+        "beijing_datetime_from_epoch",
+        _fake_beijing_datetime_from_epoch,
+        raising=False,
+    )
+
+    digital_fill_module.list_fill()
+
+    assert observed["timestamp"] == 1710000000
+    assert captured_rows[0][-1] == "2024-03-10 00:00:00"
+
+
+def test_future_fill_list_formats_trade_time_with_beijing_helper(monkeypatch):
+    observed = {}
+    collection = _FakeCollection(
+        [
+            {
+                "_id": "fill1",
+                "direction": "BUY",
+                "offset": "OPEN",
+                "instrument_id": "rb2405.SHFE",
+                "volume": 2,
+                "price": 3550.0,
+                "trade_date_time": 1710000000,
+            }
+        ]
+    )
+    captured_rows = _install_rich_spies(future_fill_module, monkeypatch)
+    monkeypatch.setattr(
+        future_fill_module,
+        "DBfreshquant",
+        SimpleNamespace(future_fills=collection),
+    )
+
+    def _fake_beijing_datetime_from_epoch(timestamp):
+        observed["timestamp"] = timestamp
+        return datetime(2024, 3, 10, 0, 0, 0)
+
+    monkeypatch.setattr(
+        future_fill_module,
+        "beijing_datetime_from_epoch",
+        _fake_beijing_datetime_from_epoch,
+        raising=False,
+    )
+
+    future_fill_module.list_fill()
+
+    assert observed["timestamp"] == 1710000000
+    assert captured_rows[0][-1] == "2024-03-10 00:00:00"

--- a/freshquant/tests/test_cli_time_semantics.py
+++ b/freshquant/tests/test_cli_time_semantics.py
@@ -1,10 +1,8 @@
+import importlib
+import sys
+import types
 from datetime import datetime
 from types import SimpleNamespace
-
-import freshquant.command.order as order_module
-import freshquant.command.trade as trade_module
-import freshquant.data.digital.fill as digital_fill_module
-import freshquant.data.future.fill as future_fill_module
 
 
 class _FakeSortedCursor:
@@ -57,7 +55,50 @@ def _install_rich_spies(module, monkeypatch):
     return captured_rows
 
 
+def _load_order_module():
+    import freshquant.command.order as module
+
+    return importlib.reload(module)
+
+
+def _load_trade_module():
+    import freshquant.command.trade as module
+
+    return importlib.reload(module)
+
+
+def _load_digital_fill_module():
+    import freshquant.data.digital.fill as module
+
+    return importlib.reload(module)
+
+
+def _load_future_fill_module(monkeypatch):
+    kline_module = types.ModuleType("freshquant.KlineDataTool")
+    kline_module.get_future_data_v2 = lambda *args, **kwargs: []
+    instrument_code_module = types.ModuleType("freshquant.instrument.code")
+    instrument_code_module.convert_code_to_tdx = lambda value: value
+    instrument_code_module.convert_code_to_tq = lambda value: value
+    instrument_general_module = types.ModuleType("freshquant.instrument.general")
+    instrument_general_module.query_instrument_info = lambda *args, **kwargs: {}
+
+    monkeypatch.setitem(sys.modules, "freshquant.KlineDataTool", kline_module)
+    monkeypatch.setitem(
+        sys.modules, "freshquant.instrument.code", instrument_code_module
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "freshquant.instrument.general",
+        instrument_general_module,
+    )
+
+    import freshquant.data.future.fill as module
+
+    return importlib.reload(module)
+
+
 def test_xt_order_list_uses_beijing_day_range_helper(monkeypatch):
+    order_module = _load_order_module()
     observed = {}
     collection = _FakeCollection([])
     _install_rich_spies(order_module, monkeypatch)
@@ -81,6 +122,7 @@ def test_xt_order_list_uses_beijing_day_range_helper(monkeypatch):
 
 
 def test_xt_order_list_formats_order_time_with_beijing_helper(monkeypatch):
+    order_module = _load_order_module()
     observed = {}
     collection = _FakeCollection([{"_id": "row1", "order_time": 1710000000}])
     captured_rows = _install_rich_spies(order_module, monkeypatch)
@@ -104,6 +146,7 @@ def test_xt_order_list_formats_order_time_with_beijing_helper(monkeypatch):
 
 
 def test_xt_trade_list_uses_beijing_day_range_helper(monkeypatch):
+    trade_module = _load_trade_module()
     observed = {}
     collection = _FakeCollection([])
     _install_rich_spies(trade_module, monkeypatch)
@@ -130,6 +173,7 @@ def test_xt_trade_list_uses_beijing_day_range_helper(monkeypatch):
 
 
 def test_digital_fill_list_formats_trade_time_with_beijing_helper(monkeypatch):
+    digital_fill_module = _load_digital_fill_module()
     observed = {}
     collection = _FakeCollection(
         [
@@ -169,6 +213,7 @@ def test_digital_fill_list_formats_trade_time_with_beijing_helper(monkeypatch):
 
 
 def test_future_fill_list_formats_trade_time_with_beijing_helper(monkeypatch):
+    future_fill_module = _load_future_fill_module(monkeypatch)
     observed = {}
     collection = _FakeCollection(
         [


### PR DESCRIPTION
## 背景
- 第 2 轮全库 review 继续围绕时间语义漂移和重复实现做高置信审查。
- 发现 CLI / 排障查看链路里仍有多处直接使用宿主机本地时区解释 epoch 时间，和前一轮已经统一过的订单主链语义不一致。

## 目标
- 把 `xt-order` / `xt-trade` / fill 查看命令的时间过滤与展示统一到 `Asia/Shanghai`。
- 收敛重复的日期归一化与日界计算逻辑。

## 范围
- 新增共享 helper：`normalize_cli_date_input`、`beijing_epoch_range_for_date`
- 修复 `freshquant/command/order.py`
- 修复 `freshquant/command/trade.py`
- 修复 `freshquant/data/digital/fill.py`
- 修复 `freshquant/data/future/fill.py`
- 新增回归测试 `freshquant/tests/test_cli_time_semantics.py`
- 同步 `docs/current/modules/order-management.md`

## 非目标
- 不调整业务账本模型
- 不改动 Web UI 或 API 返回结构
- 不做额外 CLI 功能增强

## 验收标准
- `xt-order list --date` / `xt-trade list --date` 使用北京时间自然日边界过滤
- 上述 CLI 的 epoch 时间展示统一为北京时间
- digital/future fill 查看的 `trade_date_time` 展示统一为北京时间
- 新增测试能够在非本地时区语义下稳定拦截回归

## 验证
- `..\\..\\.venv\\Scripts\\python.exe -m pytest freshquant\\tests\\test_cli_time_semantics.py freshquant\\tests\\test_order_management_xt_ingest.py freshquant\\tests\\test_order_management_reconcile.py freshquant\\tests\\test_order_management_guardian_semantics.py freshquant\\tests\\test_position_management_dashboard.py freshquant\\tests\\test_subject_management_service.py freshquant\\tests\\test_tpsl_management_service.py freshquant\\tests\\test_order_management_cli.py freshquant\\tests\\test_stock_fill_cli.py -q`
- `..\\..\\.venv\\Scripts\\python.exe -m pre_commit run --files docs/current/modules/order-management.md freshquant/order_management/time_helpers.py freshquant/command/order.py freshquant/command/trade.py freshquant/data/digital/fill.py freshquant/data/future/fill.py freshquant/tests/test_cli_time_semantics.py`
- `..\\..\\.venv\\Scripts\\python.exe script/ci/check_current_docs.py`

## 部署影响
- 改动涉及 `freshquant/order_management/**` 与 CLI / 数据查看路径，按仓库规则需要随下一次后端/API 部署一并带出。
- 本次无额外数据迁移。