### PR TITLE
fix: parse manual fill timestamps in Beijing time

### DIFF
--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -129,6 +129,8 @@
 
 排障查看口径也保持同一套时间语义：`xt-order list`、`xt-trade list` 以及依赖成交 epoch 时间的 fill 查看命令，当前统一按北京时间展示；其中 `--date` 过滤使用北京时间自然日边界，而不是宿主机本地时区。
 
+手工 fill 导入命令传入的 `dt` 文本，当前也统一按北京时间解析成 epoch，避免“查看是北京时间、导入却按宿主机本地时区”导致同一笔记录前后漂移。
+
 ### 手工导入
 
 `manual import/reset -> om_trade_facts -> om_position_entries / om_entry_slices -> stock_fills_compat mirror sync`

--- a/freshquant/data/digital/fill.py
+++ b/freshquant/data/digital/fill.py
@@ -3,7 +3,10 @@ from rich.console import Console
 from rich.table import Table
 
 from freshquant.db import DBfreshquant
-from freshquant.order_management.time_helpers import beijing_datetime_from_epoch
+from freshquant.order_management.time_helpers import (
+    beijing_datetime_from_epoch,
+    beijing_epoch_from_datetime_text,
+)
 
 
 def list_fill(instrument_id: str = None, dt: str = None):
@@ -144,7 +147,7 @@ def import_fill(op: str, instrument_id: str, volume: float, price: float, dt: st
     offset = offset.upper()
 
     # 把dt转成时间戳timestamp，保存在trade_date_time字段
-    trade_date_time = datetime.strptime(dt, '%Y-%m-%d %H:%M:%S').timestamp()
+    trade_date_time = beijing_epoch_from_datetime_text(dt)
 
     # 构建插入文档
     document = {

--- a/freshquant/data/future/fill.py
+++ b/freshquant/data/future/fill.py
@@ -8,7 +8,10 @@ from freshquant.instrument.general import query_instrument_info
 from freshquant.KlineDataTool import (
     get_future_data_v2,
 )
-from freshquant.order_management.time_helpers import beijing_datetime_from_epoch
+from freshquant.order_management.time_helpers import (
+    beijing_datetime_from_epoch,
+    beijing_epoch_from_datetime_text,
+)
 
 
 def list_fill(instrument_id: str = None, dt: str = None):
@@ -170,7 +173,7 @@ def import_fill(op: str, instrument_id: str, volume: float, price: float, dt: st
     offset = offset.upper()
 
     # 把dt转成时间戳timestamp，保存在trade_date_time字段
-    trade_date_time = datetime.strptime(dt, '%Y-%m-%d %H:%M:%S').timestamp()
+    trade_date_time = beijing_epoch_from_datetime_text(dt)
 
     # 构建插入文档
     document = {

--- a/freshquant/order_management/time_helpers.py
+++ b/freshquant/order_management/time_helpers.py
@@ -41,3 +41,8 @@ def beijing_epoch_range_for_date(date_text):
     )
     next_day_start = day_start + timedelta(days=1)
     return int(day_start.timestamp()), int(next_day_start.timestamp())
+
+
+def beijing_epoch_from_datetime_text(value, fmt="%Y-%m-%d %H:%M:%S"):
+    dt = datetime.strptime(str(value), fmt).replace(tzinfo=_BEIJING_TIMEZONE)
+    return dt.timestamp()

--- a/freshquant/tests/test_cli_time_semantics.py
+++ b/freshquant/tests/test_cli_time_semantics.py
@@ -250,3 +250,84 @@ def test_future_fill_list_formats_trade_time_with_beijing_helper(monkeypatch):
 
     assert observed["timestamp"] == 1710000000
     assert captured_rows[0][-1] == "2024-03-10 00:00:00"
+
+
+def test_digital_fill_import_uses_beijing_datetime_parser(monkeypatch):
+    digital_fill_module = _load_digital_fill_module()
+    observed = {}
+    inserted = {}
+
+    def _fake_beijing_epoch_from_datetime_text(value):
+        observed["value"] = value
+        return 1710000000
+
+    monkeypatch.setattr(
+        digital_fill_module,
+        "beijing_epoch_from_datetime_text",
+        _fake_beijing_epoch_from_datetime_text,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        digital_fill_module,
+        "DBfreshquant",
+        SimpleNamespace(
+            digital_fills=SimpleNamespace(
+                insert_one=lambda document: inserted.update(document)
+            )
+        ),
+    )
+    monkeypatch.setattr(digital_fill_module, "list_fill", lambda *args, **kwargs: None)
+
+    digital_fill_module.import_fill(
+        "buy_open",
+        "BTCUSDT",
+        1.0,
+        10.0,
+        "2024-03-10 00:00:00",
+    )
+
+    assert observed["value"] == "2024-03-10 00:00:00"
+    assert inserted["trade_date_time"] == 1710000000
+
+
+def test_future_fill_import_uses_beijing_datetime_parser(monkeypatch):
+    future_fill_module = _load_future_fill_module(monkeypatch)
+    observed = {}
+    inserted = {}
+
+    def _fake_beijing_epoch_from_datetime_text(value):
+        observed["value"] = value
+        return 1710000000
+
+    monkeypatch.setattr(
+        future_fill_module,
+        "beijing_epoch_from_datetime_text",
+        _fake_beijing_epoch_from_datetime_text,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        future_fill_module,
+        "DBfreshquant",
+        SimpleNamespace(
+            future_fills=SimpleNamespace(
+                insert_one=lambda document: inserted.update(document)
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        future_fill_module,
+        "query_instrument_info",
+        lambda *args, **kwargs: {"name": "Rebar"},
+    )
+    monkeypatch.setattr(future_fill_module, "list_fill", lambda *args, **kwargs: None)
+
+    future_fill_module.import_fill(
+        "buy_open",
+        "rb2405.SHFE",
+        2,
+        3550.0,
+        "2024-03-10 00:00:00",
+    )
+
+    assert observed["value"] == "2024-03-10 00:00:00"
+    assert inserted["trade_date_time"] == 1710000000


### PR DESCRIPTION
## 背景
- 第 3 轮全库 review 继续沿着时间语义一致性做收口。
- 发现 `digital/future fill import` 的手工导入链仍然把 `dt` 文本按宿主机本地时区转 epoch；更直接的问题是，第 2 轮清理掉 `datetime` 导入后，这两条路径在运行时会直接 `NameError`。

## 目标
- 让手工 fill 导入与前两轮已经统一过的查看/账本链路保持同一套 `Asia/Shanghai` 时间语义。
- 消除 `import_fill()` 的运行时崩溃。

## 范围
- 新增共享 helper：`beijing_epoch_from_datetime_text`
- 修复 `freshquant/data/digital/fill.py`
- 修复 `freshquant/data/future/fill.py`
- 扩展 `freshquant/tests/test_cli_time_semantics.py`
- 同步 `docs/current/modules/order-management.md`

## 非目标
- 不改动持仓计算逻辑
- 不改动 Web/API 输出结构
- 不扩大到无关历史模块

## 验收标准
- `digital fill import` 的 `dt` 按北京时间解析成 epoch
- `future fill import` 的 `dt` 按北京时间解析成 epoch
- 两条手工导入路径不再因为缺失 `datetime` 导入而报错
- 新增回归测试在单进程和 xdist 收集模式下都稳定通过

## 验证
- `..\\..\\.venv\\Scripts\\python.exe -m pytest freshquant\\tests\\test_cli_time_semantics.py -q`
- `..\\..\\.venv\\Scripts\\python.exe -m pytest freshquant\\tests\\test_cli_time_semantics.py -n 2 --dist loadfile -q`
- `..\\..\\.venv\\Scripts\\python.exe -m pytest freshquant\\tests\\test_order_management_xt_ingest.py freshquant\\tests\\test_order_management_reconcile.py freshquant\\tests\\test_order_management_guardian_semantics.py freshquant\\tests\\test_position_management_dashboard.py freshquant\\tests\\test_subject_management_service.py freshquant\\tests\\test_tpsl_management_service.py freshquant\\tests\\test_order_management_cli.py freshquant\\tests\\test_stock_fill_cli.py -q`
- `..\\..\\.venv\\Scripts\\python.exe -m pre_commit run --files docs/current/modules/order-management.md freshquant/order_management/time_helpers.py freshquant/data/digital/fill.py freshquant/data/future/fill.py freshquant/tests/test_cli_time_semantics.py`
- `..\\..\\.venv\\Scripts\\python.exe script/ci/check_current_docs.py`

## 部署影响
- 改动涉及 `freshquant/order_management/**` 与 fill CLI 路径，按仓库规则需要随下一次后端/API 部署一并带出。
- 本次无额外数据迁移。