### PR TITLE
[codex] Limit subject overview to holdings and must pools

### DIFF
--- a/docs/current/modules/subject-management.md
+++ b/docs/current/modules/subject-management.md
@@ -51,7 +51,12 @@
 
 overview 里的“单标的仓位上限摘要”当前按批量 PM dashboard 结果一次性装载，不再按 symbol 重复调用单标的 limit 读路径。
 
-左表 symbol 集合来自这些来源的并集，不再单独把孤儿 `guardian_buy_grid_states` 带进页面。
+左表 symbol 集合当前只来自：
+
+- `must_pool`
+- 当前持仓聚合
+
+Guardian 配置、止盈 profile、entry 级止损摘要和最近触发事件只作为这些标的的补充信息，不再把“仅残留配置、但不在持仓且不在 must_pool”的孤儿标的带进页面。
 
 ### detail
 

--- a/freshquant/subject_management/dashboard_service.py
+++ b/freshquant/subject_management/dashboard_service.py
@@ -58,10 +58,7 @@ class SubjectManagementDashboardService:
         stoploss_summary = self._stoploss_summary_map()
 
         symbols = set(must_pool_rows)
-        symbols.update(guardian_config_rows)
-        symbols.update(takeprofit_profiles)
         symbols.update(positions)
-        symbols.update(stoploss_summary)
         position_limit_summary_map = self._load_overview_position_limit_summary_map()
 
         latest_events = self._latest_trigger_map(symbols)

--- a/freshquant/tests/test_subject_management_overview_orphan_state.py
+++ b/freshquant/tests/test_subject_management_overview_orphan_state.py
@@ -153,13 +153,21 @@ def test_overview_ignores_symbol_sourced_only_from_guardian_state(
     assert rows == []
 
 
-def test_overview_keeps_guardian_state_for_symbol_present_in_guardian_config(
+def test_overview_keeps_guardian_state_for_symbol_present_in_must_pool(
     dashboard_service_module,
 ):
     service = _build_service(
         dashboard_service_module,
         FakeDatabase(
             {
+                "must_pool": FakeCollection(
+                    [
+                        {
+                            "code": "000001",
+                            "name": "平安银行",
+                        }
+                    ]
+                ),
                 "guardian_buy_grid_configs": FakeCollection(
                     [
                         {

--- a/freshquant/tests/test_subject_management_service.py
+++ b/freshquant/tests/test_subject_management_service.py
@@ -13,6 +13,13 @@ dashboard_service_module = None
 SubjectManagementDashboardService = None
 
 
+class FakeMongoClient(dict):
+    def __getitem__(self, name):
+        if name not in self:
+            self[name] = {}
+        return dict.__getitem__(self, name)
+
+
 @pytest.fixture(autouse=True)
 def _install_dashboard_service_stubs(monkeypatch):
     global dashboard_service_module, SubjectManagementDashboardService
@@ -25,6 +32,7 @@ def _install_dashboard_service_stubs(monkeypatch):
 
     db_module: Any = types.ModuleType("freshquant.db")
     db_module.DBfreshquant = {}
+    db_module.MongoClient = FakeMongoClient()
     monkeypatch.setitem(sys.modules, "freshquant.db", db_module)
 
     strategy_common_module: Any = types.ModuleType("freshquant.strategy.common")
@@ -422,49 +430,51 @@ def test_subject_management_overview_prefers_symbol_snapshot_market_value():
 def test_subject_management_overview_uses_default_symbol_limit_batch_loader_once(
     monkeypatch,
 ):
-    import freshquant.position_management.dashboard_service as pm_dashboard_module
+    import freshquant.subject_management.dashboard_service as sm_dashboard_module
 
     call_counts = {"dashboard": 0, "symbol": 0}
 
-    class FakePositionManagementDashboardService:
-        def get_dashboard(self):
-            call_counts["dashboard"] += 1
-            return {
-                "rows": [
-                    {
-                        "symbol": "600000",
-                        "default_limit": 800000.0,
-                        "override_limit": 500000.0,
-                        "effective_limit": 500000.0,
-                        "using_override": True,
-                        "blocked": False,
-                    },
-                    {
-                        "symbol": "000001",
-                        "default_limit": 800000.0,
-                        "override_limit": None,
-                        "effective_limit": 800000.0,
-                        "using_override": False,
-                        "blocked": False,
-                    },
-                ]
-            }
-
-        def get_symbol_limit(self, symbol):
-            call_counts["symbol"] += 1
-            return {
-                "symbol": symbol,
+    def fake_symbol_limit_map_loader():
+        call_counts["dashboard"] += 1
+        return {
+            "600000": {
+                "symbol": "600000",
+                "default_limit": 800000.0,
+                "override_limit": 500000.0,
+                "effective_limit": 500000.0,
+                "using_override": True,
+                "blocked": False,
+            },
+            "000001": {
+                "symbol": "000001",
                 "default_limit": 800000.0,
                 "override_limit": None,
                 "effective_limit": 800000.0,
                 "using_override": False,
                 "blocked": False,
-            }
+            },
+        }
+
+    def fake_symbol_limit_loader(symbol):
+        call_counts["symbol"] += 1
+        return {
+            "symbol": symbol,
+            "default_limit": 800000.0,
+            "override_limit": None,
+            "effective_limit": 800000.0,
+            "using_override": False,
+            "blocked": False,
+        }
 
     monkeypatch.setattr(
-        pm_dashboard_module,
-        "PositionManagementDashboardService",
-        FakePositionManagementDashboardService,
+        sm_dashboard_module,
+        "_default_symbol_limit_map_loader",
+        fake_symbol_limit_map_loader,
+    )
+    monkeypatch.setattr(
+        sm_dashboard_module,
+        "_default_symbol_limit_loader",
+        fake_symbol_limit_loader,
     )
 
     service = SubjectManagementDashboardService(
@@ -520,6 +530,63 @@ def test_subject_management_overview_keeps_rows_when_symbol_limit_loader_rejects
         == "symbol is not tracked by holdings or pools"
     )
     assert rows[0]["position_limit_summary"]["using_override"] is False
+
+
+def test_subject_management_overview_excludes_symbols_without_holdings_or_must_pool():
+    tpsl_repository = InMemoryTpslRepository()
+    tpsl_repository.profiles["002594"] = {
+        "symbol": "002594",
+        "tiers": [
+            {"level": 1, "price": 110.98, "manual_enabled": True},
+            {"level": 2, "price": 116.19, "manual_enabled": True},
+            {"level": 3, "price": 127.49, "manual_enabled": True},
+        ],
+    }
+
+    service = SubjectManagementDashboardService(
+        database=FakeDatabase(
+            {
+                "guardian_buy_grid_configs": FakeCollection(
+                    [
+                        {
+                            "code": "002594",
+                            "BUY-1": 98.21,
+                            "BUY-2": 93.66,
+                            "BUY-3": 89.21,
+                            "buy_enabled": [True, True, True],
+                            "enabled": True,
+                        }
+                    ]
+                ),
+                "guardian_buy_grid_states": FakeCollection(
+                    [
+                        {
+                            "code": "002594",
+                            "buy_active": [True, True, True],
+                            "last_reset_reason": "sell_trade_fact",
+                        }
+                    ]
+                ),
+            }
+        ),
+        tpsl_repository=tpsl_repository,
+        order_repository=InMemoryOrderManagementRepository(),
+        position_loader=lambda: [],
+        symbol_position_loader=lambda symbol: None,
+        pm_summary_loader=lambda: {},
+        symbol_limit_loader=lambda symbol: {
+            "symbol": symbol,
+            "default_limit": 800000.0,
+            "override_limit": None,
+            "effective_limit": 800000.0,
+            "using_override": False,
+            "blocked": False,
+        },
+    )
+
+    rows = service.get_overview()
+
+    assert rows == []
 
 
 def test_subject_management_overview_normalizes_must_pool_codes_before_grouping():


### PR DESCRIPTION
## 背景

标的管理页左侧“标的总览”当前会把 `must_pool`、Guardian 配置、止盈 profile、持仓、止损摘要做并集，因此像 `002594` 这种不在持仓、也不在 `must_pool`，但残留了 Guardian / 止盈配置的标的仍会显示在总览里。

## 本次改动

- 将 `SubjectManagementDashboardService.get_overview()` 的 symbol seed 收敛为 `must_pool + 当前持仓`
- 保留 Guardian / 止盈 / 止损 / 最近触发事件等补充字段，但不再让它们单独把孤儿标的带进 overview
- 新增回归测试，锁定“只有 Guardian/止盈配置的标的不会进入总览”
- 同步 `docs/current/modules/subject-management.md`，明确 overview 的来源边界

## 影响

- `标的管理 -> 标的总览` 现在只显示持仓股和 `must_pool` 标的
- detail 接口和单标的配置读取逻辑不变
- 不涉及现有 Mongo 历史数据清理

## 验证

- `./.venv/Scripts/python.exe -m pytest freshquant/tests/test_subject_management_service.py freshquant/tests/test_subject_management_overview_orphan_state.py -q`
- 本地结果：`14 passed`
