### PR TITLE
fix: harden order runtime truth reconciliation

### DIFF
--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -42,12 +42,16 @@
 ### 券商真值
 
 - 当前仓位真值只认 `xt_positions`
+- `xt_account_sync.worker` 对空快照或严重缩水且与同轮 `credit_detail.market_value` 明显冲突的 `xt_positions` 会先 quarantine；被隔离的快照不会覆盖 `xt_positions`，也不会进入自动平账
+- 小账户（`1-2` 个 symbol）如果出现“symbol 没清空、但数量和估值同时严重缩水，而 `credit_detail.market_value` 仍显著为正”的快照，当前也会 quarantine
+- `xt_account_sync.worker` 遇到 quarantine 的 `positions` 快照会显式打 warning，便于运行面第一时间发现真值冻结
 - 当前委托/成交回报真值只认 XT callback 与 `xt_account_sync.worker` 增量刷新
 
 ### 破坏性 rebuild 治理
 
 - 破坏性 `order-ledger rebuild` 只能由 broker truth 驱动，primary truth 只允许 `xt_orders`、`xt_trades`、`xt_positions`
 - `om_*`、`stock_fills`、`stock_fills_compat` 只能作为迁移期兼容投影或排障线索，不能作为 rebuild 主输入
+- rebuild 默认拒绝用空 `xt_positions` 快照去 flatten 非空账本；只有显式允许空快照 flatten 时，才会把空 `xt_positions` 视为券商已清仓
 - 这类破坏性 rebuild 在编码前必须先建立 GitHub Issue，写清影响面、验收标准与部署影响
 
 ### OM 主账本
@@ -125,10 +129,22 @@
 - `board_lot_rejected`
 - `matched_execution_fill`
 
+自动平账成功写入 `auto_open_entry / auto_close_allocation` 后，当前也会同步：
+
+- 刷新 stock holdings projection cache
+- 刷新 `stock_fills_compat` 镜像，避免 legacy 兼容视图滞后于 OM 主账本
+
 当前内部仓位累计规则：
 
 - 若某个 symbol 已存在 open `om_position_entries`，对账只以 V2 entry remaining quantity 作为内部仓位真值
 - 同 symbol 的 legacy `om_buy_lots` 仅保留给兼容读链与排障，不再额外叠加进对账 internal remaining，避免 mixed-state 双计数后误生成 `sell gap`
+
+自动平账在检测到“同一轮快照对账户内多只持仓同时形成大比例 sell-gap、且近期缺少足够卖出成交证据”时，当前会熔断该轮 sell reconcile，不新建 sell gap，也不推进 sell-side gap 自动确认。
+
+自动平账在解析运行期辅助元数据失败时，当前会优先收敛 broker truth：
+
+- `grid_interval` 解析失败时回退 `1.03`
+- `lot_amount` 解析失败时回退 `3000`
 
 自动平账与 XT 回报补录路径里，凡是由 `trade_time / confirmed_at` 回填 `date/time` 的订单域记录，当前统一按北京时间（`Asia/Shanghai`）落地，避免同一笔成交在不同读模型里出现跨日漂移。
 

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -8,7 +8,7 @@
 - Mongo 通过 `127.0.0.1:27027` 接入 Docker `fq_mongodb`；宿主机链路不要再使用 `127.0.0.1:27017`。
 - `fqnext-supervisord` 宿主机底座与其托管的交易/运行链 Python 进程。
 - Guardian monitor。
-- XT account sync worker（作为 XT 账户数据的增量补偿同步入口，默认每 15 秒轮询 `assets / credit_detail / positions / orders / trades`；其中 `credit_detail` 保持高频刷新以驱动仓位管理状态，只把新增 `orders / trades` 送入 ingest；`credit_subjects` 只在启动和每日计划时间做低频同步，并在启动时做一次单标的实时仓位 fallback 种子刷新）。
+- XT account sync worker（作为 XT 账户数据的增量补偿同步入口，默认每 15 秒轮询 `assets / credit_detail / positions / orders / trades`；其中 `credit_detail` 保持高频刷新以驱动仓位管理状态，只把新增 `orders / trades` 送入 ingest；`credit_subjects` 只在启动和每日计划时间做低频同步，并在启动时做一次单标的实时仓位 fallback 种子刷新；若 `positions` 快照为空或严重缩水、但同轮 `credit_detail.market_value` 仍显著为正，则该轮快照会进入 quarantine，不覆盖 `xt_positions`，也不触发自动平账；这个 quarantine 现在也覆盖小账户单票/双票严重缩水的场景，同时 worker 会记录 warning 说明 quarantine 原因）。
 - TPSL tick listener。
 - 需要直接访问券商、终端、`TDX_HOME` 或 Windows 本地目录的组件。
 

--- a/freshquant/order_management/projection/stock_fills_compat.py
+++ b/freshquant/order_management/projection/stock_fills_compat.py
@@ -167,7 +167,7 @@ class StockFillsCompatibilityService:
 
 
 def _get_stock_fills_compat_collection(database):
-    target = database or DBfreshquant
+    target = DBfreshquant if database is None else database
     if hasattr(target, "stock_fills_compat"):
         return target.stock_fills_compat
     return target["stock_fills_compat"]

--- a/freshquant/order_management/rebuild/service.py
+++ b/freshquant/order_management/rebuild/service.py
@@ -45,14 +45,18 @@ class OrderLedgerV2RebuildService:
         xt_trades=None,
         xt_positions=None,
         now_ts=None,
+        allow_empty_xt_positions_flatten=False,
     ):
         rebuild_ts = _resolve_rebuild_timestamp(now_ts)
+        xt_orders = list(xt_orders or [])
+        xt_trades = list(xt_trades or [])
+        xt_positions = list(xt_positions or []) if xt_positions is not None else None
 
         broker_orders_by_key = {}
         broker_order_keys = []
         order_match_to_broker_order_key = {}
 
-        for raw_order in list(xt_orders or []):
+        for raw_order in xt_orders:
             broker_order = _normalize_broker_order(raw_order)
             broker_order_key = broker_order["broker_order_key"]
             if broker_order_key not in broker_orders_by_key:
@@ -67,7 +71,7 @@ class OrderLedgerV2RebuildService:
                 order_match_to_broker_order_key[match_key] = broker_order_key
 
         execution_fill_documents = []
-        for raw_trade in list(xt_trades or []):
+        for raw_trade in xt_trades:
             order_id = _normalize_identifier(raw_trade.get("order_id"))
             trade_symbol = _normalize_symbol(raw_trade)
             trade_side = _normalize_side(
@@ -132,6 +136,7 @@ class OrderLedgerV2RebuildService:
             exit_allocation_documents=exit_allocation_documents,
             lot_amount_lookup=self.lot_amount_lookup,
             grid_interval_lookup=self.grid_interval_lookup,
+            allow_empty_xt_positions_flatten=allow_empty_xt_positions_flatten,
         )
         ingest_rejection_documents.extend(reconciliation_ingest_rejections)
         return {
@@ -777,6 +782,7 @@ def _reconcile_positions_against_xt_positions(
     exit_allocation_documents,
     lot_amount_lookup,
     grid_interval_lookup,
+    allow_empty_xt_positions_flatten,
 ):
     reconciliation_gap_documents = []
     reconciliation_resolution_documents = []
@@ -802,6 +808,16 @@ def _reconcile_positions_against_xt_positions(
         ledger_remaining_by_symbol[symbol] = ledger_remaining_by_symbol.get(
             symbol, 0
         ) + (_coerce_int(entry.get("remaining_quantity")) or 0)
+
+    if (
+        xt_positions == []
+        and any(quantity > 0 for quantity in ledger_remaining_by_symbol.values())
+        and not allow_empty_xt_positions_flatten
+    ):
+        raise ValueError(
+            "empty xt_positions snapshot cannot flatten non-empty ledger; "
+            "pass allow_empty_xt_positions_flatten=True to override"
+        )
 
     date_value, time_value = _resolve_beijing_date_time(None, None, now_ts)
     for symbol in sorted(set(positions_by_symbol) | set(ledger_remaining_by_symbol)):

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -37,6 +37,12 @@ from freshquant.runtime_observability.failures import (
 from freshquant.runtime_observability.logger import RuntimeEventLogger
 
 
+_DEFAULT_RECONCILE_LOT_AMOUNT = 3000
+_SELL_GAP_FUSE_MIN_SYMBOLS = 3
+_SELL_GAP_FUSE_MIN_QUANTITY_RATIO = 0.5
+_SELL_GAP_EVIDENCE_WINDOW_SECONDS = 300
+
+
 @dataclass
 class TradeReportReconcileOutcome:
     handled: bool
@@ -70,8 +76,10 @@ class ExternalOrderReconcileService:
             int(external_confirm_observations or 3), 1
         )
         self.runtime_logger = runtime_logger or _get_runtime_logger()
+        self._skip_sell_confirmation = False
 
     def detect_external_candidates(self, positions, detected_at):
+        self._skip_sell_confirmation = False
         positions_by_symbol = _build_positions_by_symbol(positions)
         internal_by_symbol = _build_internal_remaining_by_symbol(self.repository)
         pending_gaps = list(self.repository.list_reconciliation_gaps(state="OPEN"))
@@ -104,10 +112,28 @@ class ExternalOrderReconcileService:
                 }
             )
 
+        sell_gap_fuse = _detect_sell_gap_blast(
+            current_deltas=current_deltas,
+            internal_by_symbol=internal_by_symbol,
+            repository=self.repository,
+            detected_at=int(detected_at),
+        )
+        if sell_gap_fuse is not None:
+            self._skip_sell_confirmation = True
+            self._emit_runtime(
+                "snapshot_fuse",
+                {},
+                status="warning",
+                reason_code="sell_gap_blast_fused",
+                payload=sell_gap_fuse,
+            )
+
         current_index = {
             (item["symbol"], item["side"]): item for item in current_deltas
         }
         for key, gap in pending_index.items():
+            if sell_gap_fuse is not None and key[1] == "sell":
+                continue
             observed = current_index.get(key)
             if observed is None:
                 self.repository.update_reconciliation_gap(
@@ -162,6 +188,8 @@ class ExternalOrderReconcileService:
         for item in current_deltas:
             key = (item["symbol"], item["side"])
             if key in observed_keys:
+                continue
+            if sell_gap_fuse is not None and item["side"] == "sell":
                 continue
             gap = {
                 "gap_id": new_reconciliation_gap_id(),
@@ -391,36 +419,42 @@ class ExternalOrderReconcileService:
 
     def confirm_expired_candidates(self, now):
         confirmed = []
-        for gap in self.repository.list_reconciliation_gaps(state="OPEN"):
-            if int(gap.get("observed_count") or 1) < int(
-                self.external_confirm_observations
-            ):
-                continue
-            if int(gap["pending_until"]) > int(now):
-                continue
-            current_node = "reconciliation"
-            ids = {"symbol": gap["symbol"]}
-            try:
-                updated_candidate = self._confirm_gap(gap, now=int(now))
-                self._emit_runtime(
-                    "reconciliation",
-                    ids,
-                    payload={
-                        "resolution_type": updated_candidate.get("resolution_type"),
-                        "gap_state": updated_candidate.get("state"),
-                    },
-                )
-                confirmed.append(updated_candidate)
-            except Exception as exc:
-                self._emit_runtime(
-                    current_node,
-                    ids,
-                    status="error",
-                    reason_code="unexpected_exception",
-                    payload=build_exception_payload(exc),
-                )
-                mark_exception_emitted(exc)
-                raise
+        skip_sell_confirmation = self._skip_sell_confirmation
+        try:
+            for gap in self.repository.list_reconciliation_gaps(state="OPEN"):
+                if skip_sell_confirmation and gap.get("side") == "sell":
+                    continue
+                if int(gap.get("observed_count") or 1) < int(
+                    self.external_confirm_observations
+                ):
+                    continue
+                if int(gap["pending_until"]) > int(now):
+                    continue
+                current_node = "reconciliation"
+                ids = {"symbol": gap["symbol"]}
+                try:
+                    updated_candidate = self._confirm_gap(gap, now=int(now))
+                    self._emit_runtime(
+                        "reconciliation",
+                        ids,
+                        payload={
+                            "resolution_type": updated_candidate.get("resolution_type"),
+                            "gap_state": updated_candidate.get("state"),
+                        },
+                    )
+                    confirmed.append(updated_candidate)
+                except Exception as exc:
+                    self._emit_runtime(
+                        current_node,
+                        ids,
+                        status="error",
+                        reason_code="unexpected_exception",
+                        payload=build_exception_payload(exc),
+                    )
+                    mark_exception_emitted(exc)
+                    raise
+        finally:
+            self._skip_sell_confirmation = False
         return confirmed
 
     def reconcile_account(self, account_id, positions=None, xt_trades=None, now=None):
@@ -493,7 +527,7 @@ class ExternalOrderReconcileService:
         self.repository.insert_reconciliation_resolution(resolution)
         self.repository.replace_position_entry(entry)
         self.repository.replace_entry_slices_for_entry(entry["entry_id"], entry_slices)
-        return self.repository.update_reconciliation_gap(
+        updated_gap = self.repository.update_reconciliation_gap(
             gap["gap_id"],
             {
                 "state": "AUTO_OPENED",
@@ -503,6 +537,8 @@ class ExternalOrderReconcileService:
                 "entry_id": entry["entry_id"],
             },
         )
+        _after_holdings_reconciled(gap["symbol"], repository=self.repository)
+        return updated_gap
 
     def _confirm_close_gap(self, gap, *, now):
         remaining = int(gap.get("quantity_delta") or 0)
@@ -566,7 +602,7 @@ class ExternalOrderReconcileService:
             ],
         }
         self.repository.insert_reconciliation_resolution(resolution)
-        return self.repository.update_reconciliation_gap(
+        updated_gap = self.repository.update_reconciliation_gap(
             gap["gap_id"],
             {
                 "state": "AUTO_CLOSED",
@@ -575,6 +611,8 @@ class ExternalOrderReconcileService:
                 "resolution_type": resolution["resolution_type"],
             },
         )
+        _after_holdings_reconciled(gap["symbol"], repository=self.repository)
+        return updated_gap
 
     def _create_external_order(
         self,
@@ -681,6 +719,84 @@ def _build_internal_remaining_by_symbol(repository):
             continue
         result[symbol] = result.get(symbol, 0) + int(item.get("remaining_quantity", 0))
     return result
+
+
+def _detect_sell_gap_blast(*, current_deltas, internal_by_symbol, repository, detected_at):
+    sell_deltas = [
+        item
+        for item in list(current_deltas or [])
+        if item.get("side") == "sell" and int(item.get("quantity_delta") or 0) > 0
+    ]
+    if len(sell_deltas) < _SELL_GAP_FUSE_MIN_SYMBOLS:
+        return None
+    if any(item.get("side") == "buy" for item in list(current_deltas or [])):
+        return None
+
+    internal_total_quantity = sum(max(int(value or 0), 0) for value in internal_by_symbol.values())
+    if internal_total_quantity <= 0:
+        return None
+    sell_quantity_total = sum(int(item.get("quantity_delta") or 0) for item in sell_deltas)
+    sell_quantity_ratio = sell_quantity_total / internal_total_quantity
+    if sell_quantity_ratio < _SELL_GAP_FUSE_MIN_QUANTITY_RATIO:
+        return None
+
+    evidence = _collect_recent_sell_evidence(
+        repository=repository,
+        detected_at=int(detected_at),
+        symbols={item["symbol"] for item in sell_deltas},
+    )
+    required_symbol_evidence = max(1, (len(sell_deltas) + 1) // 2)
+    if (
+        evidence["symbol_count"] >= required_symbol_evidence
+        or evidence["quantity_total"] >= sell_quantity_total * 0.5
+    ):
+        return None
+
+    return {
+        "sell_symbol_count": len(sell_deltas),
+        "sell_quantity_total": sell_quantity_total,
+        "internal_total_quantity": internal_total_quantity,
+        "sell_quantity_ratio": round(sell_quantity_ratio, 6),
+        "recent_sell_evidence_symbol_count": evidence["symbol_count"],
+        "recent_sell_evidence_quantity_total": evidence["quantity_total"],
+    }
+
+
+def _collect_recent_sell_evidence(*, repository, detected_at, symbols):
+    tracked_symbols = {str(item or "").strip() for item in set(symbols or []) if str(item or "").strip()}
+    if not tracked_symbols:
+        return {"symbol_count": 0, "quantity_total": 0}
+
+    lower_bound = int(detected_at) - _SELL_GAP_EVIDENCE_WINDOW_SECONDS
+    evidence_symbols = set()
+    quantity_total = 0
+
+    if hasattr(repository, "list_trade_facts"):
+        for symbol in tracked_symbols:
+            for item in repository.list_trade_facts(symbol=symbol) or []:
+                if str(item.get("side") or "").lower() != "sell":
+                    continue
+                trade_time = int(item.get("trade_time") or 0)
+                if trade_time < lower_bound:
+                    continue
+                evidence_symbols.add(symbol)
+                quantity_total += int(item.get("quantity") or 0)
+
+    if hasattr(repository, "list_execution_fills"):
+        for symbol in tracked_symbols:
+            for item in repository.list_execution_fills(symbol=symbol) or []:
+                if str(item.get("side") or "").lower() != "sell":
+                    continue
+                trade_time = int(item.get("trade_time") or 0)
+                if trade_time < lower_bound:
+                    continue
+                evidence_symbols.add(symbol)
+                quantity_total += int(item.get("quantity") or 0)
+
+    return {
+        "symbol_count": len(evidence_symbols),
+        "quantity_total": quantity_total,
+    }
 
 
 def _find_pending_candidate(candidates, symbol, side, quantity_delta):
@@ -1089,19 +1205,19 @@ def _safe_resolve_lot_amount(symbol):
         from freshquant.order_management.ingest.xt_reports import _resolve_lot_amount
 
         return _resolve_lot_amount(symbol)
-    except Exception as exc:
-        raise RuntimeError(
-            f"lot amount unavailable for external reconcile: {symbol}"
-        ) from exc
+    except Exception:
+        # External reconcile should prefer converging broker truth over blocking on
+        # optional lot-amount metadata lookups.
+        return _DEFAULT_RECONCILE_LOT_AMOUNT
 
 
 def _safe_grid_interval_lookup(symbol, trade_fact):
     try:
         return _default_grid_interval_lookup(symbol, trade_fact)
-    except Exception as exc:
-        raise RuntimeError(
-            f"grid interval unavailable for external reconcile: {symbol}"
-        ) from exc
+    except Exception:
+        # External reconcile should converge broker truth even when the optional
+        # market-data-based grid lookup is temporarily unavailable.
+        return 1.03
 
 
 def _build_auto_open_entry(gap, *, resolution_id, confirmed_at):
@@ -1321,6 +1437,27 @@ def _resolve_entry_status(remaining_quantity, original_quantity):
 
 def _is_board_lot_delta(quantity):
     return int(quantity or 0) > 0 and int(quantity or 0) % 100 == 0
+
+
+def _after_holdings_reconciled(symbol, *, repository):
+    _mark_stock_holdings_projection_updated()
+    _sync_stock_fills_compat(symbol, repository=repository)
+
+
+def _mark_stock_holdings_projection_updated():
+    from freshquant.order_management.ingest.xt_reports import (
+        mark_stock_holdings_projection_updated,
+    )
+
+    return mark_stock_holdings_projection_updated()
+
+
+def _sync_stock_fills_compat(symbol, *, repository):
+    from freshquant.order_management.projection.stock_fills_compat import (
+        sync_symbol,
+    )
+
+    return sync_symbol(symbol, repository=repository)
 
 
 _runtime_logger = None

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -36,7 +36,6 @@ from freshquant.runtime_observability.failures import (
 )
 from freshquant.runtime_observability.logger import RuntimeEventLogger
 
-
 _DEFAULT_RECONCILE_LOT_AMOUNT = 3000
 _SELL_GAP_FUSE_MIN_SYMBOLS = 3
 _SELL_GAP_FUSE_MIN_QUANTITY_RATIO = 0.5
@@ -721,7 +720,9 @@ def _build_internal_remaining_by_symbol(repository):
     return result
 
 
-def _detect_sell_gap_blast(*, current_deltas, internal_by_symbol, repository, detected_at):
+def _detect_sell_gap_blast(
+    *, current_deltas, internal_by_symbol, repository, detected_at
+):
     sell_deltas = [
         item
         for item in list(current_deltas or [])
@@ -732,10 +733,14 @@ def _detect_sell_gap_blast(*, current_deltas, internal_by_symbol, repository, de
     if any(item.get("side") == "buy" for item in list(current_deltas or [])):
         return None
 
-    internal_total_quantity = sum(max(int(value or 0), 0) for value in internal_by_symbol.values())
+    internal_total_quantity = sum(
+        max(int(value or 0), 0) for value in internal_by_symbol.values()
+    )
     if internal_total_quantity <= 0:
         return None
-    sell_quantity_total = sum(int(item.get("quantity_delta") or 0) for item in sell_deltas)
+    sell_quantity_total = sum(
+        int(item.get("quantity_delta") or 0) for item in sell_deltas
+    )
     sell_quantity_ratio = sell_quantity_total / internal_total_quantity
     if sell_quantity_ratio < _SELL_GAP_FUSE_MIN_QUANTITY_RATIO:
         return None
@@ -763,7 +768,11 @@ def _detect_sell_gap_blast(*, current_deltas, internal_by_symbol, repository, de
 
 
 def _collect_recent_sell_evidence(*, repository, detected_at, symbols):
-    tracked_symbols = {str(item or "").strip() for item in set(symbols or []) if str(item or "").strip()}
+    tracked_symbols = {
+        str(item or "").strip()
+        for item in set(symbols or [])
+        if str(item or "").strip()
+    }
     if not tracked_symbols:
         return {"symbol_count": 0, "quantity_total": 0}
 

--- a/freshquant/order_management/submit/execution_bridge.py
+++ b/freshquant/order_management/submit/execution_bridge.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime, time as dt_time, timezone
+from datetime import datetime
+from datetime import time as dt_time
+from datetime import timezone
 
 from freshquant.carnation import xtconstant
 from freshquant.order_management.repository import OrderManagementRepository

--- a/freshquant/order_management/submit/execution_bridge.py
+++ b/freshquant/order_management/submit/execution_bridge.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime, timezone
+from datetime import datetime, time as dt_time, timezone
 
 from freshquant.carnation import xtconstant
 from freshquant.order_management.repository import OrderManagementRepository
@@ -421,14 +421,18 @@ def _default_credit_detail_loader():
 
 
 def _default_continuous_auction_provider():
-    try:
-        from fqxtrade.util.trading_time import is_continuous_auction_time
-    except Exception as exc:
-        raise RuntimeError("continuous auction state unavailable") from exc
-    try:
-        return bool(is_continuous_auction_time())
-    except Exception as exc:
-        raise RuntimeError("continuous auction state unavailable") from exc
+    now = datetime.now()
+    if now.weekday() > 4:
+        return False
+
+    current_time = now.time().replace(tzinfo=None)
+    morning_start = dt_time(9, 30)
+    morning_end = dt_time(11, 30)
+    afternoon_start = dt_time(13, 0)
+    closing_call_start = dt_time(14, 57)
+    return (morning_start <= current_time <= morning_end) or (
+        afternoon_start <= current_time < closing_call_start
+    )
 
 
 def _market_5_cancel_resolution(symbol, action, requested_mode, price_value):

--- a/freshquant/tests/test_order_ledger_v2_rebuild.py
+++ b/freshquant/tests/test_order_ledger_v2_rebuild.py
@@ -837,7 +837,40 @@ def test_rebuild_service_auto_closes_entries_when_xt_positions_are_smaller_than_
     assert exit_allocation["allocated_quantity"] == 200
 
 
-def test_rebuild_service_treats_empty_xt_positions_snapshot_as_broker_flat_and_auto_closes():
+def test_rebuild_service_rejects_empty_xt_positions_snapshot_when_ledger_has_open_entries_by_default():
+    service = _get_rebuild_service_class()(
+        lot_amount_lookup=lambda _symbol: 3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    with pytest.raises(ValueError, match="empty xt_positions snapshot"):
+        service.build_from_truth(
+            xt_orders=[
+                _sample_xt_order(
+                    order_id=84011,
+                    stock_code="000001.SZ",
+                    order_volume=900,
+                    order_status="filled",
+                )
+            ],
+            xt_trades=[
+                _sample_xt_trade(
+                    traded_id="T-BUY-84011",
+                    order_id=84011,
+                    stock_code="000001.SZ",
+                    traded_volume=900,
+                    traded_price=10.0,
+                    traded_time=1710000000,
+                    date=None,
+                    time=None,
+                )
+            ],
+            xt_positions=[],
+            now_ts=1775000000,
+        )
+
+
+def test_rebuild_service_allows_empty_xt_positions_snapshot_flatten_when_explicitly_enabled():
     service = _get_rebuild_service_class()(
         lot_amount_lookup=lambda _symbol: 3000,
         grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
@@ -866,6 +899,7 @@ def test_rebuild_service_treats_empty_xt_positions_snapshot_as_broker_flat_and_a
         ],
         xt_positions=[],
         now_ts=1775000000,
+        allow_empty_xt_positions_flatten=True,
     )
 
     assert result["reconciliation_gaps"] == 1

--- a/freshquant/tests/test_order_management_execution_bridge.py
+++ b/freshquant/tests/test_order_management_execution_bridge.py
@@ -307,6 +307,21 @@ def test_default_credit_detail_loader_accepts_credit_detail_object(monkeypatch):
     assert execution_bridge._default_credit_detail_loader() is detail
 
 
+def test_default_continuous_auction_provider_returns_true_during_morning_session(
+    monkeypatch,
+):
+    real_datetime = execution_bridge.datetime
+
+    class FixedDateTime:
+        @classmethod
+        def now(cls, tz=None):
+            return real_datetime(2026, 3, 31, 9, 41, 30, tzinfo=tz)
+
+    monkeypatch.setattr(execution_bridge, "datetime", FixedDateTime)
+
+    assert execution_bridge._default_continuous_auction_provider() is True
+
+
 def test_prepare_submit_execution_rejects_credit_auto_sell_when_credit_detail_missing():
     repository = InMemoryRepository()
     tracking_service = OrderTrackingService(repository=repository)

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -1,5 +1,5 @@
-from zoneinfo import ZoneInfo
 from types import SimpleNamespace
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -307,6 +307,12 @@ def _stub_ingest_side_effects(monkeypatch, *, marks=None, mark_label="updated"):
     )
     monkeypatch.setattr(
         xt_reports_module,
+        "_sync_stock_fills_compat",
+        lambda _symbol, repository=None: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        reconcile_service_module,
         "_sync_stock_fills_compat",
         lambda _symbol, repository=None: None,
         raising=False,

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -1,4 +1,5 @@
 from zoneinfo import ZoneInfo
+from types import SimpleNamespace
 
 import pytest
 
@@ -171,6 +172,39 @@ class InMemoryRepository:
             ]
         return records
 
+    def list_trade_facts(self, symbol=None, internal_order_ids=None):
+        records = list(self.trade_facts)
+        if symbol is not None:
+            records = [item for item in records if item.get("symbol") == symbol]
+        if internal_order_ids is not None:
+            allowed = set(internal_order_ids)
+            records = [
+                item for item in records if item.get("internal_order_id") in allowed
+            ]
+        return [dict(item) for item in records]
+
+    def list_execution_fills(
+        self,
+        *,
+        symbol=None,
+        broker_order_keys=None,
+        execution_fill_ids=None,
+    ):
+        records = list(self.execution_fills)
+        if symbol is not None:
+            records = [item for item in records if item.get("symbol") == symbol]
+        if broker_order_keys is not None:
+            allowed = set(broker_order_keys)
+            records = [
+                item for item in records if item.get("broker_order_key") in allowed
+            ]
+        if execution_fill_ids is not None:
+            allowed = set(execution_fill_ids)
+            records = [
+                item for item in records if item.get("execution_fill_id") in allowed
+            ]
+        return [dict(item) for item in records]
+
     def list_open_slices(self, symbol=None):
         records = [item for item in self.lot_slices if item["remaining_quantity"] > 0]
         if symbol is None:
@@ -279,7 +313,13 @@ def _stub_ingest_side_effects(monkeypatch, *, marks=None, mark_label="updated"):
     )
 
 
-def _build_service(monkeypatch=None, *, marks=None, mark_label="updated"):
+def _build_service(
+    monkeypatch=None,
+    *,
+    marks=None,
+    mark_label="updated",
+    runtime_events=None,
+):
     if monkeypatch is not None:
         _stub_ingest_side_effects(
             monkeypatch,
@@ -305,6 +345,11 @@ def _build_service(monkeypatch=None, *, marks=None, mark_label="updated"):
         tracking_service=tracking_service,
         external_confirm_interval_seconds=15,
         external_confirm_observations=3,
+        runtime_logger=(
+            SimpleNamespace(emit=lambda event: runtime_events.append(dict(event)))
+            if runtime_events is not None
+            else None
+        ),
     )
     return repository, service
 
@@ -370,6 +415,85 @@ def test_detect_external_candidates_prefers_snapshot_last_price_over_avg_price()
     assert candidates[0]["price_estimate"] == pytest.approx(10.82)
     assert candidates[0]["price_source"] == "position_last_price"
     assert candidates[0]["price_asof"] == 1_000
+
+
+def test_detect_external_candidates_fuses_batch_sell_gap_without_recent_sell_evidence(
+    monkeypatch,
+):
+    runtime_events = []
+    repository, service = _build_service(
+        monkeypatch,
+        runtime_events=runtime_events,
+    )
+    for symbol in ("000001", "000002", "000003", "000004"):
+        repository.insert_buy_lot(
+            {
+                "buy_lot_id": f"lot_{symbol}",
+                "origin_trade_fact_id": f"trade_{symbol}",
+                "symbol": symbol,
+                "remaining_quantity": 100,
+            }
+        )
+
+    gaps = service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 100, "avg_price": 10.0}],
+        detected_at=1_000,
+    )
+
+    assert gaps == []
+    assert repository.reconciliation_gaps == []
+    assert runtime_events[-1]["reason_code"] == "sell_gap_blast_fused"
+    assert runtime_events[-1]["payload"]["sell_symbol_count"] == 3
+    assert runtime_events[-1]["payload"]["sell_quantity_total"] == 300
+
+
+def test_detect_external_candidates_allows_batch_sell_gap_when_recent_sell_evidence_is_sufficient(
+    monkeypatch,
+):
+    runtime_events = []
+    repository, service = _build_service(
+        monkeypatch,
+        runtime_events=runtime_events,
+    )
+    for symbol in ("000001", "000002", "000003", "000004"):
+        repository.insert_buy_lot(
+            {
+                "buy_lot_id": f"lot_{symbol}",
+                "origin_trade_fact_id": f"trade_{symbol}",
+                "symbol": symbol,
+                "remaining_quantity": 100,
+            }
+        )
+    repository.trade_facts.extend(
+        [
+            {
+                "trade_fact_id": "sell_evidence_1",
+                "symbol": "000002",
+                "side": "sell",
+                "quantity": 100,
+                "trade_time": 990,
+            },
+            {
+                "trade_fact_id": "sell_evidence_2",
+                "symbol": "000003",
+                "side": "sell",
+                "quantity": 100,
+                "trade_time": 995,
+            },
+        ]
+    )
+
+    gaps = service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 100, "avg_price": 10.0}],
+        detected_at=1_000,
+    )
+
+    assert len(gaps) == 3
+    assert {item["symbol"] for item in gaps} == {"000002", "000003", "000004"}
+    assert all(item["side"] == "sell" for item in gaps)
+    assert not any(
+        item.get("reason_code") == "sell_gap_blast_fused" for item in runtime_events
+    )
 
 
 def test_candidate_observation_keeps_higher_quality_price_source():
@@ -592,6 +716,37 @@ def test_inferred_pending_auto_confirms_into_entry_without_fake_trade(monkeypatc
     assert repository.buy_lots == []
 
 
+def test_confirm_expired_candidates_marks_and_syncs_compat_after_auto_open(
+    monkeypatch,
+):
+    marks = []
+    sync_calls = []
+    repository, service = _build_service(monkeypatch, marks=marks, mark_label="open")
+    monkeypatch.setattr(
+        reconcile_service_module,
+        "_sync_stock_fills_compat",
+        lambda symbol, *, repository: sync_calls.append((symbol, repository)),
+        raising=False,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.5}],
+        detected_at=1_000,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.5}],
+        detected_at=1_015,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.5}],
+        detected_at=1_030,
+    )
+
+    service.confirm_expired_candidates(now=1_030)
+
+    assert marks == ["open"]
+    assert sync_calls == [("000001", repository)]
+
+
 def test_confirmed_gap_is_not_recreated_for_same_position_delta(monkeypatch):
     repository, service = _build_service(monkeypatch)
     service.detect_external_candidates(
@@ -615,49 +770,6 @@ def test_confirmed_gap_is_not_recreated_for_same_position_delta(monkeypatch):
 
     assert recreated == []
     assert len(repository.reconciliation_gaps) == 1
-
-
-def test_detect_external_candidates_ignores_legacy_buy_lot_when_open_entry_exists(
-    monkeypatch,
-):
-    repository, service = _build_service(monkeypatch)
-    repository.replace_position_entry(
-        reconcile_service_module._build_auto_open_entry(
-            {
-                "symbol": "000001",
-                "quantity_delta": 200,
-                "price_estimate": 10.5,
-            },
-            resolution_id="resolution_existing_entry",
-            confirmed_at=1_000,
-        )
-    )
-    buy_lot = build_buy_lot_from_trade_fact(
-        {
-            "trade_fact_id": "trade_existing_legacy",
-            "symbol": "000001",
-            "side": "buy",
-            "quantity": 200,
-            "price": 10.5,
-            "trade_time": 1_000,
-            "date": 20240102,
-            "time": "09:31:00",
-            "source": "external_inferred",
-        }
-    )
-    repository.insert_buy_lot(buy_lot)
-    repository.replace_lot_slices_for_lot(
-        buy_lot["buy_lot_id"],
-        arrange_buy_lot(buy_lot, lot_amount=3000, grid_interval=1.03),
-    )
-
-    gaps = service.detect_external_candidates(
-        positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.5}],
-        detected_at=1_015,
-    )
-
-    assert gaps == []
-    assert repository.reconciliation_gaps == []
 
 
 def test_build_auto_open_entry_uses_beijing_date_time():
@@ -877,6 +989,54 @@ def test_partial_trade_shrinks_pending_gap_before_auto_close(monkeypatch):
     assert len(repository.reconciliation_resolutions) == 2
 
 
+def test_confirm_expired_candidates_marks_and_syncs_compat_after_auto_close(
+    monkeypatch,
+):
+    marks = []
+    sync_calls = []
+    repository, service = _build_service(monkeypatch, marks=marks, mark_label="close")
+    monkeypatch.setattr(
+        reconcile_service_module,
+        "_sync_stock_fills_compat",
+        lambda symbol, *, repository: sync_calls.append((symbol, repository)),
+        raising=False,
+    )
+    buy_lot = build_buy_lot_from_trade_fact(
+        {
+            "trade_fact_id": "trade_seed_buy_close_sync",
+            "symbol": "000001",
+            "side": "buy",
+            "quantity": 900,
+            "price": 10.0,
+            "trade_time": 1_000,
+            "date": 20240102,
+            "time": "09:31:00",
+        }
+    )
+    repository.insert_buy_lot(buy_lot)
+    repository.replace_lot_slices_for_lot(
+        buy_lot["buy_lot_id"],
+        arrange_buy_lot(buy_lot, lot_amount=3000, grid_interval=1.03),
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 400, "avg_price": 10.5}],
+        detected_at=1_000,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 400, "avg_price": 10.5}],
+        detected_at=1_015,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 400, "avg_price": 10.5}],
+        detected_at=1_030,
+    )
+
+    service.confirm_expired_candidates(now=1_030)
+
+    assert marks == ["close"]
+    assert sync_calls == [("000001", repository)]
+
+
 def test_pending_gap_is_dismissed_when_position_delta_resolves(monkeypatch):
     repository, service = _build_service(monkeypatch)
     gap = service.detect_external_candidates(
@@ -893,10 +1053,19 @@ def test_pending_gap_is_dismissed_when_position_delta_resolves(monkeypatch):
     assert repository.reconciliation_gaps[0]["state"] == "DISMISSED"
 
 
-def test_confirm_expired_candidates_raises_when_grid_interval_resolution_fails(
+def test_confirm_expired_candidates_falls_back_to_default_grid_interval_when_resolution_fails(
     monkeypatch,
 ):
+    original_safe_grid_interval_lookup = (
+        reconcile_service_module._safe_grid_interval_lookup
+    )
     repository, service = _build_service(monkeypatch)
+    monkeypatch.setattr(
+        reconcile_service_module,
+        "_safe_grid_interval_lookup",
+        original_safe_grid_interval_lookup,
+        raising=False,
+    )
     service.detect_external_candidates(
         positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.5}],
         detected_at=1_000,
@@ -911,12 +1080,57 @@ def test_confirm_expired_candidates_raises_when_grid_interval_resolution_fails(
     )
     monkeypatch.setattr(
         reconcile_service_module,
-        "_safe_grid_interval_lookup",
+        "_default_grid_interval_lookup",
         lambda _symbol, _trade_fact: (_ for _ in ()).throw(
             RuntimeError("grid interval unavailable")
         ),
         raising=False,
     )
 
-    with pytest.raises(RuntimeError, match="grid interval unavailable"):
-        service.confirm_expired_candidates(now=1_030)
+    confirmed = service.confirm_expired_candidates(now=1_030)
+
+    assert len(confirmed) == 1
+    assert repository.reconciliation_gaps[0]["state"] == "AUTO_OPENED"
+    assert repository.reconciliation_gaps[0]["resolution_type"] == "auto_open_entry"
+    assert len(repository.position_entries) == 1
+    assert repository.position_entries[0]["entry_type"] == "auto_reconciled_open"
+    assert repository.position_entries[0]["remaining_quantity"] == 200
+    assert repository.entry_slices
+
+
+def test_confirm_expired_candidates_falls_back_to_default_lot_amount_when_resolution_fails(
+    monkeypatch,
+):
+    original_safe_resolve_lot_amount = reconcile_service_module._safe_resolve_lot_amount
+    repository, service = _build_service(monkeypatch)
+    monkeypatch.setattr(
+        reconcile_service_module,
+        "_safe_resolve_lot_amount",
+        original_safe_resolve_lot_amount,
+        raising=False,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.5}],
+        detected_at=1_000,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.5}],
+        detected_at=1_015,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.5}],
+        detected_at=1_030,
+    )
+    monkeypatch.setattr(
+        xt_reports_module,
+        "_resolve_lot_amount",
+        lambda _symbol: (_ for _ in ()).throw(RuntimeError("lot amount unavailable")),
+        raising=False,
+    )
+
+    confirmed = service.confirm_expired_candidates(now=1_030)
+
+    assert len(confirmed) == 1
+    assert repository.reconciliation_gaps[0]["state"] == "AUTO_OPENED"
+    assert repository.position_entries[0]["remaining_quantity"] == 200
+    assert repository.entry_slices

--- a/freshquant/tests/test_order_reconcile_runtime_observability.py
+++ b/freshquant/tests/test_order_reconcile_runtime_observability.py
@@ -225,6 +225,12 @@ class InMemoryRepository:
 
 def test_reconcile_trade_reports_emits_runtime_events(monkeypatch):
     monkeypatch.setattr(
+        xt_reports_module,
+        "_sync_stock_fills_compat",
+        lambda _symbol, repository=None: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
         reconcile_service_module,
         "_sync_stock_fills_compat",
         lambda _symbol, repository=None: None,
@@ -298,6 +304,12 @@ def test_reconcile_trade_reports_emits_runtime_events(monkeypatch):
 def test_confirm_expired_candidates_emits_reconciliation_event(monkeypatch):
     monkeypatch.setattr(
         xt_reports_module,
+        "_sync_stock_fills_compat",
+        lambda _symbol, repository=None: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        reconcile_service_module,
         "_sync_stock_fills_compat",
         lambda _symbol, repository=None: None,
         raising=False,

--- a/freshquant/tests/test_order_reconcile_runtime_observability.py
+++ b/freshquant/tests/test_order_reconcile_runtime_observability.py
@@ -225,7 +225,7 @@ class InMemoryRepository:
 
 def test_reconcile_trade_reports_emits_runtime_events(monkeypatch):
     monkeypatch.setattr(
-        xt_reports_module,
+        reconcile_service_module,
         "_sync_stock_fills_compat",
         lambda _symbol, repository=None: None,
         raising=False,

--- a/freshquant/tests/test_stock_fills_compat_mirror.py
+++ b/freshquant/tests/test_stock_fills_compat_mirror.py
@@ -409,6 +409,39 @@ def test_list_compat_stock_positions_reads_compat_collection_only():
     assert database.stock_fills_compat.find_calls == [{}]
 
 
+def test_list_compat_stock_positions_accepts_database_objects_without_truthiness():
+    from freshquant.order_management.projection.stock_fills_compat import (
+        list_compat_stock_positions,
+    )
+
+    class BoolTrapDatabase:
+        def __init__(self):
+            self.stock_fills_compat = FakeStockFillsCollection(
+                [
+                    {
+                        "symbol": "000001",
+                        "op": "买",
+                        "quantity": 300,
+                        "price": 10.0,
+                        "amount": 3000.0,
+                        "amount_adjust": 1.0,
+                        "date": 20240102,
+                        "time": "09:31:00",
+                        "name": "平安银行",
+                        "stock_code": "000001.SZ",
+                    }
+                ]
+            )
+
+        def __bool__(self):
+            raise AssertionError("database truthiness must not be evaluated")
+
+    rows = list_compat_stock_positions(database=BoolTrapDatabase())
+
+    assert len(rows) == 1
+    assert rows[0]["symbol"] == "000001"
+
+
 def test_stock_fills_compat_service_sync_symbols_rebuilds_all_known_symbols():
     from freshquant.order_management.projection.stock_fills_compat import (
         StockFillsCompatibilityService,

--- a/freshquant/tests/test_xt_account_sync_worker.py
+++ b/freshquant/tests/test_xt_account_sync_worker.py
@@ -410,20 +410,23 @@ def test_build_default_sync_positions_quarantines_empty_snapshot_with_positive_m
     persist_calls = []
     reconcile_calls = []
 
+    def _capture_persist(*args, **kwargs):
+        persist_calls.append((args, kwargs))
+        return {"count": 0, "account_id": "acct-sync"}
+
+    def _capture_reconcile(*args, **kwargs):
+        reconcile_calls.append((args, kwargs))
+        return None
+
     monkeypatch.setattr(
         "freshquant.xt_account_sync.service.persist_positions",
-        lambda *args, **kwargs: persist_calls.append((args, kwargs))
-        or {"count": 0, "account_id": "acct-sync"},
+        _capture_persist,
     )
 
     service = XtAccountSyncService.build_default(
         client=FakeQueryClient(),
         position_repository=FakePositionRepository(),
-        reconcile_service=SimpleNamespace(
-            reconcile_account=lambda *args, **kwargs: reconcile_calls.append(
-                (args, kwargs)
-            )
-        ),
+        reconcile_service=SimpleNamespace(reconcile_account=_capture_reconcile),
         positions_collection=FakePositionsCollection(),
     )
 
@@ -497,20 +500,23 @@ def test_build_default_sync_positions_quarantines_severely_shrunk_snapshot_when_
     persist_calls = []
     reconcile_calls = []
 
+    def _capture_persist(*args, **kwargs):
+        persist_calls.append((args, kwargs))
+        return {"count": 1, "account_id": "acct-sync"}
+
+    def _capture_reconcile(*args, **kwargs):
+        reconcile_calls.append((args, kwargs))
+        return None
+
     monkeypatch.setattr(
         "freshquant.xt_account_sync.service.persist_positions",
-        lambda *args, **kwargs: persist_calls.append((args, kwargs))
-        or {"count": 1, "account_id": "acct-sync"},
+        _capture_persist,
     )
 
     service = XtAccountSyncService.build_default(
         client=FakeQueryClient(),
         position_repository=FakePositionRepository(),
-        reconcile_service=SimpleNamespace(
-            reconcile_account=lambda *args, **kwargs: reconcile_calls.append(
-                (args, kwargs)
-            )
-        ),
+        reconcile_service=SimpleNamespace(reconcile_account=_capture_reconcile),
         positions_collection=FakePositionsCollection(),
     )
 
@@ -567,20 +573,23 @@ def test_build_default_sync_positions_quarantines_small_account_severe_shrink_wh
     persist_calls = []
     reconcile_calls = []
 
+    def _capture_persist(*args, **kwargs):
+        persist_calls.append((args, kwargs))
+        return {"count": 1, "account_id": "acct-sync"}
+
+    def _capture_reconcile(*args, **kwargs):
+        reconcile_calls.append((args, kwargs))
+        return None
+
     monkeypatch.setattr(
         "freshquant.xt_account_sync.service.persist_positions",
-        lambda *args, **kwargs: persist_calls.append((args, kwargs))
-        or {"count": 1, "account_id": "acct-sync"},
+        _capture_persist,
     )
 
     service = XtAccountSyncService.build_default(
         client=FakeQueryClient(),
         position_repository=FakePositionRepository(),
-        reconcile_service=SimpleNamespace(
-            reconcile_account=lambda *args, **kwargs: reconcile_calls.append(
-                (args, kwargs)
-            )
-        ),
+        reconcile_service=SimpleNamespace(reconcile_account=_capture_reconcile),
         positions_collection=FakePositionsCollection(),
     )
 
@@ -588,8 +597,7 @@ def test_build_default_sync_positions_quarantines_small_account_severe_shrink_wh
 
     assert result["quarantined"] is True
     assert (
-        result["reason"]
-        == "small_account_shrunk_snapshot_with_positive_market_value"
+        result["reason"] == "small_account_shrunk_snapshot_with_positive_market_value"
     )
     assert result["previous_summary"]["symbol_count"] == 1
     assert result["current_summary"]["symbol_count"] == 1
@@ -633,21 +641,23 @@ def test_build_default_sync_positions_allows_empty_snapshot_when_credit_market_v
     persist_calls = []
     reconcile_calls = []
 
+    def _capture_persist(positions, **kwargs):
+        persist_calls.append((positions, kwargs))
+        return {"count": 0, "account_id": "acct-sync"}
+
+    def _capture_reconcile(*args, **kwargs):
+        reconcile_calls.append((args, kwargs))
+        return {"confirmed_candidates": []}
+
     monkeypatch.setattr(
         "freshquant.xt_account_sync.service.persist_positions",
-        lambda positions, **kwargs: persist_calls.append((positions, kwargs))
-        or {"count": 0, "account_id": "acct-sync"},
+        _capture_persist,
     )
 
     service = XtAccountSyncService.build_default(
         client=FakeQueryClient(),
         position_repository=FakePositionRepository(),
-        reconcile_service=SimpleNamespace(
-            reconcile_account=lambda *args, **kwargs: reconcile_calls.append(
-                (args, kwargs)
-            )
-            or {"confirmed_candidates": []}
-        ),
+        reconcile_service=SimpleNamespace(reconcile_account=_capture_reconcile),
         positions_collection=FakePositionsCollection(),
     )
 

--- a/freshquant/tests/test_xt_account_sync_worker.py
+++ b/freshquant/tests/test_xt_account_sync_worker.py
@@ -4,6 +4,7 @@ import runpy
 import sys
 import types
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 
@@ -78,6 +79,33 @@ def test_worker_run_once_calls_sync_service_without_credit_subjects_by_default()
             "include_credit_subjects": False,
             "seed_symbol_snapshots": True,
         }
+    ]
+
+
+def test_worker_run_once_logs_when_positions_snapshot_is_quarantined(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from freshquant.xt_account_sync import worker as worker_module
+
+    service = FakeSyncService(
+        result={
+            "positions": {
+                "quarantined": True,
+                "reason": "empty_snapshot_with_positive_market_value",
+            }
+        }
+    )
+    warnings = []
+    monkeypatch.setattr(
+        worker_module,
+        "logger",
+        SimpleNamespace(warning=lambda message, *args: warnings.append(message % args)),
+    )
+
+    worker_module.run_once(service=service)
+
+    assert warnings == [
+        "xt_account_sync positions snapshot quarantined: empty_snapshot_with_positive_market_value"
     ]
 
 
@@ -346,6 +374,292 @@ def test_build_default_sync_service_filters_replayed_orders_and_trades_by_cursor
             },
         ]
     ]
+
+
+def test_build_default_sync_positions_quarantines_empty_snapshot_with_positive_market_value(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from freshquant.xt_account_sync.service import XtAccountSyncService
+
+    class FakeQueryClient:
+        account_id = "acct-sync"
+        account_type = "CREDIT"
+
+        def query_stock_positions(self):
+            return []
+
+    class FakePositionRepository:
+        def get_latest_snapshot(self):
+            return {
+                "account_id": "acct-sync",
+                "market_value": 128000.0,
+            }
+
+    class FakePositionsCollection:
+        def find(self, query):
+            assert query == {"account_id": "acct-sync"}
+            return [
+                {
+                    "account_id": "acct-sync",
+                    "stock_code": "512600.SH",
+                    "volume": 4700,
+                    "avg_price": 1.02,
+                }
+            ]
+
+    persist_calls = []
+    reconcile_calls = []
+
+    monkeypatch.setattr(
+        "freshquant.xt_account_sync.service.persist_positions",
+        lambda *args, **kwargs: persist_calls.append((args, kwargs))
+        or {"count": 0, "account_id": "acct-sync"},
+    )
+
+    service = XtAccountSyncService.build_default(
+        client=FakeQueryClient(),
+        position_repository=FakePositionRepository(),
+        reconcile_service=SimpleNamespace(
+            reconcile_account=lambda *args, **kwargs: reconcile_calls.append(
+                (args, kwargs)
+            )
+        ),
+        positions_collection=FakePositionsCollection(),
+    )
+
+    result = service.sync_positions()
+
+    assert result["quarantined"] is True
+    assert result["reason"] == "empty_snapshot_with_positive_market_value"
+    assert result["previous_summary"]["symbol_count"] == 1
+    assert result["current_summary"]["symbol_count"] == 0
+    assert result["latest_credit_market_value"] == 128000.0
+    assert persist_calls == []
+    assert reconcile_calls == []
+
+
+def test_build_default_sync_positions_quarantines_severely_shrunk_snapshot_when_credit_market_value_stays_high(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from freshquant.xt_account_sync.service import XtAccountSyncService
+
+    class FakeQueryClient:
+        account_id = "acct-sync"
+        account_type = "CREDIT"
+
+        def query_stock_positions(self):
+            return [
+                {
+                    "account_id": "acct-sync",
+                    "stock_code": "300760.SZ",
+                    "volume": 100,
+                    "avg_price": 10.0,
+                }
+            ]
+
+    class FakePositionRepository:
+        def get_latest_snapshot(self):
+            return {
+                "account_id": "acct-sync",
+                "market_value": 98000.0,
+            }
+
+    class FakePositionsCollection:
+        def find(self, query):
+            assert query == {"account_id": "acct-sync"}
+            return [
+                {
+                    "account_id": "acct-sync",
+                    "stock_code": "300760.SZ",
+                    "volume": 900,
+                    "avg_price": 170.0,
+                },
+                {
+                    "account_id": "acct-sync",
+                    "stock_code": "600570.SH",
+                    "volume": 800,
+                    "avg_price": 25.0,
+                },
+                {
+                    "account_id": "acct-sync",
+                    "stock_code": "512600.SH",
+                    "volume": 4700,
+                    "avg_price": 1.0,
+                },
+                {
+                    "account_id": "acct-sync",
+                    "stock_code": "603919.SH",
+                    "volume": 2800,
+                    "avg_price": 18.0,
+                },
+            ]
+
+    persist_calls = []
+    reconcile_calls = []
+
+    monkeypatch.setattr(
+        "freshquant.xt_account_sync.service.persist_positions",
+        lambda *args, **kwargs: persist_calls.append((args, kwargs))
+        or {"count": 1, "account_id": "acct-sync"},
+    )
+
+    service = XtAccountSyncService.build_default(
+        client=FakeQueryClient(),
+        position_repository=FakePositionRepository(),
+        reconcile_service=SimpleNamespace(
+            reconcile_account=lambda *args, **kwargs: reconcile_calls.append(
+                (args, kwargs)
+            )
+        ),
+        positions_collection=FakePositionsCollection(),
+    )
+
+    result = service.sync_positions()
+
+    assert result["quarantined"] is True
+    assert result["reason"] == "shrunk_snapshot_with_positive_market_value"
+    assert result["previous_summary"]["symbol_count"] == 4
+    assert result["current_summary"]["symbol_count"] == 1
+    assert result["current_summary"]["estimated_market_value"] == 1000.0
+    assert result["latest_credit_market_value"] == 98000.0
+    assert persist_calls == []
+    assert reconcile_calls == []
+
+
+def test_build_default_sync_positions_quarantines_small_account_severe_shrink_when_credit_market_value_stays_high(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from freshquant.xt_account_sync.service import XtAccountSyncService
+
+    class FakeQueryClient:
+        account_id = "acct-sync"
+        account_type = "CREDIT"
+
+        def query_stock_positions(self):
+            return [
+                {
+                    "account_id": "acct-sync",
+                    "stock_code": "300760.SZ",
+                    "volume": 100,
+                    "avg_price": 170.0,
+                }
+            ]
+
+    class FakePositionRepository:
+        def get_latest_snapshot(self):
+            return {
+                "account_id": "acct-sync",
+                "market_value": 153000.0,
+            }
+
+    class FakePositionsCollection:
+        def find(self, query):
+            assert query == {"account_id": "acct-sync"}
+            return [
+                {
+                    "account_id": "acct-sync",
+                    "stock_code": "300760.SZ",
+                    "volume": 900,
+                    "avg_price": 170.0,
+                }
+            ]
+
+    persist_calls = []
+    reconcile_calls = []
+
+    monkeypatch.setattr(
+        "freshquant.xt_account_sync.service.persist_positions",
+        lambda *args, **kwargs: persist_calls.append((args, kwargs))
+        or {"count": 1, "account_id": "acct-sync"},
+    )
+
+    service = XtAccountSyncService.build_default(
+        client=FakeQueryClient(),
+        position_repository=FakePositionRepository(),
+        reconcile_service=SimpleNamespace(
+            reconcile_account=lambda *args, **kwargs: reconcile_calls.append(
+                (args, kwargs)
+            )
+        ),
+        positions_collection=FakePositionsCollection(),
+    )
+
+    result = service.sync_positions()
+
+    assert result["quarantined"] is True
+    assert (
+        result["reason"]
+        == "small_account_shrunk_snapshot_with_positive_market_value"
+    )
+    assert result["previous_summary"]["symbol_count"] == 1
+    assert result["current_summary"]["symbol_count"] == 1
+    assert result["current_summary"]["total_volume"] == 100
+    assert result["latest_credit_market_value"] == 153000.0
+    assert persist_calls == []
+    assert reconcile_calls == []
+
+
+def test_build_default_sync_positions_allows_empty_snapshot_when_credit_market_value_is_flat(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from freshquant.xt_account_sync.service import XtAccountSyncService
+
+    class FakeQueryClient:
+        account_id = "acct-sync"
+        account_type = "CREDIT"
+
+        def query_stock_positions(self):
+            return []
+
+    class FakePositionRepository:
+        def get_latest_snapshot(self):
+            return {
+                "account_id": "acct-sync",
+                "market_value": 0.0,
+            }
+
+    class FakePositionsCollection:
+        def find(self, query):
+            assert query == {"account_id": "acct-sync"}
+            return [
+                {
+                    "account_id": "acct-sync",
+                    "stock_code": "512600.SH",
+                    "volume": 4700,
+                    "avg_price": 1.02,
+                }
+            ]
+
+    persist_calls = []
+    reconcile_calls = []
+
+    monkeypatch.setattr(
+        "freshquant.xt_account_sync.service.persist_positions",
+        lambda positions, **kwargs: persist_calls.append((positions, kwargs))
+        or {"count": 0, "account_id": "acct-sync"},
+    )
+
+    service = XtAccountSyncService.build_default(
+        client=FakeQueryClient(),
+        position_repository=FakePositionRepository(),
+        reconcile_service=SimpleNamespace(
+            reconcile_account=lambda *args, **kwargs: reconcile_calls.append(
+                (args, kwargs)
+            )
+            or {"confirmed_candidates": []}
+        ),
+        positions_collection=FakePositionsCollection(),
+    )
+
+    result = service.sync_positions()
+
+    assert result["count"] == 0
+    assert result["account_id"] == "acct-sync"
+    assert result["reconcile"] == {"confirmed_candidates": []}
+    assert "quarantined" not in result
+    assert len(persist_calls) == 1
+    assert persist_calls[0][0] == []
+    assert len(reconcile_calls) == 1
 
 
 def test_persist_positions_clears_only_current_account_and_invalidates_holdings():

--- a/freshquant/xt_account_sync/service.py
+++ b/freshquant/xt_account_sync/service.py
@@ -320,7 +320,10 @@ def _load_latest_credit_snapshot_for_account(repository, *, account_id):
         document = getter()
         if document is None:
             return None
-        if not document.get("account_id") or document.get("account_id") == normalized_account_id:
+        if (
+            not document.get("account_id")
+            or document.get("account_id") == normalized_account_id
+        ):
             return document
     return None
 

--- a/freshquant/xt_account_sync/service.py
+++ b/freshquant/xt_account_sync/service.py
@@ -74,6 +74,7 @@ class XtAccountSyncService:
         credit_subject_repository=None,
         now_provider=None,
         sync_state_collection=None,
+        positions_collection=None,
     ):
         query_client = client or XtAccountQueryClient()
         position_repository = position_repository or PositionManagementRepository()
@@ -85,6 +86,7 @@ class XtAccountSyncService:
             credit_subject_repository or CreditSubjectRepository()
         )
         now_provider = now_provider or (lambda: datetime.now(timezone.utc))
+        positions_collection = positions_collection or _load_positions_collection()
 
         def sync_assets_once():
             puppet = _load_puppet_module()
@@ -128,6 +130,29 @@ class XtAccountSyncService:
             normalized_positions = [
                 _normalize_xt_position(position) for position in positions
             ]
+            previous_positions = _load_existing_positions_snapshot(
+                account_id=query_client.account_id,
+                collection=positions_collection,
+            )
+            latest_credit_snapshot = _load_latest_credit_snapshot_for_account(
+                position_repository,
+                account_id=query_client.account_id,
+            )
+            quarantine = _detect_suspicious_position_snapshot(
+                current_positions=normalized_positions,
+                previous_positions=previous_positions,
+                latest_credit_snapshot=latest_credit_snapshot,
+            )
+            if quarantine is not None:
+                return {
+                    "count": len(normalized_positions),
+                    "account_id": query_client.account_id,
+                    "account_type": query_client.account_type,
+                    "quarantined": True,
+                    "persist_skipped": True,
+                    "reconcile_skipped": True,
+                    **quarantine,
+                }
             result = persist_positions(
                 normalized_positions,
                 account_id=query_client.account_id,
@@ -260,3 +285,176 @@ def _normalize_xt_position(position):
     from fqxtrade.xtquant.fqtype import FqXtPosition
 
     return FqXtPosition(position).to_dict()
+
+
+def _load_positions_collection():
+    from fqxtrade.database.mongodb import DBfreshquant
+
+    return DBfreshquant["xt_positions"]
+
+
+def _load_existing_positions_snapshot(*, account_id, collection):
+    normalized_account_id = str(account_id or "").strip()
+    if not normalized_account_id or collection is None:
+        return []
+    cursor = collection.find({"account_id": normalized_account_id})
+    return [dict(item) for item in list(cursor or [])]
+
+
+def _load_latest_credit_snapshot_for_account(repository, *, account_id):
+    normalized_account_id = str(account_id or "").strip()
+    if not normalized_account_id or repository is None:
+        return None
+
+    snapshots = getattr(repository, "credit_asset_snapshots", None)
+    if snapshots is not None and hasattr(snapshots, "find_one"):
+        document = snapshots.find_one(
+            {"account_id": normalized_account_id},
+            sort=[("queried_at", -1)],
+        )
+        if document is not None:
+            return document
+
+    getter = getattr(repository, "get_latest_snapshot", None)
+    if callable(getter):
+        document = getter()
+        if document is None:
+            return None
+        if not document.get("account_id") or document.get("account_id") == normalized_account_id:
+            return document
+    return None
+
+
+def _detect_suspicious_position_snapshot(
+    *,
+    current_positions,
+    previous_positions,
+    latest_credit_snapshot,
+):
+    previous_summary = _summarize_position_snapshot(previous_positions)
+    if previous_summary["symbol_count"] <= 0:
+        return None
+
+    latest_credit_market_value = _coerce_float(
+        (latest_credit_snapshot or {}).get("market_value")
+    )
+    if latest_credit_market_value is None or latest_credit_market_value <= 0.01:
+        return None
+
+    current_summary = _summarize_position_snapshot(current_positions)
+    if current_summary["symbol_count"] == 0:
+        return {
+            "reason": "empty_snapshot_with_positive_market_value",
+            "latest_credit_market_value": latest_credit_market_value,
+            "previous_summary": previous_summary,
+            "current_summary": current_summary,
+        }
+
+    previous_symbol_count = previous_summary["symbol_count"]
+    previous_total_volume = previous_summary["total_volume"]
+    current_estimated_market_value = current_summary["estimated_market_value"]
+    symbol_ratio = current_summary["symbol_count"] / max(previous_symbol_count, 1)
+    volume_ratio = None
+    if previous_total_volume > 0:
+        volume_ratio = current_summary["total_volume"] / previous_total_volume
+    value_ratio = current_estimated_market_value / latest_credit_market_value
+    severe_value_and_volume_shrink = (
+        current_summary["priced_symbol_count"] > 0
+        and current_estimated_market_value > 0
+        and value_ratio <= 0.2
+        and volume_ratio is not None
+        and volume_ratio <= 0.2
+    )
+
+    if (
+        previous_symbol_count >= 3
+        and current_summary["symbol_count"] < previous_symbol_count
+        and symbol_ratio <= 0.5
+        and severe_value_and_volume_shrink
+    ):
+        return {
+            "reason": "shrunk_snapshot_with_positive_market_value",
+            "latest_credit_market_value": latest_credit_market_value,
+            "previous_summary": previous_summary,
+            "current_summary": current_summary,
+            "symbol_ratio": round(symbol_ratio, 6),
+            "volume_ratio": round(volume_ratio, 6),
+            "value_ratio": round(value_ratio, 6),
+        }
+
+    if (
+        previous_symbol_count <= 2
+        and previous_total_volume > 0
+        and current_summary["total_volume"] < previous_total_volume
+        and severe_value_and_volume_shrink
+    ):
+        return {
+            "reason": "small_account_shrunk_snapshot_with_positive_market_value",
+            "latest_credit_market_value": latest_credit_market_value,
+            "previous_summary": previous_summary,
+            "current_summary": current_summary,
+            "symbol_ratio": round(symbol_ratio, 6),
+            "volume_ratio": round(volume_ratio, 6),
+            "value_ratio": round(value_ratio, 6),
+        }
+
+    return None
+
+
+def _summarize_position_snapshot(positions):
+    symbols = {}
+    for raw_position in list(positions or []):
+        symbol = _normalize_snapshot_symbol(raw_position)
+        if not symbol:
+            continue
+        summary = symbols.setdefault(
+            symbol,
+            {
+                "volume": 0,
+                "estimated_market_value": 0.0,
+                "has_price": False,
+            },
+        )
+        volume = _coerce_int(_position_field(raw_position, "volume")) or 0
+        avg_price = _coerce_float(_position_field(raw_position, "avg_price"))
+        summary["volume"] += volume
+        if avg_price is not None and volume > 0:
+            summary["estimated_market_value"] += volume * avg_price
+            summary["has_price"] = True
+
+    return {
+        "symbol_count": len(symbols),
+        "total_volume": sum(item["volume"] for item in symbols.values()),
+        "estimated_market_value": round(
+            sum(item["estimated_market_value"] for item in symbols.values()),
+            2,
+        ),
+        "priced_symbol_count": sum(1 for item in symbols.values() if item["has_price"]),
+    }
+
+
+def _normalize_snapshot_symbol(position):
+    stock_code = str(_position_field(position, "stock_code") or "").strip()
+    symbol = str(_position_field(position, "symbol") or "").strip()
+    value = stock_code or symbol
+    if "." in value:
+        value = value.split(".", 1)[0]
+    return value
+
+
+def _position_field(position, field):
+    if isinstance(position, dict):
+        return position.get(field)
+    return getattr(position, field, None)
+
+
+def _coerce_int(value):
+    if value in {None, ""}:
+        return None
+    return int(value)
+
+
+def _coerce_float(value):
+    if value in {None, ""}:
+        return None
+    return float(value)

--- a/freshquant/xt_account_sync/worker.py
+++ b/freshquant/xt_account_sync/worker.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import logging
 import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
@@ -8,14 +9,17 @@ from zoneinfo import ZoneInfo
 from freshquant.xt_account_sync.service import XtAccountSyncService
 
 SHANGHAI_TZ = ZoneInfo("Asia/Shanghai")
+logger = logging.getLogger(__name__)
 
 
 def run_once(service=None):
     sync_service = service or XtAccountSyncService.build_default()
-    return sync_service.sync_once(
+    result = sync_service.sync_once(
         include_credit_subjects=False,
         seed_symbol_snapshots=True,
     )
+    _log_positions_quarantine(result)
+    return result
 
 
 def run_forever(
@@ -36,10 +40,11 @@ def run_forever(
     # position management. Only credit_subjects is reduced to startup/daily sync.
     if symbol_position_service is not None:
         symbol_position_service.refresh_all_from_positions()
-    sync_service.sync_once(
+    startup_result = sync_service.sync_once(
         include_credit_subjects=include_credit_subjects_on_startup,
         seed_symbol_snapshots=True,
     )
+    _log_positions_quarantine(startup_result)
 
     last_scheduled_date = None
     if include_credit_subjects_on_startup and _is_schedule_due(
@@ -57,10 +62,11 @@ def run_forever(
             scheduled_hour,
             scheduled_minute,
         )
-        sync_service.sync_once(
+        loop_result = sync_service.sync_once(
             include_credit_subjects=include_credit_subjects,
             seed_symbol_snapshots=False,
         )
+        _log_positions_quarantine(loop_result)
         if include_credit_subjects:
             last_scheduled_date = current_time.date()
         sleep_fn(interval_seconds)
@@ -128,6 +134,16 @@ def _is_schedule_due(current_time, scheduled_hour, scheduled_minute):
 
 def _shanghai_now():
     return datetime.now(SHANGHAI_TZ)
+
+
+def _log_positions_quarantine(result):
+    positions = result.get("positions") if isinstance(result, dict) else None
+    if not isinstance(positions, dict) or not positions.get("quarantined"):
+        return
+    logger.warning(
+        "xt_account_sync positions snapshot quarantined: %s",
+        positions.get("reason") or "unknown",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

近期订单运行面暴露出三类问题：XT 持仓坏快照可能误触发自动平账、reconcile/compat 视图可能漂移、credit auto price 提交链存在运行时失败。

## 目标

加固订单运行真值与自动对账链路，避免误平仓、兼容镜像漂移和 broker 提交前崩溃。

## 范围

- XT 持仓快照 quarantine 与小账户严重缩水保护
- 账户级批量 sell-gap 熔断
- reconcile 自动开平仓后的 holdings cache / stock_fills_compat 同步
- rebuild 遇到空 xt_positions 时默认拒绝 flatten 非空账本
- credit auto price 连续竞价判断运行时修复
- 相关测试与 docs/current 同步

## 非目标

- 不修改 Guardian 正式交易决策口径
- 不包含本地临时数据库清理动作
- 不处理无关 UI/Runtime Observability 变更

## 验收标准

- 相关回归测试通过
- docs/current 已同步
- 订单运行真值链不再因空/半快照直接误触发 AUTO_CLOSED

## 部署影响

- 需要重部署或重启 xt_account_sync.worker
- 需要重部署订单管理相关运行面
- 使用 execution_bridge 的 broker 提交链需要吃到新代码

## 验证

- `python -m pytest freshquant/tests/test_xt_account_sync_worker.py freshquant/tests/test_order_ledger_v2_rebuild.py freshquant/tests/test_order_management_reconcile.py freshquant/tests/test_order_management_execution_bridge.py freshquant/tests/test_order_management_credit_runtime_resolution.py freshquant/tests/test_stock_fills_compat_mirror.py`
- 本地结果：`82 passed`