### PR TITLE
Fix Guardian sell-gap entry fallback allocation

### DIFF
--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -99,6 +99,14 @@
 
 `submit_order -> credit mode resolve -> position gate -> om_order_requests / om_orders / om_broker_orders / om_order_events -> STOCK_ORDER_QUEUE -> broker`
 
+Guardian 卖出请求当前会把本次卖量对应的来源入口计划一起写入 `om_order_requests.strategy_context.guardian_sell_sources`：
+
+- `requested_quantity / submit_quantity`
+- `profitable_fill_count`
+- `entries[] = { entry_id, quantity }`
+
+这组来源入口语义用于在 XT `trade` 回报缺失、系统只能退回 `xt_positions delta` 自动平账时，仍优先把卖出数量扣回本次 Guardian 计算卖量时实际选中的入口。
+
 ### 撤单
 
 `cancel_order -> om_order_requests(cancel) -> om_orders / om_broker_orders state update -> STOCK_ORDER_QUEUE -> broker`
@@ -133,6 +141,8 @@
 
 - 刷新 stock holdings projection cache
 - 刷新 `stock_fills_compat` 镜像，避免 legacy 兼容视图滞后于 OM 主账本
+
+sell-side 自动平账当前在 gap 上保留最近一笔 Guardian 卖出请求携带的 `sell_source_entries`。当正常成交回报缺失、只能走 `auto_close_allocation` 时，当前会优先按这组来源入口扣减，再回退到默认 slice 顺序，避免把卖出剩余数量错扣到未参与本次卖量计算的历史入口上。
 
 当前内部仓位累计规则：
 

--- a/docs/current/modules/position-management.md
+++ b/docs/current/modules/position-management.md
@@ -57,6 +57,8 @@
 - `market_value`
   - `xt_positions.market_value`
 
+`xt_account_sync.worker` 当前在每一轮 `15s` 同步中都会重新刷新 `pm_symbol_position_snapshots`，不再只在 worker 启动时 seed 一次；页面上的单标的仓位摘要因此会随最新 broker truth 持续收敛。
+
 ### 账本仓位
 
 账本仓位来自 `om_position_entries` 聚合，不再使用 `om_buy_lots` 或 `stock_fills` 兼容镜像定义当前仓位真值。

--- a/freshquant/order_management/guardian/read_model.py
+++ b/freshquant/order_management/guardian/read_model.py
@@ -3,8 +3,9 @@
 
 def build_arranged_fill_read_model(open_slices):
     active_slices = list_active_open_slices(open_slices)
-    return [
-        {
+    rows = []
+    for item in active_slices:
+        row = {
             "symbol": item["symbol"],
             "date": item.get("date"),
             "time": item.get("time"),
@@ -12,8 +13,14 @@ def build_arranged_fill_read_model(open_slices):
             "quantity": item["remaining_quantity"],
             "amount": round(item["guardian_price"] * item["remaining_quantity"], 2),
         }
-        for item in active_slices
-    ]
+        entry_id = str(item.get("entry_id") or "").strip()
+        if entry_id:
+            row["entry_id"] = entry_id
+        entry_slice_id = str(item.get("entry_slice_id") or "").strip()
+        if entry_slice_id:
+            row["entry_slice_id"] = entry_slice_id
+        rows.append(row)
+    return rows
 
 
 def list_active_open_slices(open_slices):

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -41,6 +41,7 @@ _SELL_GAP_FUSE_MIN_SYMBOLS = 3
 _SELL_GAP_FUSE_MIN_QUANTITY_RATIO = 0.5
 _SELL_GAP_EVIDENCE_WINDOW_SECONDS = 300
 _SELL_SOURCE_REQUEST_WINDOW_SECONDS = 900
+_SELL_SOURCE_REQUEST_LOOKBACK_LIMIT = 32
 
 
 @dataclass
@@ -885,10 +886,26 @@ def _resolve_recent_guardian_sell_source_entries(
     target_quantity = int(quantity or 0)
     if target_quantity <= 0:
         return []
+    window_start_epoch = int(detected_at) - _SELL_SOURCE_REQUEST_WINDOW_SECONDS
+    window_start_iso = datetime.fromtimestamp(
+        window_start_epoch,
+        tz=timezone.utc,
+    ).isoformat()
+
+    try:
+        request_rows = repository.list_order_requests(
+            symbol=symbol,
+            action="sell",
+            created_at_gte=window_start_iso,
+            sort_created_at_desc=True,
+            limit=_SELL_SOURCE_REQUEST_LOOKBACK_LIMIT,
+        )
+    except TypeError:
+        request_rows = repository.list_order_requests(symbol=symbol) or []
 
     best_candidate = None
     best_score = None
-    for request in repository.list_order_requests(symbol=symbol) or []:
+    for request in request_rows:
         if str(request.get("action") or "").lower() != "sell":
             continue
         raw_entries = _extract_guardian_sell_source_entries(request)
@@ -898,19 +915,17 @@ def _resolve_recent_guardian_sell_source_entries(
         if planned_quantity < target_quantity:
             continue
         created_at_epoch = _coerce_epoch_seconds(request.get("created_at"))
-        if created_at_epoch is not None:
-            if created_at_epoch > int(detected_at) + 5:
-                continue
-            if (
-                created_at_epoch
-                < int(detected_at) - _SELL_SOURCE_REQUEST_WINDOW_SECONDS
-            ):
-                continue
+        if created_at_epoch is None:
+            continue
+        if created_at_epoch > int(detected_at) + 5:
+            continue
+        if created_at_epoch < window_start_epoch:
+            continue
         score = (
             0 if planned_quantity == target_quantity else 1,
             max(planned_quantity - target_quantity, 0),
-            abs((created_at_epoch or int(detected_at)) - int(detected_at)),
-            -(created_at_epoch or 0),
+            abs(created_at_epoch - int(detected_at)),
+            -created_at_epoch,
         )
         if best_score is None or score < best_score:
             best_score = score

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -40,6 +40,7 @@ _DEFAULT_RECONCILE_LOT_AMOUNT = 3000
 _SELL_GAP_FUSE_MIN_SYMBOLS = 3
 _SELL_GAP_FUSE_MIN_QUANTITY_RATIO = 0.5
 _SELL_GAP_EVIDENCE_WINDOW_SECONDS = 300
+_SELL_SOURCE_REQUEST_WINDOW_SECONDS = 900
 
 
 @dataclass
@@ -107,6 +108,16 @@ class ExternalOrderReconcileService:
                     "symbol": symbol,
                     "side": side,
                     "quantity_delta": quantity_delta,
+                    "sell_source_entries": (
+                        _resolve_recent_guardian_sell_source_entries(
+                            repository=self.repository,
+                            symbol=symbol,
+                            quantity=quantity_delta,
+                            detected_at=int(detected_at),
+                        )
+                        if side == "sell"
+                        else []
+                    ),
                     **price_snapshot,
                 }
             )
@@ -180,6 +191,12 @@ class ExternalOrderReconcileService:
                 confirm_interval_seconds=self.external_confirm_interval_seconds,
                 confirm_observations=self.external_confirm_observations,
             )
+            if observed.get("sell_source_entries") and not gap.get(
+                "sell_source_entries"
+            ):
+                updates["sell_source_entries"] = list(
+                    observed.get("sell_source_entries") or []
+                )
             self.repository.update_reconciliation_gap(
                 gap["gap_id"],
                 updates,
@@ -211,6 +228,7 @@ class ExternalOrderReconcileService:
                 "source": "position_diff",
                 "matched_order_id": None,
                 "matched_trade_fact_id": None,
+                "sell_source_entries": list(item.get("sell_source_entries") or []),
                 **gap_price_fields,
             }
             self.repository.insert_reconciliation_gap(gap)
@@ -615,6 +633,7 @@ class ExternalOrderReconcileService:
                 symbol=gap["symbol"],
                 quantity=remaining,
                 resolution_id=resolution_id,
+                preferred_entry_quantities=gap.get("sell_source_entries"),
             )
 
         legacy_allocations = []
@@ -641,6 +660,7 @@ class ExternalOrderReconcileService:
             "entry_allocation_ids": [
                 item["allocation_id"] for item in entry_allocations
             ],
+            "sell_source_entries": list(gap.get("sell_source_entries") or []),
             "legacy_allocation_ids": [
                 item["allocation_id"] for item in legacy_allocations
             ],
@@ -851,6 +871,94 @@ def _collect_recent_sell_evidence(*, repository, detected_at, symbols):
         "symbol_count": len(evidence_symbols),
         "quantity_total": quantity_total,
     }
+
+
+def _resolve_recent_guardian_sell_source_entries(
+    *,
+    repository,
+    symbol,
+    quantity,
+    detected_at,
+):
+    if not hasattr(repository, "list_order_requests"):
+        return []
+    target_quantity = int(quantity or 0)
+    if target_quantity <= 0:
+        return []
+
+    best_candidate = None
+    best_score = None
+    for request in repository.list_order_requests(symbol=symbol) or []:
+        if str(request.get("action") or "").lower() != "sell":
+            continue
+        raw_entries = _extract_guardian_sell_source_entries(request)
+        if not raw_entries:
+            continue
+        planned_quantity = _resolve_guardian_sell_source_quantity(request, raw_entries)
+        if planned_quantity < target_quantity:
+            continue
+        created_at_epoch = _coerce_epoch_seconds(request.get("created_at"))
+        if created_at_epoch is not None:
+            if created_at_epoch > int(detected_at) + 5:
+                continue
+            if (
+                created_at_epoch
+                < int(detected_at) - _SELL_SOURCE_REQUEST_WINDOW_SECONDS
+            ):
+                continue
+        score = (
+            0 if planned_quantity == target_quantity else 1,
+            max(planned_quantity - target_quantity, 0),
+            abs((created_at_epoch or int(detected_at)) - int(detected_at)),
+            -(created_at_epoch or 0),
+        )
+        if best_score is None or score < best_score:
+            best_score = score
+            best_candidate = _normalize_preferred_entry_quantities(
+                raw_entries,
+                remaining_quantity=target_quantity,
+            )
+    return list(best_candidate or [])
+
+
+def _extract_guardian_sell_source_entries(request):
+    context = dict((request or {}).get("strategy_context") or {})
+    sell_sources = dict(context.get("guardian_sell_sources") or {})
+    return list(sell_sources.get("entries") or [])
+
+
+def _resolve_guardian_sell_source_quantity(request, raw_entries):
+    context = dict((request or {}).get("strategy_context") or {})
+    sell_sources = dict(context.get("guardian_sell_sources") or {})
+    submit_quantity = int(sell_sources.get("submit_quantity") or 0)
+    if submit_quantity > 0:
+        return submit_quantity
+    request_quantity = int((request or {}).get("quantity") or 0)
+    if request_quantity > 0:
+        return request_quantity
+    return sum(int((item or {}).get("quantity") or 0) for item in raw_entries)
+
+
+def _coerce_epoch_seconds(value):
+    if value in {None, ""}:
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return int(float(text))
+    except (TypeError, ValueError):
+        pass
+    try:
+        normalized_text = text.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized_text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp())
 
 
 def _find_pending_candidate(candidates, symbol, side, quantity_delta):
@@ -1581,7 +1689,14 @@ def _arrange_entry_remaining(
     )
 
 
-def _allocate_gap_to_entry_slices(*, repository, symbol, quantity, resolution_id):
+def _allocate_gap_to_entry_slices(
+    *,
+    repository,
+    symbol,
+    quantity,
+    resolution_id,
+    preferred_entry_quantities=None,
+):
     remaining = int(quantity or 0)
     if remaining <= 0:
         return 0, []
@@ -1608,40 +1723,38 @@ def _allocate_gap_to_entry_slices(*, repository, symbol, quantity, resolution_id
         slices_by_entry.setdefault(slice_document["entry_id"], []).append(
             slice_document
         )
+
+    preferred_plan = _normalize_preferred_entry_quantities(
+        preferred_entry_quantities,
+        remaining_quantity=remaining,
+    )
+    if preferred_plan:
+        remaining, preferred_allocations = _allocate_gap_to_preferred_entry_slices(
+            entries=entries,
+            open_slices=open_slices,
+            symbol=symbol,
+            remaining_quantity=remaining,
+            resolution_id=resolution_id,
+            preferred_plan=preferred_plan,
+        )
+        allocations.extend(preferred_allocations)
+        touched_entry_ids.update(item["entry_id"] for item in preferred_allocations)
+
+    for slice_document in open_slices:
         if remaining <= 0:
             continue
-        if int(slice_document.get("remaining_quantity") or 0) <= 0:
+        allocation = _consume_entry_slice_allocation(
+            entries=entries,
+            slice_document=slice_document,
+            resolution_id=resolution_id,
+            symbol=symbol,
+            max_quantity=remaining,
+        )
+        if allocation is None:
             continue
-        allocated_quantity = min(int(slice_document["remaining_quantity"]), remaining)
-        slice_document["remaining_quantity"] -= allocated_quantity
-        slice_document["remaining_amount"] = round(
-            float(slice_document.get("guardian_price") or 0.0)
-            * int(slice_document["remaining_quantity"]),
-            2,
-        )
-        slice_document["status"] = (
-            "CLOSED" if int(slice_document["remaining_quantity"]) == 0 else "OPEN"
-        )
-        entry = entries[slice_document["entry_id"]]
-        entry["remaining_quantity"] = (
-            int(entry.get("remaining_quantity") or 0) - allocated_quantity
-        )
-        entry["status"] = _resolve_entry_status(
-            entry["remaining_quantity"], entry["original_quantity"]
-        )
-        allocations.append(
-            {
-                "allocation_id": new_allocation_id(),
-                "resolution_id": resolution_id,
-                "entry_id": slice_document["entry_id"],
-                "entry_slice_id": slice_document["entry_slice_id"],
-                "guardian_price": slice_document.get("guardian_price"),
-                "allocated_quantity": allocated_quantity,
-                "symbol": symbol,
-            }
-        )
+        allocations.append(allocation)
         touched_entry_ids.add(slice_document["entry_id"])
-        remaining -= allocated_quantity
+        remaining -= int(allocation["allocated_quantity"] or 0)
 
     for entry_id in touched_entry_ids:
         repository.replace_position_entry(entries[entry_id])
@@ -1651,6 +1764,108 @@ def _allocate_gap_to_entry_slices(*, repository, symbol, quantity, resolution_id
     if allocations:
         repository.insert_exit_allocations(allocations)
     return remaining, allocations
+
+
+def _normalize_preferred_entry_quantities(
+    preferred_entry_quantities, *, remaining_quantity
+):
+    remaining = int(remaining_quantity or 0)
+    if remaining <= 0:
+        return []
+    normalized = []
+    for item in list(preferred_entry_quantities or []):
+        if remaining <= 0:
+            break
+        entry_id = str((item or {}).get("entry_id") or "").strip()
+        quantity = int((item or {}).get("quantity") or 0)
+        if not entry_id or quantity <= 0:
+            continue
+        allocated_quantity = min(quantity, remaining)
+        normalized.append(
+            {
+                "entry_id": entry_id,
+                "quantity": allocated_quantity,
+            }
+        )
+        remaining -= allocated_quantity
+    return normalized
+
+
+def _allocate_gap_to_preferred_entry_slices(
+    *,
+    entries,
+    open_slices,
+    symbol,
+    remaining_quantity,
+    resolution_id,
+    preferred_plan,
+):
+    remaining = int(remaining_quantity or 0)
+    allocations = []
+    for source_entry in list(preferred_plan or []):
+        entry_id = str(source_entry.get("entry_id") or "").strip()
+        entry_remaining = int(source_entry.get("quantity") or 0)
+        if remaining <= 0 or not entry_id or entry_remaining <= 0:
+            continue
+        for slice_document in open_slices:
+            if remaining <= 0 or entry_remaining <= 0:
+                break
+            if str(slice_document.get("entry_id") or "").strip() != entry_id:
+                continue
+            allocation = _consume_entry_slice_allocation(
+                entries=entries,
+                slice_document=slice_document,
+                resolution_id=resolution_id,
+                symbol=symbol,
+                max_quantity=min(remaining, entry_remaining),
+            )
+            if allocation is None:
+                continue
+            allocations.append(allocation)
+            allocated_quantity = int(allocation.get("allocated_quantity") or 0)
+            remaining -= allocated_quantity
+            entry_remaining -= allocated_quantity
+    return remaining, allocations
+
+
+def _consume_entry_slice_allocation(
+    *,
+    entries,
+    slice_document,
+    resolution_id,
+    symbol,
+    max_quantity,
+):
+    allowed_quantity = int(max_quantity or 0)
+    remaining_quantity = int(slice_document.get("remaining_quantity") or 0)
+    if allowed_quantity <= 0 or remaining_quantity <= 0:
+        return None
+    allocated_quantity = min(remaining_quantity, allowed_quantity)
+    slice_document["remaining_quantity"] -= allocated_quantity
+    slice_document["remaining_amount"] = round(
+        float(slice_document.get("guardian_price") or 0.0)
+        * int(slice_document["remaining_quantity"]),
+        2,
+    )
+    slice_document["status"] = (
+        "CLOSED" if int(slice_document["remaining_quantity"]) == 0 else "OPEN"
+    )
+    entry = entries[slice_document["entry_id"]]
+    entry["remaining_quantity"] = (
+        int(entry.get("remaining_quantity") or 0) - allocated_quantity
+    )
+    entry["status"] = _resolve_entry_status(
+        entry["remaining_quantity"], entry["original_quantity"]
+    )
+    return {
+        "allocation_id": new_allocation_id(),
+        "resolution_id": resolution_id,
+        "entry_id": slice_document["entry_id"],
+        "entry_slice_id": slice_document["entry_slice_id"],
+        "guardian_price": slice_document.get("guardian_price"),
+        "allocated_quantity": allocated_quantity,
+        "symbol": symbol,
+    }
 
 
 def _allocate_gap_to_legacy_buy_lots(

--- a/freshquant/order_management/repository.py
+++ b/freshquant/order_management/repository.py
@@ -98,14 +98,23 @@ class OrderManagementRepository:
         self,
         *,
         symbol=None,
+        action=None,
+        states=None,
         scope_type=None,
         scope_ref_id=None,
         scope_ref_ids=None,
         request_ids=None,
+        created_at_gte=None,
+        sort_created_at_desc=False,
+        limit=None,
     ):
         query = {}
         if symbol is not None:
             query["symbol"] = symbol
+        if action is not None:
+            query["action"] = action
+        if states is not None:
+            query["state"] = {"$in": list(states)}
         if scope_type is not None:
             query["scope_type"] = scope_type
         if scope_ref_id is not None:
@@ -114,7 +123,14 @@ class OrderManagementRepository:
             query["scope_ref_id"] = {"$in": list(scope_ref_ids)}
         if request_ids is not None:
             query["request_id"] = {"$in": list(request_ids)}
-        return list(self.order_requests.find(query))
+        if created_at_gte is not None:
+            query["created_at"] = {"$gte": created_at_gte}
+        cursor = self.order_requests.find(query)
+        if sort_created_at_desc:
+            cursor = cursor.sort("created_at", -1)
+        if limit is not None:
+            cursor = cursor.limit(max(int(limit), 0))
+        return list(cursor)
 
     def insert_order(self, document):
         self.orders.insert_one(document)

--- a/freshquant/strategy/guardian.py
+++ b/freshquant/strategy/guardian.py
@@ -938,6 +938,7 @@ class StrategyGuardian(metaclass=SingletonType):
             )
 
             current_node = "sellable_volume_check"
+            requested_quantity = int(quantity or 0)
             sell_quantity = resolve_sell_submission_quantity(
                 requested_quantity=quantity,
                 can_use_volume=_get_position_reader().get_can_use_volume(code),
@@ -1051,6 +1052,12 @@ class StrategyGuardian(metaclass=SingletonType):
             current_node = "submit_intent"
             signal["quantity"] = quantity
             signal.setdefault("intent_id", new_intent_id())
+            strategy_context = _build_guardian_sell_strategy_context(
+                fill_list,
+                requested_quantity=requested_quantity,
+                submit_quantity=quantity,
+                profitable_fill_count=profitable_fill_count,
+            )
             self._emit_runtime(
                 signal,
                 "submit_intent",
@@ -1071,6 +1078,7 @@ class StrategyGuardian(metaclass=SingletonType):
                     remark=remark,
                     is_profitable=True,
                     signal=signal,
+                    strategy_context=strategy_context,
                 )
             except PositionManagementRejectedError as exc:
                 rejection_context = {
@@ -1406,3 +1414,52 @@ def _resolve_guardian_arrangement_scope(code):
             int(item.get("remaining_quantity") or 0) for item in open_entries
         ),
     }
+
+
+def _build_guardian_sell_strategy_context(
+    fill_list,
+    *,
+    requested_quantity,
+    submit_quantity,
+    profitable_fill_count,
+):
+    source_entries = _resolve_guardian_sell_source_entries(
+        fill_list,
+        quantity=submit_quantity,
+    )
+    if not source_entries:
+        return None
+    return {
+        "guardian_sell_sources": {
+            "profitable_fill_count": int(profitable_fill_count or 0),
+            "requested_quantity": int(requested_quantity or 0),
+            "submit_quantity": int(submit_quantity or 0),
+            "entries": source_entries,
+        }
+    }
+
+
+def _resolve_guardian_sell_source_entries(fill_list, *, quantity):
+    remaining = int(quantity or 0)
+    if remaining <= 0:
+        return []
+
+    source_entries = []
+    for item in reversed(list(fill_list or [])):
+        if remaining <= 0:
+            break
+        entry_id = str(item.get("entry_id") or "").strip()
+        if not entry_id:
+            continue
+        available_quantity = int(item.get("quantity") or 0)
+        if available_quantity <= 0:
+            continue
+        allocated_quantity = min(available_quantity, remaining)
+        source_entries.append(
+            {
+                "entry_id": entry_id,
+                "quantity": allocated_quantity,
+            }
+        )
+        remaining -= allocated_quantity
+    return source_entries

--- a/freshquant/tests/test_guardian_strategy.py
+++ b/freshquant/tests/test_guardian_strategy.py
@@ -484,3 +484,102 @@ def test_guardian_sell_caps_quantity_by_can_use_volume_and_board_lot(monkeypatch
     assert captured["symbol"] == "000001"
     assert captured["quantity"] == 200
     assert signal["quantity"] == 200
+
+
+def test_guardian_sell_carries_selected_source_entries_in_strategy_context(
+    monkeypatch,
+):
+    captured = {}
+    fake_redis = FakeRedis()
+    fake_order_alert = FakeOrderAlert()
+    signal = _make_signal(position="SELL_SHORT", price=12.5)
+    fire_time = signal["fire_time"]
+
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.get_arranged_stock_fill_list",
+        lambda _code: [
+            {
+                "entry_id": "entry_old",
+                "date": int(fire_time.subtract(minutes=4).format("YYYYMMDD")),
+                "time": fire_time.subtract(minutes=4).format("HH:mm:ss"),
+                "price": 9.8,
+                "quantity": 100,
+            },
+            {
+                "entry_id": "entry_mid_1",
+                "date": int(fire_time.subtract(minutes=3).format("YYYYMMDD")),
+                "time": fire_time.subtract(minutes=3).format("HH:mm:ss"),
+                "price": 9.7,
+                "quantity": 1000,
+            },
+            {
+                "entry_id": "entry_mid_2",
+                "date": int(fire_time.subtract(minutes=2).format("YYYYMMDD")),
+                "time": fire_time.subtract(minutes=2).format("HH:mm:ss"),
+                "price": 9.6,
+                "quantity": 1000,
+            },
+            {
+                "entry_id": "entry_new",
+                "date": int(fire_time.subtract(minutes=1).format("YYYYMMDD")),
+                "time": fire_time.subtract(minutes=1).format("HH:mm:ss"),
+                "price": 9.5,
+                "quantity": 1000,
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.get_stock_holding_codes",
+        lambda: ["000001"],
+    )
+    monkeypatch.setattr("freshquant.strategy.guardian.queryMustPoolCodes", lambda: [])
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.eval_stock_threshold_price",
+        lambda _code, _price: {"bot_river_price": 9.0, "top_river_price": 12.0},
+    )
+    monkeypatch.setattr("freshquant.strategy.guardian.redis_db", fake_redis)
+    monkeypatch.setattr("freshquant.strategy.guardian.order_alert", fake_order_alert)
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.logger",
+        types.SimpleNamespace(info=lambda *args, **kwargs: None),
+    )
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian._get_position_reader",
+        lambda: types.SimpleNamespace(get_can_use_volume=lambda _code: 3100),
+    )
+
+    def fake_submit(action, symbol, price, quantity, **kwargs):
+        captured.update(
+            {
+                "action": action,
+                "symbol": symbol,
+                "price": price,
+                "quantity": quantity,
+                "kwargs": kwargs,
+            }
+        )
+        return {
+            "request_id": "req_sell_2",
+            "internal_order_id": "ord_sell_2",
+            "queue_payload": {},
+        }
+
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.submit_guardian_order", fake_submit
+    )
+
+    StrategyGuardian().on_signal(signal)
+
+    assert captured["action"] == "sell"
+    assert captured["quantity"] == 3100
+    assert captured["kwargs"]["strategy_context"]["guardian_sell_sources"] == {
+        "profitable_fill_count": 4,
+        "requested_quantity": 3100,
+        "submit_quantity": 3100,
+        "entries": [
+            {"entry_id": "entry_new", "quantity": 1000},
+            {"entry_id": "entry_mid_2", "quantity": 1000},
+            {"entry_id": "entry_mid_1", "quantity": 1000},
+            {"entry_id": "entry_old", "quantity": 100},
+        ],
+    }

--- a/freshquant/tests/test_order_management_holding_adapter.py
+++ b/freshquant/tests/test_order_management_holding_adapter.py
@@ -339,6 +339,8 @@ def test_arranged_fill_projection_does_not_require_legacy_buy_lots_when_v2_entri
 
     assert rows == [
         {
+            "entry_id": "entry_v2_1",
+            "entry_slice_id": "slice_v2_1",
             "symbol": "000001",
             "date": 20260329,
             "time": "09:31:00",
@@ -384,6 +386,8 @@ def test_arranged_fill_projection_resolves_trade_time_in_china_timezone(monkeypa
 
     assert rows == [
         {
+            "entry_id": "entry_v2_1",
+            "entry_slice_id": "slice_v2_1",
             "symbol": "000001",
             "date": 20260315,
             "time": "23:39:42",
@@ -620,6 +624,8 @@ def test_arranged_fill_projection_does_not_fallback_to_legacy_when_v2_api_is_emp
 
     assert rows == [
         {
+            "entry_id": "entry_missing",
+            "entry_slice_id": "slice_v2_missing",
             "symbol": "000001",
             "date": 20260329,
             "time": "09:31:00",

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 
@@ -39,6 +40,34 @@ class InMemoryRepository:
             if request["request_id"] == request_id:
                 return request
         return None
+
+    def list_order_requests(
+        self,
+        *,
+        symbol=None,
+        scope_type=None,
+        scope_ref_id=None,
+        scope_ref_ids=None,
+        request_ids=None,
+    ):
+        rows = list(self.order_requests)
+        if symbol is not None:
+            rows = [item for item in rows if item.get("symbol") == symbol]
+        if scope_type is not None:
+            rows = [item for item in rows if item.get("scope_type") == scope_type]
+        if scope_ref_id is not None:
+            rows = [item for item in rows if item.get("scope_ref_id") == scope_ref_id]
+        elif scope_ref_ids is not None:
+            allowed_scope_refs = set(scope_ref_ids)
+            rows = [
+                item for item in rows if item.get("scope_ref_id") in allowed_scope_refs
+            ]
+        if request_ids is not None:
+            allowed_request_ids = set(request_ids)
+            rows = [
+                item for item in rows if item.get("request_id") in allowed_request_ids
+            ]
+        return [dict(item) for item in rows]
 
     def insert_order(self, document):
         self.orders.append(dict(document))
@@ -1214,6 +1243,133 @@ def test_confirm_expired_candidates_marks_and_syncs_compat_after_auto_close(
 
     assert marks == ["close"]
     assert sync_calls == [("000001", repository)]
+
+
+def test_confirm_expired_candidates_prefers_guardian_sell_source_entries_for_auto_close(
+    monkeypatch,
+):
+    repository, service = _build_service(monkeypatch)
+    repository.insert_order_request(
+        {
+            "request_id": "req_guardian_sell_1",
+            "action": "sell",
+            "symbol": "000001",
+            "quantity": 3100,
+            "source": "strategy",
+            "strategy_name": "Guardian",
+            "strategy_context": {
+                "guardian_sell_sources": {
+                    "submit_quantity": 3100,
+                    "entries": [
+                        {"entry_id": "entry_new", "quantity": 1000},
+                        {"entry_id": "entry_mid_2", "quantity": 1000},
+                        {"entry_id": "entry_mid_1", "quantity": 1000},
+                        {"entry_id": "entry_old", "quantity": 100},
+                    ],
+                }
+            },
+            "created_at": datetime.fromtimestamp(995, tz=timezone.utc).isoformat(),
+            "state": "ACCEPTED",
+        }
+    )
+    repository.replace_position_entry(
+        {
+            "entry_id": "entry_old",
+            "symbol": "000001",
+            "entry_price": 49.37,
+            "original_quantity": 4000,
+            "remaining_quantity": 4000,
+            "date": 20260320,
+            "time": "10:47:36",
+            "trade_time": 900,
+            "status": "OPEN",
+        }
+    )
+    repository.replace_entry_slices_for_entry(
+        "entry_old",
+        [
+            {
+                "entry_slice_id": "slice_old_1",
+                "entry_id": "entry_old",
+                "symbol": "000001",
+                "guardian_price": 49.37,
+                "remaining_quantity": 4000,
+                "remaining_amount": 197480.0,
+                "sort_key": 1,
+                "slice_seq": 1,
+                "status": "OPEN",
+            }
+        ],
+    )
+    for index, entry_id in enumerate(
+        ("entry_mid_1", "entry_mid_2", "entry_new"), start=1
+    ):
+        repository.replace_position_entry(
+            {
+                "entry_id": entry_id,
+                "symbol": "000001",
+                "entry_price": 48.76,
+                "original_quantity": 1000,
+                "remaining_quantity": 1000,
+                "date": 20260330,
+                "time": f"13:20:3{index}",
+                "trade_time": 950 + index,
+                "status": "OPEN",
+            }
+        )
+        repository.replace_entry_slices_for_entry(
+            entry_id,
+            [
+                {
+                    "entry_slice_id": f"slice_{entry_id}",
+                    "entry_id": entry_id,
+                    "symbol": "000001",
+                    "guardian_price": 48.76,
+                    "remaining_quantity": 1000,
+                    "remaining_amount": 48760.0,
+                    "sort_key": 10 + index,
+                    "slice_seq": 1,
+                    "status": "OPEN",
+                }
+            ],
+        )
+
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 3900, "avg_price": 50.34}],
+        detected_at=1_000,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 3900, "avg_price": 50.34}],
+        detected_at=1_015,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 3900, "avg_price": 50.34}],
+        detected_at=1_030,
+    )
+
+    confirmed = service.confirm_expired_candidates(now=1_030)
+
+    assert len(confirmed) == 1
+    assert confirmed[0]["state"] == "AUTO_CLOSED"
+    allocations_by_entry = {}
+    for item in repository.exit_allocations:
+        allocations_by_entry[item["entry_id"]] = (
+            allocations_by_entry.get(item["entry_id"], 0) + item["allocated_quantity"]
+        )
+    assert allocations_by_entry == {
+        "entry_new": 1000,
+        "entry_mid_2": 1000,
+        "entry_mid_1": 1000,
+        "entry_old": 100,
+    }
+    remaining_by_entry = {
+        item["entry_id"]: item["remaining_quantity"]
+        for item in repository.position_entries
+    }
+    assert remaining_by_entry["entry_old"] == 3900
+    assert remaining_by_entry["entry_mid_1"] == 0
+    assert remaining_by_entry["entry_mid_2"] == 0
+    assert remaining_by_entry["entry_new"] == 0
 
 
 def test_pending_gap_is_dismissed_when_position_delta_resolves(monkeypatch):

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -45,14 +45,24 @@ class InMemoryRepository:
         self,
         *,
         symbol=None,
+        action=None,
+        states=None,
         scope_type=None,
         scope_ref_id=None,
         scope_ref_ids=None,
         request_ids=None,
+        created_at_gte=None,
+        sort_created_at_desc=False,
+        limit=None,
     ):
         rows = list(self.order_requests)
         if symbol is not None:
             rows = [item for item in rows if item.get("symbol") == symbol]
+        if action is not None:
+            rows = [item for item in rows if item.get("action") == action]
+        if states is not None:
+            allowed_states = set(states)
+            rows = [item for item in rows if item.get("state") in allowed_states]
         if scope_type is not None:
             rows = [item for item in rows if item.get("scope_type") == scope_type]
         if scope_ref_id is not None:
@@ -67,6 +77,20 @@ class InMemoryRepository:
             rows = [
                 item for item in rows if item.get("request_id") in allowed_request_ids
             ]
+        if created_at_gte is not None:
+            rows = [
+                item
+                for item in rows
+                if str(item.get("created_at") or "").strip() >= str(created_at_gte)
+            ]
+        if sort_created_at_desc:
+            rows = sorted(
+                rows,
+                key=lambda item: str(item.get("created_at") or ""),
+                reverse=True,
+            )
+        if limit is not None:
+            rows = rows[: max(int(limit), 0)]
         return [dict(item) for item in rows]
 
     def insert_order(self, document):
@@ -1370,6 +1394,212 @@ def test_confirm_expired_candidates_prefers_guardian_sell_source_entries_for_aut
     assert remaining_by_entry["entry_mid_1"] == 0
     assert remaining_by_entry["entry_mid_2"] == 0
     assert remaining_by_entry["entry_new"] == 0
+
+
+def test_confirm_expired_candidates_ignores_guardian_sell_sources_without_created_at(
+    monkeypatch,
+):
+    repository, service = _build_service(monkeypatch)
+    repository.insert_order_request(
+        {
+            "request_id": "req_guardian_sell_missing_time",
+            "action": "sell",
+            "symbol": "000001",
+            "quantity": 3100,
+            "strategy_context": {
+                "guardian_sell_sources": {
+                    "submit_quantity": 3100,
+                    "entries": [
+                        {"entry_id": "entry_old", "quantity": 3100},
+                    ],
+                }
+            },
+            "state": "ACCEPTED",
+        }
+    )
+    repository.insert_order_request(
+        {
+            "request_id": "req_guardian_sell_recent",
+            "action": "sell",
+            "symbol": "000001",
+            "quantity": 3100,
+            "strategy_context": {
+                "guardian_sell_sources": {
+                    "submit_quantity": 3100,
+                    "entries": [
+                        {"entry_id": "entry_new", "quantity": 1000},
+                        {"entry_id": "entry_mid_2", "quantity": 1000},
+                        {"entry_id": "entry_mid_1", "quantity": 1000},
+                        {"entry_id": "entry_old", "quantity": 100},
+                    ],
+                }
+            },
+            "created_at": datetime.fromtimestamp(995, tz=timezone.utc).isoformat(),
+            "state": "ACCEPTED",
+        }
+    )
+    repository.replace_position_entry(
+        {
+            "entry_id": "entry_old",
+            "symbol": "000001",
+            "entry_price": 49.37,
+            "original_quantity": 4000,
+            "remaining_quantity": 4000,
+            "trade_time": 900,
+            "status": "OPEN",
+        }
+    )
+    repository.replace_entry_slices_for_entry(
+        "entry_old",
+        [
+            {
+                "entry_slice_id": "slice_old_1",
+                "entry_id": "entry_old",
+                "symbol": "000001",
+                "guardian_price": 49.37,
+                "remaining_quantity": 4000,
+                "remaining_amount": 197480.0,
+                "sort_key": 1,
+                "slice_seq": 1,
+                "status": "OPEN",
+            }
+        ],
+    )
+    for index, entry_id in enumerate(
+        ("entry_mid_1", "entry_mid_2", "entry_new"), start=1
+    ):
+        repository.replace_position_entry(
+            {
+                "entry_id": entry_id,
+                "symbol": "000001",
+                "entry_price": 48.76,
+                "original_quantity": 1000,
+                "remaining_quantity": 1000,
+                "trade_time": 950 + index,
+                "status": "OPEN",
+            }
+        )
+        repository.replace_entry_slices_for_entry(
+            entry_id,
+            [
+                {
+                    "entry_slice_id": f"slice_{entry_id}",
+                    "entry_id": entry_id,
+                    "symbol": "000001",
+                    "guardian_price": 48.76,
+                    "remaining_quantity": 1000,
+                    "remaining_amount": 48760.0,
+                    "sort_key": 10 + index,
+                    "slice_seq": 1,
+                    "status": "OPEN",
+                }
+            ],
+        )
+
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 3900, "avg_price": 50.34}],
+        detected_at=1_000,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 3900, "avg_price": 50.34}],
+        detected_at=1_015,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 3900, "avg_price": 50.34}],
+        detected_at=1_030,
+    )
+
+    service.confirm_expired_candidates(now=1_030)
+
+    allocations_by_entry = {}
+    for item in repository.exit_allocations:
+        allocations_by_entry[item["entry_id"]] = (
+            allocations_by_entry.get(item["entry_id"], 0) + item["allocated_quantity"]
+        )
+    assert allocations_by_entry == {
+        "entry_new": 1000,
+        "entry_mid_2": 1000,
+        "entry_mid_1": 1000,
+        "entry_old": 100,
+    }
+
+
+def test_guardian_sell_source_lookup_queries_recent_window_and_limit(monkeypatch):
+    class RecordingRepository(InMemoryRepository):
+        def __init__(self):
+            super().__init__()
+            self.request_queries = []
+
+        def list_order_requests(self, **kwargs):
+            self.request_queries.append(dict(kwargs))
+            return super().list_order_requests(**kwargs)
+
+    if monkeypatch is not None:
+        _stub_ingest_side_effects(monkeypatch)
+        monkeypatch.setattr(
+            reconcile_service_module,
+            "_safe_resolve_lot_amount",
+            lambda _symbol: 3000,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            reconcile_service_module,
+            "_safe_grid_interval_lookup",
+            lambda _symbol, _trade_fact: 1.03,
+            raising=False,
+        )
+    repository = RecordingRepository()
+    service = ExternalOrderReconcileService(
+        repository=repository,
+        tracking_service=OrderTrackingService(repository=repository),
+        external_confirm_interval_seconds=15,
+        external_confirm_observations=3,
+    )
+    repository.insert_order_request(
+        {
+            "request_id": "req_guardian_sell_recent",
+            "action": "sell",
+            "symbol": "000001",
+            "quantity": 100,
+            "strategy_context": {
+                "guardian_sell_sources": {
+                    "submit_quantity": 100,
+                    "entries": [{"entry_id": "entry_1", "quantity": 100}],
+                }
+            },
+            "created_at": datetime.fromtimestamp(995, tz=timezone.utc).isoformat(),
+            "state": "ACCEPTED",
+        }
+    )
+    repository.replace_position_entry(
+        {
+            "entry_id": "entry_1",
+            "symbol": "000001",
+            "entry_price": 10.0,
+            "original_quantity": 100,
+            "remaining_quantity": 100,
+            "trade_time": 900,
+            "status": "OPEN",
+        }
+    )
+
+    service.detect_external_candidates(
+        positions=[],
+        detected_at=1_000,
+    )
+
+    assert repository.request_queries == [
+        {
+            "symbol": "000001",
+            "action": "sell",
+            "created_at_gte": datetime.fromtimestamp(
+                1000 - reconcile_service_module._SELL_SOURCE_REQUEST_WINDOW_SECONDS,
+                tz=timezone.utc,
+            ).isoformat(),
+            "sort_created_at_desc": True,
+            "limit": reconcile_service_module._SELL_SOURCE_REQUEST_LOOKBACK_LIMIT,
+        }
+    ]
 
 
 def test_pending_gap_is_dismissed_when_position_delta_resolves(monkeypatch):

--- a/freshquant/tests/test_xt_account_sync_worker.py
+++ b/freshquant/tests/test_xt_account_sync_worker.py
@@ -198,7 +198,7 @@ def test_worker_module_runs_main_when_executed_as_module(
     ]
 
 
-def test_worker_run_forever_schedules_credit_subjects_and_only_seeds_once():
+def test_worker_run_forever_schedules_credit_subjects_and_refreshes_symbol_snapshots_each_loop():
     from freshquant.xt_account_sync.worker import run_forever
 
     service = FakeSyncService()
@@ -237,7 +237,7 @@ def test_worker_run_forever_schedules_credit_subjects_and_only_seeds_once():
         },
         {
             "include_credit_subjects": True,
-            "seed_symbol_snapshots": False,
+            "seed_symbol_snapshots": True,
         },
     ]
     assert sleep_calls == [3]

--- a/freshquant/xt_account_sync/worker.py
+++ b/freshquant/xt_account_sync/worker.py
@@ -64,7 +64,7 @@ def run_forever(
         )
         loop_result = sync_service.sync_once(
             include_credit_subjects=include_credit_subjects,
-            seed_symbol_snapshots=False,
+            seed_symbol_snapshots=True,
         )
         _log_positions_quarantine(loop_result)
         if include_credit_subjects:


### PR DESCRIPTION
## 背景
- `2026-04-01 09:36` 的 `002475` 卖出在券商侧已经正常成交，但系统没有落入 XT trade ingest 主链，而是退回到了 `xt_positions delta -> auto_close_allocation`。
- 退回差额路径后，系统只按默认 entry slice 顺序扣减，丢失了 Guardian 这次卖量原本对应的来源入口语义，导致卖出剩余数量被错扣到历史买入入口上。
- 同时，`pm_symbol_position_snapshots` 只在 `xt_account_sync.worker` 启动时 seed 一次，导致页面摘要可能停留在成交前的旧快照。

## 目标
- 在 Guardian 卖出请求上保留本次卖量的来源入口计划。
- 在 sell-side auto close 退回差额路径时，优先按 Guardian 来源入口扣减，再回退默认 slice 顺序。
- 让 `pm_symbol_position_snapshots` 在 worker 每轮同步中持续刷新，避免页面摘要滞后。

## 范围
- `freshquant/strategy/guardian.py`
- `freshquant/order_management/guardian/read_model.py`
- `freshquant/order_management/reconcile/service.py`
- `freshquant/xt_account_sync/worker.py`
- 相关单元测试与 `docs/current/**`

## 非目标
- 不在这次 PR 内改造 XT trade callback 本身的接入稳定性。
- 不改变 sell gap 的其它匹配策略，只补足 Guardian 来源入口语义。
- 不包含正式部署动作。

## 变更摘要
- Guardian 卖出请求现在会把 `guardian_sell_sources` 写入 `strategy_context`，携带 `requested_quantity / submit_quantity / profitable_fill_count / entries`。
- arranged fill 读模型保留 `entry_id / entry_slice_id`，让卖出来源入口可以一路带到请求侧。
- external reconcile 检测 sell gap 时会关联最近 Guardian 卖出请求中的来源入口计划。
- `auto_close_allocation` 现在优先按 `sell_source_entries` 扣减 entry slices，再回退默认顺序。
- `xt_account_sync.worker` 每轮都会刷新 `pm_symbol_position_snapshots`。
- `docs/current/modules/order-management.md` 与 `docs/current/modules/position-management.md` 已同步当前行为。

## 验收标准
- `002475` 这类“券商成交存在但 trade ingest 缺失”的场景，sell gap 自动收敛时会优先扣减本次 Guardian 实际选中的买入入口。
- `pm_symbol_position_snapshots` 不再只在 worker 启动时 seed，一轮轮同步后页面摘要会跟随 broker truth 更新。
- 相关回归测试通过。

## 验证
- `D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m pytest freshquant/tests/test_guardian_strategy.py freshquant/tests/test_order_management_reconcile.py freshquant/tests/test_order_management_holding_adapter.py freshquant/tests/test_xt_account_sync_worker.py -q`
- `D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m pytest freshquant/tests/test_guardian_strategy.py freshquant/tests/test_order_management_reconcile.py freshquant/tests/test_order_management_holding_adapter.py freshquant/tests/test_xt_account_sync_worker.py freshquant/tests/test_subject_management_service.py -q`
- `py -3.12 -m uv tool run pre-commit run --files freshquant/order_management/guardian/read_model.py freshquant/order_management/reconcile/service.py freshquant/strategy/guardian.py freshquant/tests/test_guardian_strategy.py freshquant/tests/test_order_management_holding_adapter.py freshquant/tests/test_order_management_reconcile.py freshquant/tests/test_xt_account_sync_worker.py freshquant/xt_account_sync/worker.py docs/current/modules/order-management.md docs/current/modules/position-management.md`

## 部署影响
- 合并后需要按部署矩阵至少重部署后端/API，并重启 `xt_account_sync.worker`。
- 如果线上仍有依赖该链路的运行面，也建议一并做一次健康检查，确认 `subject-management` 和 `position-management` 页面口径已收敛。