### PR TITLE
[codex] Treat zero-quantity takeprofit hits as triggered

### DIFF
--- a/docs/current/modules/tpsl.md
+++ b/docs/current/modules/tpsl.md
@@ -5,6 +5,7 @@
 TPSL 在独立 tick 链路上评估止盈和止损条件，并生成退出单。当前模块已经切到 `position entry` 语义：
 
 - 止盈仍按 symbol profile 管理
+- 止盈命中档位但当前可盈利切片数量为 `0` 时，仍会消耗命中档位并写 `takeprofit_hit`，但不会生成退出单
 - 止损对象改为 open `position_entries`
 - 历史与详情优先读取 `entry ledger`
 - 止盈卖出提交前会统一按 `xt_positions.can_use_volume` 截断，并按一手向下取整；Guardian 卖出现在复用同一套约束 helper

--- a/freshquant/tests/test_tpsl_consumer.py
+++ b/freshquant/tests/test_tpsl_consumer.py
@@ -26,8 +26,18 @@ class FakeTpslService:
 
 def test_consumer_executes_takeprofit_before_stoploss():
     service = FakeTpslService(
-        takeprofit_batch={"batch_id": "tp1", "symbol": "000001", "quantity": 300},
-        stoploss_batch={"batch_id": "sl1", "symbol": "000001", "quantity": 300},
+        takeprofit_batch={
+            "batch_id": "tp1",
+            "status": "ready",
+            "symbol": "000001",
+            "quantity": 300,
+        },
+        stoploss_batch={
+            "batch_id": "sl1",
+            "status": "ready",
+            "symbol": "000001",
+            "quantity": 300,
+        },
     )
     consumer = TpslTickConsumer(
         service=service,
@@ -50,8 +60,18 @@ def test_consumer_executes_takeprofit_before_stoploss():
 
 def test_consumer_skips_symbols_outside_active_tpsl_universe():
     service = FakeTpslService(
-        takeprofit_batch={"batch_id": "tp1", "symbol": "000001", "quantity": 300},
-        stoploss_batch={"batch_id": "sl1", "symbol": "000001", "quantity": 300},
+        takeprofit_batch={
+            "batch_id": "tp1",
+            "status": "ready",
+            "symbol": "000001",
+            "quantity": 300,
+        },
+        stoploss_batch={
+            "batch_id": "sl1",
+            "status": "ready",
+            "symbol": "000001",
+            "quantity": 300,
+        },
     )
     consumer = TpslTickConsumer(
         service=service,
@@ -76,7 +96,12 @@ def test_consumer_skips_symbols_outside_active_tpsl_universe():
 def test_consumer_runs_stoploss_when_takeprofit_not_hit():
     service = FakeTpslService(
         takeprofit_batch=None,
-        stoploss_batch={"batch_id": "sl1", "symbol": "000001", "quantity": 500},
+        stoploss_batch={
+            "batch_id": "sl1",
+            "status": "ready",
+            "symbol": "000001",
+            "quantity": 500,
+        },
     )
     consumer = TpslTickConsumer(
         service=service,
@@ -101,9 +126,44 @@ def test_consumer_runs_stoploss_when_takeprofit_not_hit():
     ]
 
 
+def test_consumer_returns_zero_quantity_takeprofit_trigger_without_submitting():
+    takeprofit_result = {
+        "status": "triggered_no_order",
+        "symbol": "000001",
+        "quantity": 0,
+    }
+    service = FakeTpslService(
+        takeprofit_batch=takeprofit_result,
+        stoploss_batch={"batch_id": "sl1", "symbol": "000001", "quantity": 500},
+    )
+    consumer = TpslTickConsumer(
+        service=service,
+        universe_loader=lambda: ["sz000001"],
+        refresh_interval_s=999,
+    )
+
+    result = consumer.handle_tick(
+        {
+            "code": "000001.SZ",
+            "ask1": 10.0,
+            "bid1": 9.2,
+            "lastPrice": 9.6,
+            "time": 1710000000,
+        }
+    )
+
+    assert result == takeprofit_result
+    assert service.calls == ["evaluate_takeprofit"]
+
+
 def test_consumer_skips_ticks_when_active_tpsl_universe_is_empty():
     service = FakeTpslService(
-        takeprofit_batch={"batch_id": "tp1", "symbol": "000001", "quantity": 300},
+        takeprofit_batch={
+            "batch_id": "tp1",
+            "status": "ready",
+            "symbol": "000001",
+            "quantity": 300,
+        },
     )
     consumer = TpslTickConsumer(
         service=service,

--- a/freshquant/tests/test_tpsl_runtime_observability.py
+++ b/freshquant/tests/test_tpsl_runtime_observability.py
@@ -350,6 +350,60 @@ def test_evaluate_takeprofit_blocked_result_does_not_emit_trace_ids():
     assert all(not event.get("trace_id") for event in runtime_logger.events)
 
 
+def test_evaluate_takeprofit_zero_quantity_trigger_emits_success_trace_and_marks_level():
+    runtime_logger = FakeRuntimeLogger()
+    takeprofit_service = FakeTakeprofitService()
+
+    class ZeroQuantityOrderRepository(FakeOrderRepository):
+        def list_open_slices(self, symbol=None, buy_lot_ids=None):
+            return [
+                {
+                    "buy_lot_id": "lot1",
+                    "lot_slice_id": "slice1",
+                    "guardian_price": 10.8,
+                    "remaining_quantity": 300,
+                    "sort_key": 1,
+                    "symbol": symbol or "000001",
+                }
+            ]
+
+    service = TpslService(
+        takeprofit_service=takeprofit_service,
+        order_submit_service=FakeOrderSubmitService(),
+        order_repository=ZeroQuantityOrderRepository(),
+        position_reader=FixedPositionReader(),
+        lock_client=AlwaysAvailableLockClient(),
+        runtime_logger=runtime_logger,
+    )
+
+    batch = service.evaluate_takeprofit(
+        symbol="000001",
+        code="sz000001",
+        ask1=10.8,
+        bid1=10.7,
+        last_price=10.8,
+        tick_time=1710000000,
+    )
+
+    assert batch["status"] == "triggered_no_order"
+    assert batch["trace_id"].startswith("trc_")
+    assert [event["node"] for event in runtime_logger.events] == ["trigger_eval"]
+    assert runtime_logger.events[0]["status"] == "success"
+    assert runtime_logger.events[0]["reason_code"] == "no_profitable_quantity"
+    assert runtime_logger.events[0]["trace_id"] == batch["trace_id"]
+    assert takeprofit_service.mark_calls == [
+        {
+            "symbol": "000001",
+            "level": 2,
+            "batch_id": batch["batch_id"],
+            "updated_by": "tpsl_trigger",
+            "trigger_price": 10.8,
+            "entry_details": [],
+            "buy_lot_details": [],
+        }
+    ]
+
+
 def test_evaluate_stoploss_blocked_result_does_not_emit_trace_ids(monkeypatch):
     runtime_logger = FakeRuntimeLogger()
 

--- a/freshquant/tests/test_tpsl_service.py
+++ b/freshquant/tests/test_tpsl_service.py
@@ -264,6 +264,51 @@ def test_evaluate_takeprofit_blocks_when_sellable_volume_is_zero():
     assert batch["blocked_reason"] == "can_use_volume"
 
 
+def test_evaluate_takeprofit_zero_quantity_marks_level_triggered_without_order():
+    repo = InMemoryTpslRepository()
+    tp_service = TakeprofitService(repository=repo)
+    tp_service.save_profile(
+        "000001",
+        tiers=[
+            {"level": 1, "price": 10.0, "manual_enabled": True},
+        ],
+        updated_by="api",
+    )
+    order_repo = FakeOrderManagementRepository(
+        open_entry_slices=[
+            {
+                "entry_id": "entry1",
+                "entry_slice_id": "slice1",
+                "guardian_price": 10.0,
+                "remaining_quantity": 300,
+                "slice_seq": 1,
+                "sort_key": 10.0,
+                "symbol": "000001",
+            }
+        ]
+    )
+    service = TpslService(
+        takeprofit_service=tp_service,
+        order_repository=order_repo,
+        position_reader=FixedPositionReader(300),
+    )
+
+    batch = service.evaluate_takeprofit(symbol="000001", ask1=10.0)
+
+    assert batch["status"] == "triggered_no_order"
+    assert batch["skip_reason"] == "no_profitable_quantity"
+    assert batch["quantity"] == 0
+    assert batch["level"] == 1
+    assert batch["trace_id"].startswith("trc_")
+    assert batch["batch_id"].startswith("takeprofit_trigger_")
+    assert tp_service.get_state("000001")["armed_levels"] == {1: False}
+    assert repo.events[-1]["event_type"] == "takeprofit_hit"
+    assert repo.events[-1]["batch_id"] == batch["batch_id"]
+    assert repo.events[-1]["trigger_price"] == 10.0
+    assert repo.events[-1]["entry_details"] == []
+    assert repo.events[-1]["buy_lot_details"] == []
+
+
 class FakeCollection:
     def __init__(self, rows):
         self.rows = list(rows)

--- a/freshquant/tpsl/consumer.py
+++ b/freshquant/tpsl/consumer.py
@@ -68,7 +68,7 @@ class TpslTickConsumer:
                 tick_time=event.tick_time,
             )
             if takeprofit_batch:
-                if takeprofit_batch.get("status") == "blocked":
+                if takeprofit_batch.get("status") != "ready":
                     return takeprofit_batch
                 return self.service.submit_takeprofit_batch(takeprofit_batch)
 
@@ -81,7 +81,7 @@ class TpslTickConsumer:
                 tick_time=event.tick_time,
             )
             if stoploss_batch:
-                if stoploss_batch.get("status") == "blocked":
+                if stoploss_batch.get("status") != "ready":
                     return stoploss_batch
                 return self.service.submit_stoploss_batch(stoploss_batch)
             return None

--- a/freshquant/tpsl/service.py
+++ b/freshquant/tpsl/service.py
@@ -221,12 +221,46 @@ class TpslService:
                 tier_price=hit["price"],
             )
             if int(quantity_result["quantity"] or 0) <= 0:
+                trace_id_value = str(trace_id or "").strip() or new_trace_id()
+                batch_id = f"takeprofit_trigger_{uuid4().hex}"
+                self.mark_takeprofit_triggered(
+                    symbol=base_symbol,
+                    level=int(hit["level"]),
+                    batch_id=batch_id,
+                    updated_by="tpsl_trigger",
+                    trigger_price=hit["price"],
+                    entry_details=[],
+                    buy_lot_details=[],
+                )
                 self._emit_runtime(
                     "trigger_eval",
                     symbol=base_symbol,
-                    payload=trigger_payload,
+                    trace_id=trace_id_value,
+                    status="success",
+                    reason_code="no_profitable_quantity",
+                    payload={
+                        **trigger_payload,
+                        "quantity": 0,
+                        "batch_id": batch_id,
+                        "trigger_consumed": True,
+                    },
                 )
-                return None
+                return {
+                    "batch_id": batch_id,
+                    "status": "triggered_no_order",
+                    "symbol": base_symbol,
+                    "trace_id": trace_id_value,
+                    "price": float(hit["price"]),
+                    "quantity": 0,
+                    "level": int(hit["level"]),
+                    "tier_price": float(hit["price"]),
+                    "ask1": float(ask1 or 0.0),
+                    "bid1": float(bid1 or 0.0),
+                    "last_price": float(last_price or 0.0),
+                    "tick_time": int(tick_time or 0),
+                    "skip_reason": "no_profitable_quantity",
+                    "trigger_consumed": True,
+                }
 
             sell_cap = self.position_reader.get_can_use_volume(base_symbol)
             sell_quantity = _resolve_sell_submission_quantity(


### PR DESCRIPTION
## 背景
- `159622 / 创新药AH一致` 命中止盈档位后，如果 `guardian_price < tier_price` 过滤出的可盈利数量为 `0`，TPSL 只会持续写 `trigger_eval`
- 这种情况下不会更新 `om_takeprofit_states`，也不会写 `takeprofit_hit`，同一档位会被后续 tick 反复触发

## 目标
- 命中止盈档位但 `quantity=0` 时，也按一次成功触发处理
- 关闭命中档位及以下止盈激活状态，避免重复触发
- 不进入下单链路，不伪造 request/order/trade

## 范围
- 在 `TpslService.evaluate_takeprofit()` 为零数量止盈命中新加 `triggered_no_order` 分支
- `TpslTickConsumer` 只对 `status == "ready"` 的 TPSL 结果继续 submit
- 补齐 service / consumer / runtime observability 测试，并同步 `docs/current/modules/tpsl.md`

## 非目标
- 不修改 `guardian_price < tier_price` 的盈利切片判定语义
- 不改变 `can_use_volume` / board lot 等既有 blocked 语义

## 验证
- `python -m pytest freshquant/tests/test_tpsl_service.py freshquant/tests/test_tpsl_consumer.py freshquant/tests/test_tpsl_runtime_observability.py -q`
- `python -m pytest freshquant/tests/test_tpsl*.py -q`
- `powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure`

## 部署影响
- 命中 `freshquant/tpsl/**`
- 合并后需要正式 deploy，并重启 `tpsl` surface（`tpsl.tick_listener`）
