### PR TITLE
fix: reconcile host supervisor runtime with deploy mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 ## 运行环境
 
-- 宿主机统一使用项目根目录 `.venv`
+- 本地开发统一使用项目根目录 `.venv`
+- 正式 `fqnext-supervisord` 统一使用 `D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production\.venv`
 - 解释器版本固定为 `Python 3.12.x`
 - 依赖统一由 `uv.lock` 驱动
 - Docker 容器内分别创建 `/freshquant/.venv` 与 `/app/.venv`
@@ -72,11 +73,13 @@ Docker 并行构建默认通过 `FQ_DOCKER_BUILD_CACHE_ROOT` 使用本地 BuildK
 
 宿主机 Supervisor 统一使用：
 
-- `D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe`
+- `D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production\.venv\Scripts\python.exe`
 
 配置文件：
 
 - `D:\fqpack\config\supervisord.fqnext.conf`
+- formal deploy 会用 `script/fqnext_supervisor_config.py` 把这份配置收敛到 `main-deploy-production`
+- 命中宿主机 deployment surface 时，若 config 发生变化或 service 仍吃旧配置，formal deploy 会先受控重载 `fqnext-supervisord`
 
 正式宿主机入口：
 

--- a/deployment/examples/supervisord.fqnext.example.conf
+++ b/deployment/examples/supervisord.fqnext.example.conf
@@ -1,5 +1,5 @@
 [supervisord]
-; FreshQuant 当前宿主机 Python 口径：项目根目录 .venv
+; FreshQuant 当前宿主机 Python 口径：formal deploy mirror .venv
 ; 如仓库路径不同，请同步调整下面的 PATH、PYTHONPATH 和 command
 logfile=D:/fqdata/log/supervisord_fqnext.log
 logfile_maxbytes=50MB
@@ -9,7 +9,7 @@ pidfile=D:/fqdata/supervisord_fqnext.pid
 identifier=fqnext
 
 [program-default]
-directory=D:/fqpack/freshquant-2026.2.23
+directory=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production
 stdout_logfile_maxbytes=50MB
 stdout_logfile_backups=10
 stderr_logfile_maxbytes=50MB
@@ -17,14 +17,14 @@ stderr_logfile_backups=10
 autorestart=true
 startretries=10
 envFiles=D:/fqpack/config/envs.conf
-environment=PATH=D:/fqpack/freshquant-2026.2.23/.venv;D:/fqpack/freshquant-2026.2.23/.venv/Scripts;C:/Windows/System32,PYTHONPATH=D:/fqpack/freshquant-2026.2.23;D:/fqpack/freshquant-2026.2.23/morningglory/fqxtrade;D:/fqpack/freshquant-2026.2.23/sunflower/QUANTAXIS
+environment=PATH=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/.venv;D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/.venv/Scripts;C:/Windows/System32,PYTHONPATH=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production;D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/morningglory/fqxtrade;D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/sunflower/QUANTAXIS
 
 [inet_http_server]
 port=127.0.0.1:10011
 
 [program:fqnext_realtime_xtdata_producer]
-command=D:/fqpack/freshquant-2026.2.23/.venv/Scripts/python.exe -m freshquant.market_data.xtdata.market_producer
-directory=D:/fqpack/freshquant-2026.2.23
+command=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/.venv/Scripts/python.exe -m freshquant.market_data.xtdata.market_producer
+directory=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production
 stdout_logfile=D:/fqdata/log/fqnext_realtime_xtdata_producer.log
 stderr_logfile=D:/fqdata/log/fqnext_realtime_xtdata_producer_err.log
 autostart=true
@@ -32,8 +32,8 @@ autorestart=true
 startsecs=5
 
 [program:fqnext_realtime_xtdata_consumer]
-command=D:/fqpack/freshquant-2026.2.23/.venv/Scripts/python.exe -m freshquant.market_data.xtdata.strategy_consumer --prewarm --max-bars 20000
-directory=D:/fqpack/freshquant-2026.2.23
+command=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/.venv/Scripts/python.exe -m freshquant.market_data.xtdata.strategy_consumer --prewarm --max-bars 20000
+directory=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production
 stdout_logfile=D:/fqdata/log/fqnext_realtime_xtdata_consumer.log
 stderr_logfile=D:/fqdata/log/fqnext_realtime_xtdata_consumer_err.log
 autostart=true
@@ -41,8 +41,8 @@ autorestart=true
 startsecs=5
 
 [program:fqnext_guardian_event]
-command=D:/fqpack/freshquant-2026.2.23/.venv/Scripts/python.exe -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event
-directory=D:/fqpack/freshquant-2026.2.23
+command=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/.venv/Scripts/python.exe -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event
+directory=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production
 stdout_logfile=D:/fqdata/log/fqnext_guardian_event.log
 stderr_logfile=D:/fqdata/log/fqnext_guardian_event_err.log
 autostart=true
@@ -50,8 +50,8 @@ autorestart=true
 startsecs=5
 
 [program:fqnext_xt_account_sync_worker]
-command=D:/fqpack/freshquant-2026.2.23/.venv/Scripts/python.exe -m freshquant.xt_account_sync.worker --interval 15
-directory=D:/fqpack/freshquant-2026.2.23
+command=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/.venv/Scripts/python.exe -m freshquant.xt_account_sync.worker --interval 15
+directory=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production
 stdout_logfile=D:/fqdata/log/fqnext_xt_account_sync_worker.log
 stderr_logfile=D:/fqdata/log/fqnext_xt_account_sync_worker_err.log
 autostart=true
@@ -59,8 +59,8 @@ autorestart=true
 startsecs=5
 
 [program:fqnext_tpsl_worker]
-command=D:/fqpack/freshquant-2026.2.23/.venv/Scripts/python.exe -m freshquant.tpsl.tick_listener
-directory=D:/fqpack/freshquant-2026.2.23
+command=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/.venv/Scripts/python.exe -m freshquant.tpsl.tick_listener
+directory=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production
 stdout_logfile=D:/fqdata/log/fqnext_tpsl_worker.log
 stderr_logfile=D:/fqdata/log/fqnext_tpsl_worker_err.log
 autostart=true
@@ -68,8 +68,8 @@ autorestart=true
 startsecs=5
 
 [program:fqnext_xtquant_broker]
-command=D:/fqpack/freshquant-2026.2.23/.venv/Scripts/python.exe -m fqxtrade.xtquant.broker
-directory=D:/fqpack/freshquant-2026.2.23
+command=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/.venv/Scripts/python.exe -m fqxtrade.xtquant.broker
+directory=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production
 stdout_logfile=D:/fqdata/log/fqnext_xtquant_broker.log
 stderr_logfile=D:/fqdata/log/fqnext_xtquant_broker_err.log
 autostart=true
@@ -77,8 +77,8 @@ autorestart=true
 startsecs=5
 
 [program:fqnext_xtdata_adj_refresh_worker]
-command=D:/fqpack/freshquant-2026.2.23/.venv/Scripts/python.exe -m freshquant.market_data.xtdata.adj_refresh_worker
-directory=D:/fqpack/freshquant-2026.2.23
+command=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/.venv/Scripts/python.exe -m freshquant.market_data.xtdata.adj_refresh_worker
+directory=D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production
 stdout_logfile=D:/fqdata/log/fqnext_xtdata_adj_refresh_worker.log
 stderr_logfile=D:/fqdata/log/fqnext_xtdata_adj_refresh_worker_err.log
 autostart=true

--- a/docs/current/configuration.md
+++ b/docs/current/configuration.md
@@ -281,6 +281,8 @@ vendored `QUANTAXIS` 当前 Mongo 解析规则：
 
 若本地要复现同一模式，优先保证 `PYTHONPATH` 指向仓库源码、`morningglory/fqxtrade` 与 `sunflower/QUANTAXIS`。
 
+正式 `fqnext-supervisord` 则不再直接指向主工作树；当前正式模板会把 `directory`、`.venv\Scripts\python.exe` 与 `PYTHONPATH` 全部收敛到 `D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production`，并由 `script/fqnext_supervisor_config.py` 写入 `D:/fqpack/config/supervisord.fqnext.conf`。
+
 ## 当前宿主机模板
 
 - `deployment/examples/envs.fqnext.example`
@@ -291,6 +293,8 @@ vendored `QUANTAXIS` 当前 Mongo 解析规则：
 
 - service：`fqnext-supervisord`
 - 配置：`D:/fqpack/config/supervisord.fqnext.conf`
+- 正式 repo root：`D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production`
+- 正式解释器：`D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production\.venv\Scripts\python.exe`
 - RPC：`http://127.0.0.1:10011/RPC2`
 - 初始化入口：`D:/fqpack/initialize.bat`
 - 管理员桥接任务：`fqnext-supervisord-restart`

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -37,6 +37,7 @@ docker compose -f docker/compose.parallel.yaml up -d --build
 - `script/ci/run_production_deploy.ps1` 会先校验 `github.sha == latest origin/main`，再负责 mirror bootstrap / fast-forward、runner Python 3.12 / `uv` 自愈、mirror `.venv` 同步和 formal deploy 调用。
 - `script/ci/sync_local_deploy_mirror.py` 在 fast-forward 前会先执行 `git clean -ffdX` 清掉 mirror 内的 ignored 产物，避免历史 `build/`、`*.egg-info/`、生成的 `fqchan*.cpp` 一类文件混入后续 Docker 构建。
 - `script/ci/run_formal_deploy.py` 会读取 `production-state.json` 中的上一次成功部署 SHA，计算 `last_success_sha -> current main HEAD` 的 changed paths，再调用 `script/freshquant_deploy_plan.py` 得到本轮 deploy plan。
+- `script/ci/run_formal_deploy.py` 命中宿主机 deployment surface 时，会把当前 deploy mirror repo root 追加给 `script/fqnext_host_runtime_ctl.ps1`，由后者用 `script/fqnext_supervisor_config.py` 收敛 `D:\fqpack\config\supervisord.fqnext.conf`。
 - `script/ci/run_production_deploy.ps1` 会显式把 canonical repo root 与本机 deploy mirror 加入 git `safe.directory`，避免 runner 在多 worktree 场景下拒绝执行 git。
 - 正式 deploy 要求 production runner 至少存在一个可用的 Python 3.12；若 `py -3.12` 因旧注册失效，入口脚本会回退到已注册的 per-user / system Python 3.12，并回补 `HKCU\Software\Python\PythonCore\3.12\InstallPath`。
 - 若 runner Python 3.12 缺少 `uv` 模块，入口脚本会先执行 `python -m pip install uv --break-system-packages` 再继续部署。
@@ -88,6 +89,8 @@ powershell -ExecutionPolicy Bypass -File script/ci/run_production_deploy.ps1 -Ca
 - workflow 与人工正式 deploy 都应优先调用 `script/ci/run_production_deploy.ps1`；不要再把 mirror sync、`uv sync`、`run_formal_deploy.py` 手工拆开执行。
 - `docker/compose.parallel.yaml` 变更现在按完整 Docker 并行环境运行时变更处理；`freshquant_deploy_plan.py` 必须把它解析成实际 deploy，而不是 `deployment_required=false` 的 no-op。
 - `script/ci/run_production_deploy.ps1` 会先用 runner Python 3.12 做 `uv sync`，再切换到 deploy mirror `.venv\Scripts\python.exe` 运行 `run_formal_deploy.py`；formal deploy 内部 health check 也跟随 mirror `.venv` 解释器。
+- formal deploy 命中宿主机面时，当前 supervisor 正式解释器、`directory` 与 `PYTHONPATH` 都必须落到 `main-deploy-production`；不再允许 `main-runtime` 或主仓 `.venv\Lib\site-packages\fqxtrade` 作为兜底真值。
+- 若 `D:\fqpack\config\supervisord.fqnext.conf` 已更新但 `fqnext-supervisord` 进程仍吃着旧内存配置，`fqnext_host_runtime_ctl.ps1` 会在 surface restart 前先做一次受控 service reload/restart。
 - 如果 formal deploy 命中 `fq_apiserver` / `fq_webui` 后仍出现“像是旧代码”的症状，先检查 deploy mirror 是否残留过往 ignored 构建产物；当前正式入口会在 mirror sync 阶段主动清掉这类文件。
 - 读取 `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/plan.json`、`result.json` 与 `D:/fqpack/runtime/formal-deploy/production-state.json` 作为正式 deploy 基础证据；不要只凭终端退出码判断成功。
 - 如果 `plan.json` / `result.json` 显示 `deployment_required=false`，把这轮判定为 `no-op deploy`：`runtime-verify.json 可以不存在`，但仍要确认 `result.json` 为 `ok=true`，并且 `production-state.json` 里的 `last_success_sha` 已更新到目标 SHA。
@@ -194,9 +197,10 @@ powershell -ExecutionPolicy Bypass -File script/check_freshquant_runtime_post_de
 ```
 
 - `DeploymentSurface` 取值固定为：`api`、`web`、`dagster`、`qa`、`tradingagents`、`market_data`、`guardian`、`position_management`、`tpsl`、`order_management`
-- 输出 JSON 至少包含：`baseline`、`docker_checks`、`service_checks`、`process_checks`、`warnings`、`failures`、`passed`
+- 输出 JSON 至少包含：`baseline`、`docker_checks`、`service_checks`、`process_checks`、`supervisor_config_checks`、`warnings`、`failures`、`passed`
 - 固定检查基础容器：`fq_mongodb`、`fq_redis`
 - 固定记录宿主机服务：`fqnext-supervisord`
+- 命中宿主机 deployment surface 时，`supervisor_config_checks` 还会校验 config repo root 与关键模块 import source 是否仍在 `main-deploy-production`
 
 ### 运维面辅助命令
 

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -116,6 +116,8 @@
 - 正式 deploy 固定导出 `FQ_DOCKER_FORCE_LOCAL_BUILD=1`，确保 mirror 上的 Docker 镜像来自本机构建而不是 GHCR pull。
 - 对已经有 `last_success_sha` 的增量正式 deploy，`run_formal_deploy.py` 现在直接在 mirror 的 `.git` 工作树里计算 `last_success_sha..HEAD` changed paths，不再依赖 compare API 作为正式路径。
 - mirror 同步完成后，正式入口会先用 runner Python 3.12 在 `D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production` 执行 `python -m uv sync --frozen`，再切到 mirror `.venv\Scripts\python.exe` 调用 `run_formal_deploy.py`。
+- formal deploy 命中宿主机 deployment surface 时，会通过 `script/fqnext_supervisor_config.py` 把 `D:\fqpack\config\supervisord.fqnext.conf` 收敛到 `main-deploy-production`，并在配置发生变化或 service 仍吃旧配置时先重载一次 `fqnext-supervisord`。
+- 当前宿主机正式 Supervisor program 解释器与 `PYTHONPATH` 真值都固定落在 `D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production`；若运行面 traceback 指到 `.venv\Lib\site-packages\fqxtrade\...`，应视为 deploy/runtime truth 失配。
 - 该 workflow 中的 PowerShell steps 固定带 `-ExecutionPolicy Bypass`，避免 self-hosted Windows runner 的本机执行策略在 step 启动前拦截临时脚本
 - 该 workflow 也会显式设置 `$ErrorActionPreference = 'Stop'`，确保 PowerShell cmdlet 的 non-terminating error 仍然按 fail-fast 方式中断正式 deploy
 - `script/docker_parallel_compose.ps1` 会优先读取 `FQ_DOCKER_BUILD_CACHE_ROOT`；未显式设置时，Docker BuildKit 本地缓存默认落到仓库 `.artifacts/docker-build-cache`
@@ -143,4 +145,5 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
 
 - Docker 里的 Mongo/Redis 与宿主机 broker/xtdata 之间必须通过宿主机端口对齐，否则交易链会出现“页面正常、worker 无数据”。
 - 如果宿主机仍靠 `frequant-next.bat` 手工拉起，而不是 `fqnext-supervisord` service 开机自启，就会失去稳定的正式入口与权限边界。
+- 如果 `D:\fqpack\config\supervisord.fqnext.conf` 仍指向 `main-runtime`、空目录或 `.venv\Lib\site-packages\fqxtrade`，formal deploy/runtime verify 现在应直接判为异常，而不是继续假设线上跑的是最新代码。
 - 如果宿主机进程仍报 `127.0.0.1:27017`，优先检查进程环境是否缺少 `FRESHQUANT_MONGODB__HOST/PORT`。

--- a/docs/plans/2026-04-02-host-supervisor-deploy-mirror-design.md
+++ b/docs/plans/2026-04-02-host-supervisor-deploy-mirror-design.md
@@ -1,0 +1,80 @@
+# Host Supervisor Deploy Mirror Design
+
+## 背景
+
+- 2026-04-02 的融资买入链路故障已确认不是 `order_submit` 或 Guardian 信号逻辑错误，而是宿主机 `fqnext-supervisord` 实际运行的 `fqxtrade` 代码来源错误。
+- formal deploy 真值已经切到 `D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production`，但线上 `D:\fqpack\config\supervisord.fqnext.conf` 仍指向已经废弃的 `main-runtime`。
+- 由于宿主机配置脱离 formal deploy，`python -m fqxtrade.xtquant.broker` 在错误 `PYTHONPATH` 下回退到了 `.venv\Lib\site-packages\fqxtrade` 的旧实现，导致 `finance_buy` 仍按 `insufficient_cash` 失败。
+
+## 目标
+
+- 宿主机 Supervisor 运行真值强制收敛到 `main-deploy-production`。
+- formal deploy 命中宿主机面时，必须先确保 supervisor 配置文件与 deploy mirror 一致，再执行 surface restart。
+- runtime verify 必须能显式识别“配置还指向旧目录”或“import 实际落到 site-packages 旧包”的异常，不再允许静默通过。
+
+## 非目标
+
+- 不重写 supervisor 进程模型，不替换 `fqnext-supervisord` / NSSM / 管理员桥接任务。
+- 不在本轮改变 Docker 并行环境或 API deploy 机制。
+- 不在本轮改写 `fqxtrade` 交易逻辑本身；本轮修复聚焦宿主机 deploy/runtime 收敛。
+
+## 根因
+
+1. formal deploy 只同步了 deploy mirror 与 mirror `.venv`，但没有把 `D:\fqpack\config\supervisord.fqnext.conf` 纳入正式 deploy contract。
+2. `fqnext-supervisord` 启动后使用的是内存中的旧配置；即使后续有人手工改过磁盘文件，未重启 service 时也不会生效。
+3. deploy 后 runtime verify 只检查 service/process 是否 Running，没有核验 supervisor 配置真值或关键模块的 import source。
+
+## 方案
+
+### 1. 新增 supervisor 配置真值脚本
+
+新增 `script/fqnext_supervisor_config.py`，职责固定为：
+
+- 以给定 `repo_root` 渲染宿主机正式 `supervisord.fqnext.conf`
+- 输出固定指向 `main-deploy-production` 的：
+  - `directory`
+  - `.venv\Scripts\python.exe`
+  - `PATH`
+  - `PYTHONPATH`
+- 解析现有配置并检查：
+  - program directory / command / environment 是否与期望一致
+  - `repo_root` 是否存在且为 git worktree
+  - `freshquant`、`fqxtrade.xtquant.broker`、`fqxtrade.xtquant.puppet`、`QUANTAXIS` 的 import source 是否落在 deploy mirror，而不是 `.venv\Lib\site-packages`
+
+### 2. formal deploy 命中宿主机面时自动收敛并必要时重载 supervisor
+
+- `run_formal_deploy.py` 在执行 host deploy command 前，为宿主机控制脚本追加 `-SupervisorConfigRepoRoot <repo_root>`。
+- `fqnext_host_runtime_ctl.ps1` 在收到该参数后：
+  - 先调用 `fqnext_supervisor_config.py write`
+  - 判断配置文件是否发生变更
+  - 判断配置文件 mtime 是否晚于 `fqnext-supervisord` 当前进程启动时间
+  - 如需重载，使用现有管理员桥接任务重启 `fqnext-supervisord`
+  - 等待 service 与 XML-RPC 恢复，再继续 `restart-surfaces`
+
+这样即使磁盘配置早已手工修正，只要 service 仍吃着旧内存配置，也会被这轮 formal deploy 主动纠正。
+
+### 3. runtime post-deploy verify 增加 supervisor truth 校验
+
+`check_freshquant_runtime_post_deploy.ps1` 增加 supervisor config snapshot/check：
+
+- CaptureBaseline 时记录当前 supervisor config 检查结果
+- Verify 时对命中宿主机面的部署强制检查：
+  - 配置 repo root 等于 `main-deploy-production`
+  - config / import source 不得落到 `main-runtime` 或 `.venv\Lib\site-packages\fqxtrade`
+  - 关键模块 import source 必须在 deploy mirror 下
+
+这使“程序 Running 但跑的是旧代码”变成显式失败。
+
+## 风险与缓解
+
+- 首次迁移到 `main-deploy-production` 时，host surface deploy 会额外触发一次 `fqnext-supervisord` service restart。
+  - 缓解：只在配置内容变化或 config mtime 晚于 service start time 时触发，不对每次 deploy 无条件重启。
+- 配置模板从“主仓 `.venv`”切到“deploy mirror `.venv`”后，正式运行依赖必须来自 mirror `uv sync`。
+  - 缓解：formal deploy 已先在 mirror 执行 `uv sync --frozen`，再进入 host deploy。
+
+## 验收标准
+
+- formal deploy 命中 `order_management` / 其他宿主机面时，`D:\fqpack\config\supervisord.fqnext.conf` 会被自动写成 `main-deploy-production` 版本。
+- 若 supervisor service 仍吃着旧配置，formal deploy 会先重载 service，再做 surface restart。
+- `check_freshquant_runtime_post_deploy.ps1 -Mode Verify` 能对错误 repo root / `site-packages` import source 给出 failure。
+- 相关测试覆盖渲染、配置校验、runtime verify failure/pass 场景。

--- a/docs/plans/2026-04-02-host-supervisor-deploy-mirror.md
+++ b/docs/plans/2026-04-02-host-supervisor-deploy-mirror.md
@@ -1,0 +1,152 @@
+# Host Supervisor Deploy Mirror Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 让 formal deploy 命中宿主机面时自动把 `fqnext-supervisord` 配置收敛到 `main-deploy-production`，并在 runtime verify 中阻断错误 import source。
+
+**Architecture:** 新增一个 supervisor 配置真值脚本负责渲染/检查 `supervisord.fqnext.conf`；formal deploy 在 host restart 前调用该能力并按需重载 service；runtime post-deploy verify 同步增加配置与 import source 校验。
+
+**Tech Stack:** Python 3.12, PowerShell 5.1, pytest, supervisor XML-RPC, Windows service bridge
+
+---
+
+### Task 1: 写 supervisor 配置真值测试
+
+**Files:**
+- Create: `freshquant/tests/test_fqnext_supervisor_config.py`
+- Reference: `deployment/examples/supervisord.fqnext.example.conf`
+- Reference: `script/fqnext_host_runtime.py`
+
+**Step 1: Write the failing test**
+
+- 覆盖渲染后的 config 必须固定指向 `main-deploy-production`
+- 覆盖 inspect/validate 必须能识别 `main-runtime` 和 `site-packages` 漂移
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest freshquant/tests/test_fqnext_supervisor_config.py -q`
+
+Expected: FAIL，因为脚本文件与相关函数尚不存在。
+
+**Step 3: Write minimal implementation**
+
+- 新建 `script/fqnext_supervisor_config.py`
+- 实现 render / write / inspect 所需最小函数与 CLI
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest freshquant/tests/test_fqnext_supervisor_config.py -q`
+
+Expected: PASS
+
+### Task 2: 写 runtime verify 对 supervisor config 的失败用例
+
+**Files:**
+- Modify: `freshquant/tests/test_runtime_post_deploy_check.py`
+- Modify: `script/check_freshquant_runtime_post_deploy.ps1`
+
+**Step 1: Write the failing test**
+
+- 新增“命中 host surface 且 supervisor config 指向 `main-runtime` / `site-packages` 时 Verify 失败”的测试
+- 新增“config 正确时 Verify 通过”的测试
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest freshquant/tests/test_runtime_post_deploy_check.py -q`
+
+Expected: FAIL，因为当前脚本还没有 supervisor config checks。
+
+**Step 3: Write minimal implementation**
+
+- `check_freshquant_runtime_post_deploy.ps1` 增加 config snapshot/check
+- 支持测试快照输入，避免依赖真实宿主机 service
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest freshquant/tests/test_runtime_post_deploy_check.py -q`
+
+Expected: PASS
+
+### Task 3: 写 formal deploy host reconcile 的失败用例
+
+**Files:**
+- Modify: `freshquant/tests/test_host_runtime_management.py`
+- Modify: `freshquant/tests/test_fqnext_host_runtime.py`
+- Modify: `script/fqnext_host_runtime_ctl.ps1`
+- Modify: `script/ci/run_formal_deploy.py`
+
+**Step 1: Write the failing test**
+
+- 断言 host runtime 控制脚本暴露 `SupervisorConfigRepoRoot` 能力
+- 断言 formal deploy 在执行 host command 时会传入当前 `repo_root`
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest freshquant/tests/test_host_runtime_management.py freshquant/tests/test_fqnext_host_runtime.py -q`
+
+Expected: FAIL，因为现在还没有 config reconcile 参数与流程。
+
+**Step 3: Write minimal implementation**
+
+- `fqnext_host_runtime_ctl.ps1` 增加 config 写入、mtime/service-start 检查、必要时管理员桥接重启
+- `run_formal_deploy.py` 在 host command 上追加 `-SupervisorConfigRepoRoot`
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest freshquant/tests/test_host_runtime_management.py freshquant/tests/test_fqnext_host_runtime.py -q`
+
+Expected: PASS
+
+### Task 4: 同步模板与当前文档
+
+**Files:**
+- Modify: `deployment/examples/supervisord.fqnext.example.conf`
+- Modify: `README.md`
+- Modify: `docs/current/configuration.md`
+- Modify: `docs/current/deployment.md`
+- Modify: `docs/current/runtime.md`
+- Modify: `freshquant/tests/test_host_runtime_pythonpath.py`
+
+**Step 1: Write the failing test**
+
+- 更新或新增断言，要求模板与文档明确说明宿主机正式运行真值为 `main-deploy-production`
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest freshquant/tests/test_host_runtime_pythonpath.py freshquant/tests/test_deploy_build_cache_policy.py -q`
+
+Expected: FAIL，因为模板与文档仍保留旧口径。
+
+**Step 3: Write minimal implementation**
+
+- 更新 example config、README 与 `docs/current/**`
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest freshquant/tests/test_host_runtime_pythonpath.py freshquant/tests/test_deploy_build_cache_policy.py -q`
+
+Expected: PASS
+
+### Task 5: 完整验证
+
+**Files:**
+- Verify only
+
+**Step 1: Run targeted tests**
+
+Run: `python -m pytest freshquant/tests/test_fqnext_supervisor_config.py freshquant/tests/test_runtime_post_deploy_check.py freshquant/tests/test_host_runtime_management.py freshquant/tests/test_fqnext_host_runtime.py freshquant/tests/test_host_runtime_pythonpath.py freshquant/tests/test_deploy_build_cache_policy.py -q`
+
+Expected: PASS
+
+**Step 2: Run broader guard where relevant**
+
+Run: `python -m pytest freshquant/tests/test_runtime_memory_docs.py -q`
+
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/2026-04-02-host-supervisor-deploy-mirror-design.md docs/plans/2026-04-02-host-supervisor-deploy-mirror.md script/fqnext_supervisor_config.py script/fqnext_host_runtime_ctl.ps1 script/check_freshquant_runtime_post_deploy.ps1 script/ci/run_formal_deploy.py deployment/examples/supervisord.fqnext.example.conf README.md docs/current/configuration.md docs/current/deployment.md docs/current/runtime.md freshquant/tests/test_fqnext_supervisor_config.py freshquant/tests/test_runtime_post_deploy_check.py freshquant/tests/test_host_runtime_management.py freshquant/tests/test_fqnext_host_runtime.py freshquant/tests/test_host_runtime_pythonpath.py
+git commit -m "fix: align host supervisor runtime with deploy mirror"
+```

--- a/freshquant/tests/test_formal_deploy_orchestrator.py
+++ b/freshquant/tests/test_formal_deploy_orchestrator.py
@@ -407,7 +407,7 @@ def test_orchestrator_runs_docker_and_host_surfaces_in_order(
         "--build",
         "fq_apiserver",
     ]
-    assert commands[2] == [
+    assert commands[2][:10] == [
         "powershell",
         "-ExecutionPolicy",
         "Bypass",
@@ -418,6 +418,10 @@ def test_orchestrator_runs_docker_and_host_surfaces_in_order(
         "-DeploymentSurface",
         "market_data",
         "-BridgeIfServiceUnavailable",
+    ]
+    assert commands[2][-2:] == [
+        "-SupervisorConfigRepoRoot",
+        str(Path(".").resolve()),
     ]
     assert commands[3] == [
         sys.executable,

--- a/freshquant/tests/test_fqnext_supervisor_config.py
+++ b/freshquant/tests/test_fqnext_supervisor_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 
@@ -146,3 +147,22 @@ def test_inspect_supervisor_config_accepts_deploy_mirror_sources(
 
     assert result["ok"] is True
     assert result["failures"] == []
+
+
+def test_write_supervisor_config_preserves_mtime_when_content_unchanged(
+    tmp_path: Path,
+) -> None:
+    module = load_module()
+    config_path = tmp_path / "supervisord.fqnext.conf"
+    config_path.write_text(
+        module.build_supervisor_config(EXPECTED_REPO_ROOT),
+        encoding="utf-8",
+    )
+    original_timestamp = 1_700_000_000
+    os.utime(config_path, (original_timestamp, original_timestamp))
+    original_mtime_ns = config_path.stat().st_mtime_ns
+
+    result = module.write_supervisor_config(EXPECTED_REPO_ROOT, config_path)
+
+    assert result["changed"] is False
+    assert config_path.stat().st_mtime_ns == original_mtime_ns

--- a/freshquant/tests/test_fqnext_supervisor_config.py
+++ b/freshquant/tests/test_fqnext_supervisor_config.py
@@ -4,7 +4,6 @@ import importlib.util
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "script" / "fqnext_supervisor_config.py"
 EXPECTED_REPO_ROOT = Path(
@@ -13,7 +12,9 @@ EXPECTED_REPO_ROOT = Path(
 
 
 def load_module():
-    spec = importlib.util.spec_from_file_location("fqnext_supervisor_config", SCRIPT_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "fqnext_supervisor_config", SCRIPT_PATH
+    )
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -27,7 +28,7 @@ def test_build_supervisor_config_targets_main_deploy_production() -> None:
 
     config_text = module.build_supervisor_config(EXPECTED_REPO_ROOT)
 
-    expected_root = EXPECTED_REPO_ROOT.as_posix()
+    expected_root = str(EXPECTED_REPO_ROOT).replace("\\", "/")
     assert f"directory={expected_root}" in config_text
     assert (
         "environment=PATH="
@@ -114,7 +115,7 @@ def test_inspect_supervisor_config_accepts_deploy_mirror_sources(
         encoding="utf-8",
     )
 
-    expected_root = EXPECTED_REPO_ROOT.as_posix()
+    expected_root = str(EXPECTED_REPO_ROOT).replace("\\", "/")
     monkeypatch.setattr(
         module,
         "collect_import_sources",

--- a/freshquant/tests/test_fqnext_supervisor_config.py
+++ b/freshquant/tests/test_fqnext_supervisor_config.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "script" / "fqnext_supervisor_config.py"
+EXPECTED_REPO_ROOT = Path(
+    r"D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("fqnext_supervisor_config", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_supervisor_config_targets_main_deploy_production() -> None:
+    module = load_module()
+
+    config_text = module.build_supervisor_config(EXPECTED_REPO_ROOT)
+
+    expected_root = EXPECTED_REPO_ROOT.as_posix()
+    assert f"directory={expected_root}" in config_text
+    assert (
+        "environment=PATH="
+        f"{expected_root}/.venv;"
+        f"{expected_root}/.venv/Scripts;"
+        "C:/Windows/System32,"
+        "PYTHONPATH="
+        f"{expected_root};"
+        f"{expected_root}/morningglory/fqxtrade;"
+        f"{expected_root}/sunflower/QUANTAXIS"
+    ) in config_text
+    assert (
+        f"command={expected_root}/.venv/Scripts/python.exe -m fqxtrade.xtquant.broker"
+        in config_text
+    )
+
+
+def test_inspect_supervisor_config_rejects_main_runtime_and_site_packages(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = load_module()
+    config_path = tmp_path / "supervisord.fqnext.conf"
+    config_path.write_text(
+        module.build_supervisor_config(
+            Path(r"D:\fqpack\freshquant-2026.2.23\.worktrees\main-runtime")
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        module,
+        "collect_import_sources",
+        lambda *_args, **_kwargs: {
+            "freshquant": {
+                "path": (
+                    "D:/fqpack/freshquant-2026.2.23/.venv/Lib/site-packages/"
+                    "freshquant/__init__.py"
+                ),
+                "error": None,
+            },
+            "fqxtrade.xtquant.broker": {
+                "path": (
+                    "D:/fqpack/freshquant-2026.2.23/.venv/Lib/site-packages/"
+                    "fqxtrade/xtquant/broker.py"
+                ),
+                "error": None,
+            },
+            "fqxtrade.xtquant.puppet": {
+                "path": (
+                    "D:/fqpack/freshquant-2026.2.23/.venv/Lib/site-packages/"
+                    "fqxtrade/xtquant/puppet.py"
+                ),
+                "error": None,
+            },
+            "QUANTAXIS": {
+                "path": (
+                    "D:/fqpack/freshquant-2026.2.23/.venv/Lib/site-packages/"
+                    "QUANTAXIS/__init__.py"
+                ),
+                "error": None,
+            },
+        },
+    )
+
+    result = module.inspect_supervisor_config(
+        config_path=config_path,
+        expected_repo_root=EXPECTED_REPO_ROOT,
+    )
+
+    assert result["ok"] is False
+    assert any("main-runtime" in failure for failure in result["failures"])
+    assert any("site-packages" in failure for failure in result["failures"])
+
+
+def test_inspect_supervisor_config_accepts_deploy_mirror_sources(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = load_module()
+    config_path = tmp_path / "supervisord.fqnext.conf"
+    config_path.write_text(
+        module.build_supervisor_config(EXPECTED_REPO_ROOT),
+        encoding="utf-8",
+    )
+
+    expected_root = EXPECTED_REPO_ROOT.as_posix()
+    monkeypatch.setattr(
+        module,
+        "collect_import_sources",
+        lambda *_args, **_kwargs: {
+            "freshquant": {
+                "path": f"{expected_root}/freshquant/__init__.py",
+                "error": None,
+            },
+            "fqxtrade.xtquant.broker": {
+                "path": f"{expected_root}/morningglory/fqxtrade/fqxtrade/xtquant/broker.py",
+                "error": None,
+            },
+            "fqxtrade.xtquant.puppet": {
+                "path": f"{expected_root}/morningglory/fqxtrade/fqxtrade/xtquant/puppet.py",
+                "error": None,
+            },
+            "QUANTAXIS": {
+                "path": f"{expected_root}/sunflower/QUANTAXIS/QUANTAXIS/__init__.py",
+                "error": None,
+            },
+        },
+    )
+
+    result = module.inspect_supervisor_config(
+        config_path=config_path,
+        expected_repo_root=EXPECTED_REPO_ROOT,
+    )
+
+    assert result["ok"] is True
+    assert result["failures"] == []

--- a/freshquant/tests/test_host_runtime_management.py
+++ b/freshquant/tests/test_host_runtime_management.py
@@ -23,6 +23,14 @@ def test_host_runtime_ctl_waits_for_settled_surfaces_after_service_recovery() ->
     assert "WasRecovered" in text
 
 
+def test_host_runtime_ctl_can_reconcile_supervisor_config_to_repo_root() -> None:
+    text = Path("script/fqnext_host_runtime_ctl.ps1").read_text(encoding="utf-8")
+
+    assert "SupervisorConfigRepoRoot" in text
+    assert "fqnext_supervisor_config.py" in text
+    assert "Invoke-AdminBridgeRecovery" in text
+
+
 def test_install_fqnext_supervisord_service_uses_delayed_auto_start() -> None:
     text = Path("script/install_fqnext_supervisord_service.ps1").read_text(
         encoding="utf-8"

--- a/freshquant/tests/test_host_runtime_pythonpath.py
+++ b/freshquant/tests/test_host_runtime_pythonpath.py
@@ -1,17 +1,21 @@
 from pathlib import Path
 
 
-def test_supervisord_example_adds_vendored_quantaxis_to_pythonpath() -> None:
+def test_supervisord_example_targets_deploy_mirror_pythonpath() -> None:
     config = Path("deployment/examples/supervisord.fqnext.example.conf").read_text(
         encoding="utf-8"
     )
 
     assert (
         "PYTHONPATH="
-        "D:/fqpack/freshquant-2026.2.23;"
-        "D:/fqpack/freshquant-2026.2.23/morningglory/fqxtrade;"
-        "D:/fqpack/freshquant-2026.2.23/sunflower/QUANTAXIS"
+        "D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production;"
+        "D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/morningglory/fqxtrade;"
+        "D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/sunflower/QUANTAXIS"
     ) in config
+    assert (
+        "D:/fqpack/freshquant-2026.2.23/.worktrees/main-deploy-production/.venv/Scripts/python.exe"
+        in config
+    )
 
 
 def test_configuration_docs_call_out_vendored_quantaxis_pythonpath() -> None:
@@ -21,3 +25,10 @@ def test_configuration_docs_call_out_vendored_quantaxis_pythonpath() -> None:
         "若本地要复现同一模式，优先保证 `PYTHONPATH` 指向仓库源码、"
         "`morningglory/fqxtrade` 与 `sunflower/QUANTAXIS`"
     ) in configuration
+
+
+def test_readme_calls_out_supervisor_uses_deploy_mirror_venv() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    assert "main-deploy-production" in readme
+    assert r".worktrees\main-deploy-production\.venv\Scripts\python.exe" in readme

--- a/freshquant/tests/test_runtime_post_deploy_check.py
+++ b/freshquant/tests/test_runtime_post_deploy_check.py
@@ -670,3 +670,225 @@ def test_verify_prefers_supervisor_snapshot_for_host_managed_programs(
         check["id"] == "xt_account_sync_worker" and check["passed"] is True
         for check in payload["process_checks"]
     )
+
+
+def test_verify_fails_when_supervisor_config_still_points_to_main_runtime(
+    tmp_path: Path,
+) -> None:
+    baseline_path = _write_json(
+        tmp_path / "baseline.json",
+        {
+            "baseline": {
+                "docker": [],
+                "services": [{"name": "fqnext-supervisord", "status": "Running"}],
+                "processes": [
+                    {"id": "xtquant_broker", "running": False},
+                    {"id": "xt_account_sync_worker", "running": False},
+                ],
+            }
+        },
+    )
+    docker_path = _write_json(
+        tmp_path / "docker.json",
+        [
+            {
+                "Name": "fq_mongodb",
+                "State": {"Status": "running", "Health": {"Status": "healthy"}},
+            },
+            {
+                "Name": "fq_redis",
+                "State": {"Status": "running", "Health": {"Status": "healthy"}},
+            },
+        ],
+    )
+    service_path = _write_json(
+        tmp_path / "services.json",
+        [{"Name": "fqnext-supervisord", "Status": "Running"}],
+    )
+    process_path = _write_json(
+        tmp_path / "processes.json",
+        [
+            {
+                "ProcessId": 801,
+                "Name": "python.exe",
+                "CommandLine": "python -m fqxtrade.xtquant.broker",
+            },
+            {
+                "ProcessId": 802,
+                "Name": "python.exe",
+                "CommandLine": "python -m freshquant.xt_account_sync.worker",
+            },
+        ],
+    )
+    supervisor_path = _write_json(
+        tmp_path / "supervisor.json",
+        [
+            {
+                "name": "fqnext_xtquant_broker",
+                "statename": "RUNNING",
+                "pid": 1801,
+                "description": "pid 1801, uptime 0:01:00",
+            },
+            {
+                "name": "fqnext_xt_account_sync_worker",
+                "statename": "RUNNING",
+                "pid": 1802,
+                "description": "pid 1802, uptime 0:01:00",
+            },
+        ],
+    )
+    supervisor_config_path = _write_json(
+        tmp_path / "supervisor-config.json",
+        {
+            "ok": False,
+            "configured_repo_root": (
+                r"D:\fqpack\freshquant-2026.2.23\.worktrees\main-runtime"
+            ),
+            "expected_repo_root": (
+                r"D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production"
+            ),
+            "failures": [
+                "supervisor config repo_root drifted to main-runtime",
+                "import source drifted to .venv/Lib/site-packages/fqxtrade/xtquant/broker.py",
+            ],
+            "warnings": [],
+        },
+    )
+    output_path = tmp_path / "verify.json"
+
+    result = _run_powershell(
+        SCRIPT,
+        "-Mode",
+        "Verify",
+        "-BaselinePath",
+        str(baseline_path),
+        "-OutputPath",
+        str(output_path),
+        "-DeploymentSurface",
+        "order_management",
+        "-DockerSnapshotPath",
+        str(docker_path),
+        "-ServiceSnapshotPath",
+        str(service_path),
+        "-ProcessSnapshotPath",
+        str(process_path),
+        "-SupervisorSnapshotPath",
+        str(supervisor_path),
+        "-SupervisorConfigSnapshotPath",
+        str(supervisor_config_path),
+    )
+
+    assert result.returncode != 0
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["passed"] is False
+    assert any("main-runtime" in failure for failure in payload["failures"])
+    assert any("site-packages" in failure for failure in payload["failures"])
+
+
+def test_verify_passes_when_supervisor_config_matches_deploy_mirror(
+    tmp_path: Path,
+) -> None:
+    baseline_path = _write_json(
+        tmp_path / "baseline.json",
+        {
+            "baseline": {
+                "docker": [],
+                "services": [{"name": "fqnext-supervisord", "status": "Running"}],
+                "processes": [
+                    {"id": "xtquant_broker", "running": False},
+                    {"id": "xt_account_sync_worker", "running": False},
+                ],
+            }
+        },
+    )
+    docker_path = _write_json(
+        tmp_path / "docker.json",
+        [
+            {
+                "Name": "fq_mongodb",
+                "State": {"Status": "running", "Health": {"Status": "healthy"}},
+            },
+            {
+                "Name": "fq_redis",
+                "State": {"Status": "running", "Health": {"Status": "healthy"}},
+            },
+        ],
+    )
+    service_path = _write_json(
+        tmp_path / "services.json",
+        [{"Name": "fqnext-supervisord", "Status": "Running"}],
+    )
+    process_path = _write_json(
+        tmp_path / "processes.json",
+        [
+            {
+                "ProcessId": 901,
+                "Name": "python.exe",
+                "CommandLine": "python -m fqxtrade.xtquant.broker",
+            },
+            {
+                "ProcessId": 902,
+                "Name": "python.exe",
+                "CommandLine": "python -m freshquant.xt_account_sync.worker",
+            },
+        ],
+    )
+    supervisor_path = _write_json(
+        tmp_path / "supervisor.json",
+        [
+            {
+                "name": "fqnext_xtquant_broker",
+                "statename": "RUNNING",
+                "pid": 1901,
+                "description": "pid 1901, uptime 0:01:00",
+            },
+            {
+                "name": "fqnext_xt_account_sync_worker",
+                "statename": "RUNNING",
+                "pid": 1902,
+                "description": "pid 1902, uptime 0:01:00",
+            },
+        ],
+    )
+    supervisor_config_path = _write_json(
+        tmp_path / "supervisor-config.json",
+        {
+            "ok": True,
+            "configured_repo_root": (
+                r"D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production"
+            ),
+            "expected_repo_root": (
+                r"D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production"
+            ),
+            "failures": [],
+            "warnings": [],
+        },
+    )
+    output_path = tmp_path / "verify.json"
+
+    result = _run_powershell(
+        SCRIPT,
+        "-Mode",
+        "Verify",
+        "-BaselinePath",
+        str(baseline_path),
+        "-OutputPath",
+        str(output_path),
+        "-DeploymentSurface",
+        "order_management",
+        "-DockerSnapshotPath",
+        str(docker_path),
+        "-ServiceSnapshotPath",
+        str(service_path),
+        "-ProcessSnapshotPath",
+        str(process_path),
+        "-SupervisorSnapshotPath",
+        str(supervisor_path),
+        "-SupervisorConfigSnapshotPath",
+        str(supervisor_config_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["passed"] is True
+    assert payload["failures"] == []

--- a/freshquant/tests/test_runtime_post_deploy_check.py
+++ b/freshquant/tests/test_runtime_post_deploy_check.py
@@ -50,6 +50,23 @@ def _write_json(path: Path, payload: object) -> Path:
     return path
 
 
+def _write_valid_supervisor_config_snapshot(path: Path) -> Path:
+    return _write_json(
+        path,
+        {
+            "ok": True,
+            "configured_repo_root": (
+                r"D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production"
+            ),
+            "expected_repo_root": (
+                r"D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production"
+            ),
+            "failures": [],
+            "warnings": [],
+        },
+    )
+
+
 def test_capture_baseline_records_runtime_state_from_snapshots(tmp_path: Path) -> None:
     docker_path = _write_json(
         tmp_path / "docker.json",
@@ -223,6 +240,9 @@ def test_verify_requires_targeted_surfaces_and_preserves_baseline_processes(
         [],
     )
     output_path = tmp_path / "verify.json"
+    supervisor_config_path = _write_valid_supervisor_config_snapshot(
+        tmp_path / "supervisor-config.json"
+    )
 
     result = _run_powershell(
         SCRIPT,
@@ -240,6 +260,8 @@ def test_verify_requires_targeted_surfaces_and_preserves_baseline_processes(
         str(service_path),
         "-ProcessSnapshotPath",
         str(process_path),
+        "-SupervisorConfigSnapshotPath",
+        str(supervisor_config_path),
     )
 
     assert result.returncode != 0
@@ -345,6 +367,9 @@ def test_verify_passes_when_required_runtime_state_is_restored(tmp_path: Path) -
         ],
     )
     output_path = tmp_path / "verify.json"
+    supervisor_config_path = _write_valid_supervisor_config_snapshot(
+        tmp_path / "supervisor-config.json"
+    )
 
     result = _run_powershell(
         SCRIPT,
@@ -362,6 +387,8 @@ def test_verify_passes_when_required_runtime_state_is_restored(tmp_path: Path) -
         str(service_path),
         "-ProcessSnapshotPath",
         str(process_path),
+        "-SupervisorConfigSnapshotPath",
+        str(supervisor_config_path),
     )
 
     assert result.returncode == 0, result.stderr
@@ -478,6 +505,9 @@ def test_verify_matches_xt_account_sync_worker_without_explicit_interval_flag(
         ],
     )
     output_path = tmp_path / "verify.json"
+    supervisor_config_path = _write_valid_supervisor_config_snapshot(
+        tmp_path / "supervisor-config.json"
+    )
 
     result = _run_powershell(
         SCRIPT,
@@ -495,6 +525,8 @@ def test_verify_matches_xt_account_sync_worker_without_explicit_interval_flag(
         str(service_path),
         "-ProcessSnapshotPath",
         str(process_path),
+        "-SupervisorConfigSnapshotPath",
+        str(supervisor_config_path),
     )
 
     assert result.returncode == 0, result.stderr
@@ -555,6 +587,9 @@ def test_verify_requires_fqnext_supervisord_for_host_managed_surfaces(
         ],
     )
     output_path = tmp_path / "verify.json"
+    supervisor_config_path = _write_valid_supervisor_config_snapshot(
+        tmp_path / "supervisor-config.json"
+    )
 
     result = _run_powershell(
         SCRIPT,
@@ -572,6 +607,8 @@ def test_verify_requires_fqnext_supervisord_for_host_managed_surfaces(
         str(service_path),
         "-ProcessSnapshotPath",
         str(process_path),
+        "-SupervisorConfigSnapshotPath",
+        str(supervisor_config_path),
     )
 
     assert result.returncode != 0
@@ -638,6 +675,9 @@ def test_verify_prefers_supervisor_snapshot_for_host_managed_programs(
         ],
     )
     output_path = tmp_path / "verify.json"
+    supervisor_config_path = _write_valid_supervisor_config_snapshot(
+        tmp_path / "supervisor-config.json"
+    )
 
     result = _run_powershell(
         SCRIPT,
@@ -657,6 +697,8 @@ def test_verify_prefers_supervisor_snapshot_for_host_managed_programs(
         str(process_path),
         "-SupervisorSnapshotPath",
         str(supervisor_path),
+        "-SupervisorConfigSnapshotPath",
+        str(supervisor_config_path),
     )
 
     assert result.returncode == 0, result.stderr
@@ -892,3 +934,96 @@ def test_verify_passes_when_supervisor_config_matches_deploy_mirror(
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert payload["passed"] is True
     assert payload["failures"] == []
+
+
+def test_verify_fails_when_supervisor_config_inspection_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    baseline_path = _write_json(
+        tmp_path / "baseline.json",
+        {
+            "baseline": {
+                "docker": [],
+                "services": [{"name": "fqnext-supervisord", "status": "Running"}],
+                "processes": [
+                    {"id": "xtquant_broker", "running": False},
+                    {"id": "xt_account_sync_worker", "running": False},
+                ],
+            }
+        },
+    )
+    docker_path = _write_json(
+        tmp_path / "docker.json",
+        [
+            {
+                "Name": "fq_mongodb",
+                "State": {"Status": "running", "Health": {"Status": "healthy"}},
+            },
+            {
+                "Name": "fq_redis",
+                "State": {"Status": "running", "Health": {"Status": "healthy"}},
+            },
+        ],
+    )
+    service_path = _write_json(
+        tmp_path / "services.json",
+        [{"Name": "fqnext-supervisord", "Status": "Running"}],
+    )
+    process_path = _write_json(
+        tmp_path / "processes.json",
+        [
+            {
+                "ProcessId": 1001,
+                "Name": "python.exe",
+                "CommandLine": "python -m fqxtrade.xtquant.broker",
+            },
+            {
+                "ProcessId": 1002,
+                "Name": "python.exe",
+                "CommandLine": "python -m freshquant.xt_account_sync.worker",
+            },
+        ],
+    )
+    supervisor_path = _write_json(
+        tmp_path / "supervisor.json",
+        [
+            {
+                "name": "fqnext_xtquant_broker",
+                "statename": "RUNNING",
+                "pid": 2001,
+                "description": "pid 2001, uptime 0:01:00",
+            },
+            {
+                "name": "fqnext_xt_account_sync_worker",
+                "statename": "RUNNING",
+                "pid": 2002,
+                "description": "pid 2002, uptime 0:01:00",
+            },
+        ],
+    )
+    output_path = tmp_path / "verify.json"
+
+    result = _run_powershell(
+        SCRIPT,
+        "-Mode",
+        "Verify",
+        "-BaselinePath",
+        str(baseline_path),
+        "-OutputPath",
+        str(output_path),
+        "-DeploymentSurface",
+        "order_management",
+        "-DockerSnapshotPath",
+        str(docker_path),
+        "-ServiceSnapshotPath",
+        str(service_path),
+        "-ProcessSnapshotPath",
+        str(process_path),
+        "-SupervisorSnapshotPath",
+        str(supervisor_path),
+    )
+
+    assert result.returncode != 0
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["passed"] is False
+    assert any("supervisor config" in failure for failure in payload["failures"])

--- a/script/check_freshquant_runtime_post_deploy.ps1
+++ b/script/check_freshquant_runtime_post_deploy.ps1
@@ -925,11 +925,14 @@ function Get-SupervisorConfigChecks {
             required = $required
             available = $available
             source = if ($null -ne $SupervisorConfigState) { [string]$SupervisorConfigState.source } else { 'unknown' }
-            passed = (-not $required) -or (-not $available) -or [bool]$payload.ok
+            passed = (-not $required) -or ($available -and [bool]$payload.ok)
             configured_repo_root = Get-StringProperty -Object $payload -PropertyNames @('configured_repo_root', 'configuredRepoRoot')
             expected_repo_root = Get-StringProperty -Object $payload -PropertyNames @('expected_repo_root', 'expectedRepoRoot')
             reasons = @(
-                if ($required -and $available -and -not [bool]$payload.ok) {
+                if ($required -and -not $available) {
+                    @("supervisor config inspection unavailable: source=$([string]$SupervisorConfigState.source)")
+                }
+                elseif ($required -and -not [bool]$payload.ok) {
                     @(Convert-ToObjectArray $payload.failures)
                 }
                 else {
@@ -945,7 +948,10 @@ function Get-SupervisorConfigChecks {
     }
 
     $failures = [System.Collections.Generic.List[string]]::new()
-    if ($required -and $available -and -not [bool]$payload.ok) {
+    if ($required -and -not $available) {
+        $failures.Add("supervisor config check failed: inspection unavailable (source=$([string]$SupervisorConfigState.source))")
+    }
+    elseif ($required -and -not [bool]$payload.ok) {
         foreach ($failure in @(Convert-ToObjectArray $payload.failures)) {
             $failures.Add("supervisor config check failed: $failure")
         }

--- a/script/check_freshquant_runtime_post_deploy.ps1
+++ b/script/check_freshquant_runtime_post_deploy.ps1
@@ -10,6 +10,8 @@ param(
     [string]$ServiceSnapshotPath,
     [string]$ProcessSnapshotPath,
     [string]$SupervisorSnapshotPath,
+    [string]$SupervisorConfigSnapshotPath,
+    [string]$ExpectedSupervisorRepoRoot = 'D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production',
     [string]$SupervisorConfigPath = 'D:\fqpack\config\supervisord.fqnext.conf'
 )
 
@@ -407,6 +409,76 @@ function Get-SupervisorProgramSnapshot {
         available = $true
         source = 'live_query'
         programs = @(Convert-ToObjectArray $payload.programs)
+    }
+}
+
+function Get-SupervisorConfigSnapshot {
+    if (-not [string]::IsNullOrWhiteSpace($SupervisorConfigSnapshotPath)) {
+        $payload = Read-JsonFile -Path $SupervisorConfigSnapshotPath
+        return [pscustomobject]@{
+            available = $true
+            source = 'snapshot'
+            payload = $payload
+        }
+    }
+
+    if (
+        -not [string]::IsNullOrWhiteSpace($ServiceSnapshotPath) -or
+        -not [string]::IsNullOrWhiteSpace($ProcessSnapshotPath) -or
+        -not [string]::IsNullOrWhiteSpace($SupervisorSnapshotPath)
+    ) {
+        return [pscustomobject]@{
+            available = $false
+            source = 'disabled_for_test_snapshots'
+            payload = [pscustomobject]@{
+                ok = $true
+                failures = @()
+                warnings = @()
+            }
+        }
+    }
+
+    $configScript = Join-Path $repoRoot 'script\fqnext_supervisor_config.py'
+    if (-not (Test-Path $configScript)) {
+        return [pscustomobject]@{
+            available = $false
+            source = 'missing_supervisor_config_script'
+            payload = [pscustomobject]@{
+                ok = $true
+                failures = @()
+                warnings = @()
+            }
+        }
+    }
+
+    $command = @(
+        'py',
+        '-3.12',
+        $configScript,
+        'inspect',
+        '--config-path',
+        $SupervisorConfigPath,
+        '--expected-repo-root',
+        $ExpectedSupervisorRepoRoot
+    )
+    $result = & $command[0] $command[1..($command.Count - 1)] 2>$null
+    if ([string]::IsNullOrWhiteSpace(($result | Out-String))) {
+        return [pscustomobject]@{
+            available = $false
+            source = 'live_query_failed'
+            payload = [pscustomobject]@{
+                ok = $false
+                failures = @('supervisor config inspect returned no payload')
+                warnings = @()
+            }
+        }
+    }
+
+    $payload = $result | ConvertFrom-Json
+    return [pscustomobject]@{
+        available = $true
+        source = 'live_query'
+        payload = $payload
     }
 }
 
@@ -814,11 +886,84 @@ function Get-ProcessChecks {
     }
 }
 
+function Get-SupervisorConfigChecks {
+    param(
+        [Parameter(Mandatory = $true)]$SupervisorConfigState,
+        [string[]]$DeploymentSurfaces
+    )
+
+    $hostManagedSurfaces = @(
+        'market_data',
+        'guardian',
+        'position_management',
+        'tpsl',
+        'order_management'
+    )
+    $required = @(
+        $DeploymentSurfaces | Where-Object { $hostManagedSurfaces -contains $_ }
+    ).Count -gt 0
+
+    $payload = if ($null -ne $SupervisorConfigState) {
+        $SupervisorConfigState.payload
+    }
+    else {
+        [pscustomobject]@{
+            ok = $true
+            failures = @()
+            warnings = @()
+        }
+    }
+
+    $available = $false
+    if ($null -ne $SupervisorConfigState -and $null -ne $SupervisorConfigState.PSObject.Properties['available']) {
+        $available = [bool]$SupervisorConfigState.available
+    }
+
+    $checks = @(
+        [pscustomobject]@{
+            name = 'supervisor_config'
+            required = $required
+            available = $available
+            source = if ($null -ne $SupervisorConfigState) { [string]$SupervisorConfigState.source } else { 'unknown' }
+            passed = (-not $required) -or (-not $available) -or [bool]$payload.ok
+            configured_repo_root = Get-StringProperty -Object $payload -PropertyNames @('configured_repo_root', 'configuredRepoRoot')
+            expected_repo_root = Get-StringProperty -Object $payload -PropertyNames @('expected_repo_root', 'expectedRepoRoot')
+            reasons = @(
+                if ($required -and $available -and -not [bool]$payload.ok) {
+                    @(Convert-ToObjectArray $payload.failures)
+                }
+                else {
+                    @()
+                }
+            )
+        }
+    )
+
+    $warnings = [System.Collections.Generic.List[string]]::new()
+    foreach ($warning in @(Convert-ToObjectArray $payload.warnings)) {
+        $warnings.Add([string]$warning)
+    }
+
+    $failures = [System.Collections.Generic.List[string]]::new()
+    if ($required -and $available -and -not [bool]$payload.ok) {
+        foreach ($failure in @(Convert-ToObjectArray $payload.failures)) {
+            $failures.Add("supervisor config check failed: $failure")
+        }
+    }
+
+    return @{
+        Checks = $checks
+        Warnings = @($warnings)
+        Failures = @($failures)
+    }
+}
+
 $deploymentSurfaces = @(Resolve-DeploymentSurfaces -Values $DeploymentSurface)
 $allContainerNames = @(Get-AllKnownContainerNames)
 $dockerSnapshot = @(Get-DockerSnapshot -ContainerNames $allContainerNames)
 $serviceSnapshot = @(Get-ServiceSnapshot)
 $supervisorState = Get-SupervisorProgramSnapshot
+$supervisorConfigState = Get-SupervisorConfigSnapshot
 $processSnapshot = @(Get-ProcessSnapshot)
 $dockerBaseline = @(Normalize-DockerBaseline -Snapshot $dockerSnapshot -ContainerNames $allContainerNames)
 $serviceBaseline = @(Normalize-ServiceBaseline -Snapshot $serviceSnapshot)
@@ -832,10 +977,12 @@ $result = [ordered]@{
         docker = @($dockerBaseline)
         services = @($serviceBaseline)
         processes = @($processBaseline)
+        supervisor_config = $supervisorConfigState.payload
     }
     docker_checks = @()
     service_checks = @()
     process_checks = @()
+    supervisor_config_checks = @()
     warnings = @()
     failures = @()
     passed = $true
@@ -878,12 +1025,14 @@ foreach ($surface in $deploymentSurfaces) {
 $dockerChecks = Get-DockerChecks -CurrentEntries $dockerBaseline -RequiredContainerNames @($requiredContainerNames)
 $serviceChecks = Get-ServiceChecks -CurrentEntries $serviceBaseline -Baseline $baseline -DeploymentSurfaces $deploymentSurfaces
 $processChecks = Get-ProcessChecks -CurrentEntries $processBaseline -Baseline $baseline -DeploymentSurfaces $deploymentSurfaces
+$supervisorConfigChecks = Get-SupervisorConfigChecks -SupervisorConfigState $supervisorConfigState -DeploymentSurfaces $deploymentSurfaces
 
 $result.docker_checks = $dockerChecks.Checks
 $result.service_checks = $serviceChecks.Checks
 $result.process_checks = $processChecks.Checks
-$result.warnings = @($serviceChecks.Warnings + $processChecks.Warnings)
-$result.failures = @($dockerChecks.Failures + $serviceChecks.Failures + $processChecks.Failures)
+$result.supervisor_config_checks = $supervisorConfigChecks.Checks
+$result.warnings = @($serviceChecks.Warnings + $processChecks.Warnings + $supervisorConfigChecks.Warnings)
+$result.failures = @($dockerChecks.Failures + $serviceChecks.Failures + $processChecks.Failures + $supervisorConfigChecks.Failures)
 $result.passed = ($result.failures.Count -eq 0)
 
 $verifyJson = $result | ConvertTo-Json -Depth 12

--- a/script/ci/run_formal_deploy.py
+++ b/script/ci/run_formal_deploy.py
@@ -238,6 +238,14 @@ def build_health_commands(
     return commands
 
 
+def build_host_command(command: list[str], repo_root: Path) -> list[str]:
+    if "script/fqnext_host_runtime_ctl.ps1" not in command:
+        return list(command)
+    if "-SupervisorConfigRepoRoot" in command:
+        return list(command)
+    return [*command, "-SupervisorConfigRepoRoot", str(repo_root)]
+
+
 def build_plan(
     plan_module, bootstrap: bool, changed_paths: list[str]
 ) -> dict[str, Any]:
@@ -325,9 +333,13 @@ def run_formal_deploy(
                 )
 
             if plan["host_command"]:
-                commands.append(list(plan["host_command"]))
-                execute_command(
+                host_command = build_host_command(
                     list(plan["host_command"]),
+                    repo_root,
+                )
+                commands.append(host_command)
+                execute_command(
+                    host_command,
                     repo_root=repo_root,
                     output_path=run_dir / "11-host-deploy.log",
                 )

--- a/script/fqnext_host_runtime_ctl.ps1
+++ b/script/fqnext_host_runtime_ctl.ps1
@@ -6,6 +6,7 @@ param(
     [string]$SupervisorServiceName = 'fqnext-supervisord',
     [string]$RestartTaskName = 'fqnext-supervisord-restart',
     [string]$ConfigPath = 'D:\fqpack\config\supervisord.fqnext.conf',
+    [string]$SupervisorConfigRepoRoot,
     [double]$TimeoutSeconds = 45,
     [switch]$BridgeIfServiceUnavailable
 )
@@ -14,6 +15,7 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 $pythonScript = Join-Path $repoRoot 'script\fqnext_host_runtime.py'
+$supervisorConfigScript = Join-Path $repoRoot 'script\fqnext_supervisor_config.py'
 $invokeBridgeScript = Join-Path $repoRoot 'script\invoke_fqnext_supervisord_restart_task.ps1'
 
 function Normalize-DeploymentSurfaces {
@@ -42,6 +44,22 @@ function Get-SupervisorService {
     param([string]$ServiceName)
 
     return Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+}
+
+function Get-SupervisorServiceProcessStartTimeUtc {
+    param([string]$ServiceName)
+
+    $serviceInstance = Get-CimInstance Win32_Service -Filter "Name='$ServiceName'" -ErrorAction SilentlyContinue
+    if ($null -eq $serviceInstance -or [int]$serviceInstance.ProcessId -le 0) {
+        return $null
+    }
+
+    $process = Get-Process -Id ([int]$serviceInstance.ProcessId) -ErrorAction SilentlyContinue
+    if ($null -eq $process) {
+        return $null
+    }
+
+    return $process.StartTime.ToUniversalTime()
 }
 
 function Wait-ServiceRunning {
@@ -148,6 +166,84 @@ function Invoke-AdminBridgeRecovery {
     return Wait-ServiceRunning -ServiceName $ServiceName -TimeoutSeconds $TimeoutSeconds
 }
 
+function Reload-SupervisorServiceForConfig {
+    param(
+        [string]$ServiceName,
+        [string]$TaskName,
+        [double]$TimeoutSeconds,
+        [switch]$AllowBridge
+    )
+
+    $service = Get-SupervisorService -ServiceName $ServiceName
+    if ($null -eq $service -or $service.Status -ne 'Running') {
+        return $false
+    }
+
+    if (Test-IsElevatedSession) {
+        Restart-Service -Name $ServiceName -Force
+        Wait-ServiceRunning -ServiceName $ServiceName -TimeoutSeconds $TimeoutSeconds | Out-Null
+        return $true
+    }
+
+    if ($AllowBridge) {
+        Invoke-AdminBridgeRecovery -ServiceName $ServiceName -TaskName $TaskName -TimeoutSeconds $TimeoutSeconds | Out-Null
+        return $true
+    }
+
+    throw "Supervisor config changed but service '$ServiceName' could not be reloaded without elevation or admin bridge."
+}
+
+function Sync-SupervisorConfig {
+    param(
+        [string]$TargetRepoRoot,
+        [string]$ResolvedConfigPath,
+        [string]$ServiceName,
+        [string]$TaskName,
+        [double]$TimeoutSeconds,
+        [switch]$AllowBridge
+    )
+
+    if ([string]::IsNullOrWhiteSpace($TargetRepoRoot)) {
+        return [pscustomobject]@{
+            Changed = $false
+            WasRecovered = $false
+            ServiceReloadRequired = $false
+            ConfigPath = $ResolvedConfigPath
+        }
+    }
+
+    if (-not (Test-Path $supervisorConfigScript)) {
+        throw "Supervisor config sync script not found: $supervisorConfigScript"
+    }
+
+    $raw = & py -3.12 $supervisorConfigScript write --repo-root $TargetRepoRoot --output-path $ResolvedConfigPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "fqnext supervisor config write failed for repo root '$TargetRepoRoot'."
+    }
+
+    $payload = $raw | ConvertFrom-Json
+    $serviceReloadRequired = $false
+    if (Test-Path $ResolvedConfigPath) {
+        $serviceStartTimeUtc = Get-SupervisorServiceProcessStartTimeUtc -ServiceName $ServiceName
+        if ($null -ne $serviceStartTimeUtc) {
+            $configWriteTimeUtc = (Get-Item -LiteralPath $ResolvedConfigPath).LastWriteTimeUtc
+            $serviceReloadRequired = $configWriteTimeUtc -gt $serviceStartTimeUtc
+        }
+    }
+
+    $wasRecovered = $false
+    if ($serviceReloadRequired) {
+        $wasRecovered = Reload-SupervisorServiceForConfig -ServiceName $ServiceName -TaskName $TaskName -TimeoutSeconds $TimeoutSeconds -AllowBridge:$AllowBridge
+    }
+
+    return [pscustomobject]@{
+        Changed = [bool]$payload.changed
+        WasRecovered = [bool]$wasRecovered
+        ServiceReloadRequired = [bool]$serviceReloadRequired
+        ConfigPath = $ResolvedConfigPath
+    }
+}
+
 switch ($Mode) {
     'Status' {
         $service = Get-SupervisorService -ServiceName $SupervisorServiceName
@@ -166,12 +262,14 @@ switch ($Mode) {
         exit 0
     }
     'EnsureSupervisorService' {
+        $configSync = Sync-SupervisorConfig -TargetRepoRoot $SupervisorConfigRepoRoot -ResolvedConfigPath $ConfigPath -ServiceName $SupervisorServiceName -TaskName $RestartTaskName -TimeoutSeconds $TimeoutSeconds -AllowBridge:$BridgeIfServiceUnavailable
         $result = Ensure-SupervisorServiceRunning -ServiceName $SupervisorServiceName -TaskName $RestartTaskName -TimeoutSeconds $TimeoutSeconds -AllowBridge:$BridgeIfServiceUnavailable
         $service = $result.Service
         [ordered]@{
             service_name = $service.Name
             service_status = [string]$service.Status
-            was_recovered = [bool]$result.WasRecovered
+            was_recovered = ([bool]$result.WasRecovered -or [bool]$configSync.WasRecovered)
+            config_changed = [bool]$configSync.Changed
         } | ConvertTo-Json -Depth 4
         exit 0
     }
@@ -180,8 +278,10 @@ switch ($Mode) {
         exit 0
     }
     'EnsureServiceAndRestartSurfaces' {
+        $configSync = Sync-SupervisorConfig -TargetRepoRoot $SupervisorConfigRepoRoot -ResolvedConfigPath $ConfigPath -ServiceName $SupervisorServiceName -TaskName $RestartTaskName -TimeoutSeconds $TimeoutSeconds -AllowBridge:$BridgeIfServiceUnavailable
         $result = Ensure-SupervisorServiceRunning -ServiceName $SupervisorServiceName -TaskName $RestartTaskName -TimeoutSeconds $TimeoutSeconds -AllowBridge:$BridgeIfServiceUnavailable
-        if ($result.WasRecovered) {
+        $serviceRecovered = ([bool]$result.WasRecovered -or [bool]$configSync.WasRecovered)
+        if ($serviceRecovered) {
             Invoke-HostRuntimePython -Command 'wait-settled' -Surfaces $DeploymentSurface -ResolvedConfigPath $ConfigPath -TimeoutSeconds $TimeoutSeconds
         }
         $bridgeRetried = $false

--- a/script/fqnext_supervisor_config.py
+++ b/script/fqnext_supervisor_config.py
@@ -30,6 +30,11 @@ PROGRAM_NAMES = (
 )
 
 
+class CaseConfigParser(configparser.ConfigParser):
+    def optionxform(self, optionstr: str) -> str:
+        return optionstr
+
+
 def _to_posix(path: Path | str) -> str:
     return str(path).replace("\\", "/")
 
@@ -154,8 +159,7 @@ serverurl=http://127.0.0.1:10011
 
 
 def parse_config(config_path: Path) -> configparser.ConfigParser:
-    parser = configparser.ConfigParser()
-    parser.optionxform = str
+    parser = CaseConfigParser()
     parser.read_string(config_path.read_text(encoding="utf-8-sig"))
     return parser
 
@@ -211,10 +215,7 @@ def collect_import_sources(config_path: Path) -> dict[str, dict[str, str | None]
         error = (completed.stderr or completed.stdout).strip() or (
             f"subprocess exited with {completed.returncode}"
         )
-        return {
-            name: {"path": None, "error": error}
-            for name in MODULE_NAMES
-        }
+        return {name: {"path": None, "error": error} for name in MODULE_NAMES}
     return json.loads(completed.stdout)
 
 
@@ -269,9 +270,7 @@ def inspect_supervisor_config(
         program_directories[program_name] = directory
         program_python_executables[program_name] = python_executable
         if _normalize_path(directory) != _normalize_path(expected_root):
-            failures.append(
-                f"program directory drifted: {program_name} -> {directory}"
-            )
+            failures.append(f"program directory drifted: {program_name} -> {directory}")
         if _normalize_path(python_executable) != _normalize_path(expected_python):
             failures.append(
                 f"program python drifted: {program_name} -> {python_executable}"
@@ -283,7 +282,9 @@ def inspect_supervisor_config(
         module_path = payload.get("path")
         module_error = payload.get("error")
         if module_error:
-            failures.append(f"import source check failed: {module_name}; {module_error}")
+            failures.append(
+                f"import source check failed: {module_name}; {module_error}"
+            )
             continue
         if not module_path:
             failures.append(f"import source missing: {module_name}")
@@ -332,7 +333,9 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     render_parser = subparsers.add_parser("render")
-    render_parser.add_argument("--repo-root", type=Path, default=DEFAULT_EXPECTED_REPO_ROOT)
+    render_parser.add_argument(
+        "--repo-root", type=Path, default=DEFAULT_EXPECTED_REPO_ROOT
+    )
 
     write_parser = subparsers.add_parser("write")
     write_parser.add_argument("--repo-root", type=Path, required=True)

--- a/script/fqnext_supervisor_config.py
+++ b/script/fqnext_supervisor_config.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import argparse
+import configparser
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+DEFAULT_CONFIG_PATH = Path(r"D:\fqpack\config\supervisord.fqnext.conf")
+DEFAULT_EXPECTED_REPO_ROOT = Path(
+    r"D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production"
+)
+MODULE_NAMES = (
+    "freshquant",
+    "fqxtrade.xtquant.broker",
+    "fqxtrade.xtquant.puppet",
+    "QUANTAXIS",
+)
+PROGRAM_NAMES = (
+    "fqnext_realtime_xtdata_producer",
+    "fqnext_realtime_xtdata_consumer",
+    "fqnext_guardian_event",
+    "fqnext_xt_account_sync_worker",
+    "fqnext_tpsl_worker",
+    "fqnext_xtquant_broker",
+    "fqnext_xtdata_adj_refresh_worker",
+)
+
+
+def _to_posix(path: Path | str) -> str:
+    return str(path).replace("\\", "/")
+
+
+def _normalize_path(path: str | Path | None) -> str:
+    if path is None:
+        return ""
+    return _to_posix(path).rstrip("/").casefold()
+
+
+def _is_within(path: str | None, root: Path) -> bool:
+    normalized_path = _normalize_path(path)
+    normalized_root = _normalize_path(root)
+    return normalized_path == normalized_root or normalized_path.startswith(
+        normalized_root + "/"
+    )
+
+
+def build_supervisor_config(repo_root: Path) -> str:
+    root = _to_posix(repo_root)
+    python_executable = f"{root}/.venv/Scripts/python.exe"
+    path_value = f"{root}/.venv;{root}/.venv/Scripts;C:/Windows/System32"
+    python_path_value = (
+        f"{root};{root}/morningglory/fqxtrade;{root}/sunflower/QUANTAXIS"
+    )
+    return f"""[supervisord]
+; FreshQuant 当前宿主机 Python 口径：formal deploy mirror .venv
+; 如仓库路径不同，请同步调整下面的 PATH、PYTHONPATH 和 command
+logfile=D:/fqdata/log/supervisord_fqnext.log
+logfile_maxbytes=50MB
+logfile_backups=10
+loglevel=error
+pidfile=D:/fqdata/supervisord_fqnext.pid
+identifier=fqnext
+
+[program-default]
+directory={root}
+stdout_logfile_maxbytes=50MB
+stdout_logfile_backups=10
+stderr_logfile_maxbytes=50MB
+stderr_logfile_backups=10
+autorestart=true
+startretries=10
+envFiles=D:/fqpack/config/envs.conf
+environment=PATH={path_value},PYTHONPATH={python_path_value}
+
+[inet_http_server]
+port=127.0.0.1:10011
+
+[program:fqnext_realtime_xtdata_producer]
+command={python_executable} -m freshquant.market_data.xtdata.market_producer
+directory={root}
+stdout_logfile=D:/fqdata/log/fqnext_realtime_xtdata_producer.log
+stderr_logfile=D:/fqdata/log/fqnext_realtime_xtdata_producer_err.log
+autostart=true
+autorestart=true
+startsecs=5
+
+[program:fqnext_realtime_xtdata_consumer]
+command={python_executable} -m freshquant.market_data.xtdata.strategy_consumer --prewarm --max-bars 20000
+directory={root}
+stdout_logfile=D:/fqdata/log/fqnext_realtime_xtdata_consumer.log
+stderr_logfile=D:/fqdata/log/fqnext_realtime_xtdata_consumer_err.log
+autostart=true
+autorestart=true
+startsecs=5
+
+[program:fqnext_guardian_event]
+command={python_executable} -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event
+directory={root}
+stdout_logfile=D:/fqdata/log/fqnext_guardian_event.log
+stderr_logfile=D:/fqdata/log/fqnext_guardian_event_err.log
+autostart=true
+autorestart=true
+startsecs=5
+
+[program:fqnext_xt_account_sync_worker]
+command={python_executable} -m freshquant.xt_account_sync.worker --interval 15
+directory={root}
+stdout_logfile=D:/fqdata/log/fqnext_xt_account_sync_worker.log
+stderr_logfile=D:/fqdata/log/fqnext_xt_account_sync_worker_err.log
+autostart=true
+autorestart=true
+startsecs=5
+
+[program:fqnext_tpsl_worker]
+command={python_executable} -m freshquant.tpsl.tick_listener
+directory={root}
+stdout_logfile=D:/fqdata/log/fqnext_tpsl_worker.log
+stderr_logfile=D:/fqdata/log/fqnext_tpsl_worker_err.log
+autostart=true
+autorestart=true
+startsecs=5
+
+[program:fqnext_xtquant_broker]
+command={python_executable} -m fqxtrade.xtquant.broker
+directory={root}
+stdout_logfile=D:/fqdata/log/fqnext_xtquant_broker.log
+stderr_logfile=D:/fqdata/log/fqnext_xtquant_broker_err.log
+autostart=true
+autorestart=true
+startsecs=5
+
+[program:fqnext_xtdata_adj_refresh_worker]
+command={python_executable} -m freshquant.market_data.xtdata.adj_refresh_worker
+directory={root}
+stdout_logfile=D:/fqdata/log/fqnext_xtdata_adj_refresh_worker.log
+stderr_logfile=D:/fqdata/log/fqnext_xtdata_adj_refresh_worker_err.log
+autostart=true
+autorestart=true
+startsecs=5
+
+[group:fqnext_reference_data]
+programs=fqnext_xtdata_adj_refresh_worker
+
+[group:fqnext_trading_chain]
+programs=fqnext_realtime_xtdata_producer,fqnext_realtime_xtdata_consumer,fqnext_guardian_event,fqnext_xt_account_sync_worker,fqnext_tpsl_worker,fqnext_xtquant_broker
+
+[supervisorctl]
+serverurl=http://127.0.0.1:10011
+"""
+
+
+def parse_config(config_path: Path) -> configparser.ConfigParser:
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    parser.read_string(config_path.read_text(encoding="utf-8-sig"))
+    return parser
+
+
+def parse_environment(environment_value: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for item in environment_value.split(","):
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def collect_import_sources(config_path: Path) -> dict[str, dict[str, str | None]]:
+    parser = parse_config(config_path)
+    repo_root = Path(parser["program-default"]["directory"])
+    python_executable = (
+        parser["program:fqnext_xtquant_broker"]["command"].split(" -m ", 1)[0].strip()
+    )
+    environment = parse_environment(
+        parser["program-default"].get("environment", fallback="")
+    )
+    child_env = os.environ.copy()
+    child_env.update(environment)
+    child_env["PYTHONNOUSERSITE"] = "1"
+    payload = json.dumps(list(MODULE_NAMES), ensure_ascii=False)
+    command = [
+        python_executable,
+        "-c",
+        (
+            "import importlib, json; "
+            f"modules = json.loads({payload!r}); "
+            "result = {}; "
+            "for name in modules:\n"
+            "    try:\n"
+            "        module = importlib.import_module(name)\n"
+            "        result[name] = {'path': getattr(module, '__file__', None), 'error': None}\n"
+            "    except Exception as exc:\n"
+            "        result[name] = {'path': None, 'error': str(exc)}\n"
+            "print(json.dumps(result, ensure_ascii=False))"
+        ),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=child_env,
+    )
+    if completed.returncode != 0:
+        error = (completed.stderr or completed.stdout).strip() or (
+            f"subprocess exited with {completed.returncode}"
+        )
+        return {
+            name: {"path": None, "error": error}
+            for name in MODULE_NAMES
+        }
+    return json.loads(completed.stdout)
+
+
+def inspect_supervisor_config(
+    config_path: Path,
+    expected_repo_root: Path = DEFAULT_EXPECTED_REPO_ROOT,
+    import_inspector: Callable[[Path], dict[str, dict[str, str | None]]] | None = None,
+) -> dict[str, Any]:
+    parser = parse_config(config_path)
+    expected_root = expected_repo_root
+    expected_root_posix = _to_posix(expected_root)
+    expected_python = f"{expected_root_posix}/.venv/Scripts/python.exe"
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    configured_repo_root = parser["program-default"].get("directory", "").strip()
+    if _normalize_path(configured_repo_root) != _normalize_path(expected_root):
+        failures.append(
+            "supervisor config repo_root drifted: "
+            f"expected={expected_root_posix} actual={configured_repo_root}"
+        )
+
+    environment = parse_environment(
+        parser["program-default"].get("environment", fallback="")
+    )
+    path_value = environment.get("PATH", "")
+    python_path_value = environment.get("PYTHONPATH", "")
+    if not path_value.startswith(
+        f"{expected_root_posix}/.venv;{expected_root_posix}/.venv/Scripts;"
+    ):
+        failures.append(
+            f"supervisor config PATH drifted from deploy mirror: {path_value}"
+        )
+    expected_python_path_value = (
+        f"{expected_root_posix};"
+        f"{expected_root_posix}/morningglory/fqxtrade;"
+        f"{expected_root_posix}/sunflower/QUANTAXIS"
+    )
+    if python_path_value != expected_python_path_value:
+        failures.append(
+            "supervisor config PYTHONPATH drifted from deploy mirror: "
+            f"{python_path_value}"
+        )
+
+    program_directories: dict[str, str] = {}
+    program_python_executables: dict[str, str] = {}
+    for program_name in PROGRAM_NAMES:
+        section_name = f"program:{program_name}"
+        directory = parser[section_name].get("directory", "").strip()
+        command = parser[section_name].get("command", "").strip()
+        python_executable = command.split(" -m ", 1)[0].strip() if command else ""
+        program_directories[program_name] = directory
+        program_python_executables[program_name] = python_executable
+        if _normalize_path(directory) != _normalize_path(expected_root):
+            failures.append(
+                f"program directory drifted: {program_name} -> {directory}"
+            )
+        if _normalize_path(python_executable) != _normalize_path(expected_python):
+            failures.append(
+                f"program python drifted: {program_name} -> {python_executable}"
+            )
+
+    inspector = import_inspector or collect_import_sources
+    import_sources = inspector(config_path)
+    for module_name, payload in import_sources.items():
+        module_path = payload.get("path")
+        module_error = payload.get("error")
+        if module_error:
+            failures.append(f"import source check failed: {module_name}; {module_error}")
+            continue
+        if not module_path:
+            failures.append(f"import source missing: {module_name}")
+            continue
+        if not _is_within(module_path, expected_root):
+            failures.append(
+                f"import source drifted outside deploy mirror: {module_name} -> {module_path}"
+            )
+        if "site-packages" in _normalize_path(module_path):
+            failures.append(
+                f"import source drifted to site-packages: {module_name} -> {module_path}"
+            )
+
+    return {
+        "ok": not failures,
+        "config_path": str(config_path),
+        "expected_repo_root": expected_root_posix,
+        "configured_repo_root": configured_repo_root,
+        "expected_python_executable": expected_python,
+        "configured_python_executables": program_python_executables,
+        "program_directories": program_directories,
+        "warnings": warnings,
+        "failures": failures,
+        "import_sources": import_sources,
+    }
+
+
+def write_supervisor_config(repo_root: Path, output_path: Path) -> dict[str, Any]:
+    content = build_supervisor_config(repo_root)
+    previous = output_path.read_text(encoding="utf-8") if output_path.exists() else None
+    changed = previous != content
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+    return {
+        "ok": True,
+        "changed": changed,
+        "output_path": str(output_path),
+        "repo_root": _to_posix(repo_root),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render and validate FreshQuant host supervisor config."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    render_parser = subparsers.add_parser("render")
+    render_parser.add_argument("--repo-root", type=Path, default=DEFAULT_EXPECTED_REPO_ROOT)
+
+    write_parser = subparsers.add_parser("write")
+    write_parser.add_argument("--repo-root", type=Path, required=True)
+    write_parser.add_argument("--output-path", type=Path, default=DEFAULT_CONFIG_PATH)
+
+    inspect_parser = subparsers.add_parser("inspect")
+    inspect_parser.add_argument("--config-path", type=Path, default=DEFAULT_CONFIG_PATH)
+    inspect_parser.add_argument(
+        "--expected-repo-root",
+        type=Path,
+        default=DEFAULT_EXPECTED_REPO_ROOT,
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "render":
+        print(build_supervisor_config(args.repo_root), end="")
+        return 0
+    if args.command == "write":
+        payload = write_supervisor_config(args.repo_root, args.output_path)
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+    if args.command == "inspect":
+        payload = inspect_supervisor_config(args.config_path, args.expected_repo_root)
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0 if payload["ok"] else 1
+    raise RuntimeError(f"unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/fqnext_supervisor_config.py
+++ b/script/fqnext_supervisor_config.py
@@ -317,7 +317,8 @@ def write_supervisor_config(repo_root: Path, output_path: Path) -> dict[str, Any
     previous = output_path.read_text(encoding="utf-8") if output_path.exists() else None
     changed = previous != content
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(content, encoding="utf-8")
+    if changed:
+        output_path.write_text(content, encoding="utf-8")
     return {
         "ok": True,
         "changed": changed,


### PR DESCRIPTION
## 背景\n- closes #385\n- 2026-04-02 线上排障确认，formal deploy 已包含融资买入修复，但宿主机 qnext-supervisord 仍从废弃的 main-runtime / .venv\\Lib\\site-packages\\fqxtrade 跑旧代码\n- 这次修复把 supervisor 配置真值、formal deploy host restart、runtime verify 三处收敛到 main-deploy-production\n\n## 变更\n- 新增 script/fqnext_supervisor_config.py，统一渲染/检查 D:\\fqpack\\config\\supervisord.fqnext.conf，并核验关键模块 import source\n- formal deploy 命中宿主机面时，会把当前 deploy mirror repo root 传给 qnext_host_runtime_ctl.ps1，由后者按需写配置并在必要时重载 qnext-supervisord\n- check_freshquant_runtime_post_deploy.ps1 新增 supervisor_config_checks，能显式拦截 main-runtime / site-packages 漂移\n- 同步更新 example config、README、docs/current/** 与设计/实施计划文档\n\n## 验证\n- python -m pytest freshquant/tests/test_fqnext_supervisor_config.py freshquant/tests/test_runtime_post_deploy_check.py freshquant/tests/test_host_runtime_management.py freshquant/tests/test_formal_deploy_orchestrator.py freshquant/tests/test_host_runtime_pythonpath.py freshquant/tests/test_deploy_build_cache_policy.py freshquant/tests/test_runtime_memory_docs.py -q\n- python -m pytest freshquant/tests/test_check_current_docs.py -q\n- powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure\n\n## 部署影响\n- 首次把生产 supervisor 配置从旧 main-runtime 迁移到 main-deploy-production 时，命中宿主机面的 formal deploy 会额外触发一次受控 qnext-supervisord reload/restart\n- 之后只要 config 真值不再变化，不会在每次 deploy 中无条件重启整个宿主机 runtime\n