### PR TITLE
fix: reload host supervisor when service start time is unavailable

### DIFF
--- a/freshquant/tests/test_host_runtime_management.py
+++ b/freshquant/tests/test_host_runtime_management.py
@@ -31,6 +31,18 @@ def test_host_runtime_ctl_can_reconcile_supervisor_config_to_repo_root() -> None
     assert "Invoke-AdminBridgeRecovery" in text
 
 
+def test_host_runtime_ctl_handles_missing_service_start_time_when_syncing_config() -> (
+    None
+):
+    text = Path("script/fqnext_host_runtime_ctl.ps1").read_text(encoding="utf-8")
+
+    assert "$startTime = $process.StartTime" in text
+    assert "if ($null -eq $startTime) {" in text
+    assert "$serviceReloadRequired = [bool]$payload.changed" in text
+    assert "if ($null -eq $serviceStartTimeUtc) {" in text
+    assert "$serviceReloadRequired = $true" in text
+
+
 def test_install_fqnext_supervisord_service_uses_delayed_auto_start() -> None:
     text = Path("script/install_fqnext_supervisord_service.ps1").read_text(
         encoding="utf-8"

--- a/script/fqnext_host_runtime_ctl.ps1
+++ b/script/fqnext_host_runtime_ctl.ps1
@@ -59,7 +59,12 @@ function Get-SupervisorServiceProcessStartTimeUtc {
         return $null
     }
 
-    return $process.StartTime.ToUniversalTime()
+    $startTime = $process.StartTime
+    if ($null -eq $startTime) {
+        return $null
+    }
+
+    return $startTime.ToUniversalTime()
 }
 
 function Wait-ServiceRunning {
@@ -222,10 +227,15 @@ function Sync-SupervisorConfig {
     }
 
     $payload = $raw | ConvertFrom-Json
-    $serviceReloadRequired = $false
-    if (Test-Path $ResolvedConfigPath) {
+    $serviceReloadRequired = [bool]$payload.changed
+    if (-not $serviceReloadRequired -and (Test-Path $ResolvedConfigPath)) {
         $serviceStartTimeUtc = Get-SupervisorServiceProcessStartTimeUtc -ServiceName $ServiceName
-        if ($null -ne $serviceStartTimeUtc) {
+        if ($null -eq $serviceStartTimeUtc) {
+            # Some Windows service processes report a null StartTime; reload
+            # conservatively so the in-memory supervisor config still converges.
+            $serviceReloadRequired = $true
+        }
+        else {
             $configWriteTimeUtc = (Get-Item -LiteralPath $ResolvedConfigPath).LastWriteTimeUtc
             $serviceReloadRequired = $configWriteTimeUtc -gt $serviceStartTimeUtc
         }


### PR DESCRIPTION
## 背景
- `#387` 合并后，formal deploy 已经不再是 no-op，并且能够把 `D:\fqpack\config\supervisord.fqnext.conf` 写到 `main-deploy-production`。
- 但正式 deploy 继续执行宿主机 reconcile 时，`script/fqnext_host_runtime_ctl.ps1` 在 `Get-SupervisorServiceProcessStartTimeUtc()` 里对空 `StartTime` 直接调用 `.ToUniversalTime()`，导致 host-runtime phase 直接中断。
- 现场进一步确认，这台机器的 `fqnext-supervisord` service process 在 PowerShell 中确实会返回 `StartTime = $null`。如果只做“避免崩溃”，仍然会在“配置文件已经改好，但 service 内存配置还没 reload”的半失败状态下跳过 reload，继续把部分 program 按旧内存配置拉起。

## 本次修改
- `fqnext_host_runtime_ctl.ps1`
  - 对空的 service process `StartTime` 做显式保护，不再直接崩溃。
  - 当 `StartTime` 不可用时，改为保守地强制 reload `fqnext-supervisord`，确保 in-memory supervisor config 与已经写入磁盘的 `supervisord.fqnext.conf` 收敛一致。
- 补充 `test_host_runtime_ctl_handles_missing_service_start_time_when_syncing_config` 回归测试，锁定这条兜底逻辑。

## 验证
- `py -3.12 -m pre_commit run --files script/fqnext_host_runtime_ctl.ps1 freshquant/tests/test_host_runtime_management.py`
- `py -3.12 -m pytest freshquant/tests/test_host_runtime_management.py freshquant/tests/test_formal_deploy_orchestrator.py freshquant/tests/test_host_runtime_pythonpath.py -q`
- `powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure -BaseRef origin/main`
- 现场证据：`Get-Process -Id <fqnext-supervisord pid>` 返回的 `StartTime` 在当前机器上是 `$null`；此前 formal deploy 因此在 host-runtime phase 直接失败。

## 部署影响
- merge 到远程 `main` 后，需要重新执行正式 deploy。
- 目标是让 formal deploy 在宿主机 reconcile 阶段既不会因空 `StartTime` 崩溃，也不会因为拿不到 `StartTime` 而错误跳过 supervisor reload。