### PR TITLE
fix: harden order ledger rebuild reconciliation

### DIFF
--- a/docs/current/architecture.md
+++ b/docs/current/architecture.md
@@ -111,6 +111,7 @@
 ## 当前规则
 
 - buy fill 默认按 broker order 聚合成一个 entry
+- 对账补开的 `auto_reconciled_open` 若与相邻 open entry 满足同标的、同交易日、5 分钟内且价差不超过 0.3%，也会并入同一个 buy cluster
 - stoploss 绑定对象是 `entry_id`
 - odd-lot 不进入 `position_entries`
 - odd-lot 进入 `om_ingest_rejections`

--- a/docs/plans/2026-04-03-order-ledger-runtime-rebuild-runbook.md
+++ b/docs/plans/2026-04-03-order-ledger-runtime-rebuild-runbook.md
@@ -1,0 +1,429 @@
+# Order Ledger Runtime Rebuild Runbook
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 在最新远程 `main` 已正式部署后，冻结订单写入面，基于最新 broker truth 重建当前系统的订单账本与 compat 投影，并定点验收 `300760`、`600570`、`672137219`。
+
+**Architecture:** 先把代码真值收敛到最新远程 `main`，并通过 formal deploy 让 Docker API 与宿主机 supervisor program 都切到同一正式 SHA。随后暂停 API 与宿主机写入面，主动刷新一次 `xt_orders / xt_trades / xt_positions`，只用这三组 broker truth 执行 destructive rebuild，再重建 `stock_fills_compat`，最后做 symbol / order 级验收；若失败则按备份库整库恢复。
+
+**Tech Stack:** PowerShell, Python 3.12, `uv`, MongoDB, Docker Compose, FreshQuant order ledger V2, `fqnext-supervisord`
+
+---
+
+### Task 1: 收敛代码与部署真值
+
+**Files:**
+- Review: `docs/current/deployment.md`
+- Review: `docs/current/modules/order-management.md`
+- Review: `script/fq_local_preflight.ps1`
+- Review: `script/fq_open_pr.ps1`
+- Review: `script/ci/run_production_deploy.ps1`
+
+**Step 1: 确认 destructive rebuild 治理前置**
+
+- GitHub Issue 必须已经存在，并写清影响面、验收标准、部署影响。
+- 本次 rebuild 的正式输入只能是 `xt_orders / xt_trades / xt_positions`。
+- 不允许把 `om_*`、`stock_fills`、`stock_fills_compat` 当主真值。
+
+**Step 2: 跑本地预检**
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure
+```
+
+Expected:
+- governance / pre-commit / pytest / review threads 全部通过。
+
+**Step 3: 开 PR 并合并到远程 `main`**
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File script/fq_open_pr.ps1 -- --fill
+```
+
+Expected:
+- 修复代码经 CI 全绿后合并到远程 `main`。
+
+**Step 4: 对最新远程 `main` 执行 formal deploy**
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File script/ci/run_production_deploy.ps1 -CanonicalRoot D:\fqpack\freshquant-2026.2.23 -MirrorRoot D:\fqpack\freshquant-2026.2.23\.worktrees\main-deploy-production -MirrorBranch deploy-production-main
+```
+
+Expected:
+- `D:/fqpack/runtime/formal-deploy/runs/<timestamp>-<sha>/result.json` 显示 `ok=true`。
+- 若 `plan.json` 显示 `deployment_required=true`，同目录下 `runtime-verify.json` 必须 `passed=true`。
+- 宿主机 supervisor 配置与 import source 已切到 `main-deploy-production`。
+
+**Step 5: 记录正式 deploy 证据**
+
+- 保留本轮 `run_dir` 下的 `plan.json`、`result.json`。
+- 若命中实际 deploy，同时保留 `runtime-baseline.json`、`runtime-verify.json`。
+
+### Task 2: Freeze 写入面并刷新 broker truth
+
+**Files:**
+- Review: `script/fqnext_host_runtime_ctl.ps1`
+- Review: `script/fqnext_host_runtime.py`
+- Review: `script/docker_parallel_compose.ps1`
+- Review: `freshquant/xt_account_sync/worker.py`
+- Review: `freshquant/xt_account_sync/service.py`
+
+**Step 1: 记录 freeze 前运行面状态**
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode Status
+powershell -ExecutionPolicy Bypass -File script/docker_parallel_compose.ps1 ps fq_apiserver
+powershell -ExecutionPolicy Bypass -File script/check_freshquant_runtime_post_deploy.ps1 -Mode CaptureBaseline -OutputPath D:\fqpack\runtime\artifacts\order-ledger-rebuild\baseline-2026-04-03.json
+```
+
+Expected:
+- `fqnext_xtquant_broker`、`fqnext_xt_account_sync_worker`、`fqnext_tpsl_worker`、`fq_apiserver` 当前都可见且健康。
+
+**Step 2: 停止 API order-write surface**
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File script/docker_parallel_compose.ps1 stop fq_apiserver
+```
+
+Expected:
+- `fq_apiserver` 已停止，不再接受 `/api/order/*` 写请求。
+
+**Step 3: 停止宿主机写入面**
+
+Run:
+
+```powershell
+@'
+import xmlrpc.client
+
+server = xmlrpc.client.ServerProxy("http://127.0.0.1:10011/RPC2")
+for name in [
+    "fqnext_xtquant_broker",
+    "fqnext_xt_account_sync_worker",
+    "fqnext_tpsl_worker",
+]:
+    info = server.supervisor.getProcessInfo(name)
+    state = str(info.get("statename", "")).upper()
+    print(name, "before=", state)
+    if state == "RUNNING":
+        server.supervisor.stopProcess(name, True)
+        print(name, "stopped")
+'@ | py -3.12 -
+```
+
+Expected:
+- 三个宿主机写入程序进入 `STOPPED` 或 `EXITED`。
+
+**Step 4: 主动刷新一次 XT truth**
+
+Run:
+
+```powershell
+py -3.12 -m uv run -m freshquant.xt_account_sync.worker --once
+```
+
+Expected:
+- 单次同步正常退出。
+- 本轮会刷新 `assets / credit_detail / positions / incremental orders / incremental trades`。
+
+**Step 5: 冻结后记录 broker truth 快照**
+
+Run:
+
+```powershell
+@'
+from pprint import pprint
+from freshquant.db import DBfreshquant
+
+for name in ("xt_orders", "xt_trades", "xt_positions"):
+    print(name, DBfreshquant[name].count_documents({}))
+
+for order_id in (672137219, 672137221):
+    print("=" * 80)
+    print("xt_trades order_id", order_id)
+    pprint(
+        list(
+            DBfreshquant["xt_trades"]
+            .find({"order_id": {"$in": [order_id, str(order_id)]}}, {"_id": 0})
+            .sort([("traded_time", 1)])
+        )
+    )
+'@ | py -3.12 -m uv run -
+```
+
+Expected:
+- `xt_orders / xt_trades / xt_positions` 已是本轮 rebuild 的唯一输入真值。
+- `672137219`、`672137221` 对应的 `xt_trades` 已完整可见。
+
+### Task 3: 执行 destructive rebuild 与 compat rebuild
+
+**Files:**
+- Review: `script/maintenance/rebuild_order_ledger_v2.py`
+- Review: `freshquant/order_management/db.py`
+- Review: `freshquant/data/astock/fill.py`
+
+**Step 1: 先跑全量 dry-run**
+
+Run:
+
+```powershell
+py -3.12 -m uv run script/maintenance/rebuild_order_ledger_v2.py --dry-run
+```
+
+Expected:
+- 输出 JSON summary。
+- 重点记录：`broker_orders`、`execution_fills`、`position_entries`、`clustered_entries`、`mergeable_entry_gap`、`non_default_lot_slices`。
+
+**Step 2: 如需单账户演练，追加一次 account dry-run**
+
+Run:
+
+```powershell
+py -3.12 -m uv run script/maintenance/rebuild_order_ledger_v2.py --dry-run --account-id <broker_account_id>
+```
+
+Expected:
+- 单账户 summary 与全量口径一致，不做任何写入。
+
+**Step 3: 执行 destructive rebuild**
+
+Run:
+
+```powershell
+py -3.12 -m uv run script/maintenance/rebuild_order_ledger_v2.py --execute --backup-db freshquant_order_management_backup_20260403_rebuild1
+```
+
+Expected:
+- `backup_performed=true`
+- `purged_collections` 非空
+- 新 `om_*` 集合已由 rebuild 结果重写
+
+**Step 4: 重建 `stock_fills_compat`**
+
+Run:
+
+```powershell
+py -3.12 -m uv run -m freshquant.cli stock.fill rebuild --all
+```
+
+Expected:
+- 返回 JSON，包含 `synced_symbols` 与 `rows_by_symbol`。
+
+**Step 5: 定点比较 compat 投影**
+
+Run:
+
+```powershell
+py -3.12 -m uv run -m freshquant.cli stock.fill compare --code 300760
+py -3.12 -m uv run -m freshquant.cli stock.fill compare --code 600570
+```
+
+Expected:
+- `quantity_consistent=true`
+- `amount_adjusted_consistent=true`
+
+### Task 4: 定点验收 `300760`、`600570`、`672137219`
+
+**Files:**
+- Review: `freshquant/order_management/repository.py`
+- Review: `freshquant/order_management/rebuild/service.py`
+
+**Step 1: 查询 symbol 级 rebuild 结果**
+
+Run:
+
+```powershell
+@'
+from pprint import pprint
+from freshquant.db import DBfreshquant
+from freshquant.order_management.repository import OrderManagementRepository
+
+repo = OrderManagementRepository()
+
+for symbol in ("300760", "600570"):
+    print("=" * 100)
+    print("symbol", symbol)
+    xt_positions = list(
+        DBfreshquant["xt_positions"].find(
+            {"stock_code": {"$regex": f"^{symbol}(\\..*)?$", "$options": "i"}},
+            {"_id": 0},
+        )
+    )
+    broker_orders = repo.list_broker_orders(symbol=symbol)
+    fills = repo.list_execution_fills(symbol=symbol)
+    entries = repo.list_position_entries(symbol=symbol)
+    gaps = repo.list_reconciliation_gaps(symbol=symbol)
+    resolutions = repo.list_reconciliation_resolutions(
+        gap_ids=[item["gap_id"] for item in gaps]
+    )
+    print("xt_positions")
+    pprint(xt_positions)
+    print("broker_orders")
+    pprint(broker_orders)
+    print("execution_fills")
+    pprint(fills)
+    print("position_entries")
+    pprint(entries)
+    print("reconciliation_gaps")
+    pprint(gaps)
+    print("reconciliation_resolutions")
+    pprint(resolutions)
+'@ | py -3.12 -m uv run -
+```
+
+Expected:
+- `300760` 不应再保留“第 1 笔 / 第 2 笔入口本应聚合却未聚合”的错误拆分。
+- `600570` 同样不应再出现同日同窗口买入被错误拆分。
+- rebuild 后若仍存在 gap / resolution，应能解释为 broker truth 差异，而不是 callback 丢失副作用。
+
+**Step 2: 查询 `672137219` 与 `672137221` 的 order/fill 对齐情况**
+
+Run:
+
+```powershell
+@'
+from pprint import pprint
+from freshquant.db import DBfreshquant
+from freshquant.order_management.db import DBOrderManagement
+
+for order_id in ("672137219", "672137221"):
+    print("=" * 100)
+    print("order_id", order_id)
+    print("xt_trades")
+    pprint(
+        list(
+            DBfreshquant["xt_trades"]
+            .find({"order_id": {"$in": [int(order_id), order_id]}}, {"_id": 0})
+            .sort([("traded_time", 1)])
+        )
+    )
+    print("om_broker_orders")
+    pprint(
+        list(
+            DBOrderManagement["om_broker_orders"]
+            .find({"broker_order_id": order_id}, {"_id": 0})
+            .sort([("submitted_at", 1)])
+        )
+    )
+    print("om_execution_fills")
+    pprint(
+        list(
+            DBOrderManagement["om_execution_fills"]
+            .find({"broker_order_id": order_id}, {"_id": 0})
+            .sort([("filled_at", 1)])
+        )
+    )
+'@ | py -3.12 -m uv run -
+```
+
+Expected:
+- `672137219`：`om_execution_fills` 数量应与 `xt_trades` 里该 `order_id` 的记录数一致，不再只剩一笔 fill。
+- `672137221`：若 `xt_*` 横跨多个交易日复用了同一 `order_id`，`om_broker_orders` 应拆成多条 `broker_order_key`，不能再把跨日事实混成一单。
+
+**Step 3: 人工验收结论**
+
+- 若上面两组查询都符合预期，可以判定这次修复属于“历史数据问题已通过 broker-truth rebuild 修复”。
+- 若仍不符合预期，先不要恢复写入面，直接进入 rollback。
+
+### Task 5: 恢复写入面并做运行验证
+
+**Files:**
+- Review: `script/docker_parallel_compose.ps1`
+- Review: `script/fqnext_host_runtime_ctl.ps1`
+- Review: `script/check_freshquant_runtime_post_deploy.ps1`
+
+**Step 1: 恢复 API**
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File script/docker_parallel_compose.ps1 start fq_apiserver
+```
+
+Expected:
+- `fq_apiserver` 恢复运行。
+
+**Step 2: 恢复宿主机写入面**
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface order_management -DeploymentSurface position_management -DeploymentSurface tpsl -BridgeIfServiceUnavailable
+```
+
+Expected:
+- `fqnext_xtquant_broker`、`fqnext_xt_account_sync_worker`、`fqnext_tpsl_worker` 全部恢复 `RUNNING`。
+
+**Step 3: 做接口健康检查与 runtime verify**
+
+Run:
+
+```powershell
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:15000/api/runtime/components
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:15000/api/runtime/health/summary
+powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode Status
+powershell -ExecutionPolicy Bypass -File script/check_freshquant_runtime_post_deploy.ps1 -Mode Verify -BaselinePath D:\fqpack\runtime\artifacts\order-ledger-rebuild\baseline-2026-04-03.json -OutputPath D:\fqpack\runtime\artifacts\order-ledger-rebuild\verify-2026-04-03.json -DeploymentSurface api,order_management,position_management,tpsl
+```
+
+Expected:
+- API 健康接口返回正常。
+- `fqnext_host_runtime_ctl.ps1 -Mode Status` 中目标 program 全部为 `Running`。
+- `verify-2026-04-03.json` 显示 `passed=true`。
+
+### Task 6: 回滚预案
+
+**Files:**
+- Review: `freshquant/order_management/db.py`
+
+**Step 1: 仅在验证失败时执行**
+
+- 先保持 API 与宿主机写入面继续停止。
+- 不做局部修补；只接受整库恢复。
+
+**Step 2: 用 backup DB 整库恢复**
+
+Run:
+
+```powershell
+@'
+from freshquant.order_management.db import (
+    ORDER_LEDGER_REBUILD_PURGE_COLLECTIONS,
+    get_order_management_db,
+)
+
+active = get_order_management_db()
+backup = active.client["freshquant_order_management_backup_20260403_rebuild1"]
+
+for name in ORDER_LEDGER_REBUILD_PURGE_COLLECTIONS:
+    docs = list(backup[name].find({}))
+    active[name].delete_many({})
+    if docs:
+        active[name].insert_many(docs, ordered=False)
+    print(name, len(docs))
+'@ | py -3.12 -m uv run -
+```
+
+Expected:
+- 活跃库恢复到 rebuild 前状态。
+
+**Step 3: 恢复写入面并重新诊断**
+
+Run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File script/docker_parallel_compose.ps1 start fq_apiserver
+powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface order_management -DeploymentSurface position_management -DeploymentSurface tpsl -BridgeIfServiceUnavailable
+```
+
+Expected:
+- 系统回到 freeze 前运行态，再单独开新 Issue 继续排查。

--- a/freshquant/order_management/entry_aggregation.py
+++ b/freshquant/order_management/entry_aggregation.py
@@ -14,6 +14,7 @@ BUY_CLUSTER_SOURCE_REF_TYPE = "buy_cluster"
 BUY_CLUSTER_ENTRY_TYPE = "broker_execution_cluster"
 BUY_CLUSTER_MAX_TIME_WINDOW_SECONDS = 5 * 60
 BUY_CLUSTER_MAX_PRICE_DEVIATION_RATIO = 0.003
+RECONCILIATION_SOURCE_REF_TYPE = "reconciliation_resolution"
 
 
 def find_entry_for_broker_order(entries, broker_order_key):
@@ -195,6 +196,16 @@ def build_buy_group_member(group_trade_fact, *, broker_order_key):
     }
 
 
+def build_reconciliation_resolution_member_key(*, resolution_id=None, entry_id=None):
+    normalized_resolution_id = _normalize_text(resolution_id)
+    if normalized_resolution_id:
+        return f"{RECONCILIATION_SOURCE_REF_TYPE}:{normalized_resolution_id}"
+    normalized_entry_id = _normalize_text(entry_id)
+    if normalized_entry_id:
+        return f"{RECONCILIATION_SOURCE_REF_TYPE}:entry:{normalized_entry_id}"
+    return ""
+
+
 def list_aggregation_members(entry):
     normalized_entry = dict(entry or {})
     members = [
@@ -216,7 +227,25 @@ def list_aggregation_members(entry):
     source_ref_type = _normalize_text(normalized_entry.get("source_ref_type"))
     source_ref_id = _normalize_text(normalized_entry.get("source_ref_id"))
     if source_ref_type != "broker_order" or not source_ref_id:
-        return []
+        if source_ref_type != RECONCILIATION_SOURCE_REF_TYPE:
+            return []
+        inferred_member = _normalize_member(
+            {
+                "broker_order_key": build_reconciliation_resolution_member_key(
+                    resolution_id=source_ref_id,
+                    entry_id=normalized_entry.get("entry_id"),
+                ),
+                "trade_fact_id": source_ref_id
+                or _normalize_text(normalized_entry.get("entry_id")),
+                "quantity": normalized_entry.get("original_quantity"),
+                "entry_price": normalized_entry.get("entry_price")
+                or normalized_entry.get("buy_price_real"),
+                "trade_time": normalized_entry.get("trade_time"),
+                "date": normalized_entry.get("date"),
+                "time": normalized_entry.get("time"),
+            }
+        )
+        return [inferred_member] if inferred_member is not None else []
     legacy_member = _normalize_member(
         {
             "broker_order_key": source_ref_id,

--- a/freshquant/order_management/rebuild/service.py
+++ b/freshquant/order_management/rebuild/service.py
@@ -70,6 +70,9 @@ class OrderLedgerV2RebuildService:
         cross_day_reused_trade_only_ids = _collect_cross_day_reused_order_ids(
             xt_orders=xt_trades,
         )
+        cross_day_reused_trade_match_ids = (
+            cross_day_reused_order_ids | cross_day_reused_trade_only_ids
+        )
 
         for raw_order in xt_orders:
             order_identity = _build_broker_order_identity(raw_order)
@@ -111,7 +114,7 @@ class OrderLedgerV2RebuildService:
                 order_id=order_id,
                 trading_day=(
                     trading_day
-                    if trade_identity in cross_day_reused_order_ids
+                    if trade_identity in cross_day_reused_trade_match_ids
                     else None
                 ),
             )

--- a/freshquant/order_management/rebuild/service.py
+++ b/freshquant/order_management/rebuild/service.py
@@ -88,7 +88,9 @@ class OrderLedgerV2RebuildService:
                 side=broker_order.get("side"),
                 order_id=raw_order.get("order_id"),
                 trading_day=(
-                    trading_day if order_identity in cross_day_reused_order_ids else None
+                    trading_day
+                    if order_identity in cross_day_reused_order_ids
+                    else None
                 ),
             )
             if match_key:
@@ -108,7 +110,9 @@ class OrderLedgerV2RebuildService:
                 side=trade_side,
                 order_id=order_id,
                 trading_day=(
-                    trading_day if trade_identity in cross_day_reused_order_ids else None
+                    trading_day
+                    if trade_identity in cross_day_reused_order_ids
+                    else None
                 ),
             )
             broker_order_key = order_match_to_broker_order_key.get(match_key)
@@ -671,7 +675,9 @@ def _resolve_rebuild_trading_day(payload):
     )
     if not timestamp:
         return None
-    return int(datetime.fromtimestamp(timestamp, tz=_BEIJING_TIMEZONE).strftime("%Y%m%d"))
+    return int(
+        datetime.fromtimestamp(timestamp, tz=_BEIJING_TIMEZONE).strftime("%Y%m%d")
+    )
 
 
 def _collect_cross_day_reused_order_ids(*, xt_orders):

--- a/freshquant/order_management/rebuild/service.py
+++ b/freshquant/order_management/rebuild/service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 from freshquant.order_management.entry_aggregation import (
     build_clustered_position_entry,
+    build_reconciliation_resolution_member_key,
     count_clustered_entries,
     count_non_default_lot_slices,
     entry_requires_slice_rebuild,
@@ -63,9 +64,21 @@ class OrderLedgerV2RebuildService:
         broker_orders_by_key = {}
         broker_order_keys = []
         order_match_to_broker_order_key = {}
+        cross_day_reused_order_ids = _collect_cross_day_reused_order_ids(
+            xt_orders=xt_orders,
+        )
+        cross_day_reused_trade_only_ids = _collect_cross_day_reused_order_ids(
+            xt_orders=xt_trades,
+        )
 
         for raw_order in xt_orders:
-            broker_order = _normalize_broker_order(raw_order)
+            order_identity = _build_broker_order_identity(raw_order)
+            trading_day = _resolve_rebuild_trading_day(raw_order)
+            broker_order = _normalize_broker_order(
+                raw_order,
+                disambiguate_order_id=order_identity in cross_day_reused_order_ids,
+                trading_day=trading_day,
+            )
             broker_order_key = broker_order["broker_order_key"]
             if broker_order_key not in broker_orders_by_key:
                 broker_order_keys.append(broker_order_key)
@@ -74,6 +87,9 @@ class OrderLedgerV2RebuildService:
                 symbol=broker_order.get("symbol"),
                 side=broker_order.get("side"),
                 order_id=raw_order.get("order_id"),
+                trading_day=(
+                    trading_day if order_identity in cross_day_reused_order_ids else None
+                ),
             )
             if match_key:
                 order_match_to_broker_order_key[match_key] = broker_order_key
@@ -85,10 +101,15 @@ class OrderLedgerV2RebuildService:
             trade_side = _normalize_side(
                 raw_trade.get("order_type") or raw_trade.get("side")
             )
+            trade_identity = _build_broker_order_identity(raw_trade)
+            trading_day = _resolve_rebuild_trading_day(raw_trade)
             match_key = _build_broker_order_match_key(
                 symbol=trade_symbol,
                 side=trade_side,
                 order_id=order_id,
+                trading_day=(
+                    trading_day if trade_identity in cross_day_reused_order_ids else None
+                ),
             )
             broker_order_key = order_match_to_broker_order_key.get(match_key)
             if not broker_order_key:
@@ -97,6 +118,11 @@ class OrderLedgerV2RebuildService:
                     side=trade_side,
                     order_id=order_id,
                     traded_id=raw_trade.get("traded_id"),
+                    trading_day=(
+                        trading_day
+                        if trade_identity in cross_day_reused_trade_only_ids
+                        else None
+                    ),
                 )
 
             broker_order = broker_orders_by_key.get(broker_order_key)
@@ -377,13 +403,24 @@ def _rebuild_position_entries(
     )
 
 
-def _normalize_broker_order(raw_order):
+def _normalize_broker_order(
+    raw_order,
+    *,
+    disambiguate_order_id=False,
+    trading_day=None,
+):
     broker_order_id = _normalize_identifier(raw_order.get("order_id"))
     requested_quantity = _coerce_int(
         raw_order.get("order_volume") or raw_order.get("quantity")
     )
     return {
-        "broker_order_key": broker_order_id,
+        "broker_order_key": _build_rebuild_broker_order_key(
+            symbol=_normalize_symbol(raw_order),
+            side=_normalize_side(raw_order.get("order_type") or raw_order.get("side")),
+            order_id=broker_order_id,
+            trading_day=trading_day,
+            disambiguate=disambiguate_order_id,
+        ),
         "broker_order_id": broker_order_id,
         "broker_order_type": raw_order.get("order_type"),
         "symbol": _normalize_symbol(raw_order),
@@ -553,20 +590,58 @@ def _normalize_side(order_type):
     return str(order_type or "").strip().lower() or None
 
 
-def _build_broker_order_match_key(*, symbol, side, order_id):
+def _build_rebuild_broker_order_key(
+    *,
+    symbol,
+    side,
+    order_id,
+    trading_day=None,
+    disambiguate=False,
+):
+    normalized_order_id = _normalize_identifier(order_id)
+    if not normalized_order_id:
+        return None
+    if not disambiguate:
+        return normalized_order_id
+    normalized_symbol = str(symbol or "").strip()
+    normalized_side = str(side or "").strip().lower()
+    normalized_trading_day = _coerce_int(trading_day)
+    if normalized_symbol and normalized_side and normalized_trading_day:
+        return (
+            f"{normalized_symbol}:{normalized_side}:"
+            f"{normalized_order_id}:{normalized_trading_day}"
+        )
+    return normalized_order_id
+
+
+def _build_broker_order_match_key(*, symbol, side, order_id, trading_day=None):
     normalized_symbol = str(symbol or "").strip()
     normalized_side = str(side or "").strip().lower()
     normalized_order_id = _normalize_identifier(order_id)
     if not normalized_symbol or not normalized_side or not normalized_order_id:
         return None
+    normalized_trading_day = _coerce_int(trading_day)
+    if normalized_trading_day:
+        return (
+            f"{normalized_symbol}:{normalized_side}:"
+            f"{normalized_order_id}:{normalized_trading_day}"
+        )
     return f"{normalized_symbol}:{normalized_side}:{normalized_order_id}"
 
 
-def _build_trade_only_broker_order_key(*, symbol, side, order_id, traded_id):
+def _build_trade_only_broker_order_key(
+    *,
+    symbol,
+    side,
+    order_id,
+    traded_id,
+    trading_day=None,
+):
     match_key = _build_broker_order_match_key(
         symbol=symbol,
         side=side,
         order_id=order_id,
+        trading_day=trading_day,
     )
     if match_key:
         return f"trade_only:{match_key}"
@@ -574,6 +649,44 @@ def _build_trade_only_broker_order_key(*, symbol, side, order_id, traded_id):
     if normalized_traded_id:
         return f"trade_only:{normalized_traded_id}"
     return "trade_only:unknown"
+
+
+def _build_broker_order_identity(payload):
+    normalized_symbol = _normalize_symbol(payload)
+    normalized_side = _normalize_side(payload.get("order_type") or payload.get("side"))
+    normalized_order_id = _normalize_identifier(payload.get("order_id"))
+    if not normalized_symbol or not normalized_side or not normalized_order_id:
+        return None
+    return normalized_symbol, normalized_side, normalized_order_id
+
+
+def _resolve_rebuild_trading_day(payload):
+    date_value = _coerce_int(payload.get("date"))
+    if date_value:
+        return date_value
+    timestamp = _coerce_int(
+        payload.get("order_time")
+        or payload.get("traded_time")
+        or payload.get("trade_time")
+    )
+    if not timestamp:
+        return None
+    return int(datetime.fromtimestamp(timestamp, tz=_BEIJING_TIMEZONE).strftime("%Y%m%d"))
+
+
+def _collect_cross_day_reused_order_ids(*, xt_orders):
+    trading_days_by_identity = {}
+    for payload in list(xt_orders or []):
+        identity = _build_broker_order_identity(payload)
+        trading_day = _resolve_rebuild_trading_day(payload)
+        if identity is None or trading_day is None:
+            continue
+        trading_days_by_identity.setdefault(identity, set()).add(trading_day)
+    return {
+        identity
+        for identity, trading_days in trading_days_by_identity.items()
+        if len(trading_days) > 1
+    }
 
 
 def _normalize_broker_order_state(order_status):
@@ -919,26 +1032,46 @@ def _reconcile_positions_against_xt_positions(
                 "time": time_value,
                 "source": "external_inferred",
             }
-            position_entry = build_position_entry_from_trade_fact(
+            inferred_member_key = build_reconciliation_resolution_member_key(
+                resolution_id=resolution_id
+            )
+            existing_entry = select_cluster_entry(
+                position_entry_documents,
                 trade_fact,
-                source_ref_type="reconciliation_resolution",
-                source_ref_id=resolution_id,
-                entry_type="auto_reconciled_open",
-                original_quantity=quantity_delta,
-                remaining_quantity=quantity_delta,
-                entry_price=float(price_estimate or 0.0),
-                amount=round(float(price_estimate or 0.0) * quantity_delta, 2),
-                source="external_inferred",
-                arrange_mode="runtime_grid",
-                sell_history=[],
+                inferred_member_key,
             )
-            entry_slices = arrange_entry(
-                position_entry,
-                lot_amount=int(lot_amount_lookup(symbol)),
-                grid_interval=float(grid_interval_lookup(symbol, trade_fact)),
-            )
-            position_entry_documents.append(position_entry)
-            entry_slice_documents.extend(entry_slices)
+            if existing_entry is not None:
+                position_entry = build_clustered_position_entry(
+                    group_trade_fact=trade_fact,
+                    broker_order_key=inferred_member_key,
+                    existing_entry=existing_entry,
+                )
+                _replace_entry_document(position_entry_documents, position_entry)
+            else:
+                position_entry = build_position_entry_from_trade_fact(
+                    trade_fact,
+                    source_ref_type="reconciliation_resolution",
+                    source_ref_id=resolution_id,
+                    entry_type="auto_reconciled_open",
+                    original_quantity=quantity_delta,
+                    remaining_quantity=quantity_delta,
+                    entry_price=float(price_estimate or 0.0),
+                    amount=round(float(price_estimate or 0.0) * quantity_delta, 2),
+                    source="external_inferred",
+                    arrange_mode="runtime_grid",
+                    sell_history=[],
+                )
+                position_entry_documents.append(position_entry)
+            if entry_requires_slice_rebuild(existing_entry):
+                _replace_entry_slices(
+                    entry_slice_documents,
+                    entry_id=position_entry["entry_id"],
+                    slices=arrange_entry(
+                        position_entry,
+                        lot_amount=int(lot_amount_lookup(symbol)),
+                        grid_interval=float(grid_interval_lookup(symbol, trade_fact)),
+                    ),
+                )
 
             gap["state"] = "AUTO_OPENED"
             gap["resolution_id"] = resolution_id

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -29,6 +29,11 @@ from freshquant.order_management.ingest.xt_reports import (
     _default_grid_interval_lookup,
     normalize_xt_trade_report,
 )
+from freshquant.order_management.entry_aggregation import (
+    build_clustered_position_entry,
+    build_reconciliation_resolution_member_key,
+    select_cluster_entry,
+)
 from freshquant.order_management.reconcile.matcher import match_candidate_to_trade
 from freshquant.order_management.repository import OrderManagementRepository
 from freshquant.order_management.time_helpers import (
@@ -593,17 +598,34 @@ class ExternalOrderReconcileService:
             "quantity": quantity,
             "side": "buy",
         }
+        inferred_member_key = build_reconciliation_resolution_member_key(
+            resolution_id=resolution_id
+        )
+        existing_entry = None
+        if hasattr(self.repository, "list_position_entries"):
+            existing_entry = select_cluster_entry(
+                self.repository.list_position_entries(symbol=gap["symbol"]),
+                trade_fact,
+                inferred_member_key,
+            )
         arrange_runtime = _resolve_external_arrangement_runtime(
             gap["symbol"],
             trade_fact,
         )
-        entry = _build_auto_open_entry(
-            gap,
-            resolution_id=resolution_id,
-            confirmed_at=now,
-            price_snapshot=chosen_price_snapshot,
-            arrange_runtime=arrange_runtime,
-        )
+        if existing_entry is not None:
+            entry = build_clustered_position_entry(
+                group_trade_fact=trade_fact,
+                broker_order_key=inferred_member_key,
+                existing_entry=existing_entry,
+            )
+        else:
+            entry = _build_auto_open_entry(
+                gap,
+                resolution_id=resolution_id,
+                confirmed_at=now,
+                price_snapshot=chosen_price_snapshot,
+                arrange_runtime=arrange_runtime,
+            )
         entry_slices = []
         try:
             entry_slices = _arrange_entry_slices(

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -5,6 +5,11 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from freshquant.order_management.entry_aggregation import (
+    build_clustered_position_entry,
+    build_reconciliation_resolution_member_key,
+    select_cluster_entry,
+)
 from freshquant.order_management.guardian.allocation_policy import (
     allocate_sell_to_slices,
 )
@@ -28,11 +33,6 @@ from freshquant.order_management.ingest.xt_reports import (
     OrderManagementXtIngestService,
     _default_grid_interval_lookup,
     normalize_xt_trade_report,
-)
-from freshquant.order_management.entry_aggregation import (
-    build_clustered_position_entry,
-    build_reconciliation_resolution_member_key,
-    select_cluster_entry,
 )
 from freshquant.order_management.reconcile.matcher import match_candidate_to_trade
 from freshquant.order_management.repository import OrderManagementRepository

--- a/freshquant/tests/test_order_ledger_v2_rebuild.py
+++ b/freshquant/tests/test_order_ledger_v2_rebuild.py
@@ -253,6 +253,79 @@ def test_rebuild_service_matches_orders_by_symbol_and_side_not_raw_order_id_only
     assert execution_fill["side"] == "buy"
 
 
+def test_rebuild_service_splits_reused_broker_order_ids_across_trade_days():
+    service = _get_rebuild_service_class()(
+        lot_amount_lookup=lambda _symbol: 3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    result = service.build_from_truth(
+        xt_orders=[
+            _sample_xt_order(
+                order_id=672137221,
+                stock_code="600570.SH",
+                order_volume=100,
+                order_time=1774590970,
+                order_status="filled",
+            ),
+            _sample_xt_order(
+                order_id=672137221,
+                stock_code="600570.SH",
+                order_volume=2000,
+                price=25.47,
+                order_time=1775106355,
+                order_status="filled",
+            ),
+        ],
+        xt_trades=[
+            _sample_xt_trade(
+                traded_id="T-600570-OLD-1",
+                order_id=672137221,
+                stock_code="600570.SH",
+                traded_volume=100,
+                traded_price=25.46,
+                traded_time=1774590972,
+            ),
+            _sample_xt_trade(
+                traded_id="T-600570-NEW-1",
+                order_id=672137221,
+                stock_code="600570.SH",
+                traded_volume=2000,
+                traded_price=25.47,
+                traded_time=1775106355,
+            ),
+        ],
+        xt_positions=None,
+        now_ts=1775107000,
+    )
+
+    assert result["broker_orders"] == 2
+    assert result["execution_fills"] == 2
+    assert result["position_entries"] == 2
+
+    broker_orders = sorted(
+        result["broker_order_documents"],
+        key=lambda item: item["first_fill_time"] or 0,
+    )
+    position_entries = sorted(
+        result["position_entry_documents"],
+        key=lambda item: item["trade_time"] or 0,
+    )
+
+    assert broker_orders[0]["broker_order_id"] == "672137221"
+    assert broker_orders[0]["filled_quantity"] == 100
+    assert broker_orders[0]["first_fill_time"] == 1774590972
+    assert broker_orders[1]["broker_order_id"] == "672137221"
+    assert broker_orders[1]["filled_quantity"] == 2000
+    assert broker_orders[1]["first_fill_time"] == 1775106355
+    assert broker_orders[0]["broker_order_key"] != broker_orders[1]["broker_order_key"]
+
+    assert position_entries[0]["original_quantity"] == 100
+    assert position_entries[0]["trade_time"] == 1774590972
+    assert position_entries[1]["original_quantity"] == 2000
+    assert position_entries[1]["trade_time"] == 1775106355
+
+
 def test_rebuild_service_aggregates_buy_fills_into_single_broker_order_entry():
     service = _get_rebuild_service_class()(
         lot_amount_lookup=lambda _symbol: 3000,
@@ -978,6 +1051,70 @@ def test_rebuild_service_creates_auto_reconciled_open_entry_from_xt_positions_ga
     assert position_entry["entry_type"] == "auto_reconciled_open"
     assert position_entry["remaining_quantity"] == 300
     assert position_entry["trade_time"] == 1775000000
+
+
+def test_rebuild_service_merges_auto_open_gap_into_nearby_clustered_entry():
+    service = _get_rebuild_service_class()(
+        lot_amount_lookup=lambda _symbol: 3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    result = service.build_from_truth(
+        xt_orders=[
+            _sample_xt_order(
+                order_id=81301,
+                stock_code="000001.SZ",
+                order_volume=100,
+                order_time=1710000000,
+                order_status="filled",
+            )
+        ],
+        xt_trades=[
+            _sample_xt_trade(
+                traded_id="T-BUY-81301",
+                order_id=81301,
+                stock_code="000001.SZ",
+                traded_volume=100,
+                traded_price=10.00,
+                traded_time=1710000000,
+                date=None,
+                time=None,
+            )
+        ],
+        xt_positions=[
+            _sample_xt_position(
+                stock_code="000001.SZ",
+                volume=200,
+                avg_price=10.02,
+            )
+        ],
+        now_ts=1710000240,
+    )
+
+    assert result["reconciliation_gaps"] == 1
+    assert result["reconciliation_resolutions"] == 1
+    assert result["auto_open_entries"] == 1
+    assert result["position_entries"] == 1
+
+    gap = result["reconciliation_gap_documents"][0]
+    resolution = result["reconciliation_resolution_documents"][0]
+    position_entry = result["position_entry_documents"][0]
+
+    assert gap["state"] == "AUTO_OPENED"
+    assert gap["resolution_type"] == "auto_open_entry"
+    assert gap["entry_id"] == position_entry["entry_id"]
+    assert resolution["resolution_type"] == "auto_open_entry"
+    assert resolution["source_ref_type"] == "position_entry"
+    assert resolution["source_ref_id"] == position_entry["entry_id"]
+    assert position_entry["source_ref_type"] == "buy_cluster"
+    assert position_entry["entry_type"] == "broker_execution_cluster"
+    assert position_entry["original_quantity"] == 200
+    assert position_entry["remaining_quantity"] == 200
+    assert position_entry["trade_time"] == 1710000000
+    assert position_entry["entry_price"] == pytest.approx(10.01, abs=1e-6)
+    assert position_entry["aggregation_window"]["member_count"] == 2
+    assert position_entry["aggregation_members"][0]["broker_order_key"] == "81301"
+    assert position_entry["aggregation_members"][1]["trade_time"] == 1710000240
 
 
 def test_rebuild_service_rejects_non_board_lot_xt_positions_delta():

--- a/freshquant/tests/test_order_ledger_v2_rebuild.py
+++ b/freshquant/tests/test_order_ledger_v2_rebuild.py
@@ -326,6 +326,54 @@ def test_rebuild_service_splits_reused_broker_order_ids_across_trade_days():
     assert position_entries[1]["trade_time"] == 1775106355
 
 
+def test_rebuild_service_splits_trade_only_reused_order_ids_across_trade_days():
+    service = _get_rebuild_service_class()(
+        lot_amount_lookup=lambda _symbol: 3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    result = service.build_from_truth(
+        xt_orders=[],
+        xt_trades=[
+            _sample_xt_trade(
+                traded_id="T-300760-OLD-1",
+                order_id=672137219,
+                stock_code="300760.SZ",
+                traded_volume=300,
+                traded_price=195.20,
+                traded_time=1774587845,
+            ),
+            _sample_xt_trade(
+                traded_id="T-300760-NEW-1",
+                order_id=672137219,
+                stock_code="300760.SZ",
+                traded_volume=3600,
+                traded_price=195.32,
+                traded_time=1775106290,
+            ),
+        ],
+        xt_positions=None,
+        now_ts=1775107000,
+    )
+
+    assert result["broker_orders"] == 2
+    assert result["execution_fills"] == 2
+    assert result["position_entries"] == 2
+
+    broker_orders = sorted(
+        result["broker_order_documents"],
+        key=lambda item: item["first_fill_time"] or 0,
+    )
+
+    assert broker_orders[0]["broker_order_id"] == "672137219"
+    assert broker_orders[0]["filled_quantity"] == 300
+    assert broker_orders[0]["first_fill_time"] == 1774587845
+    assert broker_orders[1]["broker_order_id"] == "672137219"
+    assert broker_orders[1]["filled_quantity"] == 3600
+    assert broker_orders[1]["first_fill_time"] == 1775106290
+    assert broker_orders[0]["broker_order_key"] != broker_orders[1]["broker_order_key"]
+
+
 def test_rebuild_service_aggregates_buy_fills_into_single_broker_order_entry():
     service = _get_rebuild_service_class()(
         lot_amount_lookup=lambda _symbol: 3000,

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -977,6 +977,82 @@ def test_inferred_pending_auto_confirms_into_entry_without_fake_trade(monkeypatc
     assert repository.buy_lots == []
 
 
+def test_inferred_pending_auto_open_merges_into_nearby_clustered_entry(monkeypatch):
+    repository, service = _build_service(monkeypatch)
+    repository.replace_position_entry(
+        {
+            "entry_id": "entry_cluster_1",
+            "symbol": "000001",
+            "entry_type": "broker_execution_cluster",
+            "source_ref_type": "buy_cluster",
+            "source_ref_id": "buy_cluster:000001:20240310:1710000000:ord_cluster_1",
+            "entry_price": 10.0,
+            "buy_price_real": 10.0,
+            "original_quantity": 100,
+            "remaining_quantity": 100,
+            "amount": 1000.0,
+            "amount_adjust": 1.0,
+            "date": 20240310,
+            "time": "09:30:00",
+            "trade_time": 1710000000,
+            "source": "xt_trade_callback",
+            "arrange_mode": "runtime_grid",
+            "status": "OPEN",
+            "sell_history": [],
+            "aggregation_members": [
+                {
+                    "broker_order_key": "ord_cluster_1",
+                    "trade_fact_id": "trade_cluster_1",
+                    "quantity": 100,
+                    "entry_price": 10.0,
+                    "trade_time": 1710000000,
+                    "date": 20240310,
+                    "time": "09:30:00",
+                    "trading_day": 20240310,
+                }
+            ],
+            "aggregation_member_keys": ["ord_cluster_1"],
+            "aggregation_window": {
+                "start_trade_time": 1710000000,
+                "end_trade_time": 1710000000,
+                "trading_day": 20240310,
+                "member_count": 1,
+            },
+        }
+    )
+
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.02}],
+        detected_at=1710000210,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.02}],
+        detected_at=1710000225,
+    )
+    service.detect_external_candidates(
+        positions=[{"stock_code": "000001.SZ", "volume": 200, "avg_price": 10.02}],
+        detected_at=1710000240,
+    )
+
+    confirmed = service.confirm_expired_candidates(now=1710000240)
+
+    assert len(confirmed) == 1
+    assert len(repository.position_entries) == 1
+    position_entry = repository.position_entries[0]
+    assert position_entry["entry_id"] == "entry_cluster_1"
+    assert position_entry["source_ref_type"] == "buy_cluster"
+    assert position_entry["entry_type"] == "broker_execution_cluster"
+    assert position_entry["original_quantity"] == 200
+    assert position_entry["remaining_quantity"] == 200
+    assert position_entry["trade_time"] == 1710000000
+    assert position_entry["entry_price"] == pytest.approx(10.01, abs=1e-6)
+    assert position_entry["aggregation_window"]["member_count"] == 2
+    assert position_entry["aggregation_members"][0]["broker_order_key"] == "ord_cluster_1"
+    assert position_entry["aggregation_members"][1]["trade_time"] == 1710000240
+    assert repository.reconciliation_gaps[0]["entry_id"] == "entry_cluster_1"
+    assert repository.reconciliation_resolutions[0]["source_ref_id"] == "entry_cluster_1"
+
+
 def test_confirm_expired_candidates_marks_and_syncs_compat_after_auto_open(
     monkeypatch,
 ):

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -1047,10 +1047,14 @@ def test_inferred_pending_auto_open_merges_into_nearby_clustered_entry(monkeypat
     assert position_entry["trade_time"] == 1710000000
     assert position_entry["entry_price"] == pytest.approx(10.01, abs=1e-6)
     assert position_entry["aggregation_window"]["member_count"] == 2
-    assert position_entry["aggregation_members"][0]["broker_order_key"] == "ord_cluster_1"
+    assert (
+        position_entry["aggregation_members"][0]["broker_order_key"] == "ord_cluster_1"
+    )
     assert position_entry["aggregation_members"][1]["trade_time"] == 1710000240
     assert repository.reconciliation_gaps[0]["entry_id"] == "entry_cluster_1"
-    assert repository.reconciliation_resolutions[0]["source_ref_id"] == "entry_cluster_1"
+    assert (
+        repository.reconciliation_resolutions[0]["source_ref_id"] == "entry_cluster_1"
+    )
 
 
 def test_confirm_expired_candidates_marks_and_syncs_compat_after_auto_open(


### PR DESCRIPTION
## 背景

`300760`、`600570` 的“第 1 笔 / 第 2 笔入口没有聚合”根因已经确认不是单纯的聚合规则 bug，而是 2026-04-02 历史 runtime ingest 缺口叠加后续 rebuild / reconcile 口径问题：

- 历史 callback 缺口导致部分 fill 只进入 `xt_trades / stock_fills`，未完整进入 `om_execution_fills / om_trade_facts`
- rebuild 在 `broker_order_id` 跨交易日复用时，会把不同交易日的订单事实混成一条 rebuilt broker order
- reconcile 的 `auto_reconciled_open` 在满足 buy cluster 条件时，没有并回相邻 open entry，导致后续解释层仍可能看到不必要拆分

这会直接影响当前系统对 `300760`、`600570` 以及 `672137219 / 672137221` 这类历史问题单的解释结果。

## 目标

- 让 rebuild 正确拆分“跨交易日复用同一 `order_id`”的 broker order
- 让 reconcile 补开的 `auto_reconciled_open` 在满足条件时并入已有 buy cluster
- 补齐对应回归测试与正式 runbook，支撑 merge 后 formal deploy + destructive rebuild

## 范围

- `freshquant/order_management/rebuild/service.py`
- `freshquant/order_management/reconcile/service.py`
- `freshquant/order_management/entry_aggregation.py`
- 相关测试与当前架构说明
- 新增正式重建 runbook：`docs/plans/2026-04-03-order-ledger-runtime-rebuild-runbook.md`

## 非目标

- 不直接在本 PR 内执行生产 rebuild
- 不修改前端 CSS / UI
- 不改写历史 `xt_*` broker truth

## 验收标准

- `test_rebuild_service_splits_reused_broker_order_ids_across_trade_days` 通过
- `test_rebuild_service_merges_auto_open_gap_into_nearby_clustered_entry` 通过
- `test_inferred_pending_auto_open_merges_into_nearby_clustered_entry` 通过
- `freshquant/tests/test_order_ledger_v2_rebuild.py -k "not import_does_not_require_tzdata"` 通过
- `freshquant/tests/test_order_management_reconcile.py` 全量通过
- merge 后可按 runbook 执行：formal deploy -> freeze 写入面 -> `rebuild_order_ledger_v2 --execute --backup-db ...` -> `stock.fill rebuild --all` -> 定点验收 `300760` / `600570` / `672137219`

## 已验证

- `powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure`
- `.venv\Scripts\python.exe -m pytest freshquant/tests/test_order_ledger_v2_rebuild.py -k "not import_does_not_require_tzdata" -q`
- `.venv\Scripts\python.exe -m pytest freshquant/tests/test_order_management_reconcile.py -q`

备注：pytest 结束时仍会打印一个已知的 `pytest-current` atexit `PermissionError`，但用例本身已通过。

## 部署影响

命中：

- `freshquant/order_management/**`
- `freshquant/position_management/**` 关联的宿主机 `xt_account_sync.worker`
- API order-write surface

merge 后正式动作不是“只部署代码”而是：

1. 对最新远程 `main` 做 formal deploy
2. freeze `fq_apiserver`、`fqnext_xtquant_broker`、`fqnext_xt_account_sync_worker`、`fqnext_tpsl_worker`
3. 单次刷新 `xt_orders / xt_trades / xt_positions`
4. 执行 destructive rebuild 与 compat rebuild
5. 验收 `300760`、`600570`、`672137219 / 672137221`
6. 恢复写入面并做 health check / runtime verify