### PR TITLE
[codex] fix initialize coverage for bootstrap settings

### DIFF
--- a/docs/current/configuration.md
+++ b/docs/current/configuration.md
@@ -89,6 +89,7 @@
 - `mongodb.port`
 - `mongodb.db`
 - `mongodb.gantt_db`
+- `mongodb.screening_db`
 - `redis.host`
 - `redis.port`
 - `redis.db`
@@ -98,16 +99,19 @@
 - `memory.mongodb.db`
 - `memory.cold_root`
 - `memory.artifact_root`
+- `memory.reference_ref`
 
 默认值：
 
 - Mongo `127.0.0.1:27027`
 - 主库 `freshquant`
 - Gantt 库 `freshquant_gantt`
+- Screening 库 `fqscreening`
 - Redis `127.0.0.1:6379 db=1`
 - Memory 热库 `fq_memory`
 - 冷目录 `.codex/memory`
 - Artifact 根目录 `D:/fqpack/runtime/artifacts/memory`
+- Memory Reference Ref `origin/main`
 
 当前正式运行面补充口径：
 

--- a/docs/current/reference/system-settings-params.md
+++ b/docs/current/reference/system-settings-params.md
@@ -110,15 +110,15 @@
 - 含义：XTData 最大监控标的数。
 - 类型：`int`
 - 是否必填：否
-- 缺省值：`50`
-- 非法值行为：小于等于 `0` 或无法解析时回退到 `50`
+- 缺省值：`60`
+- 非法值行为：小于等于 `0` 或无法解析时回退到 `60`
 
 ### monitor.xtdata.queue_backlog_threshold
 
 - 含义：consumer 进入 backlog / catchup 的阈值。
 - 类型：`int`
 - 是否必填：否
-- 缺省值：`200`
+- 缺省值：`500`
 - 用途：控制 `strategy_consumer` 在队列积压时的处理策略
 
 ### monitor.xtdata.prewarm.max_bars
@@ -126,7 +126,7 @@
 - 含义：consumer 预热和窗口回填时保留的最大 bar 数。
 - 类型：`int`
 - 是否必填：否
-- 缺省值：`20000`
+- 缺省值：`240`
 
 示例：
 
@@ -136,10 +136,10 @@
   "value": {
     "xtdata": {
       "mode": "guardian_1m",
-      "max_symbols": 50,
-      "queue_backlog_threshold": 200,
+      "max_symbols": 60,
+      "queue_backlog_threshold": 500,
       "prewarm": {
-        "max_bars": 20000
+        "max_bars": 240
       }
     }
   }

--- a/freshquant/initialize.py
+++ b/freshquant/initialize.py
@@ -17,6 +17,7 @@ BOOTSTRAP_PROMPTS = [
     ("mongodb.port", "MongoDB 端口", "int"),
     ("mongodb.db", "MongoDB 主库", "text"),
     ("mongodb.gantt_db", "MongoDB Gantt 库", "text"),
+    ("mongodb.screening_db", "MongoDB Screening 库", "text"),
     ("redis.host", "Redis 主机", "text"),
     ("redis.port", "Redis 端口", "int"),
     ("redis.db", "Redis DB", "int"),
@@ -29,6 +30,7 @@ BOOTSTRAP_PROMPTS = [
     ("memory.mongodb.db", "Memory Mongo 库", "text"),
     ("memory.cold_root", "Memory 冷目录", "text"),
     ("memory.artifact_root", "Memory Artifact 根目录", "text"),
+    ("memory.reference_ref", "Memory Reference Ref", "text"),
     ("tdx.home", "TDX 主目录", "text"),
     ("tdx.hq.endpoint", "TDX 行情接口", "text"),
     ("api.base_url", "API Base URL", "text"),
@@ -47,7 +49,7 @@ SETTINGS_PROMPTS = [
     ("xtquant.account", "XT 账户", "text"),
     ("xtquant.account_type", "XT 账户类型", "text"),
     ("xtquant.broker_submit_mode", "Broker Submit Mode", "text"),
-    ("xtquant.auto_repay.enabled", "XT 自动还款开关", "text"),
+    ("xtquant.auto_repay.enabled", "XT 自动还款开关", "bool"),
     ("xtquant.auto_repay.reserve_cash", "XT 自动还款留底现金", "float"),
     ("guardian.stock.lot_amount", "Guardian 单次买入金额", "int"),
     ("guardian.stock.threshold.mode", "Guardian 阈值模式", "text"),
@@ -66,6 +68,11 @@ SETTINGS_PROMPTS = [
     (
         "position_management.holding_only_min_bail",
         "仅允许持仓内买入最低保证金",
+        "float",
+    ),
+    (
+        "position_management.single_symbol_position_limit",
+        "单标的默认持仓上限",
         "float",
     ),
 ]

--- a/freshquant/system_config_service.py
+++ b/freshquant/system_config_service.py
@@ -26,6 +26,7 @@ BOOTSTRAP_SECTION_META = {
             ("port", "端口"),
             ("db", "主库"),
             ("gantt_db", "Gantt 库"),
+            ("screening_db", "Screening 库"),
         ],
     },
     "redis": {
@@ -68,6 +69,7 @@ BOOTSTRAP_SECTION_META = {
             ("mongodb.db", "Mongo 库"),
             ("cold_root", "冷目录"),
             ("artifact_root", "Artifact 根目录"),
+            ("reference_ref", "Reference Ref"),
         ],
     },
     "tdx": {
@@ -297,6 +299,7 @@ class SystemConfigService:
                 "port": config.mongodb.port,
                 "db": config.mongodb.db,
                 "gantt_db": config.mongodb.gantt_db,
+                "screening_db": config.mongodb.screening_db,
             },
             "redis": {
                 "host": config.redis.host,
@@ -319,6 +322,7 @@ class SystemConfigService:
                 },
                 "cold_root": config.memory.cold_root,
                 "artifact_root": config.memory.artifact_root,
+                "reference_ref": config.memory.reference_ref,
             },
             "tdx": {
                 "home": config.tdx.home,
@@ -442,6 +446,10 @@ class SystemConfigService:
                 "gantt_db": _require_text(
                     mongodb.get("gantt_db"), field_name="mongodb.gantt_db"
                 ),
+                "screening_db": _require_text(
+                    mongodb.get("screening_db"),
+                    field_name="mongodb.screening_db",
+                ),
             },
             "redis": {
                 "host": _require_text(redis.get("host"), field_name="redis.host"),
@@ -486,6 +494,10 @@ class SystemConfigService:
                 "artifact_root": _require_text(
                     memory.get("artifact_root"),
                     field_name="memory.artifact_root",
+                ),
+                "reference_ref": _require_text(
+                    memory.get("reference_ref"),
+                    field_name="memory.reference_ref",
                 ),
             },
             "tdx": {

--- a/freshquant/tests/test_initialize.py
+++ b/freshquant/tests/test_initialize.py
@@ -17,6 +17,7 @@ def _make_dashboard():
                     "port": 27027,
                     "db": "freshquant",
                     "gantt_db": "freshquant_gantt",
+                    "screening_db": "fqscreening",
                 },
                 "redis": {
                     "host": "127.0.0.1",
@@ -39,6 +40,7 @@ def _make_dashboard():
                     },
                     "cold_root": "D:/fqpack/runtime/memory",
                     "artifact_root": "D:/fqpack/runtime/memory/artifacts",
+                    "reference_ref": "origin/main",
                 },
                 "tdx": {
                     "home": "D:/tdx_biduan",
@@ -72,6 +74,10 @@ def _make_dashboard():
                     "account": "068000076370",
                     "account_type": "CREDIT",
                     "broker_submit_mode": "observe_only",
+                    "auto_repay": {
+                        "enabled": True,
+                        "reserve_cash": 5000.0,
+                    },
                 },
                 "guardian": {
                     "stock": {
@@ -83,6 +89,7 @@ def _make_dashboard():
                 "position_management": {
                     "allow_open_min_bail": 910000.0,
                     "holding_only_min_bail": 210000.0,
+                    "single_symbol_position_limit": 880000.0,
                 },
             }
         },
@@ -108,8 +115,11 @@ def test_run_initialize_wizard_updates_bootstrap_and_settings_then_bootstraps_ru
 
     prompts = {
         "bootstrap.mongodb.host": "10.0.0.8",
+        "bootstrap.mongodb.screening_db": "fqscreening_runtime",
+        "bootstrap.memory.reference_ref": "upstream/release-main",
         "settings.xtquant.account": "123456",
         "settings.position_management.allow_open_min_bail": 950000.0,
+        "settings.position_management.single_symbol_position_limit": 990000.0,
     }
     lines = []
 
@@ -127,8 +137,14 @@ def test_run_initialize_wizard_updates_bootstrap_and_settings_then_bootstraps_ru
     )
 
     assert result["bootstrap"]["mongodb"]["host"] == "10.0.0.8"
+    assert result["bootstrap"]["mongodb"]["screening_db"] == "fqscreening_runtime"
+    assert result["bootstrap"]["memory"]["reference_ref"] == "upstream/release-main"
     assert result["settings"]["xtquant"]["account"] == "123456"
     assert result["settings"]["position_management"]["allow_open_min_bail"] == 950000.0
+    assert (
+        result["settings"]["position_management"]["single_symbol_position_limit"]
+        == 990000.0
+    )
     assert calls[0][0] == "bootstrap"
     assert calls[1][0] == "settings"
     assert any("运行态 bootstrap 完成" in line for line in lines)

--- a/freshquant/tests/test_runtime_memory_docs.py
+++ b/freshquant/tests/test_runtime_memory_docs.py
@@ -190,3 +190,22 @@ def test_current_deployment_docs_reference_selective_deploy_and_build_cache() ->
     assert "FQ_DOCKER_BUILD_CACHE_ROOT" in deployment_text
     assert "fq_local_preflight.ps1" in deployment_text
     assert "check_freshquant_runtime_post_deploy.ps1" in deployment_text
+
+
+def test_configuration_docs_cover_current_bootstrap_and_monitor_defaults() -> None:
+    configuration_text = Path("docs/current/configuration.md").read_text(
+        encoding="utf-8"
+    )
+    params_text = Path("docs/current/reference/system-settings-params.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "mongodb.screening_db" in configuration_text
+    assert "memory.reference_ref" in configuration_text
+
+    assert "缺省值：`60`" in params_text
+    assert "缺省值：`500`" in params_text
+    assert "缺省值：`240`" in params_text
+    assert '"max_symbols": 60' in params_text
+    assert '"queue_backlog_threshold": 500' in params_text
+    assert '"max_bars": 240' in params_text

--- a/freshquant/tests/test_system_config_service.py
+++ b/freshquant/tests/test_system_config_service.py
@@ -90,6 +90,7 @@ def _write_bootstrap_file(path):
                 "  port: 27027",
                 "  db: freshquant",
                 "  gantt_db: freshquant_gantt",
+                "  screening_db: fqscreening",
                 "redis:",
                 "  host: 127.0.0.1",
                 "  port: 6380",
@@ -106,6 +107,7 @@ def _write_bootstrap_file(path):
                 "    db: fq_memory",
                 "  cold_root: D:/fqpack/runtime/memory",
                 "  artifact_root: D:/fqpack/runtime/memory/artifacts",
+                "  reference_ref: origin/main",
                 "tdx:",
                 "  home: D:/tdx_biduan",
                 "  hq:",
@@ -238,6 +240,8 @@ def test_system_config_service_dashboard_reads_bootstrap_and_mongo_settings(
 
     assert dashboard["bootstrap"]["file_path"] == str(bootstrap_file)
     assert dashboard["bootstrap"]["values"]["mongodb"]["host"] == "127.0.0.1"
+    assert dashboard["bootstrap"]["values"]["mongodb"]["screening_db"] == "fqscreening"
+    assert dashboard["bootstrap"]["values"]["memory"]["reference_ref"] == "origin/main"
     assert dashboard["bootstrap"]["sections"][0]["key"] == "mongodb"
     assert (
         dashboard["settings"]["values"]["guardian"]["stock"]["threshold"]["mode"]
@@ -332,7 +336,13 @@ def test_system_config_service_update_bootstrap_persists_yaml_and_reloads(
     )
 
     payload = {
-        "mongodb": {"host": "10.0.0.8", "port": 27028, "db": "freshquant_test"},
+        "mongodb": {
+            "host": "10.0.0.8",
+            "port": 27028,
+            "db": "freshquant_test",
+            "screening_db": "fqscreening_runtime",
+        },
+        "memory": {"reference_ref": "upstream/release-main"},
         "xtdata": {"port": 58611},
         "runtime": {"log_dir": "D:/fqpack/runtime/new-logs"},
     }
@@ -341,9 +351,13 @@ def test_system_config_service_update_bootstrap_persists_yaml_and_reloads(
 
     assert result["values"]["mongodb"]["host"] == "10.0.0.8"
     assert bootstrap_module.bootstrap_config.mongodb.host == "10.0.0.8"
+    assert bootstrap_module.bootstrap_config.mongodb.screening_db == "fqscreening_runtime"
+    assert bootstrap_module.bootstrap_config.memory.reference_ref == "upstream/release-main"
     assert bootstrap_module.bootstrap_config.xtdata.port == 58611
     content = bootstrap_file.read_text(encoding="utf-8")
     assert "10.0.0.8" in content
+    assert "fqscreening_runtime" in content
+    assert "upstream/release-main" in content
     assert "58611" in content
     assert "D:/fqpack/runtime/new-logs" in content
 


### PR DESCRIPTION
## 背景
- `initialize.bat` / `freshquant.initialize` 可以做基础初始化，但当前实现没有完整覆盖最新 bootstrap 配置项。
- `SystemConfigService.update_bootstrap()` 在重写 bootstrap YAML 时不会保留 `mongodb.screening_db` 与 `memory.reference_ref`，导致初始化后可能把这两个正式配置项写丢。
- 当前文档里的 `monitor.xtdata.*` 默认值也和代码实现存在漂移。

## 本次修改
- 初始化向导补齐 `mongodb.screening_db`、`memory.reference_ref`、`position_management.single_symbol_position_limit`。
- `xtquant.auto_repay.enabled` 改为布尔输入。
- `SystemConfigService` 补齐 bootstrap 视图与持久化对 `screening_db`、`reference_ref` 的覆盖。
- `docs/current/**` 同步更新 bootstrap 配置与 monitor 默认值。
- 测试覆盖初始化、配置服务和文档一致性。

## 验证
- `D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m pytest freshquant/tests/test_bootstrap_config.py freshquant/tests/test_initialize.py freshquant/tests/test_system_config_service.py freshquant/tests/test_system_settings.py freshquant/tests/test_memory_runtime_config_bootstrap.py freshquant/tests/test_runtime_memory_docs.py -q`
- 结果：`23 passed, 1 warning`

## 部署影响
- 合并后，新机器可以直接运行 `D:\fqpack\initialize.bat` 完成初始化，不再需要额外手工补这几个缺口。
- 受影响模块为初始化流程与系统配置文档；正式部署仍应按 `docs/current/deployment.md` 走 formal deploy。