### PR TITLE
fix: self-heal stale xtdata producer subscriptions

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -37,6 +37,9 @@ producer 是唯一 XTData 入口；consumer 是唯一 bar 队列消费入口。
 
 `XTData -> market_producer -> REDIS_TICK_QUEUE_PREFIX:<shard> -> TpslTickConsumer`
 
+- `market_producer` 的 XTData 回调当前只负责规范化 tick、更新接收心跳、把 tick quote 批次交给后台写队列，并把原始 tick 交给 1 分钟 bar pump。
+- tick quote 的 Redis `rpush` 已从 XTData 回调线程移到后台 worker，避免 Redis 抖动直接卡住 XTData 回调链。
+
 ### Bar 链
 
 `XTData -> market_producer/OneMinuteBarGenerator -> REDIS_QUEUE_PREFIX:<shard> -> strategy_consumer -> realtime cache / chanlun payload / Guardian`
@@ -84,6 +87,13 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - 这两个进程通常运行在宿主机，不放进 Docker。
 - 修改 `freshquant/market_data/**` 后，至少重启 producer 与 consumer。
 - consumer 改动涉及结构缓存或 prewarm 逻辑时，建议带 `--prewarm` 重新拉起。
+- producer 当前会在交易时段内监控 `rx_age_s`：
+  - 当 `connected=1`、`subscribed_codes>0` 且 `rx_age_s >= 120` 秒时，先自动重订阅当前代码池。
+  - 若 30 秒后仍持续 stale，则升级为 `xtdata.connect() + 重订阅`。
+  - 恢复动作会写入 `subscription_guard` 运行事件，`reason_code=stale_rx`。
+- producer 心跳当前额外暴露：
+  - `tick_quote_pending_batches`
+  - `tick_quote_dropped_batches`
 
 ## 排障点
 
@@ -92,6 +102,9 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - 检查 XTQuant 是否在线。
 - 检查 `XTQUANT_PORT`。
 - 检查订阅池是否为空。
+- 检查最新 `xt_producer` 心跳里的 `rx_age_s`、`tick_count_5m`、`tick_quote_pending_batches`、`tick_quote_dropped_batches`。
+- 若 `connected=1`、`subscribed_codes>0`，但 `rx_age_s` 在交易时段持续增长且 `tick_count_5m=0`，优先判断为 producer 订阅/回调链 stale，而不是先怀疑 `minqmt` 客户端配置。
+- 检查 `subscription_guard` 事件是否已触发自动 `resubscribe` / `reconnect`；若仍不恢复，再按宿主机运行面入口重启 `market_data`。
 
 ### consumer 不更新
 

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -60,6 +60,38 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
 - 重新启动受影响宿主机进程或执行 `script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces`
 - 若仍有失败，优先看 stderr 是否是业务级 HTTP 拒绝，而不是代理错误
 
+## XTData producer 假活着但不收行情
+
+现象：
+
+- `fqnext_realtime_xtdata_producer` 在 supervisor 中仍显示 `Running`
+- `xt_producer` 心跳里 `connected=1`、`subscribed_codes>0`
+- 但 `tick_count_5m=0`、`tick_batches_5m=0`，且 `rx_age_s` 在交易时段持续增长
+- `xt_consumer` 同时没有新的 `processed_bars_5m`
+- `minqmt` / `xtquant` 客户端手工取数正常
+
+先检查：
+
+- `Get-ChildItem logs/runtime/host_xt_producer/xt_producer -Recurse -Filter *.jsonl | Sort-Object LastWriteTime -Descending | Select-Object -First 5 FullName,LastWriteTime`
+- `Get-ChildItem logs/runtime/host_xt_consumer/xt_consumer -Recurse -Filter *.jsonl | Sort-Object LastWriteTime -Descending | Select-Object -First 5 FullName,LastWriteTime`
+- `Get-Content D:/fqdata/log/fqnext_realtime_xtdata_producer_err.log -Tail 200`
+- `Get-Content D:/fqdata/log/fqnext_realtime_xtdata_consumer_err.log -Tail 200`
+
+处理：
+
+- 优先查看 `xt_producer` 心跳里的：
+  - `rx_age_s`
+  - `tick_count_5m`
+  - `tick_quote_pending_batches`
+  - `tick_quote_dropped_batches`
+- 若在交易时段出现 `connected=1`、`subscribed_codes>0`、`rx_age_s >= 120` 秒：
+  - 先看是否已有 `subscription_guard` 事件，`reason_code=stale_rx`
+  - 当前 producer 会先自动 `resubscribe`，持续 stale 时再做 `xtdata.connect() + resubscribe`
+- 若自动恢复事件已经出现，但 `rx_age_s` 仍持续增长：
+  - 按正式入口执行 `script/fqnext_host_runtime_ctl.ps1`
+  - 重启 `market_data` 宿主机运行面，不要临时手拉 ad-hoc 进程
+- 如果 `minqmt` 客户端手工订阅正常，而 producer 仍 stale，优先排查 producer 进程内的订阅/回调链，不要先改 `XTQUANT_PORT` 或监控池配置
+
 ## Runtime Observability / ClickHouse 查询异常
 
 现象：

--- a/freshquant/market_data/xtdata/market_producer.py
+++ b/freshquant/market_data/xtdata/market_producer.py
@@ -346,6 +346,8 @@ class ProducerHeartbeatState:
 
 def _is_cn_trading_session(now_dt: datetime | None = None) -> bool:
     dt = now_dt or datetime.now(tz=TZ)
+    if dt.weekday() >= 5:
+        return False
     t = dt.time()
     return (
         (t >= datetime(dt.year, dt.month, dt.day, 9, 30).time())

--- a/freshquant/market_data/xtdata/market_producer.py
+++ b/freshquant/market_data/xtdata/market_producer.py
@@ -20,8 +20,8 @@ from freshquant.market_data.xtdata.pools import (
     normalize_xtdata_mode,
 )
 from freshquant.market_data.xtdata.schema import TickQuoteEvent, normalize_prefixed_code
-from freshquant.runtime_observability.logger import RuntimeEventLogger
 from freshquant.runtime_constants import TZ
+from freshquant.runtime_observability.logger import RuntimeEventLogger
 from freshquant.system_settings import system_settings
 
 try:
@@ -347,10 +347,11 @@ class ProducerHeartbeatState:
 def _is_cn_trading_session(now_dt: datetime | None = None) -> bool:
     dt = now_dt or datetime.now(tz=TZ)
     t = dt.time()
-    return (t >= datetime(dt.year, dt.month, dt.day, 9, 30).time()) and (
-        t <= datetime(dt.year, dt.month, dt.day, 11, 30).time()
-    ) or (t >= datetime(dt.year, dt.month, dt.day, 13, 0).time()) and (
-        t <= datetime(dt.year, dt.month, dt.day, 15, 0).time()
+    return (
+        (t >= datetime(dt.year, dt.month, dt.day, 9, 30).time())
+        and (t <= datetime(dt.year, dt.month, dt.day, 11, 30).time())
+        or (t >= datetime(dt.year, dt.month, dt.day, 13, 0).time())
+        and (t <= datetime(dt.year, dt.month, dt.day, 15, 0).time())
     )
 
 

--- a/freshquant/market_data/xtdata/market_producer.py
+++ b/freshquant/market_data/xtdata/market_producer.py
@@ -7,6 +7,7 @@ import threading
 import time
 import traceback
 from collections import deque
+from datetime import datetime
 
 import click
 from loguru import logger
@@ -20,12 +21,20 @@ from freshquant.market_data.xtdata.pools import (
 )
 from freshquant.market_data.xtdata.schema import TickQuoteEvent, normalize_prefixed_code
 from freshquant.runtime_observability.logger import RuntimeEventLogger
+from freshquant.runtime_constants import TZ
 from freshquant.system_settings import system_settings
 
 try:
     from freshquant.database.redis import redis_db  # type: ignore
 except Exception:  # pragma: no cover
     redis_db = None  # type: ignore
+
+PRODUCER_HEARTBEAT_INTERVAL_S = 300.0
+PRODUCER_POOL_REFRESH_INTERVAL_S = 30.0
+PRODUCER_STALE_RX_THRESHOLD_S = 120.0
+PRODUCER_STALE_RETRY_INTERVAL_S = 30.0
+PRODUCER_STALE_RECONNECT_EVERY = 2
+PRODUCER_TICK_QUOTE_MAX_PENDING_BATCHES = 2048
 
 
 def _to_xt_symbol(code_prefixed: str) -> str:
@@ -124,6 +133,77 @@ class TickPump:
                 traceback.print_exc()
 
 
+class AsyncBatchQueue:
+    def __init__(self, handler, *, max_pending_batches: int = 2048, name: str):
+        self._handler = handler
+        self._max_pending_batches = max(int(max_pending_batches or 0), 1)
+        self._lock = threading.Lock()
+        self._pending: deque[object] = deque()
+        self._stop = threading.Event()
+        self._evt = threading.Event()
+        self._dropped_batches = 0
+        self._thread = threading.Thread(target=self._run, daemon=True, name=name)
+
+    def start(self) -> "AsyncBatchQueue":
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._evt.set()
+        try:
+            self._thread.join(timeout=5)
+        except Exception:
+            pass
+
+    def submit(self, batch) -> None:
+        if not batch:
+            return
+        with self._lock:
+            if len(self._pending) >= self._max_pending_batches:
+                self._pending.popleft()
+                self._dropped_batches += 1
+            self._pending.append(batch)
+        self._evt.set()
+
+    def snapshot(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "pending_batches": len(self._pending),
+                "dropped_batches": self._dropped_batches,
+            }
+
+    def _pop_next(self):
+        with self._lock:
+            if not self._pending:
+                return None
+            return self._pending.popleft()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._evt.wait(timeout=0.2)
+            self._evt.clear()
+            if self._stop.is_set():
+                break
+            while True:
+                batch = self._pop_next()
+                if batch is None:
+                    break
+                try:
+                    self._handler(batch)
+                except Exception:
+                    traceback.print_exc()
+
+        while True:
+            batch = self._pop_next()
+            if batch is None:
+                break
+            try:
+                self._handler(batch)
+            except Exception:
+                traceback.print_exc()
+
+
 def _extract_level_price(value) -> float:
     if isinstance(value, (list, tuple)):
         if not value:
@@ -165,25 +245,39 @@ def _build_tick_quote_event(code_prefixed: str, tick: dict) -> TickQuoteEvent | 
     )
 
 
-def _push_tick_quote_events(datas: dict[str, dict], *, redis_client=redis_db) -> None:
-    if not datas or redis_client is None:
-        return
-    try:
-        pipe = redis_client.pipeline()
-        pushed = 0
-        for code, tick in datas.items():
-            event = _build_tick_quote_event(code, tick)
-            if event is None:
-                continue
-            pipe.rpush(
+def _build_tick_quote_payloads(datas: dict[str, dict]) -> list[tuple[str, str]]:
+    payloads: list[tuple[str, str]] = []
+    for code, tick in (datas or {}).items():
+        event = _build_tick_quote_event(code, tick)
+        if event is None:
+            continue
+        payloads.append(
+            (
                 tick_queue_key_for_code(event.code),
                 json.dumps(event.to_dict(), ensure_ascii=False),
             )
-            pushed += 1
-        if pushed > 0:
-            pipe.execute()
+        )
+    return payloads
+
+
+def _push_tick_quote_payloads(
+    payloads: list[tuple[str, str]], *, redis_client=redis_db
+) -> None:
+    if not payloads or redis_client is None:
+        return
+    try:
+        pipe = redis_client.pipeline()
+        for queue_key, payload in payloads:
+            pipe.rpush(queue_key, payload)
+        pipe.execute()
     except Exception:
         traceback.print_exc()
+
+
+def _push_tick_quote_events(datas: dict[str, dict], *, redis_client=redis_db) -> None:
+    _push_tick_quote_payloads(
+        _build_tick_quote_payloads(datas), redis_client=redis_client
+    )
 
 
 def emit_producer_heartbeat(*, runtime_logger=None, **metrics) -> bool:
@@ -250,6 +344,63 @@ class ProducerHeartbeatState:
             self._batches.popleft()
 
 
+def _is_cn_trading_session(now_dt: datetime | None = None) -> bool:
+    dt = now_dt or datetime.now(tz=TZ)
+    t = dt.time()
+    return (t >= datetime(dt.year, dt.month, dt.day, 9, 30).time()) and (
+        t <= datetime(dt.year, dt.month, dt.day, 11, 30).time()
+    ) or (t >= datetime(dt.year, dt.month, dt.day, 13, 0).time()) and (
+        t <= datetime(dt.year, dt.month, dt.day, 15, 0).time()
+    )
+
+
+class ProducerRecoveryGuard:
+    def __init__(
+        self,
+        *,
+        stale_after_s: float = PRODUCER_STALE_RX_THRESHOLD_S,
+        retry_interval_s: float = PRODUCER_STALE_RETRY_INTERVAL_S,
+        reconnect_every: int = PRODUCER_STALE_RECONNECT_EVERY,
+    ):
+        self.stale_after_s = max(float(stale_after_s or 0.0), 1.0)
+        self.retry_interval_s = max(float(retry_interval_s or 0.0), 1.0)
+        self.reconnect_every = max(int(reconnect_every or 0), 1)
+        self._last_attempt_at = 0.0
+        self._stale_attempts = 0
+
+    def next_action(
+        self, *, now_ts: float, now_dt: datetime, snapshot: dict
+    ) -> str | None:
+        if not self._is_stale_snapshot(now_dt=now_dt, snapshot=snapshot):
+            self._stale_attempts = 0
+            return None
+
+        current_ts = float(now_ts)
+        if (current_ts - self._last_attempt_at) < self.retry_interval_s:
+            return None
+
+        self._last_attempt_at = current_ts
+        self._stale_attempts += 1
+        if (self._stale_attempts % self.reconnect_every) == 0:
+            return "reconnect"
+        return "resubscribe"
+
+    def _is_stale_snapshot(self, *, now_dt: datetime, snapshot: dict) -> bool:
+        if not _is_cn_trading_session(now_dt):
+            return False
+        if int(snapshot.get("connected") or 0) <= 0:
+            return False
+        if int(snapshot.get("subscribed_codes") or 0) <= 0:
+            return False
+        rx_age_s = snapshot.get("rx_age_s")
+        if rx_age_s is None:
+            return False
+        try:
+            return float(rx_age_s) >= self.stale_after_s
+        except Exception:
+            return False
+
+
 def start_producer():
     try:
         from xtquant import xtdata  # type: ignore
@@ -289,71 +440,156 @@ def start_producer():
         generator.on_tick(datas)
 
     pump = TickPump(_tick_handler, flush_interval_s=0.05).start()
+    tick_quote_queue = AsyncBatchQueue(
+        _push_tick_quote_payloads,
+        max_pending_batches=PRODUCER_TICK_QUOTE_MAX_PENDING_BATCHES,
+        name="TickQuoteWriter",
+    ).start()
     heartbeat_state = ProducerHeartbeatState(window_s=300.0)
+    recovery_guard = ProducerRecoveryGuard()
 
     sub_seq = None
     sub_codes: set[str] = set()
     subscribed_codes = 0
+    sub_lock = threading.RLock()
 
     def _subscribe(codes_prefixed: list[str]):
         nonlocal sub_seq, sub_codes, subscribed_codes
-        if not codes_prefixed:
-            logger.warning("[Producer] empty pool; waiting ...")
-            return
-        xt_codes = [_to_xt_symbol(c) for c in codes_prefixed]
+        with sub_lock:
+            if not codes_prefixed:
+                logger.warning("[Producer] empty pool; waiting ...")
+                return
+            xt_codes = [_to_xt_symbol(c) for c in codes_prefixed]
 
-        def on_data(datas):
-            norm = {
-                normalize_prefixed_code(k).lower(): v
-                for k, v in (datas or {}).items()
-                if k and v
-            }
-            heartbeat_state.record_tick_batch(tick_count=len(norm))
-            _push_tick_quote_events(norm)
-            pump.submit(norm)
+            def on_data(datas):
+                norm = {
+                    normalize_prefixed_code(k).lower(): v
+                    for k, v in (datas or {}).items()
+                    if k and v
+                }
+                heartbeat_state.record_tick_batch(tick_count=len(norm))
+                tick_quote_queue.submit(_build_tick_quote_payloads(norm))
+                pump.submit(norm)
 
-        if sub_seq is not None:
-            try:
-                xtdata.unsubscribe_quote(sub_seq)
-            except Exception:
-                pass
-        sub_seq = xtdata.subscribe_whole_quote(xt_codes, callback=on_data)
-        sub_codes = set(codes_prefixed)
-        subscribed_codes = len(sub_codes)
-        _emit_runtime(
-            _get_runtime_logger(),
-            {
-                "component": "xt_producer",
-                "node": "subscription_load",
-                "payload": {"mode": mode, "codes": len(sub_codes), "seq": sub_seq},
-            },
-        )
-        logger.info(
-            f"[Producer] subscribed: mode={mode} codes={len(sub_codes)} seq={sub_seq}"
-        )
+            if sub_seq is not None:
+                try:
+                    xtdata.unsubscribe_quote(sub_seq)
+                except Exception:
+                    pass
+            sub_seq = xtdata.subscribe_whole_quote(xt_codes, callback=on_data)
+            sub_codes = set(codes_prefixed)
+            subscribed_codes = len(sub_codes)
+            _emit_runtime(
+                _get_runtime_logger(),
+                {
+                    "component": "xt_producer",
+                    "node": "subscription_load",
+                    "payload": {"mode": mode, "codes": len(sub_codes), "seq": sub_seq},
+                },
+            )
+            logger.info(
+                f"[Producer] subscribed: mode={mode} codes={len(sub_codes)} seq={sub_seq}"
+            )
 
     _subscribe(_load_subscription_codes(mode=mode, max_symbols=max_symbols))
 
     heartbeat_stop = threading.Event()
 
     def _emit_current_heartbeat(now_ts: float | None = None):
+        with sub_lock:
+            current_subscribed_codes = subscribed_codes
+        queue_snapshot = tick_quote_queue.snapshot()
         emit_producer_heartbeat(
             runtime_logger=_get_runtime_logger(),
             **heartbeat_state.snapshot(
                 now_ts=now_ts,
-                subscribed_codes=subscribed_codes,
+                subscribed_codes=current_subscribed_codes,
                 connected=True,
             ),
+            tick_quote_pending_batches=queue_snapshot["pending_batches"],
+            tick_quote_dropped_batches=queue_snapshot["dropped_batches"],
         )
+
+    def _emit_recovery_event(*, action: str, status: str, rx_age_s, message: str):
+        _emit_runtime(
+            _get_runtime_logger(),
+            {
+                "component": "xt_producer",
+                "node": "subscription_guard",
+                "event_type": "trace_step",
+                "status": status,
+                "reason_code": "stale_rx",
+                "message": message,
+                "metrics": {
+                    "rx_age_s": rx_age_s,
+                },
+                "payload": {
+                    "action": action,
+                },
+            },
+        )
+
+    def _attempt_recovery(*, action: str, rx_age_s):
+        try:
+            with sub_lock:
+                current_codes = sorted(sub_codes)
+            if not current_codes:
+                current_codes = _load_subscription_codes(
+                    mode=mode, max_symbols=max_symbols
+                )
+            if not current_codes:
+                _emit_recovery_event(
+                    action=action,
+                    status="warning",
+                    rx_age_s=rx_age_s,
+                    message="[Producer] stale subscription recovery skipped: empty pool",
+                )
+                return
+            if action == "reconnect":
+                xtdata.connect(port=port)
+            _subscribe(current_codes)
+            _emit_recovery_event(
+                action=action,
+                status="warning",
+                rx_age_s=rx_age_s,
+                message=(
+                    f"[Producer] stale subscription recovery triggered: action={action}"
+                ),
+            )
+        except Exception:
+            logger.error(traceback.format_exc())
+            _emit_recovery_event(
+                action=action,
+                status="error",
+                rx_age_s=rx_age_s,
+                message=f"[Producer] stale subscription recovery failed: action={action}",
+            )
 
     def _heartbeat_loop():
         last_emit_at = time.time()
         while not heartbeat_stop.wait(timeout=1.0):
             now_ts = time.time()
-            if (now_ts - last_emit_at) < 300.0:
-                continue
-            _emit_current_heartbeat(now_ts)
-            last_emit_at = now_ts
+            now_dt = datetime.now(tz=TZ)
+            with sub_lock:
+                current_subscribed_codes = subscribed_codes
+            snapshot = heartbeat_state.snapshot(
+                now_ts=now_ts,
+                subscribed_codes=current_subscribed_codes,
+                connected=True,
+            )
+            action = recovery_guard.next_action(
+                now_ts=now_ts,
+                now_dt=now_dt,
+                snapshot=snapshot,
+            )
+            if action is not None:
+                _attempt_recovery(
+                    action=action,
+                    rx_age_s=snapshot.get("rx_age_s"),
+                )
+            if (now_ts - last_emit_at) >= PRODUCER_HEARTBEAT_INTERVAL_S:
+                _emit_current_heartbeat(now_ts)
+                last_emit_at = now_ts
 
     _emit_current_heartbeat()
     heartbeat_thread = threading.Thread(
@@ -366,12 +602,14 @@ def start_producer():
     def _pool_monitor_loop():
         while True:
             try:
-                time.sleep(30)
+                time.sleep(PRODUCER_POOL_REFRESH_INTERVAL_S)
                 new_list = _load_subscription_codes(mode=mode, max_symbols=max_symbols)
                 new_set = set(new_list)
-                if new_set and new_set != sub_codes:
+                with sub_lock:
+                    current_sub_codes = set(sub_codes)
+                if new_set and new_set != current_sub_codes:
                     logger.info(
-                        f"[Producer] pool changed: {len(sub_codes)} -> {len(new_set)}"
+                        f"[Producer] pool changed: {len(current_sub_codes)} -> {len(new_set)}"
                     )
                     _subscribe(new_list)
             except Exception:
@@ -392,6 +630,7 @@ def start_producer():
             heartbeat_thread.join(timeout=2)
         except Exception:
             pass
+        tick_quote_queue.stop()
         pump.stop()
         generator.stop()
         if sub_seq is not None:

--- a/freshquant/tests/test_xtdata_runtime_observability.py
+++ b/freshquant/tests/test_xtdata_runtime_observability.py
@@ -1,8 +1,8 @@
 import os
 import subprocess
 import sys
-import threading
 import textwrap
+import threading
 from datetime import datetime
 from pathlib import Path
 

--- a/freshquant/tests/test_xtdata_runtime_observability.py
+++ b/freshquant/tests/test_xtdata_runtime_observability.py
@@ -1,17 +1,22 @@
 import os
 import subprocess
 import sys
+import threading
 import textwrap
+from datetime import datetime
 from pathlib import Path
 
 from freshquant.market_data.xtdata.market_producer import (
+    AsyncBatchQueue,
     ProducerHeartbeatState,
+    ProducerRecoveryGuard,
     emit_producer_heartbeat,
 )
 from freshquant.market_data.xtdata.strategy_consumer import (
     ConsumerHeartbeatState,
     StrategyConsumer,
 )
+from freshquant.runtime_constants import TZ
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -74,6 +79,132 @@ def test_producer_heartbeat_state_tracks_recent_tick_activity_over_five_minutes(
         "tick_count_5m": 10,
         "rx_age_s": 150.0,
     }
+
+
+def test_async_batch_queue_runs_handler_on_background_thread():
+    handled = []
+    done = threading.Event()
+
+    def handler(batch):
+        handled.append((threading.get_ident(), batch))
+        done.set()
+
+    queue = AsyncBatchQueue(
+        handler,
+        max_pending_batches=4,
+        name="TestAsyncBatchQueue",
+    ).start()
+    submit_thread_id = threading.get_ident()
+    queue.submit([("QUEUE:TICK_QUOTE:1", '{"event":"TICK_QUOTE"}')])
+
+    assert done.wait(timeout=1.0) is True
+    assert handled == [
+        (
+            handled[0][0],
+            [("QUEUE:TICK_QUOTE:1", '{"event":"TICK_QUOTE"}')],
+        )
+    ]
+    assert handled[0][0] != submit_thread_id
+
+    queue.stop()
+
+
+def test_async_batch_queue_drops_oldest_batch_when_pending_queue_is_full():
+    queue = AsyncBatchQueue(
+        lambda batch: None,
+        max_pending_batches=2,
+        name="TestAsyncBatchQueueDropOldest",
+    )
+
+    queue.submit(["batch-1"])
+    queue.submit(["batch-2"])
+    queue.submit(["batch-3"])
+
+    assert queue.snapshot() == {
+        "pending_batches": 2,
+        "dropped_batches": 1,
+    }
+
+
+def test_producer_recovery_guard_escalates_from_resubscribe_to_reconnect():
+    guard = ProducerRecoveryGuard(
+        stale_after_s=120.0,
+        retry_interval_s=30.0,
+        reconnect_every=2,
+    )
+    trading_dt = datetime(2026, 4, 8, 10, 0, tzinfo=TZ)
+    stale_snapshot = {
+        "connected": 1,
+        "subscribed_codes": 14,
+        "rx_age_s": 180.0,
+    }
+
+    assert (
+        guard.next_action(now_ts=180.0, now_dt=trading_dt, snapshot=stale_snapshot)
+        == "resubscribe"
+    )
+    assert (
+        guard.next_action(now_ts=200.0, now_dt=trading_dt, snapshot=stale_snapshot)
+        is None
+    )
+    assert (
+        guard.next_action(now_ts=211.0, now_dt=trading_dt, snapshot=stale_snapshot)
+        == "reconnect"
+    )
+
+
+def test_producer_recovery_guard_resets_after_tick_flow_returns():
+    guard = ProducerRecoveryGuard(
+        stale_after_s=120.0,
+        retry_interval_s=30.0,
+        reconnect_every=2,
+    )
+    trading_dt = datetime(2026, 4, 8, 10, 0, tzinfo=TZ)
+    stale_snapshot = {
+        "connected": 1,
+        "subscribed_codes": 14,
+        "rx_age_s": 180.0,
+    }
+    healthy_snapshot = {
+        "connected": 1,
+        "subscribed_codes": 14,
+        "rx_age_s": 5.0,
+    }
+
+    assert (
+        guard.next_action(now_ts=180.0, now_dt=trading_dt, snapshot=stale_snapshot)
+        == "resubscribe"
+    )
+    assert (
+        guard.next_action(now_ts=181.0, now_dt=trading_dt, snapshot=healthy_snapshot)
+        is None
+    )
+    assert (
+        guard.next_action(now_ts=220.0, now_dt=trading_dt, snapshot=stale_snapshot)
+        == "resubscribe"
+    )
+
+
+def test_producer_recovery_guard_skips_recovery_outside_trading_session():
+    guard = ProducerRecoveryGuard(
+        stale_after_s=120.0,
+        retry_interval_s=30.0,
+        reconnect_every=2,
+    )
+    stale_snapshot = {
+        "connected": 1,
+        "subscribed_codes": 14,
+        "rx_age_s": 600.0,
+    }
+
+    assert (
+        guard.next_action(
+            now_ts=600.0,
+            now_dt=datetime(2026, 4, 8, 12, 0, tzinfo=TZ),
+            snapshot=stale_snapshot,
+        )
+        is None
+    )
 
 
 def test_consumer_heartbeat_state_tracks_recent_processing_activity_over_five_minutes():

--- a/freshquant/tests/test_xtdata_runtime_observability.py
+++ b/freshquant/tests/test_xtdata_runtime_observability.py
@@ -207,6 +207,28 @@ def test_producer_recovery_guard_skips_recovery_outside_trading_session():
     )
 
 
+def test_producer_recovery_guard_skips_recovery_on_weekends():
+    guard = ProducerRecoveryGuard(
+        stale_after_s=120.0,
+        retry_interval_s=30.0,
+        reconnect_every=2,
+    )
+    stale_snapshot = {
+        "connected": 1,
+        "subscribed_codes": 14,
+        "rx_age_s": 600.0,
+    }
+
+    assert (
+        guard.next_action(
+            now_ts=600.0,
+            now_dt=datetime(2026, 4, 11, 10, 0, tzinfo=TZ),
+            snapshot=stale_snapshot,
+        )
+        is None
+    )
+
+
 def test_consumer_heartbeat_state_tracks_recent_processing_activity_over_five_minutes():
     state = ConsumerHeartbeatState(window_s=300)
 


### PR DESCRIPTION
## ??
XTData producer ????????????????????????,???? `connected=1`?`subscribed_codes>0`,??? tick/bar ????????

## ??
- ?? Redis ???????? XTData ????
- ??????? stale ????????/????
- ???????????????????

## ??
- `freshquant.market_data.xtdata.market_producer`
- `freshquant.tests.test_xtdata_runtime_observability`
- `docs/current/modules/market-data-xtdata.md`
- `docs/current/troubleshooting.md`

## ???
- ???????????
- ????????? `XTQUANT_PORT`
- ??? consumer ???????

## ????
- XTData ???????? Redis tick quote ??
- ????? `rx_age_s` ??????? `resubscribe`,?? stale ???? `xtdata.connect() + resubscribe`
- ?????? `tick_quote_pending_batches` / `tick_quote_dropped_batches` ? `subscription_guard` ??
- ?? pytest ??

## ??
- `python -m pytest freshquant/tests/test_xtdata_runtime_observability.py freshquant/tests/test_xtdata_market_producer_subscription_pool.py freshquant/tests/test_xtdata_tick_quote_schema.py freshquant/tests/test_runtime_observability_health.py -q`
- `python -m pytest freshquant/tests -k xtdata -q`
- `python -m pytest freshquant/tests/test_runtime_observability_routes.py freshquant/tests/test_runtime_observability_clickhouse.py -q`

## ????
- ?? `freshquant/market_data/**`,???????????? `market_data` ??????
- deploy ????? `xt_producer` ? `rx_age_s`?`tick_count_5m`?`tick_quote_pending_batches`?`tick_quote_dropped_batches` ?? `subscription_guard` ??