### PR TITLE
Fix XTData 1m bar generation from whole-quote snapshots

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -45,6 +45,8 @@ producer 是唯一 XTData 入口；consumer 是唯一 bar 队列消费入口。
 `XTData -> market_producer/OneMinuteBarGenerator -> REDIS_QUEUE_PREFIX:<shard> -> strategy_consumer -> realtime cache / chanlun payload / Guardian`
 
 consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catchup 模式，暂时跳过 fullcalc，只保留最新数据。
+- `OneMinuteBarGenerator` 当前只在 `whole_quote` 快照带来正向 `volume/amount` 增量时更新 1 分钟 bar 的 OHLC；无成交的 quote-only 快照不会再改写分钟高低收。
+- `11:30:00` 与 `15:00:00` 这类交易时段结束边界快照会归入最后一个有效分钟 bar，而不是落到午休或收盘后的无效分钟桶。
 
 ## 存储
 

--- a/freshquant/market_data/xtdata/bar_generator.py
+++ b/freshquant/market_data/xtdata/bar_generator.py
@@ -73,6 +73,12 @@ def _timer_close_cutoff(dt: datetime) -> int:
     return int(dt.replace(hour=15, minute=1, second=0, microsecond=0).timestamp())
 
 
+def _should_scan_timer(dt: datetime) -> bool:
+    if _is_cn_a_trading_datetime(dt):
+        return True
+    return (dt.hour, dt.minute) in {(11, 30), (15, 0)}
+
+
 @dataclass(frozen=True)
 class BarEvent:
     code: str
@@ -263,6 +269,9 @@ class OneMinuteBarGenerator:
         while not self._timer_stop.is_set():
             try:
                 now = datetime.now(tz=TZ)
+                if not _should_scan_timer(now):
+                    time.sleep(1)
+                    continue
                 end_ts = _timer_close_cutoff(now)
                 to_push: list[BarEvent] = []
                 with self._lock:

--- a/freshquant/market_data/xtdata/bar_generator.py
+++ b/freshquant/market_data/xtdata/bar_generator.py
@@ -40,8 +40,16 @@ def _is_noon_break(dt: datetime) -> bool:
     )
 
 
+def _is_session_terminal_boundary(dt: datetime) -> bool:
+    if dt.second != 0 or dt.microsecond != 0:
+        return False
+    return (dt.hour, dt.minute) in {(11, 30), (15, 0)}
+
+
 def _ceil_minute_end(dt: datetime) -> datetime:
     dt0 = dt.replace(second=0, microsecond=0)
+    if _is_session_terminal_boundary(dt):
+        return dt0
     return dt0 + timedelta(minutes=1)
 
 
@@ -53,6 +61,16 @@ def _bucket_end(dt: datetime, period_min: int) -> datetime:
     if delta == period_min:
         delta = 0
     return dt0 + timedelta(minutes=delta)
+
+
+def _timer_close_cutoff(dt: datetime) -> int:
+    if _is_cn_a_trading_datetime(dt):
+        return int(_ceil_minute_end(dt).timestamp())
+    if _is_noon_break(dt):
+        return int(dt.replace(hour=13, minute=1, second=0, microsecond=0).timestamp())
+    if dt.time() < datetime(dt.year, dt.month, dt.day, 9, 30).time():
+        return int(dt.replace(hour=9, minute=31, second=0, microsecond=0).timestamp())
+    return int(dt.replace(hour=15, minute=1, second=0, microsecond=0).timestamp())
 
 
 @dataclass(frozen=True)
@@ -203,7 +221,12 @@ class OneMinuteBarGenerator:
         self._lock = threading.Lock()
         self._bars: dict[str, dict[str, Any]] = defaultdict(dict)
         self._tick_cache: dict[str, dict[str, Any]] = defaultdict(
-            lambda: {"last_vol": 0.0, "last_amt": 0.0}
+            lambda: {
+                "last_vol": 0.0,
+                "last_amt": 0.0,
+                "last_tick_ms": 0,
+                "trading_day": None,
+            }
         )
         self._last_close: dict[str, float] = {}
 
@@ -240,11 +263,7 @@ class OneMinuteBarGenerator:
         while not self._timer_stop.is_set():
             try:
                 now = datetime.now(tz=TZ)
-                if not _is_cn_a_trading_datetime(now):
-                    time.sleep(1)
-                    continue
-                end_dt = _ceil_minute_end(now)
-                end_ts = int(end_dt.timestamp())
+                end_ts = _timer_close_cutoff(now)
                 to_push: list[BarEvent] = []
                 with self._lock:
                     for code in list(self._bars.keys()):
@@ -256,6 +275,45 @@ class OneMinuteBarGenerator:
             except Exception:
                 traceback.print_exc()
             time.sleep(0.5)
+
+    def _update_tick_baseline(
+        self,
+        code: str,
+        *,
+        cum_vol: float,
+        cum_amt: float,
+        tick_time_ms: int,
+        trading_day: str,
+    ) -> None:
+        prev = self._tick_cache[code]
+        prev["last_vol"] = float(cum_vol)
+        prev["last_amt"] = float(cum_amt)
+        prev["last_tick_ms"] = int(tick_time_ms)
+        prev["trading_day"] = trading_day
+
+    def _ensure_bar(
+        self, code: str, *, end_ts: int, price: float, mark_tick: bool
+    ) -> dict[str, Any]:
+        bar = self._bars.get(code) or {}
+        if not bar or int(bar.get("time") or 0) != end_ts:
+            self._bars[code] = {
+                "time": end_ts,
+                "open": price,
+                "high": price,
+                "low": price,
+                "close": price,
+                "volume": 0.0,
+                "amount": 0.0,
+                "_had_tick": bool(mark_tick),
+            }
+            return self._bars[code]
+        if mark_tick and not bar.get("_had_tick"):
+            bar["open"] = price
+            bar["high"] = price
+            bar["low"] = price
+            bar["close"] = price
+            bar["_had_tick"] = True
+        return bar
 
     def _close_until(self, code: str, before_end_ts: int) -> list[BarEvent]:
         events: list[BarEvent] = []
@@ -338,42 +396,63 @@ class OneMinuteBarGenerator:
             return []
         end_ts = int(end_dt.timestamp())
 
+        events: list[BarEvent] = []
+        bar = self._bars.get(code) or {}
+        if bar and int(bar.get("time") or 0) < end_ts:
+            events.extend(self._close_until(code, end_ts))
+
         prev = self._tick_cache[code]
         last_vol = float(prev.get("last_vol") or 0.0)
         last_amt = float(prev.get("last_amt") or 0.0)
-        vol_delta = 0.0 if last_vol <= 0.0 else (cum_vol - last_vol)
-        amt_delta = 0.0 if last_vol <= 0.0 else (cum_amt - last_amt)
-        prev["last_vol"] = cum_vol
-        prev["last_amt"] = cum_amt
-        if vol_delta < 0:
-            return []
+        last_tick_ms = int(prev.get("last_tick_ms") or 0)
+        trading_day = dt.date().isoformat()
+        same_day = last_tick_ms > 0 and str(prev.get("trading_day") or "") == trading_day
+        last_vol_usable = same_day and last_vol > 0.0
+        last_amt_usable = same_day and last_amt > 0.0
 
-        bar = self._bars.get(code) or {}
-        events: list[BarEvent] = []
-        if bar and int(bar.get("time") or 0) < end_ts:
-            events.extend(self._close_until(code, end_ts))
-            bar = self._bars.get(code) or {}
+        if not same_day or (not last_vol_usable and not last_amt_usable):
+            self._update_tick_baseline(
+                code,
+                cum_vol=cum_vol,
+                cum_amt=cum_amt,
+                tick_time_ms=tick_time_ms,
+                trading_day=trading_day,
+            )
+            if price > 0.0 and (cum_vol > 0.0 or cum_amt > 0.0):
+                self._ensure_bar(code, end_ts=end_ts, price=price, mark_tick=True)
+                self._last_close[code] = float(price)
+            return events
 
-        if not bar or int(bar.get("time") or 0) != end_ts:
-            self._bars[code] = {
-                "time": end_ts,
-                "open": price,
-                "high": price,
-                "low": price,
-                "close": price,
-                "volume": 0.0,
-                "amount": 0.0,
-                "_had_tick": True,
-            }
-            bar = self._bars[code]
-        else:
-            if not bar.get("_had_tick"):
-                bar["open"] = price
-                bar["high"] = price
-                bar["low"] = price
-                bar["close"] = price
-                bar["_had_tick"] = True
+        vol_delta = 0.0 if not last_vol_usable else (cum_vol - last_vol)
+        amt_delta = 0.0 if not last_amt_usable else (cum_amt - last_amt)
+        if vol_delta < 0.0 or amt_delta < 0.0:
+            if cum_vol <= 0.0 and cum_amt <= 0.0:
+                return events
+            self._update_tick_baseline(
+                code,
+                cum_vol=cum_vol,
+                cum_amt=cum_amt,
+                tick_time_ms=tick_time_ms,
+                trading_day=trading_day,
+            )
+            return events
+        if vol_delta <= 0.0 and amt_delta <= 0.0:
+            if not last_vol_usable and cum_vol > 0.0:
+                prev["last_vol"] = float(cum_vol)
+            if not last_amt_usable and cum_amt > 0.0:
+                prev["last_amt"] = float(cum_amt)
+            prev["last_tick_ms"] = int(tick_time_ms)
+            prev["trading_day"] = trading_day
+            return events
 
+        self._update_tick_baseline(
+            code,
+            cum_vol=cum_vol,
+            cum_amt=cum_amt,
+            tick_time_ms=tick_time_ms,
+            trading_day=trading_day,
+        )
+        bar = self._ensure_bar(code, end_ts=end_ts, price=price, mark_tick=True)
         bar["high"] = max(float(bar["high"]), price)
         bar["low"] = min(float(bar["low"]), price)
         bar["close"] = price

--- a/freshquant/market_data/xtdata/bar_generator.py
+++ b/freshquant/market_data/xtdata/bar_generator.py
@@ -406,7 +406,9 @@ class OneMinuteBarGenerator:
         last_amt = float(prev.get("last_amt") or 0.0)
         last_tick_ms = int(prev.get("last_tick_ms") or 0)
         trading_day = dt.date().isoformat()
-        same_day = last_tick_ms > 0 and str(prev.get("trading_day") or "") == trading_day
+        same_day = (
+            last_tick_ms > 0 and str(prev.get("trading_day") or "") == trading_day
+        )
         last_vol_usable = same_day and last_vol > 0.0
         last_amt_usable = same_day and last_amt > 0.0
 

--- a/freshquant/tests/test_xtdata_bar_generator.py
+++ b/freshquant/tests/test_xtdata_bar_generator.py
@@ -1,0 +1,198 @@
+from datetime import datetime
+
+import pytest
+
+from freshquant import runtime_constants
+from freshquant.market_data.xtdata.bar_generator import OneMinuteBarGenerator
+
+
+def _tick(y, m, d, hour, minute, second, *, price, volume, amount):
+    dt = runtime_constants.TZ.localize(datetime(y, m, d, hour, minute, second))
+    return {
+        "time": int(dt.timestamp() * 1000),
+        "lastPrice": price,
+        "volume": volume,
+        "amount": amount,
+    }
+
+
+def _end_ts(y, m, d, hour, minute, second=0):
+    dt = runtime_constants.TZ.localize(datetime(y, m, d, hour, minute, second))
+    return int(dt.timestamp())
+
+
+@pytest.fixture
+def generator():
+    g = OneMinuteBarGenerator(enable_synthetic=True, push_1m=True, redis_client=None)
+    try:
+        yield g
+    finally:
+        g.stop()
+
+
+def test_zero_delta_snapshot_does_not_rewrite_bar_ohlc(generator):
+    code = "sh512000"
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 10, 25, 10, price=0.514, volume=1000, amount=514000),
+    )
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 10, 25, 20, price=0.515, volume=1010, amount=519140),
+    )
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 10, 25, 30, price=0.510, volume=1010, amount=519140),
+    )
+
+    bar = generator._bars[code]
+    assert bar["open"] == 0.514
+    assert bar["high"] == 0.515
+    assert bar["low"] == 0.514
+    assert bar["close"] == 0.515
+    assert bar["volume"] == 10.0
+    assert bar["amount"] == 5140.0
+
+
+def test_rejected_reset_snapshot_preserves_baseline_for_next_trade(generator):
+    code = "sh512000"
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 10, 25, 10, price=0.514, volume=1000, amount=514000),
+    )
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 10, 25, 20, price=0.515, volume=1010, amount=519140),
+    )
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 10, 25, 30, price=0.510, volume=0, amount=0),
+    )
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 10, 25, 40, price=0.516, volume=1020, amount=524300),
+    )
+
+    bar = generator._bars[code]
+    assert bar["high"] == 0.516
+    assert bar["low"] == 0.514
+    assert bar["close"] == 0.516
+    assert bar["volume"] == 20.0
+    assert bar["amount"] == 10300.0
+    assert generator._tick_cache[code]["last_vol"] == 1020.0
+    assert generator._tick_cache[code]["last_amt"] == 524300.0
+
+
+def test_amount_delta_bootstrap_is_independent_from_volume(generator):
+    code = "sh512000"
+    generator._tick_cache[code] = {
+        "last_vol": 1000.0,
+        "last_amt": 0.0,
+        "last_tick_ms": int(
+            runtime_constants.TZ.localize(datetime(2026, 4, 13, 10, 25, 0)).timestamp()
+            * 1000
+        ),
+        "trading_day": "2026-04-13",
+    }
+
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 10, 25, 10, price=0.514, volume=1010, amount=519140),
+    )
+
+    bar = generator._bars[code]
+    assert bar["volume"] == 10.0
+    assert bar["amount"] == 0.0
+    assert generator._tick_cache[code]["last_amt"] == 519140.0
+
+
+def test_quote_only_snapshot_bootstraps_missing_amount_baseline(generator):
+    code = "sh512000"
+    generator._tick_cache[code] = {
+        "last_vol": 1000.0,
+        "last_amt": 0.0,
+        "last_tick_ms": int(
+            runtime_constants.TZ.localize(datetime(2026, 4, 13, 10, 25, 0)).timestamp()
+            * 1000
+        ),
+        "trading_day": "2026-04-13",
+    }
+
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 10, 25, 5, price=0.514, volume=1000, amount=514000),
+    )
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 10, 25, 10, price=0.515, volume=1010, amount=519140),
+    )
+
+    bar = generator._bars[code]
+    assert bar["volume"] == 10.0
+    assert bar["amount"] == 5140.0
+    assert generator._tick_cache[code]["last_amt"] == 519140.0
+
+
+@pytest.mark.parametrize(
+    ("previous_tick_dt", "tick_dt", "close_before_end", "expected_end_dt"),
+    [
+        (
+            (2026, 4, 13, 11, 29, 59),
+            (2026, 4, 13, 11, 30, 0),
+            (2026, 4, 13, 13, 1, 0),
+            (2026, 4, 13, 11, 30, 0),
+        ),
+        (
+            (2026, 4, 13, 14, 59, 59),
+            (2026, 4, 13, 15, 0, 0),
+            (2026, 4, 13, 15, 1, 0),
+            (2026, 4, 13, 15, 0, 0),
+        ),
+    ],
+)
+def test_exact_session_boundary_tick_stays_in_last_trading_bar(
+    generator, previous_tick_dt, tick_dt, close_before_end, expected_end_dt
+):
+    code = "sh512000"
+    generator._process_single_tick(
+        code,
+        _tick(*previous_tick_dt, price=0.514, volume=1000, amount=514000),
+    )
+    generator._process_single_tick(
+        code,
+        _tick(*tick_dt, price=0.515, volume=1010, amount=519150),
+    )
+
+    events = generator._close_until(code, _end_ts(*close_before_end))
+
+    assert len(events) == 1
+    bar = events[0].data
+    assert bar["time"] == _end_ts(*expected_end_dt)
+    assert bar["close"] == 0.515
+    assert bar["volume"] == 10.0
+    assert bar["amount"] == 5150.0
+
+
+def test_new_trading_day_reboots_cumulative_baseline(generator):
+    code = "sh512000"
+    generator._process_single_tick(
+        code,
+        _tick(2026, 4, 10, 14, 59, 50, price=0.514, volume=1000, amount=514000),
+    )
+
+    events = generator._process_single_tick(
+        code,
+        _tick(2026, 4, 13, 9, 30, 5, price=0.520, volume=10, amount=5200),
+    )
+
+    assert len(events) == 1
+    bar = generator._bars[code]
+    assert bar["open"] == 0.520
+    assert bar["high"] == 0.520
+    assert bar["low"] == 0.520
+    assert bar["close"] == 0.520
+    assert bar["volume"] == 0.0
+    assert bar["amount"] == 0.0
+    assert generator._tick_cache[code]["last_vol"] == 10.0
+    assert generator._tick_cache[code]["last_amt"] == 5200.0
+    assert generator._tick_cache[code]["trading_day"] == "2026-04-13"

--- a/freshquant/tests/test_xtdata_bar_generator.py
+++ b/freshquant/tests/test_xtdata_bar_generator.py
@@ -3,7 +3,10 @@ from datetime import datetime
 import pytest
 
 from freshquant import runtime_constants
-from freshquant.market_data.xtdata.bar_generator import OneMinuteBarGenerator
+from freshquant.market_data.xtdata.bar_generator import (
+    OneMinuteBarGenerator,
+    _should_scan_timer,
+)
 
 
 def _tick(y, m, d, hour, minute, second, *, price, volume, amount):
@@ -21,6 +24,10 @@ def _end_ts(y, m, d, hour, minute, second=0):
     return int(dt.timestamp())
 
 
+def _dt(y, m, d, hour, minute, second=0):
+    return runtime_constants.TZ.localize(datetime(y, m, d, hour, minute, second))
+
+
 @pytest.fixture
 def generator():
     g = OneMinuteBarGenerator(enable_synthetic=True, push_1m=True, redis_client=None)
@@ -28,6 +35,21 @@ def generator():
         yield g
     finally:
         g.stop()
+
+
+@pytest.mark.parametrize(
+    ("dt", "expected"),
+    [
+        (_dt(2026, 4, 13, 9, 35, 0), True),
+        (_dt(2026, 4, 13, 11, 30, 30), True),
+        (_dt(2026, 4, 13, 11, 31, 0), False),
+        (_dt(2026, 4, 13, 12, 15, 0), False),
+        (_dt(2026, 4, 13, 15, 0, 30), True),
+        (_dt(2026, 4, 13, 15, 1, 0), False),
+    ],
+)
+def test_timer_only_scans_during_trading_or_session_close_window(dt, expected):
+    assert _should_scan_timer(dt) is expected
 
 
 def test_zero_delta_snapshot_does_not_rewrite_bar_ohlc(generator):


### PR DESCRIPTION
## ??
- `XTData subscribe_whole_quote` ??????? quote-only ???
- ?? `OneMinuteBarGenerator` ????????????????? 1 ?? OHLC??? `512000` ??? intraday low ????????????

## ??
- ????? `volume/amount` ??????? 1 ?? bar ???
- ???????? `11:30:00` / `15:00:00` ????
- ??????????? `docs/current` ?????

## ??
- `freshquant/market_data/xtdata/bar_generator.py`
- `freshquant/tests/test_xtdata_bar_generator.py`
- `docs/current/modules/market-data-xtdata.md`

## ???
- ????? Kline ?????
- ??? PR ?????????????

## ????
- ???/quote-only ???????? OHLC?
- reset ???????????????
- `11:30:00` / `15:00:00` ?? tick ????????? bar?
- ????????? xtdata ????????

## ????
- ???? `market_data` ???????producer / consumer??
- ????????? `2026-04-13` ? `index_realtime` / realtime cache?