### PR TITLE
Restrict realtime merge to current day bars

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -47,6 +47,7 @@ producer 是唯一 XTData 入口；consumer 是唯一 bar 队列消费入口。
 consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catchup 模式，暂时跳过 fullcalc，只保留最新数据。
 - `OneMinuteBarGenerator` 当前只在 `whole_quote` 快照带来正向 `volume/amount` 增量时更新 1 分钟 bar 的 OHLC；无成交的 quote-only 快照不会再改写分钟高低收。
 - `11:30:00` 与 `15:00:00` 这类交易时段结束边界快照会归入最后一个有效分钟 bar，而不是落到午休或收盘后的无效分钟桶。
+- `StrategyConsumer` 当前只允许“当天”的 realtime bar 参与 history/realtime merge；所有已完成交易日的分钟线都只信任盘后同步到 QuantAxis 的历史库，不再允许旧 `index_realtime/stock_realtime` 覆盖历史分钟线。
 
 ## 存储
 

--- a/freshquant/market_data/xtdata/strategy_consumer.py
+++ b/freshquant/market_data/xtdata/strategy_consumer.py
@@ -237,6 +237,10 @@ def _load_minute_history_from_quantaxis_db(
     return hist_df.reset_index(drop=True)
 
 
+def _current_realtime_window_start(end_dt: datetime) -> datetime:
+    return end_dt.astimezone(TZ).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
 def _worker_fullcalc(df: pd.DataFrame, model_ids: list[int]) -> dict[str, Any]:
     return run_fullcalc(df, model_ids=model_ids)
 
@@ -571,15 +575,17 @@ class StrategyConsumer:
             )
             hist_df = _empty_bar_window_df()
 
-        # realtime bars (may be empty)
+        # realtime bars are only trusted for the current calendar day; completed
+        # trading days must come from the post-close history sync.
         coll = "index_realtime" if is_index_like else "stock_realtime"
+        rt_start_dt = max(start_dt, _current_realtime_window_start(end_dt))
         rt_cur = (
             DBfreshquant[coll]
             .find(
                 {
                     "code": code,
                     "frequence": period_backend,
-                    "datetime": {"$gte": start_dt, "$lte": end_dt},
+                    "datetime": {"$gte": rt_start_dt, "$lte": end_dt},
                 },
                 {
                     "_id": 0,

--- a/freshquant/tests/test_xtdata_strategy_consumer_history.py
+++ b/freshquant/tests/test_xtdata_strategy_consumer_history.py
@@ -443,3 +443,104 @@ def test_load_window_from_db_handles_mixed_datetime_shapes_in_history_docs(
         bar_1.strftime("%H:%M"),
         bar_2.strftime("%H:%M"),
     ]
+
+
+def test_load_window_from_db_ignores_completed_day_realtime_overlap(monkeypatch):
+    _disable_quantaxis_import(monkeypatch)
+
+    now_dt = cfg.TZ.localize(datetime(2026, 4, 13, 14, 30, 0))
+    prev_day_bar = cfg.TZ.localize(datetime(2026, 4, 10, 10, 2, 0))
+    today_bar = cfg.TZ.localize(datetime(2026, 4, 13, 14, 24, 0))
+
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return now_dt
+            return now_dt.astimezone(tz)
+
+    monkeypatch.setattr(sc, "datetime", FrozenDateTime)
+    monkeypatch.setattr(
+        sc,
+        "DBQuantAxis",
+        FakeDatabase(
+            {
+                "index_min": FakeCollection(
+                    [
+                        {
+                            "code": "512000",
+                            "type": "1min",
+                            "date": prev_day_bar.strftime("%Y-%m-%d"),
+                            "datetime": prev_day_bar.strftime("%Y-%m-%d %H:%M:%S"),
+                            "time_stamp": prev_day_bar.timestamp(),
+                            "open": 0.518,
+                            "high": 0.519,
+                            "low": 0.518,
+                            "close": 0.519,
+                            "vol": 33824800.0,
+                            "amount": 17552222.0,
+                        },
+                        {
+                            "code": "512000",
+                            "type": "1min",
+                            "date": today_bar.strftime("%Y-%m-%d"),
+                            "datetime": today_bar.strftime("%Y-%m-%d %H:%M:%S"),
+                            "time_stamp": today_bar.timestamp(),
+                            "open": 0.514,
+                            "high": 0.514,
+                            "low": 0.514,
+                            "close": 0.514,
+                            "vol": 1000.0,
+                            "amount": 514000.0,
+                        },
+                    ]
+                ),
+                "etf_adj": FakeCollection([]),
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        sc,
+        "DBfreshquant",
+        FakeDatabase(
+            {
+                "index_realtime": FakeCollection(
+                    [
+                        {
+                            "code": "sh512000",
+                            "frequence": "1min",
+                            "datetime": prev_day_bar,
+                            "open": 0.518,
+                            "high": 0.519,
+                            "low": 0.493,
+                            "close": 0.519,
+                            "volume": 338248.0,
+                            "amount": 17552222.0,
+                        },
+                        {
+                            "code": "sh512000",
+                            "frequence": "1min",
+                            "datetime": today_bar,
+                            "open": 0.515,
+                            "high": 0.515,
+                            "low": 0.514,
+                            "close": 0.515,
+                            "volume": 2624.0,
+                            "amount": 134800.0,
+                        },
+                    ]
+                )
+            }
+        ),
+    )
+
+    consumer = _make_consumer(is_index_like=True)
+    result = consumer._load_window_from_db(code="sh512000", period_backend="1min")
+
+    assert result["datetime"].dt.strftime("%Y-%m-%d %H:%M").tolist() == [
+        prev_day_bar.strftime("%Y-%m-%d %H:%M"),
+        today_bar.strftime("%Y-%m-%d %H:%M"),
+    ]
+    assert result["low"].tolist() == [0.518, 0.514]
+    assert result["open"].tolist() == [0.518, 0.515]
+    assert result["close"].tolist() == [0.519, 0.515]


### PR DESCRIPTION
## 背景

`KlineSlim` 在未选择 `endDate` 时会走 realtime cache。当前 consumer 会把 QuantAxis 历史分钟线与 `index_realtime/stock_realtime` 直接拼接，同一分钟保留 realtime 版本，导致已完成交易日的旧 realtime 脏 bar 继续覆盖盘后同步的干净历史分钟线。

## 目标

让 realtime merge 只作用于当天数据；所有已完成交易日的分钟线统一以盘后同步历史为准。

## 范围

- `StrategyConsumer._load_window_from_db()` 只查询当天 realtime bar 参与 merge
- 补一条回归测试，覆盖“完成日 dirty realtime 不得覆盖 history”
- 更新 `docs/current/modules/market-data-xtdata.md`

## 非目标

- 不改前端 `KlineSlim` 的交互模式
- 不在这次 PR 里清理历史脏 realtime 数据
- 不改 producer 的 bar 生成逻辑（此前已在另一轮修复）

## 验收标准

- `_load_window_from_db()` 对于非当天分钟线只返回历史库数据
- 当天分钟线仍可被 realtime 覆盖
- 新增测试覆盖 4/10 类 completed-day overlap 场景
- 相关 `xtdata` 测试通过

## 部署影响

- 命中 `freshquant/market_data/**`
- 合并后需要重部署 `market_data`
- 部署后需要重建受影响标的的 realtime cache，确保旧 cache 不再持有 completed-day realtime 覆盖结果
