### PR TITLE
[codex] rebuild xt account sync retry self-healing

### DIFF
--- a/docs/current/modules/position-management.md
+++ b/docs/current/modules/position-management.md
@@ -23,7 +23,7 @@
 
 - worker
   - `python -m freshquant.xt_account_sync.worker --interval 15`
-  - worker 对 XT `connect/subscribe` 暂不可用采用退避重试；只在非连接类异常时退出
+  - worker 对 XT `connect/subscribe` 暂不可用采用退避重试，并在每次可重试失败后重建新的 XT sync service/client；只在非连接类异常时退出
 - HTTP
   - `GET /api/position-management/dashboard`
   - `GET /api/position-management/config`

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -8,7 +8,7 @@
 - Mongo 通过 `127.0.0.1:27027` 接入 Docker `fq_mongodb`；宿主机链路不要再使用 `127.0.0.1:27017`。
 - `fqnext-supervisord` 宿主机底座与其托管的交易/运行链 Python 进程。
 - Guardian monitor。
-- XT account sync worker（作为 XT 账户数据的增量补偿同步入口，默认每 15 秒轮询 `assets / credit_detail / positions / orders / trades`；其中 `credit_detail` 保持高频刷新以驱动仓位管理状态，只把新增 `orders / trades` 送入 ingest；`credit_subjects` 只在启动和每日计划时间做低频同步，并在启动时做一次单标的实时仓位 fallback 种子刷新；若 `positions` 快照为空或严重缩水、但同轮 `credit_detail.market_value` 仍显著为正，则该轮快照会进入 quarantine，不覆盖 `xt_positions`，也不触发自动平账；这个 quarantine 现在也覆盖小账户单票/双票严重缩水的场景，同时 worker 会记录 warning 说明 quarantine 原因）。
+- XT account sync worker（作为 XT 账户数据的增量补偿同步入口，默认每 15 秒轮询 `assets / credit_detail / positions / orders / trades`；其中 `credit_detail` 保持高频刷新以驱动仓位管理状态，只把新增 `orders / trades` 送入 ingest；`credit_subjects` 只在启动和每日计划时间做低频同步，并在启动时做一次单标的实时仓位 fallback 种子刷新；若 `positions` 快照为空或严重缩水、但同轮 `credit_detail.market_value` 仍显著为正，则该轮快照会进入 quarantine，不覆盖 `xt_positions`，也不触发自动平账；这个 quarantine 现在也覆盖小账户单票/双票严重缩水的场景，同时 worker 会记录 warning 说明 quarantine 原因；对 `xtquant connect/subscribe` 可重试失败，worker 会在退避后重建新的 XT sync service/client 再继续同步）。
 - XT auto repay worker（默认每 30 分钟低频巡检一次已同步的 `credit_detail` 快照，只处理普通融资负债；盘中命中候选后才即时执行一次 `query_credit_detail()` 二次确认，再走 `CREDIT_DIRECT_CASH_REPAY`；固定在 `14:55` 做日终硬结算、`15:05` 做一次补偿重试；`broker_submit_mode=observe_only` 时只记录事件，不真实提交还款）。
 - TPSL tick listener。
 - 需要直接访问券商、终端、`TDX_HOME` 或 Windows 本地目录的组件。

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -595,7 +595,7 @@ print(inspect.signature(resolve_stock_account))
 
 - 先确认正式 deploy 来源已经是最新远程 `main` 已合并 SHA
 - 当前仓库中的 `freshquant/xt_account_sync/client.py` 已兼容新旧 `resolve_stock_account` 签名；如果仍报这个错误，说明宿主机还没跑到最新已合并代码，先重新同步 deploy mirror 并重跑 formal deploy
-- 当前 worker 会对 `xtquant connect failed:*` 与 `xtquant subscribe failed:*` 保持 `Running` 并退避重试；如果 stderr 持续刷这两类日志，优先确认 MiniQMT 已启动且已登录正确账户
+- 当前 worker 会对 `xtquant connect failed:*` 与 `xtquant subscribe failed:*` 保持 `Running` 并退避重试，且每次可重试失败后都会重建新的 XT sync service/client；如果 stderr 持续刷这两类日志，优先确认 MiniQMT 已启动且已登录正确账户
 - 若仍需继续定位，优先以 `inspect.getsourcefile()` 与 `inspect.signature()` 的结果确认宿主机实际 import 源，而不是继续凭仓库文件内容猜测
 - worker 恢复后，再重新执行命中的 host runtime surface restart 或整轮 formal deploy，并确认 runtime verify 通过
 

--- a/freshquant/tests/test_xt_account_sync_worker.py
+++ b/freshquant/tests/test_xt_account_sync_worker.py
@@ -331,6 +331,94 @@ def test_worker_run_forever_retries_retryable_xt_errors_until_startup_succeeds(
     ]
 
 
+def test_worker_run_forever_rebuilds_default_service_after_retryable_xt_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from freshquant.xt_account_sync import worker as worker_module
+
+    failed_service = SequencedSyncService(
+        [RuntimeError("xtquant connect failed: -1")]
+    )
+    recovered_service = SequencedSyncService(
+        [
+            {"positions": {"count": 1}},
+            {"positions": {"count": 2}},
+        ]
+    )
+    built_services = []
+    service_queue = iter([failed_service, recovered_service])
+
+    monkeypatch.setattr(
+        worker_module,
+        "XtAccountSyncService",
+        type(
+            "FakeXtAccountSyncService",
+            (),
+            {
+                "build_default": staticmethod(
+                    lambda: built_services.append("build") or next(service_queue)
+                )
+            },
+        ),
+    )
+    warnings = []
+    monkeypatch.setattr(
+        worker_module,
+        "logger",
+        SimpleNamespace(
+            warning=lambda message, *args: warnings.append(message % args),
+        ),
+    )
+    moments = iter(
+        [
+            datetime(2026, 3, 19, 9, 19, tzinfo=timezone.utc),
+            datetime(2026, 3, 19, 9, 20, tzinfo=timezone.utc),
+        ]
+    )
+    sleep_calls = []
+
+    def fake_now():
+        return next(moments)
+
+    def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 2:
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        worker_module.run_forever(
+            interval_seconds=3,
+            sleep_fn=fake_sleep,
+            now_provider=fake_now,
+            scheduled_hour=9,
+            scheduled_minute=20,
+            retry_delay_seconds=5,
+            retry_delay_max_seconds=60,
+        )
+
+    assert built_services == ["build", "build"]
+    assert failed_service.calls == [
+        {
+            "include_credit_subjects": True,
+            "seed_symbol_snapshots": True,
+        }
+    ]
+    assert recovered_service.calls == [
+        {
+            "include_credit_subjects": True,
+            "seed_symbol_snapshots": True,
+        },
+        {
+            "include_credit_subjects": True,
+            "seed_symbol_snapshots": True,
+        },
+    ]
+    assert sleep_calls == [5, 3]
+    assert warnings == [
+        "xt_account_sync XT unavailable; retrying in 5.0 seconds: xtquant connect failed: -1"
+    ]
+
+
 def test_worker_run_forever_keeps_non_retryable_errors_fatal():
     from freshquant.xt_account_sync.worker import run_forever
 

--- a/freshquant/tests/test_xt_account_sync_worker.py
+++ b/freshquant/tests/test_xt_account_sync_worker.py
@@ -336,9 +336,7 @@ def test_worker_run_forever_rebuilds_default_service_after_retryable_xt_errors(
 ):
     from freshquant.xt_account_sync import worker as worker_module
 
-    failed_service = SequencedSyncService(
-        [RuntimeError("xtquant connect failed: -1")]
-    )
+    failed_service = SequencedSyncService([RuntimeError("xtquant connect failed: -1")])
     recovered_service = SequencedSyncService(
         [
             {"positions": {"count": 1}},
@@ -348,17 +346,17 @@ def test_worker_run_forever_rebuilds_default_service_after_retryable_xt_errors(
     built_services = []
     service_queue = iter([failed_service, recovered_service])
 
+    def _build_service():
+        built_services.append("build")
+        return next(service_queue)
+
     monkeypatch.setattr(
         worker_module,
         "XtAccountSyncService",
         type(
             "FakeXtAccountSyncService",
             (),
-            {
-                "build_default": staticmethod(
-                    lambda: built_services.append("build") or next(service_queue)
-                )
-            },
+            {"build_default": staticmethod(_build_service)},
         ),
     )
     warnings = []

--- a/freshquant/xt_account_sync/worker.py
+++ b/freshquant/xt_account_sync/worker.py
@@ -34,7 +34,8 @@ def run_forever(
     retry_delay_seconds=5.0,
     retry_delay_max_seconds=60.0,
 ):
-    sync_service = service or XtAccountSyncService.build_default()
+    sync_service_factory = XtAccountSyncService.build_default if service is None else None
+    sync_service = service or sync_service_factory()
     now_provider = now_provider or _shanghai_now
     startup_time = now_provider()
 
@@ -42,8 +43,9 @@ def run_forever(
     # position management. Only credit_subjects is reduced to startup/daily sync.
     if symbol_position_service is not None:
         symbol_position_service.refresh_all_from_positions()
-    _sync_once_with_xt_retry(
+    sync_service = _sync_once_with_xt_retry(
         sync_service,
+        sync_service_factory=sync_service_factory,
         include_credit_subjects=include_credit_subjects_on_startup,
         seed_symbol_snapshots=True,
         sleep_fn=sleep_fn,
@@ -67,8 +69,9 @@ def run_forever(
             scheduled_hour,
             scheduled_minute,
         )
-        _sync_once_with_xt_retry(
+        sync_service = _sync_once_with_xt_retry(
             sync_service,
+            sync_service_factory=sync_service_factory,
             include_credit_subjects=include_credit_subjects,
             seed_symbol_snapshots=True,
             sleep_fn=sleep_fn,
@@ -147,6 +150,7 @@ def _shanghai_now():
 def _sync_once_with_xt_retry(
     sync_service,
     *,
+    sync_service_factory,
     include_credit_subjects,
     seed_symbol_snapshots,
     sleep_fn,
@@ -170,9 +174,11 @@ def _sync_once_with_xt_retry(
             )
             sleep_fn(delay_seconds)
             delay_seconds = min(delay_seconds * 2, retry_delay_max_seconds)
+            if sync_service_factory is not None:
+                sync_service = sync_service_factory()
             continue
         _log_positions_quarantine(result)
-        return result
+        return sync_service
 
 
 def _is_retryable_xt_sync_error(error):

--- a/freshquant/xt_account_sync/worker.py
+++ b/freshquant/xt_account_sync/worker.py
@@ -34,7 +34,9 @@ def run_forever(
     retry_delay_seconds=5.0,
     retry_delay_max_seconds=60.0,
 ):
-    sync_service_factory = XtAccountSyncService.build_default if service is None else None
+    sync_service_factory = (
+        XtAccountSyncService.build_default if service is None else None
+    )
     sync_service = service or sync_service_factory()
     now_provider = now_provider or _shanghai_now
     startup_time = now_provider()


### PR DESCRIPTION
## Summary
- rebuild the XT account sync worker's default sync service after retryable `xtquant connect/subscribe` failures
- add a regression test covering recovery via a freshly constructed default service
- document the updated retry behavior in the current runtime and troubleshooting docs

## Root Cause
`freshquant.xt_account_sync.worker.run_forever()` built the default `XtAccountSyncService` only once. In the incident we traced, the long-running worker stayed in a retry loop with `xtquant connect failed: -1`, while a separately started one-shot sync could connect and refresh `pm_current_state` successfully. Reusing the same default service/client across retries left the worker unable to self-heal after QMT became ready.

## What Changed
- keep the existing retry/backoff behavior for retryable XT failures
- when the worker is using the default service, rebuild a fresh default sync service/client before the next retry attempt
- preserve the previous behavior for explicitly injected test services
- update `docs/current/**` to match the new runtime truth

## Validation
- `python -m pytest freshquant/tests/test_xt_account_sync_worker.py -q`
- `powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure` with repo-local `uv.exe` added to `PATH`
- runtime diagnosis before patch confirmed `pm_current_state` staleness was caused by repeated `xtquant connect failed: -1` errors in `fqnext_xt_account_sync_worker_err.log`

## Deployment Impact
- impacted host surface: `position_management` / `fqnext_xt_account_sync_worker`
- after merge, sync canonical local `main`, restart the host surface through the formal deploy path, and verify `pm_current_state.evaluated_at` keeps advancing
