### PR TITLE
Harden XT host reconnect self-healing

### DIFF
--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -165,3 +165,10 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
 - Formal deploy syncs the canonical repo root onto local `main` before it runs `uv sync` or `run_formal_deploy.py`.
 - The expected host runtime Python is `D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe`.
 - When host surfaces are hit, supervisor reconciliation and runtime verify both treat `D:\fqpack\freshquant-2026.2.23` as the only accepted repo root truth.
+
+## XT Host Reconnect Guardrails
+
+- `freshquant.xt_account_sync.client.XtAccountQueryClient` 现在会在只读 XT 查询遇到可重试连接错误时主动 `reset_connection()` 并重建连接后再重试一次；`query_credit_detail()` 在信用账户下如果返回空记录，也会先断开旧连接再补一次读取。
+- `freshquant.position_management.credit_client.PositionCreditClient` 现在对 `query_credit_detail()` 采用相同的读请求自愈逻辑；这层被 `xt_auto_repay`、`position_management.snapshot_service` 等宿主机链路复用。
+- `freshquant.xt_auto_repay.worker.XtAutoRepayWorker` 现在只对“确认还款前的 `query_credit_detail()`”做带退避的可重试 XT 自愈：命中 `xtquant connect/subscribe failed` 或空明细时，会先 reset 当前 credit client，再重建新的 executor 后继续查询。
+- `xt_auto_repay` 的真实 `submit_direct_cash_repay()` 仍然不做盲目自动重提，避免在券商侧已受理但客户端回包异常时制造重复还款。

--- a/freshquant/position_management/credit_client.py
+++ b/freshquant/position_management/credit_client.py
@@ -54,8 +54,10 @@ class PositionCreditClient:
         )
 
     def query_credit_detail(self):
-        trader, account = self._ensure_credit_connection()
-        return trader.query_credit_detail(account)
+        return self._call_read_only(
+            lambda trader, account: trader.query_credit_detail(account),
+            retry_on_empty=True,
+        )
 
     def submit_direct_cash_repay(
         self,
@@ -67,7 +69,6 @@ class PositionCreditClient:
         price_type=None,
         price=0.0,
     ):
-        trader, account = self._ensure_credit_connection()
         from freshquant.carnation import xtconstant
 
         resolved_amount = int(float(repay_amount or 0))
@@ -76,16 +77,21 @@ class PositionCreditClient:
         resolved_price_type = (
             xtconstant.FIX_PRICE if price_type is None else int(price_type)
         )
-        return trader.order_stock(
-            account,
-            str(stock_code or "").strip(),
-            xtconstant.CREDIT_DIRECT_CASH_REPAY,
-            resolved_amount,
-            resolved_price_type,
-            float(price or 0.0),
-            strategy_name,
-            order_remark,
-        )
+        trader, account = self._ensure_credit_connection()
+        try:
+            return trader.order_stock(
+                account,
+                str(stock_code or "").strip(),
+                xtconstant.CREDIT_DIRECT_CASH_REPAY,
+                resolved_amount,
+                resolved_price_type,
+                float(price or 0.0),
+                strategy_name,
+                order_remark,
+            )
+        except Exception:
+            self.reset_connection()
+            raise
 
     def _ensure_credit_connection(self):
         self._refresh_runtime_config(strict=True)
@@ -112,6 +118,35 @@ class PositionCreditClient:
         self._trader = trader
         self._account = account
         return self._trader, self._account
+
+    def reset_connection(self):
+        trader = self._trader
+        self._trader = None
+        self._account = None
+        close_fn = getattr(trader, "stop", None)
+        if callable(close_fn):
+            try:
+                close_fn()
+            except Exception:
+                pass
+
+    def _call_read_only(self, operation, *, retry_on_empty=False):
+        last_result = None
+        for _ in range(2):
+            try:
+                trader, account = self._ensure_credit_connection()
+                result = operation(trader, account)
+            except Exception as error:
+                if not _is_retryable_xt_credit_error(error):
+                    raise
+                self.reset_connection()
+                continue
+            last_result = result
+            if retry_on_empty and _is_empty_credit_detail_response(result):
+                self.reset_connection()
+                continue
+            return result
+        return last_result
 
     def _refresh_runtime_config(
         self,
@@ -154,3 +189,23 @@ class PositionCreditClient:
             self.account_type = str(
                 getattr(xtquant_settings, "account_type", "STOCK") or "STOCK"
             ).upper()
+
+
+def _is_retryable_xt_credit_error(error):
+    message = str(error or "")
+    normalized = message.lower()
+    if normalized.startswith("xtquant connect failed:") or normalized.startswith(
+        "xtquant subscribe failed:"
+    ):
+        return True
+    if "无法连接xtquant" in message or "鏃犳硶杩炴帴xtquant" in message:
+        return True
+    return "xtquant" in normalized and "qmt" in normalized
+
+
+def _is_empty_credit_detail_response(result):
+    if result is None:
+        return True
+    if isinstance(result, (list, tuple)):
+        return len(result) == 0
+    return False

--- a/freshquant/position_management/credit_client.py
+++ b/freshquant/position_management/credit_client.py
@@ -131,6 +131,7 @@ class PositionCreditClient:
                 pass
 
     def _call_read_only(self, operation, *, retry_on_empty=False):
+        last_error = None
         last_result = None
         for _ in range(2):
             try:
@@ -139,6 +140,7 @@ class PositionCreditClient:
             except Exception as error:
                 if not _is_retryable_xt_credit_error(error):
                     raise
+                last_error = error
                 self.reset_connection()
                 continue
             last_result = result
@@ -146,6 +148,8 @@ class PositionCreditClient:
                 self.reset_connection()
                 continue
             return result
+        if last_error is not None:
+            raise last_error
         return last_result
 
     def _refresh_runtime_config(

--- a/freshquant/tests/test_xt_account_sync_client.py
+++ b/freshquant/tests/test_xt_account_sync_client.py
@@ -132,3 +132,61 @@ def test_query_client_reconnects_after_empty_credit_detail_response():
     assert first_trader.connect_calls == 1
     assert first_trader.stopped is True
     assert second_trader.connect_calls == 1
+
+
+def test_query_client_reraises_retryable_xt_failure_after_retry_exhaustion():
+    import pytest
+
+    from freshquant.xt_account_sync.client import XtAccountQueryClient
+
+    class FailingTrader:
+        def __init__(self):
+            self.connect_calls = 0
+            self.stopped = False
+
+        def start(self):
+            return None
+
+        def stop(self):
+            self.stopped = True
+
+        def connect(self):
+            self.connect_calls += 1
+            return 0
+
+        def subscribe(self, account):
+            return 0
+
+        def query_credit_detail(self, account):
+            raise RuntimeError("xtquant connect failed: -1")
+
+    traders = [FailingTrader(), FailingTrader()]
+    trader_iter = iter(traders)
+
+    def resolve_account(settings_provider=None):
+        xtquant = settings_provider.xtquant
+        account = SimpleNamespace(
+            account_id=xtquant.account,
+            account_type=xtquant.account_type,
+        )
+        return account, xtquant.account, xtquant.account_type
+
+    settings_provider = SimpleNamespace(
+        xtquant=SimpleNamespace(
+            path="D:/xtquant",
+            account="068000076370",
+            account_type="CREDIT",
+        )
+    )
+    client = XtAccountQueryClient(
+        session_id=123456,
+        trader_factory=lambda path, session_id: next(trader_iter),
+        settings_provider=settings_provider,
+        account_resolver=resolve_account,
+    )
+
+    with pytest.raises(RuntimeError, match="xtquant connect failed: -1"):
+        client.query_credit_detail()
+
+    assert traders[0].stopped is True
+    assert traders[1].stopped is True

--- a/freshquant/tests/test_xt_account_sync_client.py
+++ b/freshquant/tests/test_xt_account_sync_client.py
@@ -70,3 +70,65 @@ def test_query_client_supports_legacy_account_resolver_signature():
         "account_id": "068000076370",
         "account_type": "CREDIT",
     }
+
+
+def test_query_client_reconnects_after_empty_credit_detail_response():
+    from freshquant.xt_account_sync.client import XtAccountQueryClient
+
+    class FakeTrader:
+        def __init__(self, detail):
+            self.detail = detail
+            self.started = False
+            self.stopped = False
+            self.connect_calls = 0
+            self.subscribe_calls = 0
+
+        def start(self):
+            self.started = True
+
+        def stop(self):
+            self.stopped = True
+
+        def connect(self):
+            self.connect_calls += 1
+            return 0
+
+        def subscribe(self, account):
+            self.subscribe_calls += 1
+            return 0
+
+        def query_credit_detail(self, account):
+            return self.detail
+
+    first_trader = FakeTrader([])
+    second_trader = FakeTrader([{"m_dAvailable": 9000.0, "m_dFinDebt": 2000.0}])
+    traders = iter([first_trader, second_trader])
+
+    def resolve_account(settings_provider=None):
+        xtquant = settings_provider.xtquant
+        account = SimpleNamespace(
+            account_id=xtquant.account,
+            account_type=xtquant.account_type,
+        )
+        return account, xtquant.account, xtquant.account_type
+
+    settings_provider = SimpleNamespace(
+        xtquant=SimpleNamespace(
+            path="D:/xtquant",
+            account="068000076370",
+            account_type="CREDIT",
+        )
+    )
+    client = XtAccountQueryClient(
+        session_id=123456,
+        trader_factory=lambda path, session_id: next(traders),
+        settings_provider=settings_provider,
+        account_resolver=resolve_account,
+    )
+
+    detail = client.query_credit_detail()
+
+    assert detail == [{"m_dAvailable": 9000.0, "m_dFinDebt": 2000.0}]
+    assert first_trader.connect_calls == 1
+    assert first_trader.stopped is True
+    assert second_trader.connect_calls == 1

--- a/freshquant/tests/test_xt_account_sync_worker.py
+++ b/freshquant/tests/test_xt_account_sync_worker.py
@@ -331,6 +331,14 @@ def test_worker_run_forever_retries_retryable_xt_errors_until_startup_succeeds(
     ]
 
 
+def test_worker_treats_empty_credit_detail_as_retryable_xt_failure():
+    from freshquant.xt_account_sync.worker import _is_retryable_xt_sync_error
+
+    assert _is_retryable_xt_sync_error(
+        ValueError("query_credit_detail returned no records")
+    )
+
+
 def test_worker_run_forever_rebuilds_default_service_after_retryable_xt_errors(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/freshquant/tests/test_xt_auto_repay_executor.py
+++ b/freshquant/tests/test_xt_auto_repay_executor.py
@@ -8,6 +8,7 @@ from freshquant.carnation import xtconstant
 class FakeTrader:
     def __init__(self):
         self.start_calls = 0
+        self.stop_calls = 0
         self.connect_calls = 0
         self.subscribe_calls = []
         self.order_calls = []
@@ -18,6 +19,9 @@ class FakeTrader:
     def connect(self):
         self.connect_calls += 1
         return 0
+
+    def stop(self):
+        self.stop_calls += 1
 
     def subscribe(self, account):
         self.subscribe_calls.append(account)
@@ -176,3 +180,95 @@ def test_credit_client_does_not_reload_global_settings_when_all_overrides_are_ex
 
     assert trader.connect_calls == 1
     assert len(detail) == 1
+
+
+def test_credit_client_reconnects_after_retryable_query_error():
+    from freshquant.position_management.credit_client import PositionCreditClient
+
+    class FlakyQueryTrader(FakeTrader):
+        def __init__(self, *, error=None, detail=None):
+            super().__init__()
+            self.error = error
+            self.detail = detail or [
+                type(
+                    "FakeCreditDetail",
+                    (),
+                    {
+                        "m_dAvailable": 12000.0,
+                        "m_dFinDebt": 9000.0,
+                    },
+                )()
+            ]
+
+        def query_credit_detail(self, account):
+            if self.error is not None:
+                raise self.error
+            return list(self.detail)
+
+    first_trader = FlakyQueryTrader(error=RuntimeError("xtquant connect failed: -1"))
+    second_trader = FlakyQueryTrader()
+    traders = iter([first_trader, second_trader])
+    client = PositionCreditClient(
+        path="D:/mock/xtquant",
+        account_id="068000076370",
+        account_type="CREDIT",
+        trader_factory=lambda path, session_id: next(traders),
+        account_factory=lambda account_id, account_type: type(
+            "FakeAccount",
+            (),
+            {"account_id": account_id, "account_type": account_type},
+        )(),
+    )
+
+    detail = client.query_credit_detail()
+
+    assert len(detail) == 1
+    assert first_trader.connect_calls == 1
+    assert first_trader.stop_calls == 1
+    assert second_trader.connect_calls == 1
+
+
+def test_credit_client_reconnects_after_empty_credit_detail_response():
+    from freshquant.position_management.credit_client import PositionCreditClient
+
+    class EmptyThenReadyTrader(FakeTrader):
+        def __init__(self, detail):
+            super().__init__()
+            self.detail = detail
+
+        def query_credit_detail(self, account):
+            return self.detail
+
+    first_trader = EmptyThenReadyTrader([])
+    second_trader = EmptyThenReadyTrader(
+        [
+            type(
+                "FakeCreditDetail",
+                (),
+                {
+                    "m_dAvailable": 12000.0,
+                    "m_dFinDebt": 9000.0,
+                },
+            )()
+        ]
+    )
+    traders = iter([first_trader, second_trader])
+
+    client = PositionCreditClient(
+        path="D:/mock/xtquant",
+        account_id="068000076370",
+        account_type="CREDIT",
+        trader_factory=lambda path, session_id: next(traders),
+        account_factory=lambda account_id, account_type: type(
+            "FakeAccount",
+            (),
+            {"account_id": account_id, "account_type": account_type},
+        )(),
+    )
+
+    detail = client.query_credit_detail()
+
+    assert len(detail) == 1
+    assert first_trader.connect_calls == 1
+    assert first_trader.stop_calls == 1
+    assert second_trader.connect_calls == 1

--- a/freshquant/tests/test_xt_auto_repay_executor.py
+++ b/freshquant/tests/test_xt_auto_repay_executor.py
@@ -272,3 +272,33 @@ def test_credit_client_reconnects_after_empty_credit_detail_response():
     assert first_trader.connect_calls == 1
     assert first_trader.stop_calls == 1
     assert second_trader.connect_calls == 1
+
+
+def test_credit_client_reraises_retryable_xt_failure_after_retry_exhaustion():
+    import pytest
+
+    from freshquant.position_management.credit_client import PositionCreditClient
+
+    class FailingQueryTrader(FakeTrader):
+        def query_credit_detail(self, account):
+            raise RuntimeError("xtquant connect failed: -1")
+
+    traders = [FailingQueryTrader(), FailingQueryTrader()]
+    trader_iter = iter(traders)
+    client = PositionCreditClient(
+        path="D:/mock/xtquant",
+        account_id="068000076370",
+        account_type="CREDIT",
+        trader_factory=lambda path, session_id: next(trader_iter),
+        account_factory=lambda account_id, account_type: type(
+            "FakeAccount",
+            (),
+            {"account_id": account_id, "account_type": account_type},
+        )(),
+    )
+
+    with pytest.raises(RuntimeError, match="xtquant connect failed: -1"):
+        client.query_credit_detail()
+
+    assert traders[0].stop_calls == 1
+    assert traders[1].stop_calls == 1

--- a/freshquant/tests/test_xt_auto_repay_worker.py
+++ b/freshquant/tests/test_xt_auto_repay_worker.py
@@ -112,6 +112,33 @@ class FakeExecutor:
         return 9911
 
 
+class SequencedExecutor:
+    def __init__(self, outcomes, *, order_id=9911):
+        self.outcomes = list(outcomes)
+        self.query_calls = 0
+        self.submit_calls = []
+        self.order_id = order_id
+        self.reset_calls = []
+        self.credit_client = type(
+            "FakeCreditClient",
+            (),
+            {"reset_connection": lambda inner_self: self.reset_calls.append("reset")},
+        )()
+
+    def query_credit_detail(self):
+        self.query_calls += 1
+        if not self.outcomes:
+            raise AssertionError("no more outcomes configured")
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    def submit_direct_cash_repay(self, *, repay_amount, remark):
+        self.submit_calls.append({"repay_amount": repay_amount, "remark": remark})
+        return self.order_id
+
+
 class FakeLockClient:
     def __init__(self, result=True):
         if isinstance(result, list):
@@ -321,3 +348,37 @@ def test_worker_next_sleep_retries_quickly_when_intraday_check_is_overdue():
     )
 
     assert sleep_seconds == 1.0
+
+
+def test_worker_retries_retryable_xt_errors_by_rebuilding_executor():
+    from freshquant.xt_auto_repay.worker import XtAutoRepayWorker
+
+    service = FakeService()
+    first_executor = SequencedExecutor([RuntimeError("xtquant connect failed: -1")])
+    second_executor = FakeExecutor()
+    built = []
+    sleep_calls = []
+
+    def build_executor():
+        built.append("build")
+        return second_executor
+
+    worker = XtAutoRepayWorker(
+        service=service,
+        executor=first_executor,
+        executor_factory=build_executor,
+        lock_client=FakeLockClient(),
+        retry_sleep_fn=lambda seconds: sleep_calls.append(seconds),
+    )
+
+    result = worker.run_mode(
+        "intraday",
+        now=datetime.fromisoformat("2026-04-05T10:30:00+08:00"),
+    )
+
+    assert result["status"] == "submitted"
+    assert first_executor.query_calls == 1
+    assert first_executor.reset_calls == ["reset"]
+    assert built == ["build"]
+    assert second_executor.query_calls == 1
+    assert sleep_calls == [5.0]

--- a/freshquant/xt_account_sync/client.py
+++ b/freshquant/xt_account_sync/client.py
@@ -137,6 +137,7 @@ class XtAccountQueryClient:
                 pass
 
     def _call_read_only(self, operation, *, retry_on_empty=False):
+        last_error = None
         last_result = None
         for _ in range(2):
             try:
@@ -145,6 +146,7 @@ class XtAccountQueryClient:
             except Exception as error:
                 if not _is_retryable_xt_query_error(error):
                     raise
+                last_error = error
                 self.reset_connection()
                 continue
             last_result = result
@@ -152,6 +154,8 @@ class XtAccountQueryClient:
                 self.reset_connection()
                 continue
             return result
+        if last_error is not None:
+            raise last_error
         return last_result
 
     def _refresh_runtime_config(self, *, path=None, strict=False):

--- a/freshquant/xt_account_sync/client.py
+++ b/freshquant/xt_account_sync/client.py
@@ -51,50 +51,50 @@ class XtAccountQueryClient:
         self.settings_provider = (
             settings_provider or _load_default_system_settings_provider()
         )
-        xtquant_settings = getattr(self.settings_provider, "xtquant", None)
-        self.path = path or getattr(xtquant_settings, "path", "")
+        self._path_override = path is not None
+        self.path = ""
         self.session_id = session_id or int(time.time())
         self.trader_factory = trader_factory or _load_default_trader_factory()
         self.account_resolver = account_resolver or _load_default_account_resolver()
-        self.account_id = str(getattr(xtquant_settings, "account", "") or "").strip()
-        self.account_type = (
-            str(getattr(xtquant_settings, "account_type", "STOCK") or "STOCK")
-            .strip()
-            .upper()
-            or "STOCK"
-        )
+        self.account_id = ""
+        self.account_type = "STOCK"
         self._trader = None
         self._account = None
+        self._refresh_runtime_config(path=path, strict=False)
 
     def query_stock_asset(self):
-        trader, account = self._ensure_connection()
-        return trader.query_stock_asset(account)
+        return self._call_read_only(lambda trader, account: trader.query_stock_asset(account))
 
     def query_stock_positions(self):
-        trader, account = self._ensure_connection()
-        return trader.query_stock_positions(account)
+        return self._call_read_only(
+            lambda trader, account: trader.query_stock_positions(account)
+        )
 
     def query_stock_orders(self):
-        trader, account = self._ensure_connection()
-        return trader.query_stock_orders(account)
+        return self._call_read_only(lambda trader, account: trader.query_stock_orders(account))
 
     def query_stock_trades(self):
-        trader, account = self._ensure_connection()
-        return trader.query_stock_trades(account)
+        return self._call_read_only(lambda trader, account: trader.query_stock_trades(account))
 
     def query_credit_detail(self):
+        self._refresh_runtime_config(strict=False)
         if self.account_type != "CREDIT":
             return []
-        trader, account = self._ensure_connection()
-        return trader.query_credit_detail(account)
+        return self._call_read_only(
+            lambda trader, account: trader.query_credit_detail(account),
+            retry_on_empty=True,
+        )
 
     def query_credit_subjects(self):
+        self._refresh_runtime_config(strict=False)
         if self.account_type != "CREDIT":
             return []
-        trader, account = self._ensure_connection()
-        return trader.query_credit_subjects(account)
+        return self._call_read_only(
+            lambda trader, account: trader.query_credit_subjects(account)
+        )
 
     def _ensure_connection(self):
+        self._refresh_runtime_config(strict=True)
         if self._trader is not None and self._account is not None:
             return self._trader, self._account
         if not self.path:
@@ -118,6 +118,56 @@ class XtAccountQueryClient:
         self._trader = trader
         self._account = account
         return self._trader, self._account
+
+    def reset_connection(self):
+        trader = self._trader
+        self._trader = None
+        self._account = None
+        close_fn = getattr(trader, "stop", None)
+        if callable(close_fn):
+            try:
+                close_fn()
+            except Exception:
+                pass
+
+    def _call_read_only(self, operation, *, retry_on_empty=False):
+        last_result = None
+        for _ in range(2):
+            try:
+                trader, account = self._ensure_connection()
+                result = operation(trader, account)
+            except Exception as error:
+                if not _is_retryable_xt_query_error(error):
+                    raise
+                self.reset_connection()
+                continue
+            last_result = result
+            if retry_on_empty and _is_empty_xt_query_result(result):
+                self.reset_connection()
+                continue
+            return result
+        return last_result
+
+    def _refresh_runtime_config(self, *, path=None, strict=False):
+        if not self._path_override:
+            reload_fn = getattr(self.settings_provider, "reload", None)
+            if callable(reload_fn):
+                try:
+                    reload_fn(strict=strict)
+                except TypeError:
+                    reload_fn()
+        xtquant_settings = getattr(self.settings_provider, "xtquant", None)
+        if self._path_override:
+            self.path = path or self.path
+        else:
+            self.path = str(getattr(xtquant_settings, "path", "") or "")
+        self.account_id = str(getattr(xtquant_settings, "account", "") or "").strip()
+        self.account_type = (
+            str(getattr(xtquant_settings, "account_type", self.account_type) or "STOCK")
+            .strip()
+            .upper()
+            or "STOCK"
+        )
 
     def _resolve_account(self):
         supports_settings_provider = _resolver_accepts_settings_provider(
@@ -143,3 +193,23 @@ class XtAccountQueryClient:
         if key == "xtquant.account_type":
             return getattr(xtquant_settings, "account_type", default)
         return default
+
+
+def _is_retryable_xt_query_error(error):
+    message = str(error or "")
+    normalized = message.lower()
+    if normalized.startswith("xtquant connect failed:") or normalized.startswith(
+        "xtquant subscribe failed:"
+    ):
+        return True
+    if "无法连接xtquant" in message or "鏃犳硶杩炴帴xtquant" in message:
+        return True
+    return "xtquant" in normalized and "qmt" in normalized
+
+
+def _is_empty_xt_query_result(result):
+    if result is None:
+        return True
+    if isinstance(result, (list, tuple)):
+        return len(result) == 0
+    return False

--- a/freshquant/xt_account_sync/client.py
+++ b/freshquant/xt_account_sync/client.py
@@ -63,7 +63,9 @@ class XtAccountQueryClient:
         self._refresh_runtime_config(path=path, strict=False)
 
     def query_stock_asset(self):
-        return self._call_read_only(lambda trader, account: trader.query_stock_asset(account))
+        return self._call_read_only(
+            lambda trader, account: trader.query_stock_asset(account)
+        )
 
     def query_stock_positions(self):
         return self._call_read_only(
@@ -71,10 +73,14 @@ class XtAccountQueryClient:
         )
 
     def query_stock_orders(self):
-        return self._call_read_only(lambda trader, account: trader.query_stock_orders(account))
+        return self._call_read_only(
+            lambda trader, account: trader.query_stock_orders(account)
+        )
 
     def query_stock_trades(self):
-        return self._call_read_only(lambda trader, account: trader.query_stock_trades(account))
+        return self._call_read_only(
+            lambda trader, account: trader.query_stock_trades(account)
+        )
 
     def query_credit_detail(self):
         self._refresh_runtime_config(strict=False)

--- a/freshquant/xt_account_sync/worker.py
+++ b/freshquant/xt_account_sync/worker.py
@@ -184,7 +184,10 @@ def _sync_once_with_xt_retry(
 
 
 def _is_retryable_xt_sync_error(error):
-    if isinstance(error, ValueError) and str(error) == "query_credit_detail returned no records":
+    if (
+        isinstance(error, ValueError)
+        and str(error) == "query_credit_detail returned no records"
+    ):
         return True
     if not isinstance(error, RuntimeError):
         return False

--- a/freshquant/xt_account_sync/worker.py
+++ b/freshquant/xt_account_sync/worker.py
@@ -184,6 +184,8 @@ def _sync_once_with_xt_retry(
 
 
 def _is_retryable_xt_sync_error(error):
+    if isinstance(error, ValueError) and str(error) == "query_credit_detail returned no records":
+        return True
     if not isinstance(error, RuntimeError):
         return False
     message = str(error)

--- a/freshquant/xt_auto_repay/worker.py
+++ b/freshquant/xt_auto_repay/worker.py
@@ -51,8 +51,8 @@ class XtAutoRepayWorker:
     ):
         self.service = service or XtAutoRepayService()
         self.executor = executor or XtAutoRepayExecutor()
-        self.executor_factory = (
-            executor_factory or (XtAutoRepayExecutor if executor is None else None)
+        self.executor_factory = executor_factory or (
+            XtAutoRepayExecutor if executor is None else None
         )
         self.lock_client = lock_client or _CooldownLockClient(redis_db)
         self.intraday_interval_seconds = max(
@@ -483,7 +483,10 @@ def _next_intraday_delay_seconds(now_value, state, intraday_interval_seconds):
 
 
 def _is_retryable_xt_auto_repay_error(error):
-    if isinstance(error, ValueError) and str(error) == "query_credit_detail returned no records":
+    if (
+        isinstance(error, ValueError)
+        and str(error) == "query_credit_detail returned no records"
+    ):
         return True
     message = str(error or "")
     normalized = message.lower()

--- a/freshquant/xt_auto_repay/worker.py
+++ b/freshquant/xt_auto_repay/worker.py
@@ -25,6 +25,8 @@ SHANGHAI_TZ = ZoneInfo("Asia/Shanghai")
 DEFAULT_INTRADAY_INTERVAL_SECONDS = 1800.0
 DEFAULT_COOLDOWN_SECONDS = 1800.0
 DEFAULT_LOCK_TTL_SECONDS = 120
+DEFAULT_RETRY_DELAY_SECONDS = 5.0
+DEFAULT_RETRY_DELAY_MAX_SECONDS = 60.0
 HARD_SETTLE_TIME = (14, 55)
 RETRY_TIME = (15, 5)
 
@@ -37,20 +39,36 @@ class XtAutoRepayWorker:
         *,
         service=None,
         executor=None,
+        executor_factory=None,
         lock_client=None,
         intraday_interval_seconds=DEFAULT_INTRADAY_INTERVAL_SECONDS,
         cooldown_seconds=DEFAULT_COOLDOWN_SECONDS,
         lock_ttl_seconds=DEFAULT_LOCK_TTL_SECONDS,
+        retry_delay_seconds=DEFAULT_RETRY_DELAY_SECONDS,
+        retry_delay_max_seconds=DEFAULT_RETRY_DELAY_MAX_SECONDS,
+        retry_sleep_fn=None,
         now_provider=None,
     ):
         self.service = service or XtAutoRepayService()
         self.executor = executor or XtAutoRepayExecutor()
+        self.executor_factory = (
+            executor_factory or (XtAutoRepayExecutor if executor is None else None)
+        )
         self.lock_client = lock_client or _CooldownLockClient(redis_db)
         self.intraday_interval_seconds = max(
             float(intraday_interval_seconds or DEFAULT_INTRADAY_INTERVAL_SECONDS), 1.0
         )
         self.cooldown_seconds = max(float(cooldown_seconds or 0.0), 0.0)
         self.lock_ttl_seconds = max(int(lock_ttl_seconds or 0), 1)
+        self.retry_delay_seconds = max(
+            float(retry_delay_seconds or DEFAULT_RETRY_DELAY_SECONDS),
+            1.0,
+        )
+        self.retry_delay_max_seconds = max(
+            float(retry_delay_max_seconds or DEFAULT_RETRY_DELAY_MAX_SECONDS),
+            self.retry_delay_seconds,
+        )
+        self.retry_sleep_fn = retry_sleep_fn or time.sleep
         self.now_provider = now_provider or _shanghai_now
 
     def run_mode(self, mode, *, now=None):
@@ -106,7 +124,7 @@ class XtAutoRepayWorker:
                 mark_mode_completed=False,
             )
 
-        detail = self.executor.query_credit_detail()
+        detail = self._query_credit_detail_with_xt_retry()
         confirmed_decision = self.service.evaluate_confirmed_detail(
             detail,
             mode=resolved_mode,
@@ -303,6 +321,37 @@ class XtAutoRepayWorker:
         logger.warning("xt auto repay worker skipped without persistence: %s", reason)
         return {"mode": mode, "status": "skip", "reason": reason}
 
+    def _query_credit_detail_with_xt_retry(self):
+        delay_seconds = self.retry_delay_seconds
+        while True:
+            try:
+                return self.executor.query_credit_detail()
+            except Exception as error:
+                if not _is_retryable_xt_auto_repay_error(error):
+                    raise
+                logger.warning(
+                    "xt auto repay XT unavailable; retrying in %.1f seconds: %s",
+                    delay_seconds,
+                    error,
+                )
+                self._reset_executor_after_retryable_xt_error()
+                self.retry_sleep_fn(delay_seconds)
+                delay_seconds = min(delay_seconds * 2, self.retry_delay_max_seconds)
+
+    def _reset_executor_after_retryable_xt_error(self):
+        credit_client = getattr(self.executor, "credit_client", None)
+        reset_fn = getattr(credit_client, "reset_connection", None)
+        if callable(reset_fn):
+            try:
+                reset_fn()
+            except Exception:
+                logger.debug(
+                    "xt auto repay credit client reset failed",
+                    exc_info=True,
+                )
+        if self.executor_factory is not None:
+            self.executor = self.executor_factory()
+
 
 class _CooldownLockClient:
     def __init__(self, redis_client):
@@ -431,6 +480,20 @@ def _next_intraday_delay_seconds(now_value, state, intraday_interval_seconds):
     if remaining_seconds <= 0:
         return 1.0
     return max(1.0, remaining_seconds)
+
+
+def _is_retryable_xt_auto_repay_error(error):
+    if isinstance(error, ValueError) and str(error) == "query_credit_detail returned no records":
+        return True
+    message = str(error or "")
+    normalized = message.lower()
+    if normalized.startswith("xtquant connect failed:") or normalized.startswith(
+        "xtquant subscribe failed:"
+    ):
+        return True
+    if "无法连接xtquant" in message or "鏃犳硶杩炴帴xtquant" in message:
+        return True
+    return "xtquant" in normalized and "qmt" in normalized
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add self-healing reconnect handling to shared XT credit/query clients so read-only XT calls reset stale connections and rebuild once before surfacing errors
- teach `xt_auto_repay.worker` to back off and rebuild its executor on retryable XT credit-detail reads without blindly retrying real repay submissions
- extend `xt_account_sync.worker` retry classification for empty credit detail reads, document the new host reconnect guardrails, and add regression tests

## Testing
- `.venv\\Scripts\\python.exe -m pytest freshquant/tests/test_xt_auto_repay_executor.py freshquant/tests/test_xt_auto_repay_worker.py freshquant/tests/test_xt_account_sync_client.py freshquant/tests/test_xt_account_sync_worker.py -q`
- `powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure`