### PR TITLE
Fix XT auto repay worker submit handling

### DIFF
--- a/docs/current/architecture.md
+++ b/docs/current/architecture.md
@@ -47,7 +47,7 @@
 
 ### 当前自动还款链
 
-`xt_account_sync.worker -> pm_credit_asset_snapshots -> xt_auto_repay.worker -> query_credit_detail confirm -> CREDIT_DIRECT_CASH_REPAY`
+`xt_account_sync.worker -> pm_credit_asset_snapshots -> xt_auto_repay.worker -> query_credit_detail confirm -> XtQuantTrader.order_stock(CREDIT_DIRECT_CASH_REPAY, placeholder stock_code, LATEST_PRICE)`
 
 ## 当前订单账本边界
 

--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -229,8 +229,11 @@ py -3.12 script/maintenance/repair_guardian_sell_entry_allocations.py --execute 
 - `/system-settings -> XTQuant` 当前直接控制 `xtquant.auto_repay.enabled` 与 `xtquant.auto_repay.reserve_cash`
 - 盘中默认每 30 分钟只读一次已同步的 `credit_detail` 快照做候选判断
 - 只有候选命中后，才会即时调用 `query_credit_detail()` 二次确认
+- 真实提交当前通过 `XtQuantTrader.order_stock(..., stock_code='000001.SZ', order_type=CREDIT_DIRECT_CASH_REPAY, price_type=LATEST_PRICE, price=0)` 发起；空 `stock_code` 会被 XT 直接拒绝
 - 固定 `14:55` 做日终硬结算，固定 `15:05` 做一次补偿重试
 - `broker_submit_mode=observe_only` 时只记录事件，不真实提交还款
+- XT 柜台处于非交易状态时会拒绝直接还款；worker 当前会把这类拒单记成 `failed`，而不是误判为 `submitted`
+- 自动还款冷却锁当前只用于防并发，不再把同一轮 `run_pending()` 内串行执行的 `hard_settle -> retry` 互相挡成 `lock_unavailable`
 - `system_settings` 读取失败时当前会先重试；若进程内已经存在上一版有效配置，则保留上一版，不再回退成空 `xtquant.path/account`
 - `xt_auto_repay.worker` 启动后下一次盘中巡检当前按 `last_checked_at + 30 分钟` 对齐；若已错过应跑时间，会在 1 秒级快速补跑，而不是从重启时刻重新整等 30 分钟
 

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -166,6 +166,10 @@ pprint(svc.load_latest_snapshot())
 
 - 若是宿主机启动早于 Mongo 恢复，当前 `system_settings` 会先重试；重试后仍失败时不会再把已有有效配置降级成空 `xtquant.path/account`
 - 若 worker 在盘中巡检窗口之间重启，当前下一次巡检时间按 `last_checked_at` 对齐；若已逾期，会 1 秒级补跑，不需要再等满新的 30 分钟
+- 若直接还款提交后长时间没有事件推进，先核对 `XtQuantTrader.order_stock()` 的参数是否为 `CREDIT_DIRECT_CASH_REPAY + placeholder stock_code + LATEST_PRICE + 0`；空 `stock_code` 会触发 `wrong stock market format`
+- 若盘后/非交易状态出现 `节点当前非交易状态,禁止做直接还款`，说明柜台当前不受理该操作；需要等到下一个允许的交易窗口再提交
+- 当前 `PositionCreditClient` 会给 XT 同步调用设置超时，避免错误参数把 worker 卡死在 `order_stock()` 上
+- 若 worker 错过了 `14:55` 与 `15:05` 后才恢复，当前会在同一轮补跑里串行完成 `hard_settle` 与 `retry`，不再因为共享冷却锁把第二步误记成 `lock_unavailable`
 - 若 stderr 仍持续出现 `xtquant connect failed: -1`，优先排查 QMT 连接稳定性，不要先怀疑自动还款金额判定
 
 ## Memory context 缺失或过期

--- a/freshquant/position_management/credit_client.py
+++ b/freshquant/position_management/credit_client.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import inspect
+import threading
 import time
+
+DEFAULT_XT_TRADER_TIMEOUT_MS = 5000
+DEFAULT_DIRECT_CASH_REPAY_PLACEHOLDER_STOCK_CODE = "000001.SZ"
+DEFAULT_DIRECT_CASH_REPAY_ERROR_GRACE_SECONDS = 1.0
 
 
 def _load_default_trader_factory():
@@ -15,10 +21,93 @@ def _load_default_account_factory():
     return StockAccount
 
 
+def _load_default_trader_callback_base():
+    from xtquant.xttrader import XtQuantTraderCallback
+
+    return XtQuantTraderCallback
+
+
 def _load_default_system_settings_provider():
     from freshquant.system_settings import system_settings
 
     return system_settings
+
+
+def _trader_factory_accepts_callback(trader_factory):
+    try:
+        signature = inspect.signature(trader_factory)
+    except (TypeError, ValueError):
+        return None
+
+    parameters = signature.parameters
+    if "callback" in parameters:
+        return True
+    if any(
+        parameter.kind == inspect.Parameter.VAR_POSITIONAL
+        for parameter in parameters.values()
+    ):
+        return True
+
+    positional_parameters = [
+        parameter
+        for parameter in parameters.values()
+        if parameter.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    return len(positional_parameters) >= 3
+
+
+def _default_session_id():
+    resolved = int(time.time_ns() % 2147483647)
+    return resolved or int(time.time())
+
+
+class _OrderErrorRecorder(_load_default_trader_callback_base()):
+    def __init__(self):
+        super().__init__()
+        self._lock = threading.Lock()
+        self._errors = []
+
+    def clear(self):
+        with self._lock:
+            self._errors.clear()
+
+    def on_order_error(self, order_error):
+        with self._lock:
+            self._errors.append(order_error)
+
+    def wait_for_matching_error(
+        self,
+        *,
+        order_id=None,
+        order_remark="",
+        timeout_seconds=0.0,
+    ):
+        deadline = time.monotonic() + max(float(timeout_seconds or 0.0), 0.0)
+        normalized_remark = str(order_remark or "").strip()
+        while True:
+            error = self._take_matching_error(
+                order_id=order_id,
+                order_remark=normalized_remark,
+            )
+            if error is not None or time.monotonic() >= deadline:
+                return error
+            time.sleep(0.05)
+
+    def _take_matching_error(self, *, order_id=None, order_remark=""):
+        normalized_remark = str(order_remark or "").strip()
+        with self._lock:
+            for index, error in enumerate(self._errors):
+                error_order_id = getattr(error, "order_id", None)
+                error_remark = str(getattr(error, "order_remark", "") or "").strip()
+                if order_id is not None and int(error_order_id or 0) == int(order_id):
+                    return self._errors.pop(index)
+                if normalized_remark and error_remark == normalized_remark:
+                    return self._errors.pop(index)
+        return None
 
 
 class PositionCreditClient:
@@ -41,11 +130,15 @@ class PositionCreditClient:
         self.path = ""
         self.account_id = ""
         self.account_type = "STOCK"
-        self.session_id = session_id or int(time.time())
+        self.session_id = (
+            int(_default_session_id()) if session_id is None else int(session_id)
+        )
         self.trader_factory = trader_factory or _load_default_trader_factory()
         self.account_factory = account_factory or _load_default_account_factory()
         self._trader = None
         self._account = None
+        self._order_error_callback = _OrderErrorRecorder()
+        self._order_error_callback_enabled = False
         self._refresh_runtime_config(
             path=path,
             account_id=account_id,
@@ -65,7 +158,7 @@ class PositionCreditClient:
         repay_amount,
         strategy_name="XtAutoRepay",
         order_remark="xt_auto_repay",
-        stock_code="",
+        stock_code=DEFAULT_DIRECT_CASH_REPAY_PLACEHOLDER_STOCK_CODE,
         price_type=None,
         price=0.0,
     ):
@@ -74,14 +167,20 @@ class PositionCreditClient:
         resolved_amount = int(float(repay_amount or 0))
         if resolved_amount <= 0:
             raise ValueError("repay_amount must be positive")
+        resolved_stock_code = (
+            str(stock_code or DEFAULT_DIRECT_CASH_REPAY_PLACEHOLDER_STOCK_CODE).strip()
+            or DEFAULT_DIRECT_CASH_REPAY_PLACEHOLDER_STOCK_CODE
+        )
         resolved_price_type = (
-            xtconstant.FIX_PRICE if price_type is None else int(price_type)
+            xtconstant.LATEST_PRICE if price_type is None else int(price_type)
         )
         trader, account = self._ensure_credit_connection()
+        if self._order_error_callback_enabled:
+            self._order_error_callback.clear()
         try:
-            return trader.order_stock(
+            order_id = trader.order_stock(
                 account,
-                str(stock_code or "").strip(),
+                resolved_stock_code,
                 xtconstant.CREDIT_DIRECT_CASH_REPAY,
                 resolved_amount,
                 resolved_price_type,
@@ -89,6 +188,18 @@ class PositionCreditClient:
                 strategy_name,
                 order_remark,
             )
+            rejected_error = None
+            if self._order_error_callback_enabled:
+                rejected_error = self._order_error_callback.wait_for_matching_error(
+                    order_id=order_id if int(order_id or 0) > 0 else None,
+                    order_remark=order_remark,
+                    timeout_seconds=DEFAULT_DIRECT_CASH_REPAY_ERROR_GRACE_SECONDS,
+                )
+            if rejected_error is not None:
+                raise RuntimeError(_format_xt_order_error(rejected_error))
+            if int(order_id or 0) <= 0:
+                raise RuntimeError("xtquant direct cash repay returned no order id")
+            return order_id
         except Exception:
             self.reset_connection()
             raise
@@ -104,8 +215,15 @@ class PositionCreditClient:
         if self._trader is not None and self._account is not None:
             return self._trader, self._account
 
-        trader = self.trader_factory(self.path, self.session_id)
+        trader, callback_enabled = self._build_trader(
+            self.path,
+            self.session_id,
+            self._order_error_callback,
+        )
         trader.start()
+        set_timeout_fn = getattr(trader, "set_timeout", None)
+        if callable(set_timeout_fn):
+            set_timeout_fn(DEFAULT_XT_TRADER_TIMEOUT_MS)
         connect_result = trader.connect()
         if connect_result != 0:
             raise RuntimeError(f"xtquant connect failed: {connect_result}")
@@ -117,12 +235,27 @@ class PositionCreditClient:
 
         self._trader = trader
         self._account = account
+        self._order_error_callback_enabled = callback_enabled
         return self._trader, self._account
+
+    def _build_trader(self, path, session_id, callback):
+        supports_callback = _trader_factory_accepts_callback(self.trader_factory)
+        if supports_callback is not False:
+            trader = self.trader_factory(path, session_id, callback)
+            return trader, True
+        trader = self.trader_factory(path, session_id)
+        register_callback = getattr(trader, "register_callback", None)
+        if callable(register_callback):
+            register_callback(callback)
+            return trader, True
+        return trader, False
 
     def reset_connection(self):
         trader = self._trader
         self._trader = None
         self._account = None
+        self._order_error_callback_enabled = False
+        self._order_error_callback.clear()
         close_fn = getattr(trader, "stop", None)
         if callable(close_fn):
             try:
@@ -213,3 +346,15 @@ def _is_empty_credit_detail_response(result):
     if isinstance(result, (list, tuple)):
         return len(result) == 0
     return False
+
+
+def _format_xt_order_error(error):
+    error_id = getattr(error, "error_id", None)
+    message = str(getattr(error, "error_msg", "") or "").strip()
+    if error_id not in {None, ""} and message:
+        return f"xtquant direct cash repay rejected ({error_id}): {message}"
+    if message:
+        return f"xtquant direct cash repay rejected: {message}"
+    if error_id not in {None, ""}:
+        return f"xtquant direct cash repay rejected ({error_id})"
+    return "xtquant direct cash repay rejected"

--- a/freshquant/position_management/credit_client.py
+++ b/freshquant/position_management/credit_client.py
@@ -3,7 +3,6 @@
 import inspect
 import threading
 import time
-from typing import TYPE_CHECKING
 
 DEFAULT_XT_TRADER_TIMEOUT_MS = 5000
 DEFAULT_DIRECT_CASH_REPAY_PLACEHOLDER_STOCK_CODE = "000001.SZ"
@@ -66,19 +65,18 @@ def _default_session_id():
     return resolved or int(time.time())
 
 
-if TYPE_CHECKING:
+def _build_order_error_callback(recorder):
+    callback_base = _load_default_trader_callback_base()
 
-    class _TraderCallbackBase:
-        def __init__(self):
-            pass
+    class _RuntimeOrderErrorCallback(callback_base):  # type: ignore[misc, valid-type]
+        def on_order_error(self, order_error):
+            recorder.on_order_error(order_error)
 
-else:
-    _TraderCallbackBase = _load_default_trader_callback_base()
+    return _RuntimeOrderErrorCallback()
 
 
-class _OrderErrorRecorder(_TraderCallbackBase):
+class _OrderErrorRecorder:
     def __init__(self):
-        super().__init__()
         self._lock = threading.Lock()
         self._errors = []
 
@@ -148,7 +146,8 @@ class PositionCreditClient:
         self.account_factory = account_factory or _load_default_account_factory()
         self._trader = None
         self._account = None
-        self._order_error_callback = _OrderErrorRecorder()
+        self._order_error_recorder = _OrderErrorRecorder()
+        self._order_error_callback = None
         self._order_error_callback_enabled = False
         self._refresh_runtime_config(
             path=path,
@@ -187,7 +186,7 @@ class PositionCreditClient:
         )
         trader, account = self._ensure_credit_connection()
         if self._order_error_callback_enabled:
-            self._order_error_callback.clear()
+            self._order_error_recorder.clear()
         try:
             order_id = trader.order_stock(
                 account,
@@ -201,7 +200,7 @@ class PositionCreditClient:
             )
             rejected_error = None
             if self._order_error_callback_enabled:
-                rejected_error = self._order_error_callback.wait_for_matching_error(
+                rejected_error = self._order_error_recorder.wait_for_matching_error(
                     order_id=order_id if int(order_id or 0) > 0 else None,
                     order_remark=order_remark,
                     timeout_seconds=DEFAULT_DIRECT_CASH_REPAY_ERROR_GRACE_SECONDS,
@@ -226,10 +225,10 @@ class PositionCreditClient:
         if self._trader is not None and self._account is not None:
             return self._trader, self._account
 
-        trader, callback_enabled = self._build_trader(
+        trader, callback_enabled, callback = self._build_trader(
             self.path,
             self.session_id,
-            self._order_error_callback,
+            self._order_error_recorder,
         )
         trader.start()
         set_timeout_fn = getattr(trader, "set_timeout", None)
@@ -246,27 +245,31 @@ class PositionCreditClient:
 
         self._trader = trader
         self._account = account
+        self._order_error_callback = callback
         self._order_error_callback_enabled = callback_enabled
         return self._trader, self._account
 
-    def _build_trader(self, path, session_id, callback):
+    def _build_trader(self, path, session_id, recorder):
         supports_callback = _trader_factory_accepts_callback(self.trader_factory)
         if supports_callback is not False:
+            callback = _build_order_error_callback(recorder)
             trader = self.trader_factory(path, session_id, callback)
-            return trader, True
+            return trader, True, callback
         trader = self.trader_factory(path, session_id)
         register_callback = getattr(trader, "register_callback", None)
         if callable(register_callback):
+            callback = _build_order_error_callback(recorder)
             register_callback(callback)
-            return trader, True
-        return trader, False
+            return trader, True, callback
+        return trader, False, None
 
     def reset_connection(self):
         trader = self._trader
         self._trader = None
         self._account = None
+        self._order_error_callback = None
         self._order_error_callback_enabled = False
-        self._order_error_callback.clear()
+        self._order_error_recorder.clear()
         close_fn = getattr(trader, "stop", None)
         if callable(close_fn):
             try:

--- a/freshquant/position_management/credit_client.py
+++ b/freshquant/position_management/credit_client.py
@@ -66,7 +66,10 @@ def _default_session_id():
 
 
 def _build_order_error_callback(recorder):
-    callback_base = _load_default_trader_callback_base()
+    try:
+        callback_base = _load_default_trader_callback_base()
+    except Exception:
+        callback_base = object
 
     class _RuntimeOrderErrorCallback(callback_base):  # type: ignore[misc, valid-type]
         def on_order_error(self, order_error):

--- a/freshquant/position_management/credit_client.py
+++ b/freshquant/position_management/credit_client.py
@@ -3,6 +3,7 @@
 import inspect
 import threading
 import time
+from typing import TYPE_CHECKING
 
 DEFAULT_XT_TRADER_TIMEOUT_MS = 5000
 DEFAULT_DIRECT_CASH_REPAY_PLACEHOLDER_STOCK_CODE = "000001.SZ"
@@ -65,7 +66,17 @@ def _default_session_id():
     return resolved or int(time.time())
 
 
-class _OrderErrorRecorder(_load_default_trader_callback_base()):
+if TYPE_CHECKING:
+
+    class _TraderCallbackBase:
+        def __init__(self):
+            pass
+
+else:
+    _TraderCallbackBase = _load_default_trader_callback_base()
+
+
+class _OrderErrorRecorder(_TraderCallbackBase):
     def __init__(self):
         super().__init__()
         self._lock = threading.Lock()

--- a/freshquant/tests/test_xt_auto_repay_executor.py
+++ b/freshquant/tests/test_xt_auto_repay_executor.py
@@ -10,11 +10,15 @@ class FakeTrader:
         self.start_calls = 0
         self.stop_calls = 0
         self.connect_calls = 0
+        self.set_timeout_calls = []
         self.subscribe_calls = []
         self.order_calls = []
 
     def start(self):
         self.start_calls += 1
+
+    def set_timeout(self, timeout):
+        self.set_timeout_calls.append(timeout)
 
     def connect(self):
         self.connect_calls += 1
@@ -130,8 +134,9 @@ def test_executor_submits_credit_direct_cash_repay():
 
     assert order_id == 7788
     assert trader.order_calls[0]["order_type"] == xtconstant.CREDIT_DIRECT_CASH_REPAY
+    assert trader.order_calls[0]["stock_code"] == "000001.SZ"
     assert trader.order_calls[0]["order_volume"] == 6000
-    assert trader.order_calls[0]["price_type"] == xtconstant.FIX_PRICE
+    assert trader.order_calls[0]["price_type"] == xtconstant.LATEST_PRICE
     assert trader.order_calls[0]["price"] == 0.0
 
 
@@ -153,6 +158,7 @@ def test_credit_client_refreshes_settings_before_connecting():
     detail = client.query_credit_detail()
 
     assert settings_provider.reload_calls == [False, True]
+    assert trader.set_timeout_calls == [5000]
     assert trader.connect_calls == 1
     assert client.path == "D:/mock/xtquant"
     assert client.account_id == "068000076370"
@@ -302,3 +308,77 @@ def test_credit_client_reraises_retryable_xt_failure_after_retry_exhaustion():
 
     assert traders[0].stop_calls == 1
     assert traders[1].stop_calls == 1
+
+
+def test_credit_client_raises_when_direct_cash_repay_is_rejected():
+    import pytest
+
+    from freshquant.position_management.credit_client import PositionCreditClient
+
+    class CallbackTrader(FakeTrader):
+        def __init__(self):
+            super().__init__()
+            self.callback = None
+
+        def register_callback(self, callback):
+            self.callback = callback
+
+        def order_stock(
+            self,
+            account,
+            stock_code,
+            order_type,
+            order_volume,
+            price_type,
+            price,
+            strategy_name="",
+            order_remark="",
+        ):
+            order_id = super().order_stock(
+                account,
+                stock_code,
+                order_type,
+                order_volume,
+                price_type,
+                price,
+                strategy_name=strategy_name,
+                order_remark=order_remark,
+            )
+            self.callback.on_order_error(
+                type(
+                    "FakeOrderError",
+                    (),
+                    {
+                        "order_id": order_id,
+                        "error_id": -1020,
+                        "error_msg": "节点当前非交易状态,禁止做直接还款",
+                        "order_remark": order_remark,
+                    },
+                )()
+            )
+            return order_id
+
+    trader = CallbackTrader()
+    client = PositionCreditClient(
+        path="D:/mock/xtquant",
+        account_id="068000076370",
+        account_type="CREDIT",
+        session_id=9527,
+        trader_factory=lambda path, session_id: trader,
+        account_factory=lambda account_id, account_type: type(
+            "FakeAccount",
+            (),
+            {"account_id": account_id, "account_type": account_type},
+        )(),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="xtquant direct cash repay rejected \\(-1020\\): 节点当前非交易状态,禁止做直接还款",
+    ):
+        client.submit_direct_cash_repay(
+            repay_amount=1000,
+            order_remark="xt_auto_repay:hard_settle",
+        )
+
+    assert trader.stop_calls == 1

--- a/freshquant/tests/test_xt_auto_repay_executor.py
+++ b/freshquant/tests/test_xt_auto_repay_executor.py
@@ -165,6 +165,36 @@ def test_credit_client_refreshes_settings_before_connecting():
     assert len(detail) == 1
 
 
+def test_credit_client_defers_callback_base_load_until_connection():
+    from freshquant.position_management import credit_client as credit_client_module
+
+    original_loader = credit_client_module._load_default_trader_callback_base
+    callback_load_calls = []
+
+    def _unexpected_loader():
+        callback_load_calls.append("load")
+        raise AssertionError("callback base should not be loaded during client init")
+
+    credit_client_module._load_default_trader_callback_base = _unexpected_loader
+    try:
+        client = credit_client_module.PositionCreditClient(
+            path="D:/mock/xtquant",
+            account_id="068000076370",
+            account_type="CREDIT",
+            trader_factory=lambda path, session_id: FakeTrader(),
+            account_factory=lambda account_id, account_type: type(
+                "FakeAccount",
+                (),
+                {"account_id": account_id, "account_type": account_type},
+            )(),
+        )
+    finally:
+        credit_client_module._load_default_trader_callback_base = original_loader
+
+    assert callback_load_calls == []
+    assert client._order_error_callback_enabled is False
+
+
 def test_credit_client_does_not_reload_global_settings_when_all_overrides_are_explicit():
     from freshquant.position_management.credit_client import PositionCreditClient
 

--- a/freshquant/tests/test_xt_auto_repay_executor.py
+++ b/freshquant/tests/test_xt_auto_repay_executor.py
@@ -343,7 +343,7 @@ def test_credit_client_reraises_retryable_xt_failure_after_retry_exhaustion():
 def test_credit_client_raises_when_direct_cash_repay_is_rejected():
     import pytest
 
-    from freshquant.position_management.credit_client import PositionCreditClient
+    from freshquant.position_management import credit_client as credit_client_module
 
     class CallbackTrader(FakeTrader):
         def __init__(self):
@@ -389,26 +389,32 @@ def test_credit_client_raises_when_direct_cash_repay_is_rejected():
             return order_id
 
     trader = CallbackTrader()
-    client = PositionCreditClient(
-        path="D:/mock/xtquant",
-        account_id="068000076370",
-        account_type="CREDIT",
-        session_id=9527,
-        trader_factory=lambda path, session_id: trader,
-        account_factory=lambda account_id, account_type: type(
-            "FakeAccount",
-            (),
-            {"account_id": account_id, "account_type": account_type},
-        )(),
-    )
-
-    with pytest.raises(
-        RuntimeError,
-        match="xtquant direct cash repay rejected \\(-1020\\): 节点当前非交易状态,禁止做直接还款",
-    ):
-        client.submit_direct_cash_repay(
-            repay_amount=1000,
-            order_remark="xt_auto_repay:hard_settle",
+    original_loader = credit_client_module._load_default_trader_callback_base
+    credit_client_module._load_default_trader_callback_base = lambda: (
+        _ for _ in ()
+    ).throw(ImportError("xt callback base unavailable"))
+    try:
+        client = credit_client_module.PositionCreditClient(
+            path="D:/mock/xtquant",
+            account_id="068000076370",
+            account_type="CREDIT",
+            session_id=9527,
+            trader_factory=lambda path, session_id: trader,
+            account_factory=lambda account_id, account_type: type(
+                "FakeAccount",
+                (),
+                {"account_id": account_id, "account_type": account_type},
+            )(),
         )
+        with pytest.raises(
+            RuntimeError,
+            match="xtquant direct cash repay rejected \\(-1020\\): 节点当前非交易状态,禁止做直接还款",
+        ):
+            client.submit_direct_cash_repay(
+                repay_amount=1000,
+                order_remark="xt_auto_repay:hard_settle",
+            )
+    finally:
+        credit_client_module._load_default_trader_callback_base = original_loader
 
     assert trader.stop_calls == 1

--- a/freshquant/tests/test_xt_auto_repay_worker.py
+++ b/freshquant/tests/test_xt_auto_repay_worker.py
@@ -308,9 +308,13 @@ def test_worker_records_failed_state_when_submit_returns_zero_order_id():
         "broker_order_id": 0,
     }
     assert service.events[-1]["event_type"] == "failed"
-    assert service.events[-1]["reason"] == "xtquant direct cash repay returned no order id"
+    assert (
+        service.events[-1]["reason"] == "xtquant direct cash repay returned no order id"
+    )
     assert service.state["last_status"] == "failed"
-    assert service.state["last_reason"] == "xtquant direct cash repay returned no order id"
+    assert (
+        service.state["last_reason"] == "xtquant direct cash repay returned no order id"
+    )
     assert service.state["last_submit_order_id"] is None
 
 
@@ -342,9 +346,7 @@ def test_cooldown_lock_client_releases_redis_lock_atomically():
     lock_client = _CooldownLockClient(redis_client=redis_client)
 
     assert lock_client.acquire("xt_auto_repay:068000076370", ttl_seconds=120) is True
-    assert (
-        lock_client.release("xt_auto_repay:068000076370") is True
-    )
+    assert lock_client.release("xt_auto_repay:068000076370") is True
     assert redis_client.values == {}
     assert redis_client.eval_calls[0]["numkeys"] == 1
     assert "redis.call('get', KEYS[1])" in redis_client.eval_calls[0]["script"]

--- a/freshquant/tests/test_xt_auto_repay_worker.py
+++ b/freshquant/tests/test_xt_auto_repay_worker.py
@@ -122,6 +122,12 @@ class FailingSubmitExecutor(FakeExecutor):
         raise RuntimeError(self.message)
 
 
+class ZeroOrderIdExecutor(FakeExecutor):
+    def submit_direct_cash_repay(self, *, repay_amount, remark):
+        self.submit_calls.append({"repay_amount": repay_amount, "remark": remark})
+        return 0
+
+
 class SequencedExecutor:
     def __init__(self, outcomes, *, order_id=9911):
         self.outcomes = list(outcomes)
@@ -171,6 +177,32 @@ class FakeLockClient:
     def release(self, key):
         self.release_calls.append(key)
         return True
+
+
+class FakeRedisLockClient:
+    def __init__(self):
+        self.values = {}
+        self.eval_calls = []
+
+    def set(self, key, value, *, ex=None, nx=False):
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    def eval(self, script, numkeys, key, token):
+        self.eval_calls.append(
+            {
+                "script": script,
+                "numkeys": numkeys,
+                "key": key,
+                "token": token,
+            }
+        )
+        if self.values.get(key) != token:
+            return 0
+        self.values.pop(key, None)
+        return 1
 
 
 def test_worker_uses_snapshot_for_intraday_candidate_and_requeries_before_submit():
@@ -253,6 +285,35 @@ def test_worker_records_failed_submit_without_killing_state_progress():
     assert service.state["last_hard_settle_at"] == "2026-04-05T14:55:00+08:00"
 
 
+def test_worker_records_failed_state_when_submit_returns_zero_order_id():
+    from freshquant.xt_auto_repay.worker import XtAutoRepayWorker
+
+    service = FakeService()
+    executor = ZeroOrderIdExecutor()
+    worker = XtAutoRepayWorker(
+        service=service,
+        executor=executor,
+        lock_client=FakeLockClient(),
+    )
+
+    result = worker.run_mode(
+        "hard_settle",
+        now=datetime.fromisoformat("2026-04-05T14:55:00+08:00"),
+    )
+
+    assert result == {
+        "mode": "hard_settle",
+        "status": "failed",
+        "repay_amount": 600.0,
+        "broker_order_id": 0,
+    }
+    assert service.events[-1]["event_type"] == "failed"
+    assert service.events[-1]["reason"] == "xtquant direct cash repay returned no order id"
+    assert service.state["last_status"] == "failed"
+    assert service.state["last_reason"] == "xtquant direct cash repay returned no order id"
+    assert service.state["last_submit_order_id"] is None
+
+
 def test_worker_releases_lock_between_due_modes_in_same_pending_cycle():
     from freshquant.xt_auto_repay.worker import XtAutoRepayWorker, _CooldownLockClient
 
@@ -272,6 +333,21 @@ def test_worker_releases_lock_between_due_modes_in_same_pending_cycle():
     assert [item["status"] for item in results] == ["submitted", "submitted"]
     assert executor.submit_calls[0]["repay_amount"] == 600.0
     assert executor.submit_calls[1]["repay_amount"] == 500.0
+
+
+def test_cooldown_lock_client_releases_redis_lock_atomically():
+    from freshquant.xt_auto_repay.worker import _CooldownLockClient
+
+    redis_client = FakeRedisLockClient()
+    lock_client = _CooldownLockClient(redis_client=redis_client)
+
+    assert lock_client.acquire("xt_auto_repay:068000076370", ttl_seconds=120) is True
+    assert (
+        lock_client.release("xt_auto_repay:068000076370") is True
+    )
+    assert redis_client.values == {}
+    assert redis_client.eval_calls[0]["numkeys"] == 1
+    assert "redis.call('get', KEYS[1])" in redis_client.eval_calls[0]["script"]
 
 
 def test_worker_runs_hard_settle_at_1455_and_retry_at_1505():

--- a/freshquant/tests/test_xt_auto_repay_worker.py
+++ b/freshquant/tests/test_xt_auto_repay_worker.py
@@ -164,7 +164,6 @@ class FakeLockClient:
             self.results = None
             self.result = result
         self.calls = []
-        self.release_calls = []
 
     def acquire(self, key, *, ttl_seconds):
         self.calls.append({"key": key, "ttl_seconds": ttl_seconds})
@@ -173,36 +172,6 @@ class FakeLockClient:
                 return False
             return self.results.pop(0)
         return self.result
-
-    def release(self, key):
-        self.release_calls.append(key)
-        return True
-
-
-class FakeRedisLockClient:
-    def __init__(self):
-        self.values = {}
-        self.eval_calls = []
-
-    def set(self, key, value, *, ex=None, nx=False):
-        if nx and key in self.values:
-            return False
-        self.values[key] = value
-        return True
-
-    def eval(self, script, numkeys, key, token):
-        self.eval_calls.append(
-            {
-                "script": script,
-                "numkeys": numkeys,
-                "key": key,
-                "token": token,
-            }
-        )
-        if self.values.get(key) != token:
-            return 0
-        self.values.pop(key, None)
-        return 1
 
 
 def test_worker_uses_snapshot_for_intraday_candidate_and_requeries_before_submit():
@@ -318,15 +287,16 @@ def test_worker_records_failed_state_when_submit_returns_zero_order_id():
     assert service.state["last_submit_order_id"] is None
 
 
-def test_worker_releases_lock_between_due_modes_in_same_pending_cycle():
-    from freshquant.xt_auto_repay.worker import XtAutoRepayWorker, _CooldownLockClient
+def test_worker_uses_mode_scoped_locks_between_due_modes_in_same_pending_cycle():
+    from freshquant.xt_auto_repay.worker import XtAutoRepayWorker
 
     service = FakeService(state={})
     executor = FakeExecutor()
+    lock_client = FakeLockClient()
     worker = XtAutoRepayWorker(
         service=service,
         executor=executor,
-        lock_client=_CooldownLockClient(redis_client=None),
+        lock_client=lock_client,
     )
 
     results = worker.run_pending(
@@ -337,19 +307,42 @@ def test_worker_releases_lock_between_due_modes_in_same_pending_cycle():
     assert [item["status"] for item in results] == ["submitted", "submitted"]
     assert executor.submit_calls[0]["repay_amount"] == 600.0
     assert executor.submit_calls[1]["repay_amount"] == 500.0
+    assert [call["key"] for call in lock_client.calls] == [
+        "xt_auto_repay:068000076370:hard_settle",
+        "xt_auto_repay:068000076370:retry",
+    ]
 
 
-def test_cooldown_lock_client_releases_redis_lock_atomically():
-    from freshquant.xt_auto_repay.worker import _CooldownLockClient
+def test_cooldown_lock_preserves_mode_dedupe_window_across_workers():
+    from freshquant.xt_auto_repay.worker import XtAutoRepayWorker, _CooldownLockClient
 
-    redis_client = FakeRedisLockClient()
-    lock_client = _CooldownLockClient(redis_client=redis_client)
+    lock_client = _CooldownLockClient(redis_client=None)
+    first_worker = XtAutoRepayWorker(
+        service=FakeService(state={}),
+        executor=FakeExecutor(),
+        lock_client=lock_client,
+    )
+    second_worker = XtAutoRepayWorker(
+        service=FakeService(state={}),
+        executor=FakeExecutor(),
+        lock_client=lock_client,
+    )
 
-    assert lock_client.acquire("xt_auto_repay:068000076370", ttl_seconds=120) is True
-    assert lock_client.release("xt_auto_repay:068000076370") is True
-    assert redis_client.values == {}
-    assert redis_client.eval_calls[0]["numkeys"] == 1
-    assert "redis.call('get', KEYS[1])" in redis_client.eval_calls[0]["script"]
+    first_result = first_worker.run_mode(
+        "hard_settle",
+        now=datetime.fromisoformat("2026-04-05T14:55:00+08:00"),
+    )
+    second_result = second_worker.run_mode(
+        "hard_settle",
+        now=datetime.fromisoformat("2026-04-05T14:55:01+08:00"),
+    )
+
+    assert first_result["status"] == "submitted"
+    assert second_result == {
+        "mode": "hard_settle",
+        "status": "skip",
+        "reason": "lock_unavailable",
+    }
 
 
 def test_worker_runs_hard_settle_at_1455_and_retry_at_1505():

--- a/freshquant/tests/test_xt_auto_repay_worker.py
+++ b/freshquant/tests/test_xt_auto_repay_worker.py
@@ -112,6 +112,16 @@ class FakeExecutor:
         return 9911
 
 
+class FailingSubmitExecutor(FakeExecutor):
+    def __init__(self, message):
+        super().__init__()
+        self.message = message
+
+    def submit_direct_cash_repay(self, *, repay_amount, remark):
+        self.submit_calls.append({"repay_amount": repay_amount, "remark": remark})
+        raise RuntimeError(self.message)
+
+
 class SequencedExecutor:
     def __init__(self, outcomes, *, order_id=9911):
         self.outcomes = list(outcomes)
@@ -148,6 +158,7 @@ class FakeLockClient:
             self.results = None
             self.result = result
         self.calls = []
+        self.release_calls = []
 
     def acquire(self, key, *, ttl_seconds):
         self.calls.append({"key": key, "ttl_seconds": ttl_seconds})
@@ -156,6 +167,10 @@ class FakeLockClient:
                 return False
             return self.results.pop(0)
         return self.result
+
+    def release(self, key):
+        self.release_calls.append(key)
+        return True
 
 
 def test_worker_uses_snapshot_for_intraday_candidate_and_requeries_before_submit():
@@ -201,6 +216,62 @@ def test_worker_skips_real_submit_in_observe_only_mode():
     assert executor.query_calls == 1
     assert executor.submit_calls == []
     assert service.events[-1]["event_type"] == "observe_only"
+
+
+def test_worker_records_failed_submit_without_killing_state_progress():
+    from freshquant.xt_auto_repay.worker import XtAutoRepayWorker
+
+    service = FakeService()
+    executor = FailingSubmitExecutor("xtquant direct cash repay rejected")
+    worker = XtAutoRepayWorker(
+        service=service,
+        executor=executor,
+        lock_client=FakeLockClient(),
+    )
+
+    result = worker.run_mode(
+        "hard_settle",
+        now=datetime.fromisoformat("2026-04-05T14:55:00+08:00"),
+    )
+
+    assert result == {
+        "mode": "hard_settle",
+        "status": "failed",
+        "repay_amount": 600.0,
+        "reason": "xtquant direct cash repay rejected",
+    }
+    assert executor.submit_calls == [
+        {
+            "repay_amount": 600.0,
+            "remark": "xt_auto_repay:hard_settle:2026-04-05T14:55:00+08:00",
+        }
+    ]
+    assert service.events[-1]["event_type"] == "failed"
+    assert service.events[-1]["reason"] == "xtquant direct cash repay rejected"
+    assert service.state["last_status"] == "failed"
+    assert service.state["last_reason"] == "xtquant direct cash repay rejected"
+    assert service.state["last_hard_settle_at"] == "2026-04-05T14:55:00+08:00"
+
+
+def test_worker_releases_lock_between_due_modes_in_same_pending_cycle():
+    from freshquant.xt_auto_repay.worker import XtAutoRepayWorker, _CooldownLockClient
+
+    service = FakeService(state={})
+    executor = FakeExecutor()
+    worker = XtAutoRepayWorker(
+        service=service,
+        executor=executor,
+        lock_client=_CooldownLockClient(redis_client=None),
+    )
+
+    results = worker.run_pending(
+        now=datetime.fromisoformat("2026-04-05T15:05:00+08:00"),
+    )
+
+    assert [item["mode"] for item in results] == ["hard_settle", "retry"]
+    assert [item["status"] for item in results] == ["submitted", "submitted"]
+    assert executor.submit_calls[0]["repay_amount"] == 600.0
+    assert executor.submit_calls[1]["repay_amount"] == 500.0
 
 
 def test_worker_runs_hard_settle_at_1455_and_retry_at_1505():

--- a/freshquant/xt_auto_repay/worker.py
+++ b/freshquant/xt_auto_repay/worker.py
@@ -268,9 +268,7 @@ class XtAutoRepayWorker:
                 confirmed_fin_debt=_decision_value(
                     confirmed_decision, "confirmed_fin_debt"
                 ),
-                candidate_amount=_decision_value(
-                    snapshot_decision, "candidate_amount"
-                ),
+                candidate_amount=_decision_value(snapshot_decision, "candidate_amount"),
                 submitted_amount=repay_amount,
                 broker_order_id=broker_order_id,
             )

--- a/freshquant/xt_auto_repay/worker.py
+++ b/freshquant/xt_auto_repay/worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import time
+import uuid
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
@@ -112,8 +113,9 @@ class XtAutoRepayWorker:
                     snapshot_decision=snapshot_decision,
                 )
 
+        lock_key = f"xt_auto_repay:{self.service.account_id}"
         if not self.lock_client.acquire(
-            f"xt_auto_repay:{self.service.account_id}",
+            lock_key,
             ttl_seconds=self.lock_ttl_seconds,
         ):
             return self._skip(
@@ -123,37 +125,123 @@ class XtAutoRepayWorker:
                 snapshot_decision=snapshot_decision,
                 mark_mode_completed=False,
             )
-
-        detail = self._query_credit_detail_with_xt_retry()
-        confirmed_decision = self.service.evaluate_confirmed_detail(
-            detail,
-            mode=resolved_mode,
-            now=resolved_now,
-        )
-        if not confirmed_decision.get("eligible"):
-            return self._skip(
+        try:
+            detail = self._query_credit_detail_with_xt_retry()
+            confirmed_decision = self.service.evaluate_confirmed_detail(
+                detail,
                 mode=resolved_mode,
                 now=resolved_now,
-                reason=confirmed_decision.get("reason"),
-                snapshot_decision=snapshot_decision,
-                confirmed_decision=confirmed_decision,
             )
+            if not confirmed_decision.get("eligible"):
+                return self._skip(
+                    mode=resolved_mode,
+                    now=resolved_now,
+                    reason=confirmed_decision.get("reason"),
+                    snapshot_decision=snapshot_decision,
+                    confirmed_decision=confirmed_decision,
+                )
 
-        state_updates = {
-            "last_checked_at": checked_at,
-            "last_status": (
-                "observe_only" if self.service.observe_only else "submitted"
-            ),
-            "last_reason": confirmed_decision.get("reason"),
-            "last_submit_amount": confirmed_decision.get("repay_amount"),
-        }
-        state_updates.update(_mode_timestamp_fields(resolved_mode, checked_at))
+            state_updates = {
+                "last_checked_at": checked_at,
+                "last_status": (
+                    "observe_only" if self.service.observe_only else "submitted"
+                ),
+                "last_reason": confirmed_decision.get("reason"),
+                "last_submit_amount": confirmed_decision.get("repay_amount"),
+            }
+            state_updates.update(_mode_timestamp_fields(resolved_mode, checked_at))
 
-        if self.service.observe_only:
+            if self.service.observe_only:
+                self.service.record_event(
+                    event_type="observe_only",
+                    mode=resolved_mode,
+                    reason="observe_only",
+                    snapshot_available_amount=_decision_value(
+                        snapshot_decision,
+                        "snapshot_available_amount",
+                    ),
+                    snapshot_fin_debt=_decision_value(
+                        snapshot_decision, "snapshot_fin_debt"
+                    ),
+                    confirmed_available_amount=_decision_value(
+                        confirmed_decision,
+                        "confirmed_available_amount",
+                    ),
+                    confirmed_fin_debt=_decision_value(
+                        confirmed_decision,
+                        "confirmed_fin_debt",
+                    ),
+                    candidate_amount=_decision_value(
+                        snapshot_decision, "candidate_amount"
+                    ),
+                    submitted_amount=_decision_value(
+                        confirmed_decision, "repay_amount"
+                    ),
+                )
+                self.service.update_state(**state_updates)
+                return {
+                    "mode": resolved_mode,
+                    "status": "observe_only",
+                    "repay_amount": confirmed_decision.get("repay_amount"),
+                }
+
+            repay_amount = confirmed_decision.get("repay_amount")
+            try:
+                broker_order_id = self.executor.submit_direct_cash_repay(
+                    repay_amount=repay_amount,
+                    remark=f"xt_auto_repay:{resolved_mode}:{checked_at}",
+                )
+            except Exception as error:
+                failure_reason = _submit_failure_reason(error)
+                logger.warning(
+                    "xt auto repay submit failed for %s: %s",
+                    resolved_mode,
+                    failure_reason,
+                    exc_info=True,
+                )
+                state_updates["last_status"] = "failed"
+                state_updates["last_reason"] = failure_reason
+                state_updates["last_submit_order_id"] = None
+                self.service.record_event(
+                    event_type="failed",
+                    mode=resolved_mode,
+                    reason=failure_reason,
+                    snapshot_available_amount=_decision_value(
+                        snapshot_decision,
+                        "snapshot_available_amount",
+                    ),
+                    snapshot_fin_debt=_decision_value(
+                        snapshot_decision, "snapshot_fin_debt"
+                    ),
+                    confirmed_available_amount=_decision_value(
+                        confirmed_decision,
+                        "confirmed_available_amount",
+                    ),
+                    confirmed_fin_debt=_decision_value(
+                        confirmed_decision, "confirmed_fin_debt"
+                    ),
+                    candidate_amount=_decision_value(
+                        snapshot_decision, "candidate_amount"
+                    ),
+                    submitted_amount=repay_amount,
+                )
+                self.service.update_state(**state_updates)
+                return {
+                    "mode": resolved_mode,
+                    "status": "failed",
+                    "repay_amount": repay_amount,
+                    "reason": failure_reason,
+                }
+            event_type = "submitted" if int(broker_order_id or 0) > 0 else "failed"
+            state_updates["last_submit_order_id"] = (
+                None if broker_order_id in {None, "", "None"} else str(broker_order_id)
+            )
+            if event_type == "submitted":
+                state_updates["last_submit_at"] = checked_at
             self.service.record_event(
-                event_type="observe_only",
+                event_type=event_type,
                 mode=resolved_mode,
-                reason="observe_only",
+                reason=confirmed_decision.get("reason"),
                 snapshot_available_amount=_decision_value(
                     snapshot_decision,
                     "snapshot_available_amount",
@@ -166,57 +254,23 @@ class XtAutoRepayWorker:
                     "confirmed_available_amount",
                 ),
                 confirmed_fin_debt=_decision_value(
-                    confirmed_decision,
-                    "confirmed_fin_debt",
+                    confirmed_decision, "confirmed_fin_debt"
                 ),
-                candidate_amount=_decision_value(snapshot_decision, "candidate_amount"),
-                submitted_amount=_decision_value(confirmed_decision, "repay_amount"),
+                candidate_amount=_decision_value(
+                    snapshot_decision, "candidate_amount"
+                ),
+                submitted_amount=repay_amount,
+                broker_order_id=broker_order_id,
             )
             self.service.update_state(**state_updates)
             return {
                 "mode": resolved_mode,
-                "status": "observe_only",
-                "repay_amount": confirmed_decision.get("repay_amount"),
+                "status": event_type,
+                "repay_amount": repay_amount,
+                "broker_order_id": broker_order_id,
             }
-
-        repay_amount = confirmed_decision.get("repay_amount")
-        broker_order_id = self.executor.submit_direct_cash_repay(
-            repay_amount=repay_amount,
-            remark=f"xt_auto_repay:{resolved_mode}:{checked_at}",
-        )
-        event_type = "submitted" if int(broker_order_id or 0) > 0 else "failed"
-        state_updates["last_submit_order_id"] = (
-            None if broker_order_id in {None, "", "None"} else str(broker_order_id)
-        )
-        if event_type == "submitted":
-            state_updates["last_submit_at"] = checked_at
-        self.service.record_event(
-            event_type=event_type,
-            mode=resolved_mode,
-            reason=confirmed_decision.get("reason"),
-            snapshot_available_amount=_decision_value(
-                snapshot_decision,
-                "snapshot_available_amount",
-            ),
-            snapshot_fin_debt=_decision_value(snapshot_decision, "snapshot_fin_debt"),
-            confirmed_available_amount=_decision_value(
-                confirmed_decision,
-                "confirmed_available_amount",
-            ),
-            confirmed_fin_debt=_decision_value(
-                confirmed_decision, "confirmed_fin_debt"
-            ),
-            candidate_amount=_decision_value(snapshot_decision, "candidate_amount"),
-            submitted_amount=repay_amount,
-            broker_order_id=broker_order_id,
-        )
-        self.service.update_state(**state_updates)
-        return {
-            "mode": resolved_mode,
-            "status": event_type,
-            "repay_amount": repay_amount,
-            "broker_order_id": broker_order_id,
-        }
+        finally:
+            self.lock_client.release(lock_key)
 
     def run_pending(self, *, now=None):
         resolved_now = now or self.now_provider()
@@ -357,21 +411,56 @@ class _CooldownLockClient:
     def __init__(self, redis_client):
         self.redis_client = redis_client
         self._memory = {}
+        self._tokens = {}
 
     def acquire(self, key, *, ttl_seconds):
         ttl = max(int(ttl_seconds or 0), 0)
         if ttl <= 0:
             return True
+        token = uuid.uuid4().hex
         if self.redis_client is not None:
             try:
-                return bool(self.redis_client.set(key, "1", ex=ttl, nx=True))
+                acquired = bool(self.redis_client.set(key, token, ex=ttl, nx=True))
             except Exception as exc:
                 raise RuntimeError("xt auto repay redis lock failed") from exc
+            if acquired:
+                self._tokens[key] = token
+            return acquired
         now_value = time.time()
-        expires_at = float(self._memory.get(key) or 0.0)
+        entry = self._memory.get(key)
+        expires_at = float(entry["expires_at"]) if isinstance(entry, dict) else 0.0
         if expires_at > now_value:
             return False
-        self._memory[key] = now_value + ttl
+        self._memory[key] = {
+            "token": token,
+            "expires_at": now_value + ttl,
+        }
+        self._tokens[key] = token
+        return True
+
+    def release(self, key):
+        token = self._tokens.pop(key, None)
+        if token is None:
+            return False
+        if self.redis_client is not None:
+            try:
+                current_value = self.redis_client.get(key)
+            except Exception as exc:
+                raise RuntimeError("xt auto repay redis lock release failed") from exc
+            if current_value is None:
+                return False
+            if isinstance(current_value, bytes):
+                current_value = current_value.decode("utf-8", errors="ignore")
+            if str(current_value) == str(token):
+                self.redis_client.delete(key)
+                return True
+            return False
+        entry = self._memory.get(key)
+        if not isinstance(entry, dict):
+            return False
+        if str(entry.get("token") or "") != str(token):
+            return False
+        self._memory.pop(key, None)
         return True
 
 
@@ -384,8 +473,13 @@ def run_forever(worker=None, *, sleep_fn=time.sleep, now_provider=None):
     auto_repay_worker = worker or XtAutoRepayWorker(now_provider=now_provider)
     while True:
         current_now = auto_repay_worker.now_provider()
-        auto_repay_worker.run_pending(now=current_now)
-        sleep_fn(auto_repay_worker.next_sleep_seconds(now=current_now))
+        try:
+            auto_repay_worker.run_pending(now=current_now)
+            sleep_seconds = auto_repay_worker.next_sleep_seconds(now=current_now)
+        except Exception:
+            logger.exception("xt auto repay worker loop failed")
+            sleep_seconds = 1.0
+        sleep_fn(sleep_seconds)
 
 
 def main(argv=None, worker=None):
@@ -497,6 +591,13 @@ def _is_retryable_xt_auto_repay_error(error):
     if "无法连接xtquant" in message or "鏃犳硶杩炴帴xtquant" in message:
         return True
     return "xtquant" in normalized and "qmt" in normalized
+
+
+def _submit_failure_reason(error):
+    message = str(error or "").strip()
+    if message:
+        return message
+    return error.__class__.__name__
 
 
 if __name__ == "__main__":

--- a/freshquant/xt_auto_repay/worker.py
+++ b/freshquant/xt_auto_repay/worker.py
@@ -32,6 +32,12 @@ HARD_SETTLE_TIME = (14, 55)
 RETRY_TIME = (15, 5)
 
 logger = logging.getLogger(__name__)
+_REDIS_RELEASE_LOCK_LUA = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+end
+return 0
+"""
 
 
 class XtAutoRepayWorker:
@@ -232,16 +238,22 @@ class XtAutoRepayWorker:
                     "repay_amount": repay_amount,
                     "reason": failure_reason,
                 }
-            event_type = "submitted" if int(broker_order_id or 0) > 0 else "failed"
+            broker_order_id_value = _positive_order_id_value(broker_order_id)
+            event_type = "submitted" if broker_order_id_value is not None else "failed"
             state_updates["last_submit_order_id"] = (
-                None if broker_order_id in {None, "", "None"} else str(broker_order_id)
+                None if broker_order_id_value is None else str(broker_order_id_value)
             )
             if event_type == "submitted":
                 state_updates["last_submit_at"] = checked_at
+                event_reason = confirmed_decision.get("reason")
+            else:
+                event_reason = "xtquant direct cash repay returned no order id"
+                state_updates["last_status"] = "failed"
+                state_updates["last_reason"] = event_reason
             self.service.record_event(
                 event_type=event_type,
                 mode=resolved_mode,
-                reason=confirmed_decision.get("reason"),
+                reason=event_reason,
                 snapshot_available_amount=_decision_value(
                     snapshot_decision,
                     "snapshot_available_amount",
@@ -444,17 +456,15 @@ class _CooldownLockClient:
             return False
         if self.redis_client is not None:
             try:
-                current_value = self.redis_client.get(key)
+                released = self.redis_client.eval(
+                    _REDIS_RELEASE_LOCK_LUA,
+                    1,
+                    key,
+                    token,
+                )
             except Exception as exc:
                 raise RuntimeError("xt auto repay redis lock release failed") from exc
-            if current_value is None:
-                return False
-            if isinstance(current_value, bytes):
-                current_value = current_value.decode("utf-8", errors="ignore")
-            if str(current_value) == str(token):
-                self.redis_client.delete(key)
-                return True
-            return False
+            return bool(int(released or 0) > 0)
         entry = self._memory.get(key)
         if not isinstance(entry, dict):
             return False
@@ -598,6 +608,16 @@ def _submit_failure_reason(error):
     if message:
         return message
     return error.__class__.__name__
+
+
+def _positive_order_id_value(value):
+    try:
+        resolved = int(value or 0)
+    except (TypeError, ValueError):
+        return None
+    if resolved <= 0:
+        return None
+    return resolved
 
 
 if __name__ == "__main__":

--- a/freshquant/xt_auto_repay/worker.py
+++ b/freshquant/xt_auto_repay/worker.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import logging
 import time
-import uuid
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
@@ -32,12 +31,6 @@ HARD_SETTLE_TIME = (14, 55)
 RETRY_TIME = (15, 5)
 
 logger = logging.getLogger(__name__)
-_REDIS_RELEASE_LOCK_LUA = """
-if redis.call('get', KEYS[1]) == ARGV[1] then
-    return redis.call('del', KEYS[1])
-end
-return 0
-"""
 
 
 class XtAutoRepayWorker:
@@ -119,7 +112,7 @@ class XtAutoRepayWorker:
                     snapshot_decision=snapshot_decision,
                 )
 
-        lock_key = f"xt_auto_repay:{self.service.account_id}"
+        lock_key = f"xt_auto_repay:{self.service.account_id}:{resolved_mode}"
         if not self.lock_client.acquire(
             lock_key,
             ttl_seconds=self.lock_ttl_seconds,
@@ -131,129 +124,82 @@ class XtAutoRepayWorker:
                 snapshot_decision=snapshot_decision,
                 mark_mode_completed=False,
             )
-        try:
-            detail = self._query_credit_detail_with_xt_retry()
-            confirmed_decision = self.service.evaluate_confirmed_detail(
-                detail,
+        detail = self._query_credit_detail_with_xt_retry()
+        confirmed_decision = self.service.evaluate_confirmed_detail(
+            detail,
+            mode=resolved_mode,
+            now=resolved_now,
+        )
+        if not confirmed_decision.get("eligible"):
+            return self._skip(
                 mode=resolved_mode,
                 now=resolved_now,
+                reason=confirmed_decision.get("reason"),
+                snapshot_decision=snapshot_decision,
+                confirmed_decision=confirmed_decision,
             )
-            if not confirmed_decision.get("eligible"):
-                return self._skip(
-                    mode=resolved_mode,
-                    now=resolved_now,
-                    reason=confirmed_decision.get("reason"),
-                    snapshot_decision=snapshot_decision,
-                    confirmed_decision=confirmed_decision,
-                )
 
-            state_updates = {
-                "last_checked_at": checked_at,
-                "last_status": (
-                    "observe_only" if self.service.observe_only else "submitted"
-                ),
-                "last_reason": confirmed_decision.get("reason"),
-                "last_submit_amount": confirmed_decision.get("repay_amount"),
-            }
-            state_updates.update(_mode_timestamp_fields(resolved_mode, checked_at))
+        state_updates = {
+            "last_checked_at": checked_at,
+            "last_status": (
+                "observe_only" if self.service.observe_only else "submitted"
+            ),
+            "last_reason": confirmed_decision.get("reason"),
+            "last_submit_amount": confirmed_decision.get("repay_amount"),
+        }
+        state_updates.update(_mode_timestamp_fields(resolved_mode, checked_at))
 
-            if self.service.observe_only:
-                self.service.record_event(
-                    event_type="observe_only",
-                    mode=resolved_mode,
-                    reason="observe_only",
-                    snapshot_available_amount=_decision_value(
-                        snapshot_decision,
-                        "snapshot_available_amount",
-                    ),
-                    snapshot_fin_debt=_decision_value(
-                        snapshot_decision, "snapshot_fin_debt"
-                    ),
-                    confirmed_available_amount=_decision_value(
-                        confirmed_decision,
-                        "confirmed_available_amount",
-                    ),
-                    confirmed_fin_debt=_decision_value(
-                        confirmed_decision,
-                        "confirmed_fin_debt",
-                    ),
-                    candidate_amount=_decision_value(
-                        snapshot_decision, "candidate_amount"
-                    ),
-                    submitted_amount=_decision_value(
-                        confirmed_decision, "repay_amount"
-                    ),
-                )
-                self.service.update_state(**state_updates)
-                return {
-                    "mode": resolved_mode,
-                    "status": "observe_only",
-                    "repay_amount": confirmed_decision.get("repay_amount"),
-                }
-
-            repay_amount = confirmed_decision.get("repay_amount")
-            try:
-                broker_order_id = self.executor.submit_direct_cash_repay(
-                    repay_amount=repay_amount,
-                    remark=f"xt_auto_repay:{resolved_mode}:{checked_at}",
-                )
-            except Exception as error:
-                failure_reason = _submit_failure_reason(error)
-                logger.warning(
-                    "xt auto repay submit failed for %s: %s",
-                    resolved_mode,
-                    failure_reason,
-                    exc_info=True,
-                )
-                state_updates["last_status"] = "failed"
-                state_updates["last_reason"] = failure_reason
-                state_updates["last_submit_order_id"] = None
-                self.service.record_event(
-                    event_type="failed",
-                    mode=resolved_mode,
-                    reason=failure_reason,
-                    snapshot_available_amount=_decision_value(
-                        snapshot_decision,
-                        "snapshot_available_amount",
-                    ),
-                    snapshot_fin_debt=_decision_value(
-                        snapshot_decision, "snapshot_fin_debt"
-                    ),
-                    confirmed_available_amount=_decision_value(
-                        confirmed_decision,
-                        "confirmed_available_amount",
-                    ),
-                    confirmed_fin_debt=_decision_value(
-                        confirmed_decision, "confirmed_fin_debt"
-                    ),
-                    candidate_amount=_decision_value(
-                        snapshot_decision, "candidate_amount"
-                    ),
-                    submitted_amount=repay_amount,
-                )
-                self.service.update_state(**state_updates)
-                return {
-                    "mode": resolved_mode,
-                    "status": "failed",
-                    "repay_amount": repay_amount,
-                    "reason": failure_reason,
-                }
-            broker_order_id_value = _positive_order_id_value(broker_order_id)
-            event_type = "submitted" if broker_order_id_value is not None else "failed"
-            state_updates["last_submit_order_id"] = (
-                None if broker_order_id_value is None else str(broker_order_id_value)
-            )
-            if event_type == "submitted":
-                state_updates["last_submit_at"] = checked_at
-                event_reason = confirmed_decision.get("reason")
-            else:
-                event_reason = "xtquant direct cash repay returned no order id"
-                state_updates["last_status"] = "failed"
-                state_updates["last_reason"] = event_reason
+        if self.service.observe_only:
             self.service.record_event(
-                event_type=event_type,
+                event_type="observe_only",
                 mode=resolved_mode,
-                reason=event_reason,
+                reason="observe_only",
+                snapshot_available_amount=_decision_value(
+                    snapshot_decision,
+                    "snapshot_available_amount",
+                ),
+                snapshot_fin_debt=_decision_value(
+                    snapshot_decision, "snapshot_fin_debt"
+                ),
+                confirmed_available_amount=_decision_value(
+                    confirmed_decision,
+                    "confirmed_available_amount",
+                ),
+                confirmed_fin_debt=_decision_value(
+                    confirmed_decision,
+                    "confirmed_fin_debt",
+                ),
+                candidate_amount=_decision_value(snapshot_decision, "candidate_amount"),
+                submitted_amount=_decision_value(confirmed_decision, "repay_amount"),
+            )
+            self.service.update_state(**state_updates)
+            return {
+                "mode": resolved_mode,
+                "status": "observe_only",
+                "repay_amount": confirmed_decision.get("repay_amount"),
+            }
+
+        repay_amount = confirmed_decision.get("repay_amount")
+        try:
+            broker_order_id = self.executor.submit_direct_cash_repay(
+                repay_amount=repay_amount,
+                remark=f"xt_auto_repay:{resolved_mode}:{checked_at}",
+            )
+        except Exception as error:
+            failure_reason = _submit_failure_reason(error)
+            logger.warning(
+                "xt auto repay submit failed for %s: %s",
+                resolved_mode,
+                failure_reason,
+                exc_info=True,
+            )
+            state_updates["last_status"] = "failed"
+            state_updates["last_reason"] = failure_reason
+            state_updates["last_submit_order_id"] = None
+            self.service.record_event(
+                event_type="failed",
+                mode=resolved_mode,
+                reason=failure_reason,
                 snapshot_available_amount=_decision_value(
                     snapshot_decision,
                     "snapshot_available_amount",
@@ -270,17 +216,53 @@ class XtAutoRepayWorker:
                 ),
                 candidate_amount=_decision_value(snapshot_decision, "candidate_amount"),
                 submitted_amount=repay_amount,
-                broker_order_id=broker_order_id,
             )
             self.service.update_state(**state_updates)
             return {
                 "mode": resolved_mode,
-                "status": event_type,
+                "status": "failed",
                 "repay_amount": repay_amount,
-                "broker_order_id": broker_order_id,
+                "reason": failure_reason,
             }
-        finally:
-            self.lock_client.release(lock_key)
+        broker_order_id_value = _positive_order_id_value(broker_order_id)
+        event_type = "submitted" if broker_order_id_value is not None else "failed"
+        state_updates["last_submit_order_id"] = (
+            None if broker_order_id_value is None else str(broker_order_id_value)
+        )
+        if event_type == "submitted":
+            state_updates["last_submit_at"] = checked_at
+            event_reason = confirmed_decision.get("reason")
+        else:
+            event_reason = "xtquant direct cash repay returned no order id"
+            state_updates["last_status"] = "failed"
+            state_updates["last_reason"] = event_reason
+        self.service.record_event(
+            event_type=event_type,
+            mode=resolved_mode,
+            reason=event_reason,
+            snapshot_available_amount=_decision_value(
+                snapshot_decision,
+                "snapshot_available_amount",
+            ),
+            snapshot_fin_debt=_decision_value(snapshot_decision, "snapshot_fin_debt"),
+            confirmed_available_amount=_decision_value(
+                confirmed_decision,
+                "confirmed_available_amount",
+            ),
+            confirmed_fin_debt=_decision_value(
+                confirmed_decision, "confirmed_fin_debt"
+            ),
+            candidate_amount=_decision_value(snapshot_decision, "candidate_amount"),
+            submitted_amount=repay_amount,
+            broker_order_id=broker_order_id,
+        )
+        self.service.update_state(**state_updates)
+        return {
+            "mode": resolved_mode,
+            "status": event_type,
+            "repay_amount": repay_amount,
+            "broker_order_id": broker_order_id,
+        }
 
     def run_pending(self, *, now=None):
         resolved_now = now or self.now_provider()
@@ -421,54 +403,21 @@ class _CooldownLockClient:
     def __init__(self, redis_client):
         self.redis_client = redis_client
         self._memory = {}
-        self._tokens = {}
 
     def acquire(self, key, *, ttl_seconds):
         ttl = max(int(ttl_seconds or 0), 0)
         if ttl <= 0:
             return True
-        token = uuid.uuid4().hex
         if self.redis_client is not None:
             try:
-                acquired = bool(self.redis_client.set(key, token, ex=ttl, nx=True))
+                return bool(self.redis_client.set(key, "1", ex=ttl, nx=True))
             except Exception as exc:
                 raise RuntimeError("xt auto repay redis lock failed") from exc
-            if acquired:
-                self._tokens[key] = token
-            return acquired
         now_value = time.time()
-        entry = self._memory.get(key)
-        expires_at = float(entry["expires_at"]) if isinstance(entry, dict) else 0.0
+        expires_at = float(self._memory.get(key) or 0.0)
         if expires_at > now_value:
             return False
-        self._memory[key] = {
-            "token": token,
-            "expires_at": now_value + ttl,
-        }
-        self._tokens[key] = token
-        return True
-
-    def release(self, key):
-        token = self._tokens.pop(key, None)
-        if token is None:
-            return False
-        if self.redis_client is not None:
-            try:
-                released = self.redis_client.eval(
-                    _REDIS_RELEASE_LOCK_LUA,
-                    1,
-                    key,
-                    token,
-                )
-            except Exception as exc:
-                raise RuntimeError("xt auto repay redis lock release failed") from exc
-            return bool(int(released or 0) > 0)
-        entry = self._memory.get(key)
-        if not isinstance(entry, dict):
-            return False
-        if str(entry.get("token") or "") != str(token):
-            return False
-        self._memory.pop(key, None)
+        self._memory[key] = now_value + ttl
         return True
 
 


### PR DESCRIPTION
## 背景

本次自动还款链路在实盘排障中暴露出几个关键问题：
- `XtQuantTrader.order_stock()` 的直接还款参数不符合 XT 的实际受理形态，空 `stock_code` 会被直接拒绝。
- 自动还款 worker 对 XT 同步调用缺少超时与提交失败兜底，曾出现主循环卡住、盘后补跑失效。
- 本轮 review 又继续发现了两个状态一致性风险：同轮 `hard_settle -> retry` 会被共享冷却锁互相挡住，以及 `order_id<=0` 时事件会记成 failed、state 却可能残留 submitted。

## 目标

把 XT 自动还款链路修正为可观测、可失败、不会卡死，并确保 worker 状态和事件一致。

## 范围

- 修正 XT 直接还款提交流程，改用 placeholder `stock_code` + `LATEST_PRICE`，并识别柜台拒单。
- 给 `PositionCreditClient` 的 XT 连接补超时与 order-error callback 支持。
- 修复 `xt_auto_repay.worker` 的失败记账、循环异常保护、冷却锁释放与补跑行为。
- 为上述行为补测试，并同步 `docs/current/**` 当前事实。

## 非目标

- 不改变券商柜台的交易时段限制；盘后 `-1020 节点当前非交易状态,禁止做直接还款` 仍属于柜台拒单。
- 不在本 PR 内改自动还款的业务策略阈值或触发时点。

## 验收标准

- 直接还款提交使用 XT 当前可接受的参数形态。
- 提交被拒单时，worker 记录 `failed` 事件和状态，而不是卡死或误记为 `submitted`。
- worker 错过 `14:55` / `15:05` 后恢复时，同一轮补跑可以依次完成 `hard_settle` 与 `retry`。
- 本地预检查和相关 pytest 通过，`docs/current/**` 与当前实现一致。

## 部署影响

- 命中 `freshquant/position_management/**`、`freshquant/xt_auto_repay/**`、`freshquant/order_management/**`，需要正式重部署受影响宿主机运行面。
- 合并后需要同步本地 `main`，执行 formal deploy，并做 health check / runtime verify。