### PR TITLE
Fix XT report matching for reused broker order ids

### DIFF
--- a/docs/current/architecture.md
+++ b/docs/current/architecture.md
@@ -92,6 +92,7 @@
   - 定义当前券商仓位真值
 - `om_broker_orders + om_execution_fills`
   - 定义执行事实
+  - XT 回报进入订单账本时，`broker_order_id` 只作为候选检索键；重复券商订单号需要结合 `symbol`、`side/order_type` 与回报时间确定内部订单
 - `om_position_entries`
   - 定义系统可消费的持仓入口
 - `om_reconciliation_*`

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -14,10 +14,11 @@
 - TPSL tick listener。
 - 需要直接访问券商、终端、`TDX_HOME` 或 Windows 本地目录的组件。
 
-当前运行面还有两条与订单对账相关的固定语义：
+当前运行面还有三条与订单对账相关的固定语义：
 
 - `ExternalOrderReconcileService` 对 buy gap 会同时记录 `initial/latest/chosen` 三组价格快照；运行面和排障口径里若看到 `chosen_price_policy=freeze_initial`，表示最终确认价按首次发现快照冻结，而不是跟随长时间观测漂移。
 - Guardian 遇到“持仓 entry 已确认但 arranged fills 不可用”的场景时，当前会显式区分 `arrangement_degraded` 与 `entry_without_slices`；这两种情况默认保守跳过，不再误记成“无持仓”。
+- XT 委托/成交回报匹配内部订单时，`broker_order_id` 不视为全局唯一键；同一 `broker_order_id` 命中多条 `om_orders` 时，会继续按 `symbol`、`side/order_type` 与回报时间选择候选。
 
 ### Docker 并行环境承担
 

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -123,6 +123,30 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
   - 最后再恢复 indexer
 - 不要直接删除 progress 后让 indexer 从 0 全量重扫；`runtime_events` 当前不是去重表，这样会把历史事件重复写入 ClickHouse。
 
+## Runtime Trace 显示 XT 回报链路状态迁移失败
+
+现象：
+
+- `/runtime-observability` 单条 Trace 显示 `链路类型=外部上报`、`链路状态=失败`
+- 右侧异常阶段包含 `xt_report_ingest.order_match`
+- stderr 或 runtime payload 出现 `InvalidOrderTransition`，例如 `FILLED -> SUBMITTED`
+
+先检查：
+
+- `Get-ChildItem logs/runtime/host_broker/broker_gateway -Recurse -Filter *.jsonl | Select-String -Pattern "<trace_id>|<broker_order_id>"`
+- `Get-ChildItem logs/runtime/host_xt_report_ingest/xt_report_ingest -Recurse -Filter *.jsonl | Select-String -Pattern "<trace_id>|<broker_order_id>"`
+- `@'
+from freshquant.order_management.db import DBOrderManagement
+broker_order_id = "<broker_order_id>"
+print(list(DBOrderManagement["om_orders"].find({"broker_order_id": str(broker_order_id)}, {"_id": 0, "internal_order_id": 1, "trace_id": 1, "symbol": 1, "side": 1, "broker_order_type": 1, "state": 1, "submitted_at": 1})))
+'@ | py -3.12 -m uv run -`
+
+处理：
+
+- 当前 `broker_order_id` 不能单独当作全局唯一键；如果同号命中多条 `om_orders`，以 `symbol`、`side/order_type` 与回报时间确认真实内部订单。
+- 若重复券商订单号曾把回报挂到旧内部订单，需要同步核对 `om_execution_fills`、`om_trade_facts` 与 `om_position_entries` 是否已有错归属事实；必要时按券商真值 `xt_orders/xt_trades/xt_positions` 做账本修复。
+- 修复代码后需要重新部署 `order_management` host surface，并确认 broker / XT report ingest runtime event 已回到新内部订单对应的 trace。
+
 ## broker_gateway 健康摘要停留在旧 warning
 
 现象：

--- a/freshquant/order_management/broker_match.py
+++ b/freshquant/order_management/broker_match.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+_BEIJING_TZ = ZoneInfo("Asia/Shanghai")
+_BUY_ORDER_TYPES = {23, 27, 28, "23", "27", "28", "buy", "BUY"}
+_SELL_ORDER_TYPES = {24, 31, 32, "24", "31", "32", "sell", "SELL"}
+_NONTERMINAL_STATES = {
+    "ACCEPTED",
+    "VALIDATED",
+    "QUEUED",
+    "SUBMITTING",
+    "SUBMITTED",
+    "PARTIAL_FILLED",
+    "CANCEL_REQUESTED",
+    "INFERRED_PENDING",
+}
+
+
+def find_order_for_broker_report(
+    repository,
+    *,
+    broker_order_id,
+    report=None,
+    symbol=None,
+    side=None,
+    order_type=None,
+    report_time=None,
+):
+    if repository is None or broker_order_id in (None, "", "None"):
+        return None
+
+    candidates = _list_order_candidates(repository, broker_order_id)
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    report = report or {}
+    symbol = _normalize_symbol(
+        symbol or report.get("symbol") or report.get("stock_code")
+    )
+    order_type = order_type if order_type is not None else report.get("order_type")
+    side = _normalize_side(side) or side_from_order_type(order_type)
+    report_time = _coalesce_report_time(report_time, report)
+
+    filtered = candidates
+    if symbol:
+        by_symbol = [
+            item for item in filtered if _normalize_symbol(item.get("symbol")) == symbol
+        ]
+        if by_symbol:
+            filtered = by_symbol
+
+    if side:
+        by_side = [item for item in filtered if _candidate_side(item) in (None, side)]
+        if by_side:
+            filtered = by_side
+
+    if order_type is not None and len(filtered) > 1:
+        report_side = side_from_order_type(order_type)
+        by_order_type = [
+            item
+            for item in filtered
+            if _order_type_equivalent(item.get("broker_order_type"), order_type)
+            or (
+                report_side is not None
+                and side_from_order_type(item.get("broker_order_type")) == report_side
+            )
+        ]
+        if by_order_type:
+            filtered = by_order_type
+
+    scored = sorted(
+        ((_candidate_score(item, report_time), item) for item in filtered),
+        key=lambda pair: pair[0],
+        reverse=True,
+    )
+    if not scored:
+        return None
+    if len(scored) > 1 and scored[0][0] == scored[1][0]:
+        return None
+    return scored[0][1]
+
+
+def side_from_order_type(order_type):
+    if order_type in _BUY_ORDER_TYPES:
+        return "buy"
+    if order_type in _SELL_ORDER_TYPES:
+        return "sell"
+    try:
+        numeric = int(order_type)
+    except (TypeError, ValueError):
+        return None
+    if numeric in {23, 27, 28}:
+        return "buy"
+    if numeric in {24, 31, 32}:
+        return "sell"
+    return None
+
+
+def _list_order_candidates(repository, broker_order_id):
+    if hasattr(repository, "list_orders_by_broker_order_id"):
+        return list(repository.list_orders_by_broker_order_id(broker_order_id))
+
+    order = repository.find_order_by_broker_order_id(broker_order_id)
+    return [order] if order is not None else []
+
+
+def _candidate_side(order):
+    return _normalize_side(order.get("side")) or side_from_order_type(
+        order.get("broker_order_type")
+    )
+
+
+def _candidate_score(order, report_time):
+    state_score = 1 if order.get("state") in _NONTERMINAL_STATES else 0
+    submitted_at = _parse_order_datetime(
+        order.get("submitted_at") or order.get("updated_at") or order.get("created_at")
+    )
+    if report_time is None or submitted_at is None:
+        time_score = 0
+        distance_score = 0
+    else:
+        distance = abs((report_time - submitted_at).total_seconds())
+        time_score = 1
+        distance_score = -distance
+    recency = submitted_at.timestamp() if submitted_at is not None else 0
+    return (time_score, state_score, distance_score, recency)
+
+
+def _coalesce_report_time(report_time, report):
+    if report_time is not None:
+        return _parse_report_datetime(report_time)
+    for key in ("traded_time", "trade_time", "order_time"):
+        if report.get(key) is not None:
+            return _parse_report_datetime(report.get(key))
+    return None
+
+
+def _parse_report_datetime(value):
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return _as_aware(value)
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return _parse_order_datetime(value)
+
+
+def _parse_order_datetime(value):
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return _as_aware(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return _as_aware(parsed)
+
+
+def _as_aware(value):
+    if value.tzinfo is None:
+        return value.replace(tzinfo=_BEIJING_TZ).astimezone(timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _normalize_symbol(value):
+    if value in (None, ""):
+        return None
+    text = str(value).strip().upper()
+    return text[:6] if len(text) >= 6 else text
+
+
+def _normalize_side(value):
+    if value in (None, ""):
+        return None
+    text = str(value).strip().lower()
+    if text in {"buy", "sell"}:
+        return text
+    return None
+
+
+def _order_type_equivalent(left, right):
+    if left in (None, "") or right in (None, ""):
+        return False
+    try:
+        return int(left) == int(right)
+    except (TypeError, ValueError):
+        return str(left).strip().lower() == str(right).strip().lower()

--- a/freshquant/order_management/ingest/xt_reports.py
+++ b/freshquant/order_management/ingest/xt_reports.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from loguru import logger
 
 from freshquant.carnation import xtconstant
+from freshquant.order_management.broker_match import find_order_for_broker_report
 from freshquant.order_management.entry_adapter import (
     list_open_entry_slices_compat,
     list_open_entry_views,
@@ -434,7 +435,14 @@ def normalize_xt_trade_report(report, repository=None):
     if internal_order_id is not None and repository is not None:
         order = repository.find_order(internal_order_id)
     if internal_order_id is None and repository is not None and order_id is not None:
-        order = repository.find_order_by_broker_order_id(order_id)
+        order = find_order_for_broker_report(
+            repository,
+            broker_order_id=order_id,
+            report=report,
+            symbol=symbol,
+            order_type=order_type,
+            report_time=traded_time,
+        )
         if order is not None:
             internal_order_id = order["internal_order_id"]
     if order is not None and order.get("broker_order_type") is not None:
@@ -468,7 +476,14 @@ def normalize_xt_order_report(report, repository=None):
     internal_order_id = report.get("internal_order_id")
     order = None
     if internal_order_id is None and repository is not None:
-        order = repository.find_order_by_broker_order_id(broker_order_id)
+        order = find_order_for_broker_report(
+            repository,
+            broker_order_id=broker_order_id,
+            report=report,
+            symbol=report.get("symbol") or report.get("stock_code"),
+            order_type=report.get("order_type"),
+            report_time=report.get("order_time"),
+        )
         if order is not None:
             internal_order_id = order["internal_order_id"]
     else:

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -5,6 +5,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from freshquant.order_management.broker_match import find_order_for_broker_report
 from freshquant.order_management.entry_aggregation import (
     build_clustered_position_entry,
     build_reconciliation_resolution_member_key,
@@ -275,9 +276,21 @@ class ExternalOrderReconcileService:
                 repository=self.repository,
             )
             ids["symbol"] = normalized.get("symbol")
-            known_order = self.repository.find_order_by_broker_order_id(
-                normalized.get("broker_order_id")
-            )
+            known_order = None
+            if normalized.get("internal_order_id"):
+                known_order = self.repository.find_order(
+                    normalized.get("internal_order_id")
+                )
+            if known_order is None:
+                known_order = find_order_for_broker_report(
+                    self.repository,
+                    broker_order_id=normalized.get("broker_order_id"),
+                    report=report,
+                    symbol=normalized.get("symbol"),
+                    side=normalized.get("side"),
+                    order_type=report.get("order_type"),
+                    report_time=normalized.get("trade_time"),
+                )
             if known_order:
                 ids.update(
                     {

--- a/freshquant/order_management/repository.py
+++ b/freshquant/order_management/repository.py
@@ -172,6 +172,11 @@ class OrderManagementRepository:
     def find_order_by_broker_order_id(self, broker_order_id):
         return self.orders.find_one({"broker_order_id": str(broker_order_id)})
 
+    def list_orders_by_broker_order_id(self, broker_order_id):
+        if broker_order_id in (None, "", "None"):
+            return []
+        return list(self.orders.find({"broker_order_id": str(broker_order_id)}))
+
     def update_order(self, internal_order_id, updates):
         self.orders.update_one(
             {"internal_order_id": internal_order_id},

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -150,6 +150,13 @@ class InMemoryRepository:
                 return order
         return None
 
+    def list_orders_by_broker_order_id(self, broker_order_id):
+        return [
+            order
+            for order in self.orders
+            if str(order.get("broker_order_id")) == str(broker_order_id)
+        ]
+
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)
         if order is None:
@@ -941,6 +948,98 @@ def test_reconcile_trade_report_ingests_known_internal_sell_order(monkeypatch):
         == 700
     )
     assert len(repository.sell_allocations) == 1
+
+
+def test_reconcile_trade_report_uses_matching_duplicate_broker_order_candidate(
+    monkeypatch,
+):
+    repository, service = _build_service(monkeypatch)
+    tracking_service = OrderTrackingService(repository=repository)
+    buy_lot = build_buy_lot_from_trade_fact(
+        {
+            "trade_fact_id": "trade_duplicate_seed_buy_1",
+            "symbol": "002262",
+            "side": "buy",
+            "quantity": 2300,
+            "price": 21.0,
+            "trade_time": 1_000,
+            "date": 20260429,
+            "time": "09:31:00",
+        }
+    )
+    repository.insert_buy_lot(buy_lot)
+    repository.replace_lot_slices_for_lot(
+        buy_lot["buy_lot_id"],
+        arrange_buy_lot(buy_lot, lot_amount=50_000, grid_interval=1.03),
+    )
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "002262",
+            "price": 21.0,
+            "quantity": 2300,
+            "source": "strategy",
+            "internal_order_id": "ord_old_buy_duplicate",
+            "broker_order_type": 27,
+            "trace_id": "trc_old",
+            "request_id": "req_old",
+        }
+    )
+    repository.update_order(
+        "ord_old_buy_duplicate",
+        {
+            "broker_order_id": "1477443585",
+            "broker_order_type": 27,
+            "state": "FILLED",
+            "submitted_at": "2026-04-13T14:22:07+08:00",
+        },
+    )
+    tracking_service.submit_order(
+        {
+            "action": "sell",
+            "symbol": "002262",
+            "price": 22.41,
+            "quantity": 2300,
+            "source": "strategy",
+            "internal_order_id": "ord_new_sell_duplicate",
+            "broker_order_type": 24,
+            "trace_id": "trc_new",
+            "request_id": "req_new",
+        }
+    )
+    repository.update_order(
+        "ord_new_sell_duplicate",
+        {
+            "broker_order_id": "1477443585",
+            "broker_order_type": 24,
+            "state": "SUBMITTED",
+            "submitted_at": "2026-04-29T10:14:06+08:00",
+        },
+    )
+
+    outcome = service.reconcile_trade_report(
+        {
+            "order_id": 1477443585,
+            "traded_id": "0103000030649603",
+            "stock_code": "002262.SZ",
+            "order_type": 24,
+            "traded_volume": 2300,
+            "traded_price": 22.41,
+            "traded_time": 1777428846,
+        }
+    )
+
+    assert outcome.handled is True
+    assert outcome.ingested is True
+    assert outcome.action == "known_internal_order_ingested"
+    assert outcome.result["trade_fact"]["internal_order_id"] == (
+        "ord_new_sell_duplicate"
+    )
+    assert outcome.result["trade_fact"]["side"] == "sell"
+    assert repository.trade_facts[0]["internal_order_id"] == "ord_new_sell_duplicate"
+    assert repository.execution_fills[0]["broker_order_key"] == (
+        "ord_new_sell_duplicate"
+    )
 
 
 def test_inferred_pending_auto_confirms_into_entry_without_fake_trade(monkeypatch):

--- a/freshquant/tests/test_order_management_xt_ingest.py
+++ b/freshquant/tests/test_order_management_xt_ingest.py
@@ -86,6 +86,13 @@ class InMemoryRepository:
                 return order
         return None
 
+    def list_orders_by_broker_order_id(self, broker_order_id):
+        return [
+            order
+            for order in self.orders
+            if str(order.get("broker_order_id")) == str(broker_order_id)
+        ]
+
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)
         if order is None:
@@ -364,6 +371,138 @@ def test_normalize_xt_trade_report_prefers_order_domain_broker_order_type():
 
     assert normalized["internal_order_id"] == "ord_credit_ingest_1"
     assert normalized["side"] == "buy"
+
+
+def test_normalize_xt_trade_report_disambiguates_reused_broker_order_id():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "002262",
+            "price": 21.0,
+            "quantity": 2300,
+            "source": "api",
+            "internal_order_id": "ord_old_buy",
+            "broker_order_type": 27,
+            "trace_id": "trc_old",
+            "request_id": "req_old",
+        }
+    )
+    repository.update_order(
+        "ord_old_buy",
+        {
+            "broker_order_id": "1477443585",
+            "broker_order_type": 27,
+            "state": "FILLED",
+            "submitted_at": "2026-04-13T14:22:07+08:00",
+        },
+    )
+    tracking_service.submit_order(
+        {
+            "action": "sell",
+            "symbol": "002262",
+            "price": 22.41,
+            "quantity": 2300,
+            "source": "api",
+            "internal_order_id": "ord_new_sell",
+            "broker_order_type": 24,
+            "trace_id": "trc_new",
+            "request_id": "req_new",
+        }
+    )
+    repository.update_order(
+        "ord_new_sell",
+        {
+            "broker_order_id": "1477443585",
+            "broker_order_type": 24,
+            "state": "SUBMITTED",
+            "submitted_at": "2026-04-29T10:14:06+08:00",
+        },
+    )
+
+    normalized = normalize_xt_trade_report(
+        {
+            "order_id": "1477443585",
+            "traded_id": "0103000030649603",
+            "stock_code": "002262.SZ",
+            "order_type": 24,
+            "traded_volume": 2300,
+            "traded_price": 22.41,
+            "traded_time": 1777428846,
+        },
+        repository=repository,
+    )
+
+    assert normalized["internal_order_id"] == "ord_new_sell"
+    assert normalized["side"] == "sell"
+    assert normalized["trace_id"] == "trc_new"
+    assert normalized["request_id"] == "req_new"
+
+
+def test_normalize_xt_order_report_disambiguates_reused_broker_order_id():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "002262",
+            "price": 21.0,
+            "quantity": 2300,
+            "source": "api",
+            "internal_order_id": "ord_old_buy",
+            "broker_order_type": 27,
+            "trace_id": "trc_old",
+            "request_id": "req_old",
+        }
+    )
+    repository.update_order(
+        "ord_old_buy",
+        {
+            "broker_order_id": "1477443585",
+            "broker_order_type": 27,
+            "state": "FILLED",
+            "submitted_at": "2026-04-13T14:22:07+08:00",
+        },
+    )
+    tracking_service.submit_order(
+        {
+            "action": "sell",
+            "symbol": "002262",
+            "price": 22.41,
+            "quantity": 2300,
+            "source": "api",
+            "internal_order_id": "ord_new_sell",
+            "broker_order_type": 24,
+            "trace_id": "trc_new",
+            "request_id": "req_new",
+        }
+    )
+    repository.update_order(
+        "ord_new_sell",
+        {
+            "broker_order_id": "1477443585",
+            "broker_order_type": 24,
+            "state": "SUBMITTED",
+            "submitted_at": "2026-04-29T10:14:06+08:00",
+        },
+    )
+
+    normalized = normalize_xt_order_report(
+        {
+            "order_id": 1477443585,
+            "stock_code": "002262.SZ",
+            "order_type": 24,
+            "order_time": 1777428846,
+            "order_status": 50,
+        },
+        repository=repository,
+    )
+
+    assert normalized["internal_order_id"] == "ord_new_sell"
+    assert normalized["state"] == "SUBMITTED"
+    assert normalized["trace_id"] == "trc_new"
+    assert normalized["request_id"] == "req_new"
 
 
 def test_upsert_broker_position_entry_uses_beijing_time_when_local_fromtimestamp_differs(

--- a/freshquant/tests/test_xtquant_runtime_observability.py
+++ b/freshquant/tests/test_xtquant_runtime_observability.py
@@ -644,6 +644,61 @@ def test_broker_trade_callback_emits_resolved_runtime_context(monkeypatch):
     assert collector.events[0]["payload"]["broker_trade_id"] == "T-90001"
 
 
+def test_broker_trade_callback_disambiguates_reused_broker_order_id(monkeypatch):
+    _install_broker_stubs(monkeypatch)
+    broker = _load_module("test_runtime_broker_duplicate_order", BROKER_PATH)
+    collector = EventCollector()
+    broker._runtime_logger = collector
+
+    class DuplicateBrokerOrderRepository:
+        def list_orders_by_broker_order_id(self, broker_order_id):
+            assert str(broker_order_id) == "1477443585"
+            return [
+                {
+                    "trace_id": "trc_old",
+                    "intent_id": "int_old",
+                    "request_id": "req_old",
+                    "internal_order_id": "ord_old_buy",
+                    "symbol": "002262",
+                    "side": "buy",
+                    "broker_order_type": 27,
+                    "state": "FILLED",
+                    "submitted_at": "2026-04-13T14:22:07+08:00",
+                },
+                {
+                    "trace_id": "trc_new",
+                    "intent_id": "int_new",
+                    "request_id": "req_new",
+                    "internal_order_id": "ord_new_sell",
+                    "symbol": "002262",
+                    "side": "sell",
+                    "broker_order_type": 24,
+                    "state": "SUBMITTED",
+                    "submitted_at": "2026-04-29T10:14:06+08:00",
+                },
+            ]
+
+    broker.order_management_repository = DuplicateBrokerOrderRepository()
+
+    callback = broker.MyXtQuantTraderCallback()
+    callback.on_stock_trade(
+        types.SimpleNamespace(
+            order_id="1477443585",
+            traded_id="0103000030649603",
+            stock_code="002262.SZ",
+            order_type=24,
+            traded_time=1777428846,
+        )
+    )
+
+    assert collector.events[0]["node"] == "trade_callback"
+    assert collector.events[0]["trace_id"] == "trc_new"
+    assert collector.events[0]["request_id"] == "req_new"
+    assert collector.events[0]["internal_order_id"] == "ord_new_sell"
+    assert collector.events[0]["symbol"] == "002262"
+    assert collector.events[0]["action"] == "sell"
+
+
 def test_broker_observe_only_submit_emits_bypass_event_without_calling_executor(
     monkeypatch,
 ):

--- a/morningglory/fqxtrade/fqxtrade/xtquant/broker.py
+++ b/morningglory/fqxtrade/fqxtrade/xtquant/broker.py
@@ -28,6 +28,7 @@ from fqxtrade.xtquant.trading_manager import TradingManager
 from loguru import logger
 from xtquant.xttrader import XtQuantTrader, XtQuantTraderCallback
 
+from freshquant.order_management.broker_match import find_order_for_broker_report
 from freshquant.order_management.repository import OrderManagementRepository
 from freshquant.order_management.submit.execution_bridge import (
     dispatch_cancel_execution,
@@ -89,9 +90,7 @@ class MyXtQuantTraderCallback(XtQuantTraderCallback):
         logger.info("收到委托回报推送: {order}", order=order_dict)
         _emit_broker_event(
             "order_callback",
-            context=_resolve_runtime_context_by_broker_order_id(
-                order_dict.get("order_id")
-            ),
+            context=_resolve_runtime_context_by_broker_report(order_dict),
             symbol=str(order_dict.get("stock_code") or "")[:6],
             payload={
                 "broker_order_id": order_dict.get("order_id"),
@@ -119,9 +118,7 @@ class MyXtQuantTraderCallback(XtQuantTraderCallback):
         logger.info("收到成交变动推送: {trade}", trade=trade_dict)
         _emit_broker_event(
             "trade_callback",
-            context=_resolve_runtime_context_by_broker_order_id(
-                trade_dict.get("order_id")
-            ),
+            context=_resolve_runtime_context_by_broker_report(trade_dict),
             symbol=str(trade_dict.get("stock_code") or "")[:6],
             payload={
                 "broker_order_id": trade_dict.get("order_id"),
@@ -586,12 +583,23 @@ def _handle_cancel_action(order, *, broker_submit_mode):
         raise
 
 
-def _resolve_runtime_context_by_broker_order_id(broker_order_id):
+def _resolve_runtime_context_by_broker_report(report):
+    report = dict(report or {})
+    broker_order_id = report.get("order_id") or report.get("broker_order_id")
     if broker_order_id in (None, "", "None"):
         return {}
     try:
-        order = order_management_repository.find_order_by_broker_order_id(
-            broker_order_id
+        order = find_order_for_broker_report(
+            order_management_repository,
+            broker_order_id=broker_order_id,
+            report=report,
+            symbol=report.get("symbol") or report.get("stock_code"),
+            order_type=report.get("order_type"),
+            report_time=(
+                report.get("order_time")
+                or report.get("traded_time")
+                or report.get("trade_time")
+            ),
         )
     except Exception:
         order = None
@@ -605,6 +613,10 @@ def _resolve_runtime_context_by_broker_order_id(broker_order_id):
         "symbol": order.get("symbol"),
         "action": order.get("side"),
     }
+
+
+def _resolve_runtime_context_by_broker_order_id(broker_order_id):
+    return _resolve_runtime_context_by_broker_report({"order_id": broker_order_id})
 
 
 def _emit_broker_event(


### PR DESCRIPTION
## 背景

`trc_aad8896bad0d` 的 runtime-observability 失败链路显示 `xt_report_ingest.order_match` 抛出 `InvalidOrderTransition: FILLED -> SUBMITTED`。排查发现券商侧 `broker_order_id=1477443585` 被复用：2026-04-29 的 002262 卖出回报被仅凭 `broker_order_id` 匹配到了 2026-04-13 的旧买入内部订单，导致 runtime trace、trade fact 和 execution fill 错归属。

## 目标

- 防止 XT 委托/成交回报仅凭 `broker_order_id` 误匹配旧订单。
- 让 broker runtime event、XT ingest、external reconcile 使用同一套候选订单匹配逻辑。
- 补充重复券商订单号的回归测试和当前文档口径。

## 范围

- 新增 `freshquant.order_management.broker_match.find_order_for_broker_report()`。
- `OrderManagementRepository` 增加按 `broker_order_id` 列出候选订单的方法。
- XT trade/order normalize、external reconcile、`fqxtrade.xtquant.broker` runtime context 均改为按 `symbol`、`side/order_type`、回报时间在候选中收敛。
- 补充 ingest / reconcile / broker runtime-observability 回归测试。
- 更新 `docs/current/**` 中关于 `broker_order_id` 非全局唯一的当前事实和排障方式。

## 非目标

- 不直接修改线上 Mongo 账本历史数据。
- 不重建 Order Ledger V2。
- 不调整 runtime-observability 前端展示逻辑。

## 验收标准

- 重复 `broker_order_id` 且新旧订单 side/order_type 不同时，XT 回报归属到正确的新内部订单。
- 单候选 `broker_order_id` 的历史兼容逻辑保持不变。
- `xt_report_ingest.order_match` 不再因新订单 SUBMITTED 回报打到旧 FILLED 订单而失败。

## 本地验证

- `python -m pytest freshquant/tests/test_order_management_xt_ingest.py freshquant/tests/test_order_management_reconcile.py freshquant/tests/test_xtquant_runtime_observability.py freshquant/tests/test_xt_reports_runtime_observability.py -q` -> 82 passed
- `python script/ci/check_current_docs.py ...` -> docs-current-guard: OK
- `python -m black --check ...` -> unchanged
- `git diff --check` -> OK

全量 `freshquant/tests -q` 本地仍有既有环境/顺序失败，抽查失败项单跑显示 Gantt / puppet 相关项可单独通过；`test_runtime_proxy_config.py::test_host_runtime_envs_clear_all_proxy_variants` 单跑仍因宿主机 `D:/fqpack/config/envs.conf` 缺少代理空键失败，和本次改动无关。

## 部署影响

命中 `freshquant/order_management/**` 和 `morningglory/fqxtrade/**`：合并后需要重部署后端/API，并重启 `order_management` 相关宿主机运行面，尤其是 broker / XT report ingest 路径；随后检查 runtime-observability 中 broker 和 xt_report_ingest 新事件是否落到正确 trace。