### PR TITLE
Fix TPSL preopen order trace semantics

### DIFF
--- a/docs/current/modules/runtime-observability.md
+++ b/docs/current/modules/runtime-observability.md
@@ -92,6 +92,11 @@ Runtime Observability 当前采用“双存储”：
 
 这样可以保留显式链路，同时阻断 `xt_report_ingest` 这类长生命周期回报把一整天事件并进单条 Trace。
 
+Trace 类型当前由 ClickHouse 查询层按组件与语义字段共同推导：
+
+- TPSL 链路优先读取 `source / strategy_name / payload_json.kind / payload_json.scope_type`，`takeprofit_batch` 显示为止盈，`stoploss_batch / symbol_stoploss_batch` 显示为止损
+- `manual_api_order` 只匹配 `order_submit` 且 `source` 属于 `api / web-order / manual_import` 的链路，不再把 TPSL 退出单兜底显示成手动下单
+
 ## ClickHouse 表
 
 ### `runtime_events`

--- a/docs/current/modules/tpsl.md
+++ b/docs/current/modules/tpsl.md
@@ -10,6 +10,7 @@ TPSL 在独立 tick 链路上评估止盈和止损条件，并生成退出单。
 - `must_pool.stop_loss_price` 当前承担 symbol 级 `全仓止损价`
 - 历史与详情优先读取 `entry ledger`
 - 止盈卖出提交前会统一按 `xt_positions.can_use_volume` 截断，并按一手向下取整；Guardian 卖出现在复用同一套约束 helper
+- tick listener 在北京时间 `09:30:00` 前不响应 tick 事件，不评估止盈/止损，也不生成退出单或 Runtime Trace
 
 ## 入口
 

--- a/freshquant/runtime_observability/clickhouse_store.py
+++ b/freshquant/runtime_observability/clickhouse_store.py
@@ -880,9 +880,37 @@ def _build_trace_summary_query(
             countIf(component = 'guardian_strategy') > 0, 'guardian_signal',
             countIf(component = 'xt_report_ingest') > 0, 'external_reported',
             countIf(component = 'order_reconcile') > 0, 'external_inferred',
-            countIf(component = 'tpsl_worker' AND (reason_code = 'takeprofit' OR lowerUTF8(message) LIKE '%takeprofit%')) > 0, 'takeprofit',
-            countIf(component = 'tpsl_worker' AND (reason_code = 'stoploss' OR lowerUTF8(message) LIKE '%stoploss%')) > 0, 'stoploss',
-            countIf(component = 'order_submit') > 0, 'manual_api_order',
+            countIf(
+                lowerUTF8(source) IN ('takeprofit', 'tpsl_takeprofit')
+                OR lowerUTF8(strategy_name) = 'takeprofit'
+                OR lowerUTF8(payload_json) LIKE '%"kind": "takeprofit"%'
+                OR lowerUTF8(payload_json) LIKE '%"scope_type": "takeprofit_batch"%'
+                OR (
+                    component = 'tpsl_worker'
+                    AND (
+                        reason_code = 'takeprofit'
+                        OR lowerUTF8(message) LIKE '%takeprofit%'
+                    )
+                )
+            ) > 0, 'takeprofit',
+            countIf(
+                lowerUTF8(source) IN ('stoploss', 'tpsl_stoploss', 'tpsl_symbol_stoploss')
+                OR lowerUTF8(strategy_name) LIKE '%stoploss%'
+                OR lowerUTF8(payload_json) LIKE '%"kind": "stoploss"%'
+                OR lowerUTF8(payload_json) LIKE '%"scope_type": "stoploss_batch"%'
+                OR lowerUTF8(payload_json) LIKE '%"scope_type": "symbol_stoploss_batch"%'
+                OR (
+                    component = 'tpsl_worker'
+                    AND (
+                        reason_code = 'stoploss'
+                        OR lowerUTF8(message) LIKE '%stoploss%'
+                    )
+                )
+            ) > 0, 'stoploss',
+            countIf(
+                component = 'order_submit'
+                AND lowerUTF8(source) IN ('api', 'web-order', 'manual_import')
+            ) > 0, 'manual_api_order',
             'unknown'
         ) AS trace_kind,
         multiIf(

--- a/freshquant/tests/test_runtime_observability_clickhouse.py
+++ b/freshquant/tests/test_runtime_observability_clickhouse.py
@@ -1125,6 +1125,22 @@ def test_clickhouse_store_list_traces_accepts_trace_kind_filter(monkeypatch):
 
     assert payload["items"] == []
     assert "trace_kind = 'takeprofit'" in queries[0]
+    assert "lowerUTF8(source) IN ('takeprofit', 'tpsl_takeprofit')" in queries[0]
+    assert (
+        'lowerUTF8(payload_json) LIKE \'%"scope_type": "takeprofit_batch"%\''
+        in queries[0]
+    )
+    assert (
+        "lowerUTF8(source) IN ('stoploss', 'tpsl_stoploss', " "'tpsl_symbol_stoploss')"
+    ) in queries[0]
+    assert (
+        'lowerUTF8(payload_json) LIKE \'%"scope_type": "symbol_stoploss_batch"%\''
+        in queries[0]
+    )
+    assert "lowerUTF8(source) IN ('api', 'web-order', 'manual_import')" in queries[0]
+    assert (
+        "countIf(component = 'order_submit') > 0, 'manual_api_order'" not in queries[0]
+    )
     assert len(queries) == 1
 
 

--- a/freshquant/tests/test_tpsl_consumer.py
+++ b/freshquant/tests/test_tpsl_consumer.py
@@ -1,4 +1,15 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
 from freshquant.tpsl.consumer import TpslTickConsumer
+
+BEIJING_TZ = ZoneInfo("Asia/Shanghai")
+AFTER_CONTINUOUS_AUCTION_TS = int(
+    datetime(2026, 4, 30, 9, 30, 1, tzinfo=BEIJING_TZ).timestamp()
+)
+PRE_CONTINUOUS_AUCTION_TS = int(
+    datetime(2026, 4, 30, 9, 16, 17, tzinfo=BEIJING_TZ).timestamp()
+)
 
 
 class FakeTpslService:
@@ -51,7 +62,7 @@ def test_consumer_executes_takeprofit_before_stoploss():
             "ask1": 10.8,
             "bid1": 9.2,
             "lastPrice": 10.0,
-            "time": 1710000000,
+            "time": AFTER_CONTINUOUS_AUCTION_TS,
         }
     )
 
@@ -85,7 +96,7 @@ def test_consumer_skips_symbols_outside_active_tpsl_universe():
             "ask1": 10.8,
             "bid1": 9.2,
             "lastPrice": 10.0,
-            "time": 1710000000,
+            "time": AFTER_CONTINUOUS_AUCTION_TS,
         }
     )
 
@@ -115,7 +126,7 @@ def test_consumer_runs_stoploss_when_takeprofit_not_hit():
             "ask1": 10.0,
             "bid1": 9.2,
             "lastPrice": 9.6,
-            "time": 1710000000,
+            "time": AFTER_CONTINUOUS_AUCTION_TS,
         }
     )
 
@@ -148,7 +159,7 @@ def test_consumer_returns_zero_quantity_takeprofit_trigger_without_submitting():
             "ask1": 10.0,
             "bid1": 9.2,
             "lastPrice": 9.6,
-            "time": 1710000000,
+            "time": AFTER_CONTINUOUS_AUCTION_TS,
         }
     )
 
@@ -177,7 +188,42 @@ def test_consumer_skips_ticks_when_active_tpsl_universe_is_empty():
             "ask1": 10.8,
             "bid1": 9.2,
             "lastPrice": 10.0,
-            "time": 1710000000,
+            "time": AFTER_CONTINUOUS_AUCTION_TS,
+        }
+    )
+
+    assert result is None
+    assert service.calls == []
+
+
+def test_consumer_ignores_ticks_before_continuous_auction():
+    service = FakeTpslService(
+        takeprofit_batch={
+            "batch_id": "tp1",
+            "status": "ready",
+            "symbol": "000001",
+            "quantity": 300,
+        },
+        stoploss_batch={
+            "batch_id": "sl1",
+            "status": "ready",
+            "symbol": "000001",
+            "quantity": 300,
+        },
+    )
+    consumer = TpslTickConsumer(
+        service=service,
+        universe_loader=lambda: ["sz000001"],
+        refresh_interval_s=999,
+    )
+
+    result = consumer.handle_tick(
+        {
+            "code": "sz000001",
+            "ask1": 10.8,
+            "bid1": 9.2,
+            "lastPrice": 10.0,
+            "time": PRE_CONTINUOUS_AUCTION_TS,
         }
     )
 

--- a/freshquant/tests/test_tpsl_runtime_observability.py
+++ b/freshquant/tests/test_tpsl_runtime_observability.py
@@ -1,7 +1,18 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
 import pytest
 
 from freshquant.tpsl.consumer import TpslTickConsumer
 from freshquant.tpsl.service import TpslService
+
+BEIJING_TZ = ZoneInfo("Asia/Shanghai")
+AFTER_CONTINUOUS_AUCTION_TS = int(
+    datetime(2026, 4, 30, 9, 30, 1, tzinfo=BEIJING_TZ).timestamp()
+)
+PRE_CONTINUOUS_AUCTION_TS = int(
+    datetime(2026, 4, 30, 9, 16, 17, tzinfo=BEIJING_TZ).timestamp()
+)
 
 
 class FakeRuntimeLogger:
@@ -178,12 +189,50 @@ def test_tpsl_tick_consumer_does_not_emit_pretrigger_info_events():
             "ask1": 10.8,
             "bid1": 9.2,
             "lastPrice": 10.0,
-            "time": 1710000000,
+            "time": AFTER_CONTINUOUS_AUCTION_TS,
         }
     )
 
     assert runtime_logger.events == []
     assert service.calls == [("takeprofit", "000001")]
+
+
+def test_tpsl_tick_consumer_ignores_preopen_ticks_without_runtime_events():
+    runtime_logger = FakeRuntimeLogger()
+
+    class FakeService:
+        def __init__(self):
+            self.calls = []
+
+        def evaluate_takeprofit(self, **kwargs):
+            self.calls.append(("takeprofit", kwargs["symbol"]))
+            return None
+
+        def evaluate_stoploss(self, **kwargs):
+            self.calls.append(("stoploss", kwargs["symbol"]))
+            return None
+
+    service = FakeService()
+    consumer = TpslTickConsumer(
+        service=service,
+        universe_loader=lambda: ["sz000001"],
+        refresh_interval_s=999,
+        runtime_logger=runtime_logger,
+    )
+
+    result = consumer.handle_tick(
+        {
+            "code": "sz000001",
+            "ask1": 10.8,
+            "bid1": 9.2,
+            "lastPrice": 10.0,
+            "time": PRE_CONTINUOUS_AUCTION_TS,
+        }
+    )
+
+    assert result is None
+    assert runtime_logger.events == []
+    assert service.calls == []
 
 
 def test_tpsl_tick_consumer_emits_error_when_universe_refresh_fails():
@@ -204,7 +253,7 @@ def test_tpsl_tick_consumer_emits_error_when_universe_refresh_fails():
                 "ask1": 10.8,
                 "bid1": 9.2,
                 "lastPrice": 10.0,
-                "time": 1710000000,
+                "time": AFTER_CONTINUOUS_AUCTION_TS,
             }
         )
 
@@ -314,7 +363,7 @@ def test_tpsl_tick_consumer_without_takeprofit_hit_does_not_create_global_trace(
             "ask1": 10.0,
             "bid1": 9.9,
             "lastPrice": 10.0,
-            "time": 1710000000,
+            "time": AFTER_CONTINUOUS_AUCTION_TS,
         }
     )
 

--- a/freshquant/tpsl/consumer.py
+++ b/freshquant/tpsl/consumer.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import time
+from datetime import datetime
+from datetime import time as time_of_day
+from datetime import timezone
+from zoneinfo import ZoneInfo
 
 from freshquant.market_data.xtdata.schema import TickQuoteEvent, normalize_prefixed_code
 from freshquant.runtime_observability.failures import (
@@ -15,6 +19,9 @@ from freshquant.tpsl.pools import load_active_tpsl_codes
 from freshquant.tpsl.service import TpslService
 from freshquant.util.code import normalize_to_base_code
 
+_BEIJING_TZ = ZoneInfo("Asia/Shanghai")
+_CONTINUOUS_AUCTION_START = time_of_day(9, 30)
+
 
 class TpslTickConsumer:
     def __init__(
@@ -24,6 +31,7 @@ class TpslTickConsumer:
         universe_loader=None,
         refresh_interval_s=30,
         runtime_logger=None,
+        now_provider=None,
     ):
         self.service = service or TpslService()
         self.universe_loader = universe_loader or load_active_tpsl_codes
@@ -31,6 +39,7 @@ class TpslTickConsumer:
         self.active_codes = set()
         self._last_refresh_at = 0.0
         self.runtime_logger = runtime_logger or _get_runtime_logger()
+        self.now_provider = now_provider or time.time
 
     def refresh_universe(self, *, force=False):
         now = time.time()
@@ -56,6 +65,8 @@ class TpslTickConsumer:
 
         symbol = normalize_to_base_code(event.code)
         try:
+            if _is_before_continuous_auction(event, now_provider=self.now_provider):
+                return None
             active_codes = self.refresh_universe()
             if event.code not in active_codes:
                 return None
@@ -121,6 +132,36 @@ def _coerce_tick_event(raw):
     payload = dict(raw)
     payload.setdefault("event", "TICK_QUOTE")
     return TickQuoteEvent.from_dict(payload)
+
+
+def _is_before_continuous_auction(event, *, now_provider) -> bool:
+    event_time = _resolve_event_time(event, now_provider=now_provider)
+    return event_time.time() < _CONTINUOUS_AUCTION_START
+
+
+def _resolve_event_time(event, *, now_provider) -> datetime:
+    for raw in (getattr(event, "tick_time", None), getattr(event, "created_at", None)):
+        dt = _coerce_timestamp(raw)
+        if dt is not None:
+            return dt
+    return _coerce_timestamp(now_provider()) or datetime.now(_BEIJING_TZ)
+
+
+def _coerce_timestamp(raw) -> datetime | None:
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        dt = raw if raw.tzinfo is not None else raw.replace(tzinfo=_BEIJING_TZ)
+        return dt.astimezone(_BEIJING_TZ)
+    try:
+        timestamp = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if timestamp <= 0:
+        return None
+    if timestamp >= 1_000_000_000_000:
+        timestamp = timestamp / 1000.0
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).astimezone(_BEIJING_TZ)
 
 
 _runtime_logger = None


### PR DESCRIPTION
## 背景

2026-04-30 09:16:17 的 `600037 / 歌华有线` Runtime Trace 被页面显示为“手动下单”，但真实日志显示该链路来自 TPSL 止盈触发：`tpsl_worker -> order_submit -> broker_gateway`。由于 broker 在非交易时间消费 Redis 订单后只记录“非交易时间，不执行交易下单”，订单账本停留在 `QUEUED`，同时 TPSL 止盈档位被消耗，造成运行面和账本污染。

## 目标

- 修正 Runtime Trace 类型推导，避免 TPSL 止盈/止损退出单被兜底显示为“手动下单”。
- TPSL tick listener 在北京时间 `09:30:00` 前不响应 tick 事件，不评估止盈/止损，不生成退出单或 Runtime Trace。
- 同步当前文档和测试。

## 范围

- `freshquant/tpsl/consumer.py`
- `freshquant/runtime_observability/clickhouse_store.py`
- TPSL / Runtime Observability 相关单测
- `docs/current/modules/tpsl.md`
- `docs/current/modules/runtime-observability.md`

## 非目标

- 不改变 broker 非交易时间订单消费逻辑。
- 不改变 TPSL service 的止盈/止损命中算法。
- 不引入新的交易时段日历规则，仅按当前需求处理 `09:30:00` 前的非连续竞价阶段。

## 验收标准

- `09:30:00` 前的 TPSL tick 不调用 evaluate / submit，不生成 Runtime Event。
- TPSL `takeprofit_batch` 显示为止盈，`stoploss_batch / symbol_stoploss_batch` 显示为止损。
- `manual_api_order` 只匹配真正 API/Web/manual 来源的 order_submit 链路。
- 相关测试通过。

## 已验证

- `python -m pytest freshquant/tests/test_tpsl_consumer.py freshquant/tests/test_tpsl_runtime_observability.py freshquant/tests/test_runtime_observability_clickhouse.py -q` -> `34 passed`
- `git diff --check` -> passed

## 部署影响

涉及：

- `freshquant/tpsl/**`：需要重启 `tpsl.tick_listener`
- `freshquant/runtime_observability/**`：需要重建/重启 API Server，并确认 Runtime ClickHouse / runtime indexer 恢复

本地已按事故 ID 定向清理污染数据：订单链路、TPSL 触发事件、对应 Runtime ClickHouse trace，并重新 rearm `600037` 止盈 1 档。