### PR TITLE
Persist trade calendar cache for Dagster runs

### DIFF
--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -173,3 +173,10 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
 - `freshquant.position_management.credit_client.PositionCreditClient` 现在对 `query_credit_detail()` 采用相同的读请求自愈逻辑；这层被 `xt_auto_repay`、`position_management.snapshot_service` 等宿主机链路复用。
 - `freshquant.xt_auto_repay.worker.XtAutoRepayWorker` 现在只对“确认还款前的 `query_credit_detail()`”做带退避的可重试 XT 自愈：命中 `xtquant connect/subscribe failed` 或空明细时，会先 reset 当前 credit client，再重建新的 executor 后继续查询。
 - `xt_auto_repay` 的真实 `submit_direct_cash_repay()` 仍然不做盲目自动重提，避免在券商侧已受理但客户端回包异常时制造重复还款。
+
+## Trade Calendar Refresh Runtime
+
+- Dagster provides `trade_calendar_refresh_job` to refresh the persisted A-share trade calendar cache.
+- `trade_calendar_morning_refresh_schedule` runs at `08:30` Asia/Shanghai on weekdays.
+- `trade_calendar_postclose_refresh_schedule` runs at `15:10` Asia/Shanghai on weekdays.
+- Stock, ETF, Gantt, and daily-screening date resolution read the shared FreshQuant trade calendar entry, which falls back to Mongo last-known-good data when the live Sina/AkShare request fails.

--- a/docs/current/storage.md
+++ b/docs/current/storage.md
@@ -146,3 +146,10 @@
 - 查执行事实先看 `om_broker_orders / om_execution_fills`
 - 查 odd-lot 或拒绝写入先看 `om_ingest_rejections`
 - 查 legacy 镜像问题最后再看 `stock_fills_compat / om_buy_lots`
+
+## Trade Calendar Cache
+
+- `freshquant.trade_calendar_cache` stores the persisted A-share trade calendar snapshot used by FreshQuant and Dagster.
+- The current document key is `market=cn_a`, `source=sina`, with `_id=cn_a:sina`.
+- `trade_dates` are stored as ISO date strings, with `min_trade_date`, `max_trade_date`, `date_count`, `checksum`, `last_success_at`, `last_error_*`, and `fallback_hits` for audit.
+- Redis is not the durable truth for the trade calendar; Mongo is the last-known-good source used when the live Sina/AkShare request fails.

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -773,3 +773,10 @@ print(inspect.signature(resolve_stock_account))
 - 确认 `fqnext-supervisord` 为 `Running`
 - 用 `script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces` 恢复命中的宿主机 surface
 - 若 verify 失败，先修运行面，再重新执行正式 deploy
+
+## Trade Calendar Failures
+
+- If Dagster stock, ETF, Gantt, or daily-screening runs fail while resolving a trade date, inspect `freshquant.trade_calendar_cache` first.
+- The expected document is `_id=cn_a:sina`; it must have non-empty `trade_dates` and `max_trade_date >= today`.
+- `last_error_type`, `last_error_message`, and `fallback_hits` show whether FreshQuant is serving the last-known-good calendar after a Sina/AkShare request failure.
+- Run `trade_calendar_refresh_job` in Dagster to force a live refresh after the upstream endpoint recovers.

--- a/freshquant/data/trade_calendar_cache.py
+++ b/freshquant/data/trade_calendar_cache.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import date, datetime, timezone
+from typing import Any, Callable
+
+import pandas as pd
+
+from freshquant.db import DBfreshquant
+
+COL_TRADE_CALENDAR_CACHE = "trade_calendar_cache"
+DEFAULT_MARKET = "cn_a"
+DEFAULT_SOURCE = "sina"
+SCHEMA_VERSION = 1
+MIN_RETAIN_RATIO = 0.8
+
+logger = logging.getLogger(__name__)
+
+
+class TradeCalendarUnavailable(RuntimeError):
+    pass
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _today(now_provider=None) -> date:
+    now = now_provider() if callable(now_provider) else datetime.now()
+    if isinstance(now, datetime):
+        return now.date()
+    return now
+
+
+def _cache_id(market: str, source: str) -> str:
+    return f"{market}:{source}"
+
+
+def _get_collection(collection=None):
+    if collection is not None:
+        return collection
+    return DBfreshquant[COL_TRADE_CALENDAR_CACHE]
+
+
+def ensure_trade_calendar_cache_indexes(collection=None) -> None:
+    target_collection = _get_collection(collection)
+    if hasattr(target_collection, "create_index"):
+        target_collection.create_index(
+            [("market", 1), ("source", 1)],
+            unique=True,
+            name="uniq_market_source",
+        )
+
+
+def _normalize_trade_dates(frame: pd.DataFrame) -> list[str]:
+    if "trade_date" not in frame.columns:
+        raise ValueError("trade calendar dataframe missing trade_date column")
+    values = pd.to_datetime(frame["trade_date"], errors="coerce")
+    if values.isna().any():
+        raise ValueError("trade calendar contains unparseable trade_date values")
+    dates = sorted({value.date().isoformat() for value in values})
+    if not dates:
+        raise ValueError("trade calendar is empty")
+    return dates
+
+
+def _dates_to_frame(trade_dates: list[str]) -> pd.DataFrame:
+    values = pd.to_datetime(list(trade_dates)).date
+    return pd.DataFrame({"trade_date": list(values)})
+
+
+def _checksum(trade_dates: list[str]) -> str:
+    payload = "\n".join(trade_dates).encode("utf-8")
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _load_cache_doc(
+    *,
+    market: str = DEFAULT_MARKET,
+    source: str = DEFAULT_SOURCE,
+    collection=None,
+) -> dict[str, Any] | None:
+    target_collection = _get_collection(collection)
+    if not hasattr(target_collection, "find_one"):
+        return None
+    return target_collection.find_one({"market": market, "source": source})
+
+
+def _doc_trade_dates(doc: dict[str, Any] | None) -> list[str]:
+    if not doc:
+        return []
+    trade_dates = doc.get("trade_dates")
+    if not isinstance(trade_dates, list):
+        return []
+    return sorted({str(value).strip() for value in trade_dates if str(value).strip()})
+
+
+def _doc_covers_today(doc: dict[str, Any] | None, *, now_provider=None) -> bool:
+    trade_dates = _doc_trade_dates(doc)
+    if not trade_dates:
+        return False
+    return trade_dates[-1] >= _today(now_provider).isoformat()
+
+
+def _validate_update_against_existing(
+    trade_dates: list[str],
+    existing_doc: dict[str, Any] | None,
+) -> None:
+    existing_dates = _doc_trade_dates(existing_doc)
+    if not existing_dates:
+        return
+    min_allowed = int(len(existing_dates) * MIN_RETAIN_RATIO)
+    if len(trade_dates) < min_allowed:
+        raise ValueError(
+            "trade calendar update rejected because it shrank from "
+            f"{len(existing_dates)} to {len(trade_dates)} dates"
+        )
+
+
+def _build_cache_doc(
+    trade_dates: list[str],
+    *,
+    market: str,
+    source: str,
+    now_provider=None,
+) -> dict[str, Any]:
+    now = now_provider() if callable(now_provider) else _utc_now()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return {
+        "_id": _cache_id(market, source),
+        "market": market,
+        "source": source,
+        "schema_version": SCHEMA_VERSION,
+        "trade_dates": trade_dates,
+        "min_trade_date": trade_dates[0],
+        "max_trade_date": trade_dates[-1],
+        "date_count": len(trade_dates),
+        "checksum": _checksum(trade_dates),
+        "last_success_at": now,
+        "last_error_at": None,
+        "last_error_type": "",
+        "last_error_message": "",
+    }
+
+
+def _record_source_error(
+    exc: Exception,
+    *,
+    market: str,
+    source: str,
+    collection=None,
+    increment_fallback_hits: bool = False,
+    now_provider=None,
+) -> None:
+    target_collection = _get_collection(collection)
+    if not hasattr(target_collection, "update_one"):
+        return
+    now = now_provider() if callable(now_provider) else _utc_now()
+    update: dict[str, Any] = {
+        "$set": {
+            "market": market,
+            "source": source,
+            "last_error_at": now,
+            "last_error_type": type(exc).__name__,
+            "last_error_message": str(exc),
+        }
+    }
+    if increment_fallback_hits:
+        update["$inc"] = {"fallback_hits": 1}
+    target_collection.update_one(
+        {"market": market, "source": source},
+        update,
+        upsert=False,
+    )
+
+
+def read_trade_calendar_cache(
+    *,
+    market: str = DEFAULT_MARKET,
+    source: str = DEFAULT_SOURCE,
+    collection=None,
+    require_covering_today: bool = True,
+    now_provider=None,
+) -> pd.DataFrame | None:
+    doc = _load_cache_doc(market=market, source=source, collection=collection)
+    if require_covering_today and not _doc_covers_today(doc, now_provider=now_provider):
+        return None
+    trade_dates = _doc_trade_dates(doc)
+    if not trade_dates:
+        return None
+    return _dates_to_frame(trade_dates)
+
+
+def refresh_trade_calendar_cache(
+    fetcher: Callable[[], pd.DataFrame],
+    *,
+    market: str = DEFAULT_MARKET,
+    source: str = DEFAULT_SOURCE,
+    collection=None,
+    now_provider=None,
+) -> pd.DataFrame:
+    target_collection = _get_collection(collection)
+    ensure_trade_calendar_cache_indexes(target_collection)
+    existing_doc = _load_cache_doc(
+        market=market, source=source, collection=target_collection
+    )
+    trade_dates = _normalize_trade_dates(fetcher())
+    _validate_update_against_existing(trade_dates, existing_doc)
+    cache_doc = _build_cache_doc(
+        trade_dates,
+        market=market,
+        source=source,
+        now_provider=now_provider,
+    )
+    target_collection.update_one(
+        {"market": market, "source": source},
+        {"$set": cache_doc, "$setOnInsert": {"fallback_hits": 0}},
+        upsert=True,
+    )
+    return _dates_to_frame(trade_dates)
+
+
+def fetch_trade_dates_with_persistent_cache(
+    fetcher: Callable[[], pd.DataFrame],
+    *,
+    market: str = DEFAULT_MARKET,
+    source: str = DEFAULT_SOURCE,
+    collection=None,
+    now_provider=None,
+    prefer_cache: bool = True,
+) -> pd.DataFrame:
+    target_collection = _get_collection(collection)
+    if prefer_cache:
+        cached = read_trade_calendar_cache(
+            market=market,
+            source=source,
+            collection=target_collection,
+            require_covering_today=True,
+            now_provider=now_provider,
+        )
+        if cached is not None:
+            return cached
+
+    try:
+        return refresh_trade_calendar_cache(
+            fetcher,
+            market=market,
+            source=source,
+            collection=target_collection,
+            now_provider=now_provider,
+        )
+    except Exception as exc:
+        cached = read_trade_calendar_cache(
+            market=market,
+            source=source,
+            collection=target_collection,
+            require_covering_today=True,
+            now_provider=now_provider,
+        )
+        if cached is not None:
+            _record_source_error(
+                exc,
+                market=market,
+                source=source,
+                collection=target_collection,
+                increment_fallback_hits=True,
+                now_provider=now_provider,
+            )
+            logger.warning("using cached trade calendar after source failure: %s", exc)
+            return cached
+
+        _record_source_error(
+            exc,
+            market=market,
+            source=source,
+            collection=target_collection,
+            now_provider=now_provider,
+        )
+        raise TradeCalendarUnavailable(
+            f"trade calendar unavailable for {market}:{source}: {exc}"
+        ) from exc

--- a/freshquant/data/trade_date_hist.py
+++ b/freshquant/data/trade_date_hist.py
@@ -7,9 +7,22 @@ from freshquant.database.cache import redis_cache
 from freshquant.trading.dt import fq_trading_fetch_trade_dates
 
 
-@redis_cache.memoize(expiration=86400)
 def tool_trade_date_hist_sina():
     return fq_trading_fetch_trade_dates(source="sina")
+
+
+def refresh_trade_date_hist_sina_cache():
+    import akshare as ak
+
+    from freshquant.data.trade_calendar_cache import (
+        refresh_trade_calendar_cache,
+    )
+    from freshquant.trading.dt import _fetch_trade_dates_from_source
+
+    return refresh_trade_calendar_cache(
+        lambda: _fetch_trade_dates_from_source(ak.tool_trade_date_hist_sina),
+        source="sina",
+    )
 
 
 @redis_cache.memoize(expiration=15)
@@ -86,12 +99,12 @@ def get_trade_dates_between(start_date, end_date):
     """
     # 转换输入参数为date对象
     if isinstance(start_date, str):
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date()
+        start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
     elif isinstance(start_date, datetime):
         start_date = start_date.date()
 
     if isinstance(end_date, str):
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date()
+        end_date = datetime.strptime(end_date, "%Y-%m-%d").date()
     elif isinstance(end_date, datetime):
         end_date = end_date.date()
 
@@ -115,4 +128,4 @@ if __name__ == "__main__":
     print(tool_trade_date_last())
 
     # 测试新函数
-    print(get_trade_dates_between('2024-01-01', '2024-01-31'))
+    print(get_trade_dates_between("2024-01-01", "2024-01-31"))

--- a/freshquant/tests/test_trade_calendar_cache.py
+++ b/freshquant/tests/test_trade_calendar_cache.py
@@ -1,0 +1,183 @@
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+from requests.exceptions import SSLError  # type: ignore[import-untyped]
+
+from freshquant.data.trade_calendar_cache import (
+    TradeCalendarUnavailable,
+    fetch_trade_dates_with_persistent_cache,
+    refresh_trade_calendar_cache,
+)
+from freshquant.trading import dt
+
+
+class FakeTradeCalendarCollection:
+    def __init__(self, docs=None):
+        self.docs = {}
+        self.created_indexes = []
+        for doc in docs or []:
+            self.docs[(doc["market"], doc["source"])] = dict(doc)
+
+    def create_index(self, fields, **kwargs):
+        self.created_indexes.append((fields, kwargs))
+
+    def find_one(self, query):
+        doc = self.docs.get((query.get("market"), query.get("source")))
+        if doc is None:
+            return None
+        return dict(doc)
+
+    def update_one(self, query, update, upsert=False):
+        key = (query.get("market"), query.get("source"))
+        doc = self.docs.get(key)
+        is_insert = doc is None
+        if doc is None:
+            if not upsert:
+                return None
+            doc = dict(query)
+        if is_insert:
+            doc.update(dict(update.get("$setOnInsert") or {}))
+        doc.update(dict(update.get("$set") or {}))
+        for field, increment in dict(update.get("$inc") or {}).items():
+            doc[field] = int(doc.get(field) or 0) + int(increment)
+        self.docs[(doc["market"], doc["source"])] = doc
+        return doc
+
+
+def _cache_doc(*, max_trade_date="2026-12-31"):
+    return {
+        "_id": "cn_a:sina",
+        "market": "cn_a",
+        "source": "sina",
+        "schema_version": 1,
+        "trade_dates": ["2026-03-18", "2026-03-19", max_trade_date],
+        "min_trade_date": "2026-03-18",
+        "max_trade_date": max_trade_date,
+        "date_count": 3,
+        "checksum": "sha256:old",
+        "last_success_at": datetime(2026, 3, 19, tzinfo=timezone.utc),
+        "last_error_at": None,
+        "last_error_type": "",
+        "last_error_message": "",
+        "fallback_hits": 0,
+    }
+
+
+def _now():
+    return datetime(2026, 3, 20, 9, 0, tzinfo=timezone.utc)
+
+
+def test_fetch_trade_dates_uses_valid_mongo_cache_without_remote_call():
+    collection = FakeTradeCalendarCollection([_cache_doc()])
+
+    def unexpected_fetch():
+        raise AssertionError("valid trade calendar cache should be used first")
+
+    result = fetch_trade_dates_with_persistent_cache(
+        unexpected_fetch,
+        collection=collection,
+        now_provider=_now,
+    )
+
+    assert list(result["trade_date"].astype(str)) == [
+        "2026-03-18",
+        "2026-03-19",
+        "2026-12-31",
+    ]
+
+
+def test_refresh_trade_calendar_cache_persists_normalized_source_dates():
+    collection = FakeTradeCalendarCollection()
+
+    result = refresh_trade_calendar_cache(
+        lambda: pd.DataFrame(
+            {
+                "trade_date": [
+                    "2026-03-19",
+                    "2026-03-18",
+                    "2026-03-19",
+                ]
+            }
+        ),
+        collection=collection,
+        now_provider=_now,
+    )
+
+    doc = collection.find_one({"market": "cn_a", "source": "sina"})
+    assert list(result["trade_date"].astype(str)) == ["2026-03-18", "2026-03-19"]
+    assert doc["trade_dates"] == ["2026-03-18", "2026-03-19"]
+    assert doc["min_trade_date"] == "2026-03-18"
+    assert doc["max_trade_date"] == "2026-03-19"
+    assert doc["date_count"] == 2
+    assert doc["last_error_type"] == ""
+    assert collection.created_indexes
+
+
+def test_fetch_trade_dates_falls_back_to_cache_and_records_source_error():
+    collection = FakeTradeCalendarCollection([_cache_doc()])
+
+    result = fetch_trade_dates_with_persistent_cache(
+        lambda: (_ for _ in ()).throw(SSLError("temporary ssl failure")),
+        collection=collection,
+        now_provider=_now,
+        prefer_cache=False,
+    )
+
+    doc = collection.find_one({"market": "cn_a", "source": "sina"})
+    assert list(result["trade_date"].astype(str))[-1] == "2026-12-31"
+    assert doc["last_error_type"] == "SSLError"
+    assert doc["last_error_message"] == "temporary ssl failure"
+    assert doc["fallback_hits"] == 1
+
+
+def test_fetch_trade_dates_fails_closed_when_cache_no_longer_covers_today():
+    collection = FakeTradeCalendarCollection([_cache_doc(max_trade_date="2026-03-19")])
+
+    with pytest.raises(TradeCalendarUnavailable):
+        fetch_trade_dates_with_persistent_cache(
+            lambda: (_ for _ in ()).throw(SSLError("temporary ssl failure")),
+            collection=collection,
+            now_provider=_now,
+        )
+
+
+def test_refresh_trade_calendar_cache_rejects_abnormally_shrunken_update():
+    collection = FakeTradeCalendarCollection(
+        [
+            {
+                **_cache_doc(),
+                "trade_dates": [f"2026-03-{day:02d}" for day in range(1, 11)],
+                "date_count": 10,
+                "max_trade_date": "2026-03-10",
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match="shrank"):
+        refresh_trade_calendar_cache(
+            lambda: pd.DataFrame({"trade_date": ["2026-03-10"]}),
+            collection=collection,
+            now_provider=_now,
+        )
+
+    doc = collection.find_one({"market": "cn_a", "source": "sina"})
+    assert doc["date_count"] == 10
+    assert doc["checksum"] == "sha256:old"
+
+
+def test_fq_trading_fetch_trade_dates_uses_persistent_cache_entry(monkeypatch):
+    calls = []
+
+    def fake_fetch_with_cache(fetcher, **kwargs):
+        calls.append(kwargs)
+        return pd.DataFrame({"trade_date": [datetime(2026, 3, 19).date()]})
+
+    monkeypatch.setattr(
+        dt, "fetch_trade_dates_with_persistent_cache", fake_fetch_with_cache
+    )
+
+    result = dt.fq_trading_fetch_trade_dates(source="sina")
+
+    assert list(result["trade_date"].astype(str)) == ["2026-03-19"]
+    assert calls == [{"source": "sina"}]

--- a/freshquant/tests/test_trade_calendar_dagster.py
+++ b/freshquant/tests/test_trade_calendar_dagster.py
@@ -1,0 +1,124 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pandas as pd
+
+
+def _build_dagster_stub():
+    module = ModuleType("dagster")
+    module.__path__ = []
+
+    class _FakeAssetDef:
+        def __init__(self, fn, name, group_name=None):
+            self._fn = fn
+            self.name = name
+            self.group_name = group_name
+
+        def __call__(self, *args, **kwargs):
+            return self._fn(*args, **kwargs)
+
+    class _FakeAssetSelection:
+        def __init__(self, asset_names=None):
+            self.asset_names = tuple(asset_names or ())
+
+        @classmethod
+        def assets(cls, *assets):
+            return cls([getattr(asset, "name", str(asset)) for asset in assets])
+
+    class _FakeJobDef:
+        def __init__(self, name, selection=None, tags=None):
+            self.name = name
+            self.selection = selection
+            self.tags = tags or {}
+
+    class ScheduleDefinition:
+        def __init__(self, **kwargs):
+            self.name = kwargs.get("name")
+            self.job = kwargs.get("job")
+            self.cron_schedule = kwargs.get("cron_schedule")
+            self.execution_timezone = kwargs.get("execution_timezone")
+            self.default_status = kwargs.get("default_status")
+
+    def asset(fn=None, **kwargs):
+        if fn is None:
+            return lambda inner: _FakeAssetDef(
+                inner,
+                kwargs.get("name") or inner.__name__,
+                group_name=kwargs.get("group_name"),
+            )
+        return _FakeAssetDef(
+            fn,
+            kwargs.get("name") or fn.__name__,
+            group_name=kwargs.get("group_name"),
+        )
+
+    def define_asset_job(name, selection=None, tags=None, **kwargs):
+        return _FakeJobDef(name, selection=selection, tags=tags)
+
+    module.asset = asset
+    module.AssetSelection = _FakeAssetSelection
+    module.define_asset_job = define_asset_job
+    module.ScheduleDefinition = ScheduleDefinition
+    module.DefaultScheduleStatus = SimpleNamespace(RUNNING="RUNNING")
+    return module
+
+
+def _prepare_fqdagster_import(monkeypatch):
+    project_src = (
+        Path(__file__).resolve().parents[2] / "morningglory" / "fqdagster" / "src"
+    )
+    monkeypatch.syspath_prepend(str(project_src))
+    monkeypatch.setitem(sys.modules, "dagster", _build_dagster_stub())
+    assets_dir = project_src / "fqdagster" / "defs" / "assets"
+    assets_package = ModuleType("fqdagster.defs.assets")
+    assets_package.__path__ = [str(assets_dir)]
+    monkeypatch.setitem(sys.modules, "fqdagster.defs.assets", assets_package)
+    for module_name in [
+        "fqdagster.defs.assets.trade_calendar",
+        "fqdagster.defs.schedules.trade_calendar",
+    ]:
+        sys.modules.pop(module_name, None)
+
+
+def test_trade_calendar_asset_refreshes_persistent_cache(monkeypatch):
+    _prepare_fqdagster_import(monkeypatch)
+    assets_module = importlib.import_module("fqdagster.defs.assets.trade_calendar")
+
+    monkeypatch.setattr(
+        assets_module,
+        "refresh_trade_date_hist_sina_cache",
+        lambda: pd.DataFrame(
+            {"trade_date": pd.to_datetime(["2026-03-18", "2026-03-19"]).date}
+        ),
+    )
+
+    assert assets_module.trade_calendar_cache_asset.group_name == "trade_calendar"
+    assert assets_module.trade_calendar_cache_asset() == {
+        "date_count": 2,
+        "min_trade_date": "2026-03-18",
+        "max_trade_date": "2026-03-19",
+        "source": "sina",
+    }
+
+
+def test_trade_calendar_schedules_import(monkeypatch):
+    _prepare_fqdagster_import(monkeypatch)
+    schedules_module = importlib.import_module(
+        "fqdagster.defs.schedules.trade_calendar"
+    )
+
+    assert schedules_module.trade_calendar_refresh_job.name == (
+        "trade_calendar_refresh_job"
+    )
+    assert schedules_module.trade_calendar_morning_refresh_schedule.cron_schedule == (
+        "30 8 * * 1-5"
+    )
+    assert schedules_module.trade_calendar_postclose_refresh_schedule.cron_schedule == (
+        "10 15 * * 1-5"
+    )
+    assert (
+        schedules_module.trade_calendar_morning_refresh_schedule.default_status
+        == "RUNNING"
+    )

--- a/freshquant/trading/dt.py
+++ b/freshquant/trading/dt.py
@@ -9,7 +9,7 @@ import pydash
 from requests.exceptions import RequestException  # type: ignore[import-untyped]
 
 from freshquant.carnation.config import DT_FORMAT_DAY
-from freshquant.database.cache import redis_cache
+from freshquant.data.trade_calendar_cache import fetch_trade_dates_with_persistent_cache
 from freshquant.runtime.network import without_proxy_env
 
 T = TypeVar("T")
@@ -36,11 +36,16 @@ def _fetch_trade_dates_from_source(
     raise RuntimeError("trade date fetch failed without exception")
 
 
-@redis_cache.memoize(expiration=86400)
 def fq_trading_fetch_trade_dates(source="sina") -> pd.DataFrame:
     if source == "sina":
-        return _fetch_trade_dates_from_source(ak.tool_trade_date_hist_sina)
-    return _fetch_trade_dates_from_source(ak.tool_trade_date_hist_sina)
+        return fetch_trade_dates_with_persistent_cache(
+            lambda: _fetch_trade_dates_from_source(ak.tool_trade_date_hist_sina),
+            source="sina",
+        )
+    return fetch_trade_dates_with_persistent_cache(
+        lambda: _fetch_trade_dates_from_source(ak.tool_trade_date_hist_sina),
+        source="sina",
+    )
 
 
 def query_current_trade_date() -> Optional[date]:

--- a/morningglory/fqdagster/src/fqdagster/defs/assets/trade_calendar.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/assets/trade_calendar.py
@@ -1,0 +1,16 @@
+from dagster import asset
+
+from freshquant.data.trade_date_hist import refresh_trade_date_hist_sina_cache
+
+TRADE_CALENDAR_GROUP = "trade_calendar"
+
+
+@asset(group_name=TRADE_CALENDAR_GROUP)
+def trade_calendar_cache_asset() -> dict:
+    trade_dates = refresh_trade_date_hist_sina_cache()["trade_date"]
+    return {
+        "date_count": len(trade_dates),
+        "min_trade_date": trade_dates.min().strftime("%Y-%m-%d"),
+        "max_trade_date": trade_dates.max().strftime("%Y-%m-%d"),
+        "source": "sina",
+    }

--- a/morningglory/fqdagster/src/fqdagster/defs/schedules/trade_calendar.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/schedules/trade_calendar.py
@@ -1,0 +1,33 @@
+from dagster import (
+    AssetSelection,
+    DefaultScheduleStatus,
+    ScheduleDefinition,
+    define_asset_job,
+)
+from fqdagster.defs.assets.trade_calendar import trade_calendar_cache_asset
+
+from freshquant.config import cfg
+
+TIME_ZONE = getattr(cfg, "TIME_ZONE", "Asia/Shanghai")
+
+trade_calendar_refresh_job = define_asset_job(
+    name="trade_calendar_refresh_job",
+    selection=AssetSelection.assets(trade_calendar_cache_asset),
+    tags={"dagster/max_concurrent_runs": "1"},
+)
+
+trade_calendar_morning_refresh_schedule = ScheduleDefinition(
+    name="trade_calendar_morning_refresh_schedule",
+    job=trade_calendar_refresh_job,
+    cron_schedule="30 8 * * 1-5",
+    execution_timezone=TIME_ZONE,
+    default_status=DefaultScheduleStatus.RUNNING,
+)
+
+trade_calendar_postclose_refresh_schedule = ScheduleDefinition(
+    name="trade_calendar_postclose_refresh_schedule",
+    job=trade_calendar_refresh_job,
+    cron_schedule="10 15 * * 1-5",
+    execution_timezone=TIME_ZONE,
+    default_status=DefaultScheduleStatus.RUNNING,
+)


### PR DESCRIPTION
## 背景
最近 `stock_data_job` 和 `etf_data_job` 的 Dagster run 在解析最新已完成交易日时失败，直接原因是 AkShare/Sina 交易日历接口出现 `SSLError`，导致前置 ready step 失败。

## 目标
让交易日历具备 Mongo last-known-good 持久化缓存，避免 Dagster 关键路径在新浪短时 TLS/HTTPS 异常时直接失败。

## 范围
- 新增 `freshquant.trade_calendar_cache` 持久化快照读写逻辑。
- 将 `fq_trading_fetch_trade_dates()` / `tool_trade_date_hist_sina()` 切到 Mongo 持久化缓存入口。
- 新增 Dagster `trade_calendar_refresh_job`，工作日 `08:30` 和 `15:10` 刷新新浪交易日历。
- 补充缓存命中、刷新、fallback、覆盖不足 fail-closed、Dagster schedule 导入测试。
- 同步 `docs/current/**` 当前运行/存储/排障事实。

## 非目标
- 不更换交易日历上游数据源。
- 不调整 stock/ETF/Gantt/daily-screening 的业务处理逻辑。

## 验收标准
- 当 Sina/AkShare 请求失败但 Mongo 快照覆盖当前日期时，交易日历读取返回本地快照。
- 当 Mongo 快照不覆盖当前日期且上游失败时，明确失败，不静默返回过期日历。
- 成功刷新时原子写入快照，异常缩水更新会被拒绝。
- 定向测试通过：`test_trade_calendar_cache.py`、`test_trade_calendar_dagster.py`、相关 Dagster 日期解析测试。

## 部署影响
- 命中 `freshquant/data/**` 与 `morningglory/fqdagster/**`。
- 需要重部署 API server，重启 Dagster webserver/daemon。
- 部署计划也会命中 market_data/guardian 宿主机 surface，formal deploy 应按计划处理。
- 部署后需要 seed/刷新 `trade_calendar_refresh_job`，并重新运行最近失败的 `stock_data_job` 和 `etf_data_job` 验证。