### PR TITLE
Preserve runtime artifacts during deploy clean

### DIFF
--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -119,6 +119,7 @@
 - GHCR 预构建镜像仅用于加速 Docker 部署，不改变运行真值；实际运行真值仍来自当前 `main`、deploy 结果与 health/runtime ops evidence
 - `deploy-production.yml` 在正式 Windows self-hosted runner 上把 deploy state / logs 固化到 `formal-deploy` artifacts 目录，但正式 deploy 真值已经改为本机 mirror，不再依赖下载部署归档或把 Docker Images 作为前置。
 - `deploy-production.yml` 不走 `actions/checkout`，而是先把 `D:\fqpack\freshquant-2026.2.23` 这个 local main sync root reset 到目标 SHA，再直接调用那里的 `script/ci/run_production_deploy.ps1`；随后该脚本继续确保 `D:\fqpack\freshquant-2026.2.23` 这个本机 canonical repo root worktree 存在并 fast-forward 到目标 SHA。
+- canonical repo root clean 会保留 `.venv`、`.pytest_cache` 和 `logs/runtime`；这些路径分别承载 live virtualenv、pytest 本地缓存和运行日志，不作为 formal deploy 的 stale source artifact 清理对象。
 - bootstrap entrypoint 在 canonical main sync 阶段会从当前 entrypoint repo 解析 `sync_local_deploy_mirror.py`，避免 stale `canonical repo root` 工作树里的旧 helper 把 `.venv\` 清理逻辑回退到 `git clean -ffdX`。
 - 如果 live host runtime 仍在占用 `.venv\Lib\site-packages` 里的二进制扩展，正式入口会先 quiesce 宿主机 surfaces、重试 `uv sync`，再统一拉起这些 surfaces；这样 deploy 不会在 `.pyd` / `.dll` rename 阶段直接中断。
 - 如果 `D:\fqpack\freshquant-2026.2.23\.venv\pyvenv.cfg` 缺失，或保留下来的 `.venv\Scripts\python.exe` 已经不能正常启动，正式入口会把该 mirror `.venv\` 视为损坏状态：先 quiesce 宿主机 surfaces，再用 runner Python 3.12 重建 `.venv` metadata 并重新执行 `uv sync --frozen`，然后才允许进入 formal deploy。

--- a/script/ci/run_production_deploy.ps1
+++ b/script/ci/run_production_deploy.ps1
@@ -227,7 +227,15 @@ function Invoke-GitCleanPreservingRepoVenv {
         "-e",
         ".venv/",
         "-e",
-        ".venv"
+        ".venv",
+        "-e",
+        ".pytest_cache/",
+        "-e",
+        ".pytest_cache",
+        "-e",
+        "logs/runtime/",
+        "-e",
+        "logs/runtime"
     )
 }
 


### PR DESCRIPTION
## 背景
本次 formal deploy 在 canonical sync 阶段失败，原因是 `git clean -ffdx` 尝试删除本地 `.pytest_cache` 和正在写入的 `logs/runtime/**.jsonl`，被权限/文件锁阻塞。该失败发生在 formal deploy artifacts 创建前。

## 目标
让 production deploy 的 canonical repo clean 保留 live/runtime 本地产物，避免部署入口被非源码 artifact 阻塞。

## 范围
- `script/ci/run_production_deploy.ps1` 的 clean 保留 `.venv`、`.pytest_cache`、`logs/runtime`。
- 同步 `docs/current/runtime.md` 当前部署清理边界。

## 非目标
- 不修改业务代码。
- 不修改 Docker/Dagster 部署计划。

## 验收标准
- PowerShell 脚本语法解析通过。
- 本地预检入口返回 0。
- CI 通过后，可重新执行 formal deploy。

## 部署影响
- 仅影响 formal deploy entrypoint 的 canonical clean 阶段。
- 合并后需要重新基于最新 `origin/main` 执行 formal deploy。