### PR TITLE
Fix production deploy compose env source

### DIFF
--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -115,7 +115,7 @@
 
 - 宿主机 `.env` 示例：`deployment/examples/envs.fqnext.example`
 - 宿主机 `.env` 示例默认不再携带 `ALL_PROXY`、`HTTP_PROXY`、`HTTPS_PROXY`、`NO_PROXY` 及其小写变量
-- Docker API 使用 `FQ_COMPOSE_ENV_FILE` 指向主工作树 `.env`
+- Production Docker API 使用 `FQ_COMPOSE_ENV_FILE` 指向 `D:/fqpack/config/fqnext.compose.env`，不要依赖会被 `git clean -ffdx` 清理的仓库根 `.env`
 - GHCR 预构建镜像仅用于加速 Docker 部署，不改变运行真值；实际运行真值仍来自当前 `main`、deploy 结果与 health/runtime ops evidence
 - `deploy-production.yml` 在正式 Windows self-hosted runner 上把 deploy state / logs 固化到 `formal-deploy` artifacts 目录，但正式 deploy 真值已经改为本机 mirror，不再依赖下载部署归档或把 Docker Images 作为前置。
 - `deploy-production.yml` 不走 `actions/checkout`，而是先把 `D:\fqpack\freshquant-2026.2.23` 这个 local main sync root reset 到目标 SHA，再直接调用那里的 `script/ci/run_production_deploy.ps1`；随后该脚本继续确保 `D:\fqpack\freshquant-2026.2.23` 这个本机 canonical repo root worktree 存在并 fast-forward 到目标 SHA。

--- a/freshquant/tests/test_deploy_production_workflow.py
+++ b/freshquant/tests/test_deploy_production_workflow.py
@@ -78,6 +78,15 @@ def test_run_production_deploy_cleans_ignored_artifacts_but_keeps_repo_venv() ->
     assert '".venv"' in text
 
 
+def test_run_production_deploy_sets_production_compose_env_file() -> None:
+    text = Path("script/ci/run_production_deploy.ps1").read_text(encoding="utf-8")
+
+    assert "function Ensure-ProductionComposeEnvFile" in text
+    assert '$env:FQ_COMPOSE_ENV_FILE' in text
+    assert '"config\\fqnext.compose.env"' in text
+    assert "Ensure-ProductionComposeEnvFile -CanonicalRoot $CanonicalRoot" in text
+
+
 def test_run_production_deploy_quiesces_host_runtime_before_retrying_uv_sync() -> None:
     text = Path("script/ci/run_production_deploy.ps1").read_text(encoding="utf-8")
 

--- a/script/ci/run_production_deploy.ps1
+++ b/script/ci/run_production_deploy.ps1
@@ -217,6 +217,24 @@ function Ensure-SafeDirectory {
     }
 }
 
+function Ensure-ProductionComposeEnvFile {
+    param([string]$CanonicalRoot)
+
+    if (-not [string]::IsNullOrWhiteSpace($env:FQ_COMPOSE_ENV_FILE)) {
+        if (-not (Test-Path $env:FQ_COMPOSE_ENV_FILE)) {
+            throw "FQ_COMPOSE_ENV_FILE does not exist: $($env:FQ_COMPOSE_ENV_FILE)"
+        }
+        return
+    }
+
+    $fqpackRoot = Split-Path -Parent $CanonicalRoot
+    $productionComposeEnvFile = Join-Path $fqpackRoot "config\fqnext.compose.env"
+    if (-not (Test-Path $productionComposeEnvFile)) {
+        throw "production compose env file not found: $productionComposeEnvFile"
+    }
+    $env:FQ_COMPOSE_ENV_FILE = $productionComposeEnvFile
+}
+
 function Invoke-GitCleanPreservingRepoVenv {
     param([string]$RepoRoot)
 
@@ -413,6 +431,7 @@ $CanonicalRoot = [System.IO.Path]::GetFullPath((Resolve-Path $CanonicalRoot).Pat
 if (-not (Test-Path $CanonicalRoot)) {
     throw "canonical repo root does not exist: $CanonicalRoot"
 }
+Ensure-ProductionComposeEnvFile -CanonicalRoot $CanonicalRoot
 
 $pythonExe = Resolve-Python312Executable
 Ensure-UserPythonCoreRegistration -PythonExe $pythonExe


### PR DESCRIPTION
## 背景

formal deploy 在 canonical repo `git clean -ffdx` 后执行 Docker compose，当前 `script/docker_parallel_compose.ps1` 未拿到 `FQ_COMPOSE_ENV_FILE` 时会回退到主工作树 `.env`。生产环境中 `.env` 是 ignored runtime 文件，会被 `git clean` 清理，导致部署失败：`FQ_COMPOSE_ENV_FILE does not exist: D:\fqpack\freshquant-2026.2.23\.env`。

## 目标

让正式部署入口在执行 deploy 前自动使用生产 compose env 真值 `D:/fqpack/config/fqnext.compose.env`，并在缺失时提前失败。

## 范围

- `script/ci/run_production_deploy.ps1`：新增 `Ensure-ProductionComposeEnvFile`，未显式设置 `FQ_COMPOSE_ENV_FILE` 时解析为 canonical root 上一级的 `config/fqnext.compose.env`。
- `freshquant/tests/test_deploy_production_workflow.py`：增加文本回归测试。
- `docs/current/runtime.md`：同步 production compose env 口径。

## 非目标

- 不改变本地开发直接调用 `script/docker_parallel_compose.ps1` 的默认行为。
- 不修改生产 secret 内容。

## 验收标准

- PowerShell 能解析 `script/ci/run_production_deploy.ps1`。
- 部署入口测试覆盖 production compose env 行为。
- CI 全绿。

## 部署影响

影响 formal deploy 入口本身；合并后需要重新执行正式部署，以解除当前 `.env` 缺失导致的部署中断。