### PR TITLE
[codex] Harden trade calendar refresh fallback

### DIFF
--- a/docker/compose.parallel.yaml
+++ b/docker/compose.parallel.yaml
@@ -74,12 +74,14 @@ services:
       FRESHQUANT_MONGODB__PORT: "27017"
       FRESHQUANT_REDIS__HOST: fq_redis
       FRESHQUANT_REDIS__PORT: "6379"
+      FQ_TRADE_CALENDAR_STATE_DIR: /freshquant/state/trade-calendar
       MONGODB: fq_mongodb
       MONGODB_PORT: "27017"
     command: ["/freshquant/.venv/bin/python", "-m", "freshquant.rear.api_server", "--port", "5000"]
     ports:
       - "15000:5000"
     volumes:
+      - fqnext_trade_calendar_state:/freshquant/state/trade-calendar
       - ${FQ_RUNTIME_LOG_HOST_DIR:?Set FQ_RUNTIME_LOG_HOST_DIR to the host runtime log directory}:/freshquant/logs/runtime
       - type: bind
         source: ${FQPACK_TDX_SYNC_DIR:-D:/tdx_biduan}
@@ -155,6 +157,7 @@ services:
       FRESHQUANT_MONGODB__PORT: "27017"
       FRESHQUANT_REDIS__HOST: fq_redis
       FRESHQUANT_REDIS__PORT: "6379"
+      FQ_TRADE_CALENDAR_STATE_DIR: /freshquant/state/trade-calendar
       MONGODB: fq_mongodb
       MONGODB_PORT: "27017"
     command:
@@ -166,6 +169,7 @@ services:
     ports:
       - "11003:10003"
     volumes:
+      - fqnext_trade_calendar_state:/freshquant/state/trade-calendar
       - fqnext_dagster_data:/opt/dagster
       - type: bind
         source: ${FQPACK_CONFIG_DIR:-D:/fqpack/config}
@@ -197,6 +201,7 @@ services:
       FRESHQUANT_MONGODB__PORT: "27017"
       FRESHQUANT_REDIS__HOST: fq_redis
       FRESHQUANT_REDIS__PORT: "6379"
+      FQ_TRADE_CALENDAR_STATE_DIR: /freshquant/state/trade-calendar
       MONGODB: fq_mongodb
       MONGODB_PORT: "27017"
     command:
@@ -206,6 +211,7 @@ services:
         "mkdir -p /opt/dagster/home; cp -f /freshquant/morningglory/fqdagsterconfig/* /opt/dagster/home/; /freshquant/.venv/bin/dagster-daemon run -w /opt/dagster/home/workspace.yaml",
       ]
     volumes:
+      - fqnext_trade_calendar_state:/freshquant/state/trade-calendar
       - fqnext_dagster_data:/opt/dagster
       - type: bind
         source: ${FQPACK_CONFIG_DIR:-D:/fqpack/config}
@@ -382,3 +388,4 @@ volumes:
   fqnext_redis_data:
   fqnext_runtime_clickhouse_data:
   fqnext_dagster_data:
+  fqnext_trade_calendar_state:

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -180,4 +180,6 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
 - Dagster provides `trade_calendar_refresh_job` to refresh the persisted A-share trade calendar cache.
 - `trade_calendar_morning_refresh_schedule` runs at `08:30` Asia/Shanghai on weekdays.
 - `trade_calendar_postclose_refresh_schedule` runs at `15:10` Asia/Shanghai on weekdays.
-- Stock, ETF, Gantt, and daily-screening date resolution read the shared FreshQuant trade calendar entry, which falls back to Mongo last-known-good data when the live Sina/AkShare request fails.
+- A successful live Sina/AkShare refresh updates Mongo and the shared disk snapshot under `FQ_TRADE_CALENDAR_STATE_DIR`.
+- When a live refresh fails, FreshQuant falls back to Mongo last-known-good first, then the disk snapshot; the Dagster asset reports `refresh_status` and `degraded` so a cache-served refresh is visible without failing the run.
+- Stock, ETF, Gantt, and daily-screening date resolution read the shared FreshQuant trade calendar entry, which falls back to Mongo last-known-good data and then the disk snapshot when the live Sina/AkShare request fails.

--- a/docs/current/storage.md
+++ b/docs/current/storage.md
@@ -152,4 +152,5 @@
 - `freshquant.trade_calendar_cache` stores the persisted A-share trade calendar snapshot used by FreshQuant and Dagster.
 - The current document key is `market=cn_a`, `source=sina`, with `_id=cn_a:sina`.
 - `trade_dates` are stored as ISO date strings, with `min_trade_date`, `max_trade_date`, `date_count`, `checksum`, `last_success_at`, `last_error_*`, and `fallback_hits` for audit.
-- Redis is not the durable truth for the trade calendar; Mongo is the last-known-good source used when the live Sina/AkShare request fails.
+- Docker API and Dagster share a disk snapshot volume at `FQ_TRADE_CALENDAR_STATE_DIR`; the default file is `cn_a_sina.json` and is rewritten only after a successful live refresh.
+- Redis is not the durable truth for the trade calendar; Mongo is the primary last-known-good source and the disk snapshot is the cold fallback when the live Sina/AkShare request or Mongo read path fails.

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -779,4 +779,6 @@ print(inspect.signature(resolve_stock_account))
 - If Dagster stock, ETF, Gantt, or daily-screening runs fail while resolving a trade date, inspect `freshquant.trade_calendar_cache` first.
 - The expected document is `_id=cn_a:sina`; it must have non-empty `trade_dates` and `max_trade_date >= today`.
 - `last_error_type`, `last_error_message`, and `fallback_hits` show whether FreshQuant is serving the last-known-good calendar after a Sina/AkShare request failure.
-- Run `trade_calendar_refresh_job` in Dagster to force a live refresh after the upstream endpoint recovers.
+- In Docker, API and Dagster also share `FQ_TRADE_CALENDAR_STATE_DIR`; check `cn_a_sina.json` there if Mongo is unavailable or the cache document is missing.
+- `trade_calendar_refresh_job` can complete in degraded mode when live Sina/AkShare fails but Mongo or the disk snapshot covers the current date; inspect the asset result fields `refresh_status`, `degraded`, `source_error_type`, and `source_error_message`.
+- Run `trade_calendar_refresh_job` in Dagster to force a live refresh after the upstream endpoint recovers; a successful live refresh rewrites both Mongo and the disk snapshot.

--- a/freshquant/data/trade_calendar_cache.py
+++ b/freshquant/data/trade_calendar_cache.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
+import os
 from datetime import date, datetime, timezone
+from pathlib import Path
 from typing import Any, Callable
 
 import pandas as pd
@@ -14,6 +17,14 @@ DEFAULT_MARKET = "cn_a"
 DEFAULT_SOURCE = "sina"
 SCHEMA_VERSION = 1
 MIN_RETAIN_RATIO = 0.8
+SNAPSHOT_PATH_ENV = "FQ_TRADE_CALENDAR_SNAPSHOT_PATH"
+SNAPSHOT_STATE_DIR_ENV = "FQ_TRADE_CALENDAR_STATE_DIR"
+FRAME_ATTR_STATUS = "freshquant_trade_calendar_status"
+FRAME_ATTR_ERROR_TYPE = "freshquant_trade_calendar_error_type"
+FRAME_ATTR_ERROR_MESSAGE = "freshquant_trade_calendar_error_message"
+STATUS_LIVE = "live"
+STATUS_MONGO_CACHE = "mongo_cache"
+STATUS_FILE_SNAPSHOT = "file_snapshot"
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +79,19 @@ def _normalize_trade_dates(frame: pd.DataFrame) -> list[str]:
 def _dates_to_frame(trade_dates: list[str]) -> pd.DataFrame:
     values = pd.to_datetime(list(trade_dates)).date
     return pd.DataFrame({"trade_date": list(values)})
+
+
+def _with_frame_attrs(
+    frame: pd.DataFrame,
+    *,
+    status: str,
+    error: Exception | None = None,
+) -> pd.DataFrame:
+    frame.attrs[FRAME_ATTR_STATUS] = status
+    if error is not None:
+        frame.attrs[FRAME_ATTR_ERROR_TYPE] = type(error).__name__
+        frame.attrs[FRAME_ATTR_ERROR_MESSAGE] = str(error)
+    return frame
 
 
 def _checksum(trade_dates: list[str]) -> str:
@@ -145,6 +169,100 @@ def _build_cache_doc(
     }
 
 
+def _json_safe_doc(doc: dict[str, Any]) -> dict[str, Any]:
+    safe_doc = dict(doc)
+    for key, value in list(safe_doc.items()):
+        if isinstance(value, datetime):
+            safe_doc[key] = value.isoformat()
+        elif isinstance(value, date):
+            safe_doc[key] = value.isoformat()
+    safe_doc["snapshot_written_at"] = _utc_now().isoformat()
+    return safe_doc
+
+
+def _snapshot_filename(market: str, source: str) -> str:
+    return f"{market}_{source}.json"
+
+
+def resolve_trade_calendar_snapshot_path(
+    *,
+    market: str = DEFAULT_MARKET,
+    source: str = DEFAULT_SOURCE,
+    snapshot_path: str | os.PathLike[str] | None = None,
+) -> Path | None:
+    explicit_path = str(
+        snapshot_path or os.environ.get(SNAPSHOT_PATH_ENV) or ""
+    ).strip()
+    if explicit_path:
+        return Path(explicit_path)
+
+    state_dir = str(os.environ.get(SNAPSHOT_STATE_DIR_ENV) or "").strip()
+    if state_dir:
+        return Path(state_dir) / _snapshot_filename(market, source)
+
+    dagster_home = str(os.environ.get("DAGSTER_HOME") or "").strip()
+    if dagster_home:
+        return (
+            Path(dagster_home).parent
+            / "state"
+            / "trade-calendar"
+            / _snapshot_filename(market, source)
+        )
+
+    return None
+
+
+def write_trade_calendar_snapshot(
+    doc: dict[str, Any],
+    *,
+    market: str = DEFAULT_MARKET,
+    source: str = DEFAULT_SOURCE,
+    snapshot_path: str | os.PathLike[str] | None = None,
+) -> Path | None:
+    target_path = resolve_trade_calendar_snapshot_path(
+        market=market, source=source, snapshot_path=snapshot_path
+    )
+    if target_path is None:
+        return None
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = target_path.with_name(f".{target_path.name}.tmp")
+    temp_path.write_text(
+        json.dumps(_json_safe_doc(doc), ensure_ascii=False, sort_keys=True, indent=2),
+        encoding="utf-8",
+    )
+    os.replace(temp_path, target_path)
+    return target_path
+
+
+def read_trade_calendar_snapshot(
+    *,
+    market: str = DEFAULT_MARKET,
+    source: str = DEFAULT_SOURCE,
+    require_covering_today: bool = True,
+    now_provider=None,
+    snapshot_path: str | os.PathLike[str] | None = None,
+) -> pd.DataFrame | None:
+    target_path = resolve_trade_calendar_snapshot_path(
+        market=market, source=source, snapshot_path=snapshot_path
+    )
+    if target_path is None or not target_path.exists():
+        return None
+    payload = json.loads(target_path.read_text(encoding="utf-8"))
+    if str(payload.get("market") or "") != market:
+        return None
+    if str(payload.get("source") or "") != source:
+        return None
+    if require_covering_today and not _doc_covers_today(
+        payload, now_provider=now_provider
+    ):
+        return None
+    trade_dates = _doc_trade_dates(payload)
+    if not trade_dates:
+        return None
+    return _with_frame_attrs(_dates_to_frame(trade_dates), status=STATUS_FILE_SNAPSHOT)
+
+
 def _record_source_error(
     exc: Exception,
     *,
@@ -176,6 +294,13 @@ def _record_source_error(
     )
 
 
+def _safe_record_source_error(exc: Exception, **kwargs) -> None:
+    try:
+        _record_source_error(exc, **kwargs)
+    except Exception:
+        logger.warning("failed to record trade calendar source error", exc_info=True)
+
+
 def read_trade_calendar_cache(
     *,
     market: str = DEFAULT_MARKET,
@@ -190,7 +315,7 @@ def read_trade_calendar_cache(
     trade_dates = _doc_trade_dates(doc)
     if not trade_dates:
         return None
-    return _dates_to_frame(trade_dates)
+    return _with_frame_attrs(_dates_to_frame(trade_dates), status=STATUS_MONGO_CACHE)
 
 
 def refresh_trade_calendar_cache(
@@ -200,13 +325,18 @@ def refresh_trade_calendar_cache(
     source: str = DEFAULT_SOURCE,
     collection=None,
     now_provider=None,
+    snapshot_path: str | os.PathLike[str] | None = None,
 ) -> pd.DataFrame:
     target_collection = _get_collection(collection)
-    ensure_trade_calendar_cache_indexes(target_collection)
-    existing_doc = _load_cache_doc(
-        market=market, source=source, collection=target_collection
-    )
     trade_dates = _normalize_trade_dates(fetcher())
+    existing_doc = None
+    try:
+        ensure_trade_calendar_cache_indexes(target_collection)
+        existing_doc = _load_cache_doc(
+            market=market, source=source, collection=target_collection
+        )
+    except Exception:
+        logger.warning("failed to inspect trade calendar mongo cache", exc_info=True)
     _validate_update_against_existing(trade_dates, existing_doc)
     cache_doc = _build_cache_doc(
         trade_dates,
@@ -214,12 +344,24 @@ def refresh_trade_calendar_cache(
         source=source,
         now_provider=now_provider,
     )
-    target_collection.update_one(
-        {"market": market, "source": source},
-        {"$set": cache_doc, "$setOnInsert": {"fallback_hits": 0}},
-        upsert=True,
-    )
-    return _dates_to_frame(trade_dates)
+    try:
+        target_collection.update_one(
+            {"market": market, "source": source},
+            {"$set": cache_doc, "$setOnInsert": {"fallback_hits": 0}},
+            upsert=True,
+        )
+    except Exception:
+        logger.warning("failed to persist trade calendar mongo cache", exc_info=True)
+    try:
+        write_trade_calendar_snapshot(
+            cache_doc,
+            market=market,
+            source=source,
+            snapshot_path=snapshot_path,
+        )
+    except Exception:
+        logger.warning("failed to write trade calendar snapshot", exc_info=True)
+    return _with_frame_attrs(_dates_to_frame(trade_dates), status=STATUS_LIVE)
 
 
 def fetch_trade_dates_with_persistent_cache(
@@ -230,18 +372,36 @@ def fetch_trade_dates_with_persistent_cache(
     collection=None,
     now_provider=None,
     prefer_cache: bool = True,
+    snapshot_path: str | os.PathLike[str] | None = None,
 ) -> pd.DataFrame:
     target_collection = _get_collection(collection)
     if prefer_cache:
-        cached = read_trade_calendar_cache(
-            market=market,
-            source=source,
-            collection=target_collection,
-            require_covering_today=True,
-            now_provider=now_provider,
-        )
+        try:
+            cached = read_trade_calendar_cache(
+                market=market,
+                source=source,
+                collection=target_collection,
+                require_covering_today=True,
+                now_provider=now_provider,
+            )
+        except Exception:
+            logger.warning("failed to read trade calendar mongo cache", exc_info=True)
+            cached = None
         if cached is not None:
             return cached
+        try:
+            snapshot = read_trade_calendar_snapshot(
+                market=market,
+                source=source,
+                require_covering_today=True,
+                now_provider=now_provider,
+                snapshot_path=snapshot_path,
+            )
+        except Exception:
+            logger.warning("failed to read trade calendar snapshot", exc_info=True)
+            snapshot = None
+        if snapshot is not None:
+            return snapshot
 
     try:
         return refresh_trade_calendar_cache(
@@ -250,17 +410,22 @@ def fetch_trade_dates_with_persistent_cache(
             source=source,
             collection=target_collection,
             now_provider=now_provider,
+            snapshot_path=snapshot_path,
         )
     except Exception as exc:
-        cached = read_trade_calendar_cache(
-            market=market,
-            source=source,
-            collection=target_collection,
-            require_covering_today=True,
-            now_provider=now_provider,
-        )
+        try:
+            cached = read_trade_calendar_cache(
+                market=market,
+                source=source,
+                collection=target_collection,
+                require_covering_today=True,
+                now_provider=now_provider,
+            )
+        except Exception:
+            logger.warning("failed to read trade calendar mongo cache", exc_info=True)
+            cached = None
         if cached is not None:
-            _record_source_error(
+            _safe_record_source_error(
                 exc,
                 market=market,
                 source=source,
@@ -268,10 +433,36 @@ def fetch_trade_dates_with_persistent_cache(
                 increment_fallback_hits=True,
                 now_provider=now_provider,
             )
+            _with_frame_attrs(cached, status=STATUS_MONGO_CACHE, error=exc)
             logger.warning("using cached trade calendar after source failure: %s", exc)
             return cached
+        try:
+            snapshot = read_trade_calendar_snapshot(
+                market=market,
+                source=source,
+                require_covering_today=True,
+                now_provider=now_provider,
+                snapshot_path=snapshot_path,
+            )
+        except Exception:
+            logger.warning("failed to read trade calendar snapshot", exc_info=True)
+            snapshot = None
+        if snapshot is not None:
+            _safe_record_source_error(
+                exc,
+                market=market,
+                source=source,
+                collection=target_collection,
+                increment_fallback_hits=True,
+                now_provider=now_provider,
+            )
+            _with_frame_attrs(snapshot, status=STATUS_FILE_SNAPSHOT, error=exc)
+            logger.warning(
+                "using trade calendar file snapshot after source failure: %s", exc
+            )
+            return snapshot
 
-        _record_source_error(
+        _safe_record_source_error(
             exc,
             market=market,
             source=source,

--- a/freshquant/data/trade_date_hist.py
+++ b/freshquant/data/trade_date_hist.py
@@ -15,13 +15,14 @@ def refresh_trade_date_hist_sina_cache():
     import akshare as ak
 
     from freshquant.data.trade_calendar_cache import (
-        refresh_trade_calendar_cache,
+        fetch_trade_dates_with_persistent_cache,
     )
     from freshquant.trading.dt import _fetch_trade_dates_from_source
 
-    return refresh_trade_calendar_cache(
+    return fetch_trade_dates_with_persistent_cache(
         lambda: _fetch_trade_dates_from_source(ak.tool_trade_date_hist_sina),
         source="sina",
+        prefer_cache=False,
     )
 
 

--- a/freshquant/tests/test_trade_calendar_cache.py
+++ b/freshquant/tests/test_trade_calendar_cache.py
@@ -5,8 +5,15 @@ import pytest
 from requests.exceptions import SSLError  # type: ignore[import-untyped]
 
 from freshquant.data.trade_calendar_cache import (
+    FRAME_ATTR_ERROR_MESSAGE,
+    FRAME_ATTR_ERROR_TYPE,
+    FRAME_ATTR_STATUS,
+    STATUS_FILE_SNAPSHOT,
+    STATUS_LIVE,
+    STATUS_MONGO_CACHE,
     TradeCalendarUnavailable,
     fetch_trade_dates_with_persistent_cache,
+    read_trade_calendar_snapshot,
     refresh_trade_calendar_cache,
 )
 from freshquant.trading import dt
@@ -43,6 +50,17 @@ class FakeTradeCalendarCollection:
             doc[field] = int(doc.get(field) or 0) + int(increment)
         self.docs[(doc["market"], doc["source"])] = doc
         return doc
+
+
+class FailingTradeCalendarCollection:
+    def create_index(self, fields, **kwargs):
+        raise RuntimeError("mongo unavailable")
+
+    def find_one(self, query):
+        raise RuntimeError("mongo unavailable")
+
+    def update_one(self, query, update, upsert=False):
+        raise RuntimeError("mongo unavailable")
 
 
 def _cache_doc(*, max_trade_date="2026-12-31"):
@@ -85,10 +103,12 @@ def test_fetch_trade_dates_uses_valid_mongo_cache_without_remote_call():
         "2026-03-19",
         "2026-12-31",
     ]
+    assert result.attrs[FRAME_ATTR_STATUS] == STATUS_MONGO_CACHE
 
 
-def test_refresh_trade_calendar_cache_persists_normalized_source_dates():
+def test_refresh_trade_calendar_cache_persists_normalized_source_dates(tmp_path):
     collection = FakeTradeCalendarCollection()
+    snapshot_path = tmp_path / "cn_a_sina.json"
 
     result = refresh_trade_calendar_cache(
         lambda: pd.DataFrame(
@@ -102,16 +122,25 @@ def test_refresh_trade_calendar_cache_persists_normalized_source_dates():
         ),
         collection=collection,
         now_provider=_now,
+        snapshot_path=snapshot_path,
     )
 
     doc = collection.find_one({"market": "cn_a", "source": "sina"})
     assert list(result["trade_date"].astype(str)) == ["2026-03-18", "2026-03-19"]
+    assert result.attrs[FRAME_ATTR_STATUS] == STATUS_LIVE
     assert doc["trade_dates"] == ["2026-03-18", "2026-03-19"]
     assert doc["min_trade_date"] == "2026-03-18"
     assert doc["max_trade_date"] == "2026-03-19"
     assert doc["date_count"] == 2
     assert doc["last_error_type"] == ""
     assert collection.created_indexes
+    snapshot = read_trade_calendar_snapshot(
+        snapshot_path=snapshot_path,
+        require_covering_today=False,
+    )
+    assert snapshot is not None
+    assert list(snapshot["trade_date"].astype(str)) == ["2026-03-18", "2026-03-19"]
+    assert snapshot.attrs[FRAME_ATTR_STATUS] == STATUS_FILE_SNAPSHOT
 
 
 def test_fetch_trade_dates_falls_back_to_cache_and_records_source_error():
@@ -126,9 +155,37 @@ def test_fetch_trade_dates_falls_back_to_cache_and_records_source_error():
 
     doc = collection.find_one({"market": "cn_a", "source": "sina"})
     assert list(result["trade_date"].astype(str))[-1] == "2026-12-31"
+    assert result.attrs[FRAME_ATTR_STATUS] == STATUS_MONGO_CACHE
+    assert result.attrs[FRAME_ATTR_ERROR_TYPE] == "SSLError"
+    assert result.attrs[FRAME_ATTR_ERROR_MESSAGE] == "temporary ssl failure"
     assert doc["last_error_type"] == "SSLError"
     assert doc["last_error_message"] == "temporary ssl failure"
     assert doc["fallback_hits"] == 1
+
+
+def test_fetch_trade_dates_falls_back_to_file_snapshot_when_mongo_unavailable(
+    tmp_path,
+):
+    snapshot_path = tmp_path / "cn_a_sina.json"
+    refresh_trade_calendar_cache(
+        lambda: pd.DataFrame({"trade_date": ["2026-03-18", "2026-12-31"]}),
+        collection=FakeTradeCalendarCollection(),
+        now_provider=_now,
+        snapshot_path=snapshot_path,
+    )
+
+    result = fetch_trade_dates_with_persistent_cache(
+        lambda: (_ for _ in ()).throw(SSLError("temporary ssl failure")),
+        collection=FailingTradeCalendarCollection(),
+        now_provider=_now,
+        prefer_cache=False,
+        snapshot_path=snapshot_path,
+    )
+
+    assert list(result["trade_date"].astype(str)) == ["2026-03-18", "2026-12-31"]
+    assert result.attrs[FRAME_ATTR_STATUS] == STATUS_FILE_SNAPSHOT
+    assert result.attrs[FRAME_ATTR_ERROR_TYPE] == "SSLError"
+    assert result.attrs[FRAME_ATTR_ERROR_MESSAGE] == "temporary ssl failure"
 
 
 def test_fetch_trade_dates_fails_closed_when_cache_no_longer_covers_today():

--- a/freshquant/tests/test_trade_calendar_dagster.py
+++ b/freshquant/tests/test_trade_calendar_dagster.py
@@ -5,6 +5,14 @@ from types import ModuleType, SimpleNamespace
 
 import pandas as pd
 
+from freshquant.data.trade_calendar_cache import (
+    FRAME_ATTR_ERROR_MESSAGE,
+    FRAME_ATTR_ERROR_TYPE,
+    FRAME_ATTR_STATUS,
+    STATUS_FILE_SNAPSHOT,
+    STATUS_LIVE,
+)
+
 
 def _build_dagster_stub():
     module = ModuleType("dagster")
@@ -100,6 +108,41 @@ def test_trade_calendar_asset_refreshes_persistent_cache(monkeypatch):
         "min_trade_date": "2026-03-18",
         "max_trade_date": "2026-03-19",
         "source": "sina",
+        "refresh_status": STATUS_LIVE,
+        "degraded": False,
+        "source_error_type": "",
+        "source_error_message": "",
+    }
+
+
+def test_trade_calendar_asset_reports_degraded_cache_refresh(monkeypatch):
+    _prepare_fqdagster_import(monkeypatch)
+    assets_module = importlib.import_module("fqdagster.defs.assets.trade_calendar")
+
+    def fake_refresh():
+        frame = pd.DataFrame(
+            {"trade_date": pd.to_datetime(["2026-03-18", "2026-12-31"]).date}
+        )
+        frame.attrs[FRAME_ATTR_STATUS] = STATUS_FILE_SNAPSHOT
+        frame.attrs[FRAME_ATTR_ERROR_TYPE] = "SSLError"
+        frame.attrs[FRAME_ATTR_ERROR_MESSAGE] = "temporary ssl failure"
+        return frame
+
+    monkeypatch.setattr(
+        assets_module,
+        "refresh_trade_date_hist_sina_cache",
+        fake_refresh,
+    )
+
+    assert assets_module.trade_calendar_cache_asset() == {
+        "date_count": 2,
+        "min_trade_date": "2026-03-18",
+        "max_trade_date": "2026-12-31",
+        "source": "sina",
+        "refresh_status": STATUS_FILE_SNAPSHOT,
+        "degraded": True,
+        "source_error_type": "SSLError",
+        "source_error_message": "temporary ssl failure",
     }
 
 

--- a/morningglory/fqdagster/src/fqdagster/defs/assets/trade_calendar.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/assets/trade_calendar.py
@@ -1,5 +1,11 @@
 from dagster import asset
 
+from freshquant.data.trade_calendar_cache import (
+    FRAME_ATTR_ERROR_MESSAGE,
+    FRAME_ATTR_ERROR_TYPE,
+    FRAME_ATTR_STATUS,
+    STATUS_LIVE,
+)
 from freshquant.data.trade_date_hist import refresh_trade_date_hist_sina_cache
 
 TRADE_CALENDAR_GROUP = "trade_calendar"
@@ -7,10 +13,16 @@ TRADE_CALENDAR_GROUP = "trade_calendar"
 
 @asset(group_name=TRADE_CALENDAR_GROUP)
 def trade_calendar_cache_asset() -> dict:
-    trade_dates = refresh_trade_date_hist_sina_cache()["trade_date"]
+    frame = refresh_trade_date_hist_sina_cache()
+    trade_dates = frame["trade_date"]
+    refresh_status = str(frame.attrs.get(FRAME_ATTR_STATUS) or STATUS_LIVE)
     return {
         "date_count": len(trade_dates),
         "min_trade_date": trade_dates.min().strftime("%Y-%m-%d"),
         "max_trade_date": trade_dates.max().strftime("%Y-%m-%d"),
         "source": "sina",
+        "refresh_status": refresh_status,
+        "degraded": refresh_status != STATUS_LIVE,
+        "source_error_type": str(frame.attrs.get(FRAME_ATTR_ERROR_TYPE) or ""),
+        "source_error_message": str(frame.attrs.get(FRAME_ATTR_ERROR_MESSAGE) or ""),
     }


### PR DESCRIPTION
## Background

Dagster `trade_calendar_refresh_job` failed when the Sina/AkShare trade calendar endpoint returned a transient HTTPS SSL EOF. The failure was not caused by Redis; Redis had a separate AOF corruption incident, while the Dagster stack pointed at `finance.sina.com.cn/realstock/company/klc_td_sh.txt` with `SSLEOFError`.

## What Changed

- Added a disk JSON snapshot fallback for the A-share trade calendar.
- Successful live refresh now writes Mongo and the configured disk snapshot.
- Refresh consumers can fall back in this order: live Sina/AkShare, Mongo last-known-good, disk snapshot.
- `trade_calendar_refresh_job` now reports `refresh_status`, `degraded`, `source_error_type`, and `source_error_message` so cache-served refreshes are visible without failing the run.
- Docker API and Dagster share `fqnext_trade_calendar_state` at `/freshquant/state/trade-calendar`.
- Updated `docs/current/**` with the current runtime, storage, and troubleshooting behavior.

## Non-goals

- Does not replace Sina/AkShare as the primary live calendar source.
- Does not add TuShare as a source because this runtime has no `TUSHARE_TOKEN` configured.
- Does not change Redis durability or queue semantics.

## Validation

- `powershell -ExecutionPolicy Bypass -File script/fq_local_preflight.ps1 -Mode Ensure`
- `py -3.12 -m uv run pytest freshquant/tests/test_trade_calendar_cache.py freshquant/tests/test_trade_calendar_dagster.py freshquant/tests/test_gantt_dagster_ops.py freshquant/tests/test_docker_runtime_policy.py freshquant/tests/test_deploy_build_cache_policy.py freshquant/tests/test_freshquant_deploy_plan.py freshquant/tests/test_docker_parallel_compose.py -q`
- `git diff --check`

Note: the local uv environment does not expose `ruff` or `pre-commit` commands directly, but the repository preflight entrypoint returned success.

## Deployment Impact

`docker/compose.parallel.yaml` changed, so the deploy plan treats this as a Docker parallel runtime configuration update and recreates/restarts managed Docker services. The affected runtime surfaces include API and Dagster; the shared compose change expands the deploy plan to the managed Docker environment.