### PR TITLE
[codex] Fix web Docker pnpm build approvals

### DIFF
--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -13,7 +13,7 @@ RUN pnpm config set fetch-retries 5 && \
     pnpm config set fetch-retry-maxtimeout 120000
 
 WORKDIR /fqwebui
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --prefer-offline --fetch-timeout 100000 --loglevel warn
 
 COPY .browserslistrc jsconfig.json index.html vite.config.js ./

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -21,6 +21,7 @@ docker compose -f docker/compose.parallel.yaml up -d --build
 
 - 这条命令只用于显式全量重建；日常 selective deploy 统一优先走 `script/fq_apply_deploy_plan.ps1`
 - Docker 构建默认启用 BuildKit 本地缓存；未显式设置时，`script/docker_parallel_compose.ps1` 会把 `FQ_DOCKER_BUILD_CACHE_ROOT` 设为仓库下的 `.artifacts/docker-build-cache`
+- `fq_webui` Docker 构建在 `pnpm install` 前复制 `pnpm-workspace.yaml`；其中的 `allowBuilds` 只允许 `core-js`、`esbuild`、`vue-demi` 执行安装期 build scripts，避免 pnpm 11 非交互构建被 `ERR_PNPM_IGNORED_BUILDS` 阻断。
 - Runtime Observability 的 ClickHouse 默认通过 `FQ_RUNTIME_CLICKHOUSE_USER/FQ_RUNTIME_CLICKHOUSE_PASSWORD` 创建并使用专用查询用户；不要再让 API / indexer 走无凭证 `default`
 - 当前默认不会主动拉取 GHCR 远端缓存；只有显式设置 `FQ_ENABLE_REMOTE_CACHE_PULL=1` 时，`docker_parallel_compose.ps1` 才会进入 `remote_cached` 分支并执行 `docker pull`
 - `main` 合并后的镜像发布 workflow：`.github/workflows/docker-images.yml`

--- a/freshquant/tests/test_deploy_build_cache_policy.py
+++ b/freshquant/tests/test_deploy_build_cache_policy.py
@@ -23,7 +23,9 @@ def test_web_context_has_local_dockerignore_for_build_outputs() -> None:
 def test_dockerfile_web_installs_dependencies_before_copying_sources() -> None:
     text = Path("docker/Dockerfile.web").read_text(encoding="utf-8")
 
-    manifest_copy = text.index("COPY package.json pnpm-lock.yaml ./")
+    manifest_copy = text.index(
+        "COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./"
+    )
     source_copy = text.index("COPY src ./src")
     install = text.index("pnpm install --prefer-offline")
 

--- a/morningglory/fqwebui/pnpm-workspace.yaml
+++ b/morningglory/fqwebui/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  core-js: true
+  esbuild: true
+  vue-demi: true


### PR DESCRIPTION
## 背景

PR #449 已合并后执行 formal deploy，本轮 deploy 命中 `docker/compose.parallel.yaml`，因此按当前部署规则触发全量受管 Docker 并行环境构建。formal deploy run `D:\fqpack\runtime\formal-deploy\runs\20260702T154557Z-72fbf6da614b` 在 `fq_webui` 镜像构建阶段失败：`pnpm install` 报 `ERR_PNPM_IGNORED_BUILDS`，阻断后续 health/runtime verify 与 Dagster 重跑。

## 目标

- 修复 `fq_webui` Docker 镜像在 pnpm 11 非交互安装时的 build script approval 问题。
- 保持依赖 build scripts 受控，只允许当前构建需要的已知依赖执行安装脚本。
- 让 formal deploy 可以继续完成 Web surface 构建与部署。

## 范围

- `docker/Dockerfile.web` 在 `pnpm install` 前复制 `pnpm-workspace.yaml`。
- 新增 `morningglory/fqwebui/pnpm-workspace.yaml`，使用 pnpm 11 的 `allowBuilds` map 允许 `core-js`、`esbuild`、`vue-demi`。
- 更新部署测试与当前部署文档。

## 非目标

- 不改交易日历修复逻辑。
- 不调整前端业务代码。
- 不扩大 Docker compose 部署面。

## 验收标准

- Web Docker 构建中的 `pnpm install` 不再出现 `ERR_PNPM_IGNORED_BUILDS`。
- `docker build --pull=false -f docker/Dockerfile.web --build-arg FQ_IMAGE_GIT_SHA=pnpm-fix-test -t fqnext_webui:pnpm-fix-test morningglory/fqwebui` 成功。
- 部署相关 pytest 通过。

## 本地验证

- `docker run --rm -v "${PWD}\morningglory\fqwebui:/src:ro" node:lts-alpine sh -lc "... pnpm install --prefer-offline --fetch-timeout 100000 --loglevel warn"` -> passed，只有 deprecated warning。
- `docker build --pull=false -f docker/Dockerfile.web --build-arg FQ_IMAGE_GIT_SHA=pnpm-fix-test -t fqnext_webui:pnpm-fix-test morningglory/fqwebui` -> passed。
- `py -3.12 -m uv run pytest freshquant/tests/test_deploy_build_cache_policy.py freshquant/tests/test_docker_runtime_policy.py freshquant/tests/test_freshquant_deploy_plan.py freshquant/tests/test_docker_parallel_compose.py -q` -> `53 passed`。
- `git diff --check` -> passed。

## 部署影响

`freshquant_deploy_plan.py` 对本 PR 解析结果：`deployment_surfaces: web`，重建/重启 `fq_webui`，并执行 Web health checks。合并后需要重新执行 formal deploy，以完成 PR #449 日历修复后的正式部署链路。