### PR TITLE
fix: guard xtdata non-trading realtime bars

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -48,6 +48,8 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - `OneMinuteBarGenerator` 当前只在 `whole_quote` 快照带来正向 `volume/amount` 增量时更新 1 分钟 bar 的 OHLC；无成交的 quote-only 快照不会再改写分钟高低收。
 - `11:30:00` 与 `15:00:00` 这类交易时段结束边界快照会归入最后一个有效分钟 bar，而不是落到午休或收盘后的无效分钟桶。
 - `StrategyConsumer` 当前只允许“当天”的 realtime bar 参与 history/realtime merge；所有已完成交易日的分钟线都只信任盘后同步到 QuantAxis 的历史库，不再允许旧 `index_realtime/stock_realtime` 覆盖历史分钟线。
+- `OneMinuteBarGenerator` 和 `StrategyConsumer` 都会通过 FreshQuant A 股交易日历拦截非交易日 bar；周末/节假日 tick 不生成 bar，非交易日 `BAR_CLOSE` 不写入 `stock_realtime/index_realtime`。
+- consumer prewarm 与股票分钟线 API 拼接都会过滤非交易日 realtime 行，避免历史脏数据继续进入 Redis Kline cache 或 `/api/stock_data` 返回值。
 
 ## 存储
 
@@ -121,6 +123,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 
 - 检查 Redis realtime cache 是否更新。
 - 检查 `/api/stock_data` 是否启用了 realtime cache。
+- 如果页面出现周末/节假日 Kline，先查 `freshquant.stock_realtime` 与 `freshquant.index_realtime` 对应日期是否存在 `source=xtdata` 行；这些行属于实时表脏数据，需要先备份后删除，并同步清理受影响的 `CACHE:KLINE:<code>:<period>` Redis 缓存。
 
 ### TPSL 不收到 tick
 

--- a/freshquant/data/stock.py
+++ b/freshquant/data/stock.py
@@ -14,6 +14,7 @@ from freshquant.data.adj_intraday import (
 )
 from freshquant.database.cache import redis_cache
 from freshquant.db import DBfreshquant
+from freshquant.trading.trade_date_guard import is_cn_a_trade_date
 from freshquant.util.code import fq_util_code_append_market_code, normalize_to_base_code
 
 
@@ -64,6 +65,13 @@ def _apply_stock_qfq(
     )
 
 
+def _filter_trade_date_realtime_rows(rows: pd.DataFrame) -> pd.DataFrame:
+    if rows is None or len(rows) == 0 or "datetime" not in rows.columns:
+        return rows
+    mask = rows["datetime"].apply(is_cn_a_trade_date)
+    return rows.loc[mask].copy()
+
+
 def fq_data_stock_fetch_min(code, frequence, start=None, end=None):
     start_dt = start
     end_dt = end
@@ -95,6 +103,7 @@ def fq_data_stock_fetch_min(code, frequence, start=None, end=None):
         .sort("datetime", pymongo.ASCENDING)
     )
     realtime_data_list = pd.DataFrame(realtime_data_list)
+    realtime_data_list = _filter_trade_date_realtime_rows(realtime_data_list)
     data = data[
         ["datetime", "open", "close", "high", "low", "volume", "amount", "time_stamp"]
     ]
@@ -171,7 +180,7 @@ def fq_data_stock_fetch_day(code, start=None, end=None):
         .find(
             {
                 "code": fq_util_code_append_market_code(code, upper_case=False),
-                "frequence": '1d',
+                "frequence": "1d",
                 "datetime": {"$gt": last_datetime, "$lte": end},
                 "open": {"$gt": 0},
                 "high": {"$gt": 0},
@@ -182,6 +191,7 @@ def fq_data_stock_fetch_day(code, start=None, end=None):
         .sort("datetime", pymongo.ASCENDING)
     )
     realtime_data_list = pd.DataFrame(realtime_data_list)
+    realtime_data_list = _filter_trade_date_realtime_rows(realtime_data_list)
     if len(realtime_data_list) > 0:
         realtime_data_list["time_stamp"] = realtime_data_list["datetime"].apply(
             lambda value: QA_util_time_stamp(value)

--- a/freshquant/market_data/xtdata/bar_generator.py
+++ b/freshquant/market_data/xtdata/bar_generator.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 from freshquant.market_data.xtdata.constants import queue_key_for_code
 from freshquant.market_data.xtdata.schema import normalize_prefixed_code
 from freshquant.runtime_constants import TZ
+from freshquant.trading.trade_date_guard import is_cn_a_trade_date
 
 try:
     from freshquant.database.redis import redis_db  # type: ignore
@@ -22,6 +23,8 @@ except Exception:  # pragma: no cover
 
 
 def _is_cn_a_trading_datetime(dt: datetime) -> bool:
+    if not is_cn_a_trade_date(dt):
+        return False
     t = dt.time()
     return (
         t >= datetime(dt.year, dt.month, dt.day, 9, 30).time()
@@ -74,6 +77,8 @@ def _timer_close_cutoff(dt: datetime) -> int:
 
 
 def _should_scan_timer(dt: datetime) -> bool:
+    if not is_cn_a_trade_date(dt):
+        return False
     if _is_cn_a_trading_datetime(dt):
         return True
     return (dt.hour, dt.minute) in {(11, 30), (15, 0)}

--- a/freshquant/market_data/xtdata/strategy_consumer.py
+++ b/freshquant/market_data/xtdata/strategy_consumer.py
@@ -40,6 +40,7 @@ from freshquant.market_data.xtdata.schema import BarCloseEvent
 from freshquant.runtime_constants import TZ
 from freshquant.runtime_observability.logger import RuntimeEventLogger
 from freshquant.system_settings import system_settings
+from freshquant.trading.trade_date_guard import is_cn_a_trade_date
 from freshquant.util.period import (
     PUBSUB_CHANNEL,
     get_redis_cache_key,
@@ -104,6 +105,8 @@ def _is_cn_a_trading_bar_end(dt: datetime) -> bool:
     """
     dt is bar end time (e.g. 09:31, 11:30, 13:01, 15:00).
     """
+    if not is_cn_a_trade_date(dt):
+        return False
     t = dt.time()
     return (
         t >= datetime(dt.year, dt.month, dt.day, 9, 31).time()
@@ -183,6 +186,15 @@ def _normalize_bar_window_df(df: pd.DataFrame) -> pd.DataFrame:
     bars["datetime"] = pd.DatetimeIndex(bars["datetime"])
 
     return bars.sort_values("datetime").reset_index(drop=True)
+
+
+def _filter_trade_date_bar_df(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty or "datetime" not in df.columns:
+        return df
+    bars = df.copy()
+    bars["_fq_is_trade_date"] = bars["datetime"].apply(is_cn_a_trade_date)
+    bars = bars[bars["_fq_is_trade_date"]].drop(columns=["_fq_is_trade_date"])
+    return bars.reset_index(drop=True)
 
 
 def _load_minute_history_from_quantaxis_db(
@@ -601,6 +613,7 @@ class StrategyConsumer:
             .sort("datetime", 1)
         )
         rt_df = pd.DataFrame(list(rt_cur))
+        rt_df = _filter_trade_date_bar_df(rt_df)
 
         start_date = start_dt.strftime("%Y-%m-%d")
         end_date = end_dt.strftime("%Y-%m-%d")
@@ -1104,6 +1117,12 @@ class StrategyConsumer:
             return
 
         dt = datetime.fromtimestamp(ts, tz=TZ)
+        if not _is_cn_a_trading_bar_end(dt):
+            logger.warning(
+                f"[Consumer] ignore non-trading bar close {code} {period} {dt.isoformat()}"
+            )
+            return
+
         bar_raw = {
             "datetime": dt,
             "code": code,

--- a/freshquant/tests/test_stock_data_fetch.py
+++ b/freshquant/tests/test_stock_data_fetch.py
@@ -102,6 +102,7 @@ def _patch_common(monkeypatch, stock_module, collection):
         lambda code, upper_case=False: f"sz{code}",
     )
     monkeypatch.setattr(stock_module, "QA_util_time_stamp", lambda _: 0)
+    monkeypatch.setattr(stock_module, "is_cn_a_trade_date", lambda _value: True)
     monkeypatch.setattr(
         stock_module,
         "QA_util_datetime_to_strdatetime",

--- a/freshquant/tests/test_trade_date_guard.py
+++ b/freshquant/tests/test_trade_date_guard.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+import freshquant.trading.trade_date_guard as guard
+from freshquant.runtime_constants import TZ
+
+
+@pytest.fixture(autouse=True)
+def _clear_guard_cache():
+    guard.clear_trade_date_guard_cache()
+    yield
+    guard.clear_trade_date_guard_cache()
+
+
+def test_is_cn_a_trade_date_uses_trade_calendar(monkeypatch):
+    monkeypatch.setattr(
+        guard, "_trade_date_set", lambda: frozenset({"2026-07-03", "2026-07-06"})
+    )
+
+    assert guard.is_cn_a_trade_date(TZ.localize(datetime(2026, 7, 3, 15, 0))) is True
+    assert guard.is_cn_a_trade_date(TZ.localize(datetime(2026, 7, 4, 9, 35))) is False
+    assert guard.is_cn_a_trade_date(TZ.localize(datetime(2026, 7, 6, 9, 35))) is True
+
+
+def test_is_cn_a_trade_date_fails_closed_when_calendar_unavailable(monkeypatch):
+    def raise_unavailable():
+        raise RuntimeError("calendar unavailable")
+
+    monkeypatch.setattr(guard, "_trade_date_set", raise_unavailable)
+
+    assert guard.is_cn_a_trade_date(TZ.localize(datetime(2026, 7, 6, 9, 35))) is False

--- a/freshquant/tests/test_xtdata_bar_generator.py
+++ b/freshquant/tests/test_xtdata_bar_generator.py
@@ -9,6 +9,14 @@ from freshquant.market_data.xtdata.bar_generator import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _patch_trade_calendar(monkeypatch):
+    monkeypatch.setattr(
+        "freshquant.market_data.xtdata.bar_generator.is_cn_a_trade_date",
+        lambda dt: dt.weekday() < 5,
+    )
+
+
 def _tick(y, m, d, hour, minute, second, *, price, volume, amount):
     dt = runtime_constants.TZ.localize(datetime(y, m, d, hour, minute, second))
     return {
@@ -50,6 +58,21 @@ def generator():
 )
 def test_timer_only_scans_during_trading_or_session_close_window(dt, expected):
     assert _should_scan_timer(dt) is expected
+
+
+def test_timer_skips_non_trading_day_session_window():
+    assert _should_scan_timer(_dt(2026, 7, 4, 9, 35, 0)) is False
+    assert _should_scan_timer(_dt(2026, 7, 4, 15, 0, 0)) is False
+
+
+def test_weekend_tick_is_ignored(generator):
+    events = generator._process_single_tick(
+        "sh600104",
+        _tick(2026, 7, 4, 9, 35, 0, price=9.87, volume=100, amount=98700),
+    )
+
+    assert events == []
+    assert "sh600104" not in generator._bars
 
 
 def test_zero_delta_snapshot_does_not_rewrite_bar_ohlc(generator):

--- a/freshquant/tests/test_xtdata_strategy_consumer_history.py
+++ b/freshquant/tests/test_xtdata_strategy_consumer_history.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any, cast
 
 import pandas as pd
+import pytest
 
 import freshquant.market_data.xtdata.strategy_consumer as sc
 from freshquant.config import cfg
@@ -113,6 +114,11 @@ def _make_consumer(*, is_index_like: bool) -> sc.StrategyConsumer:
     consumer._is_index_like = lambda _code: is_index_like
     consumer._heartbeat_state = sc.ConsumerHeartbeatState(window_s=300.0)
     return cast(sc.StrategyConsumer, consumer)
+
+
+@pytest.fixture(autouse=True)
+def _patch_trade_calendar(monkeypatch):
+    monkeypatch.setattr(sc, "is_cn_a_trade_date", lambda dt: dt.weekday() < 5)
 
 
 def test_load_window_from_db_reads_stock_history_without_external_quantaxis(
@@ -224,7 +230,7 @@ def test_load_window_from_db_applies_single_qfq_to_raw_stock_realtime(
 
 
 def test_handle_bar_close_stores_stock_realtime_as_raw_bar(monkeypatch):
-    now_dt = datetime.now(tz=cfg.TZ).replace(second=0, microsecond=0)
+    now_dt = cfg.TZ.localize(datetime(2026, 7, 6, 9, 35, 0))
     captured: dict[str, Any] = {}
 
     def fake_upsert_realtime_bars(*, collection, code, frequence, records):
@@ -300,10 +306,61 @@ def test_handle_bar_close_stores_stock_realtime_as_raw_bar(monkeypatch):
     assert captured["records"][0]["close"] == 10.5
 
 
+def test_handle_bar_close_skips_non_trading_day(monkeypatch):
+    weekend_dt = cfg.TZ.localize(datetime(2026, 7, 4, 9, 35, 0))
+    calls: list[dict[str, Any]] = []
+
+    class DummyScheduler:
+        def __init__(self) -> None:
+            self.updates: list[tuple[tuple[str, str], dict[str, Any]]] = []
+
+        def update(self, key, meta) -> None:
+            self.updates.append((key, meta))
+
+    monkeypatch.setattr(
+        sc, "upsert_realtime_bars", lambda **kwargs: calls.append(kwargs)
+    )
+
+    consumer = cast(Any, object.__new__(sc.StrategyConsumer))
+    consumer.max_bars = 32
+    consumer._is_index_like = lambda _code: False
+    consumer._lock = threading.Lock()
+    consumer._backfill_lock = threading.Lock()
+    consumer._backfilling_codes = set()
+    consumer._known_codes = {"sh600104"}
+    consumer._last_bar_ts = {}
+    consumer._windows = {}
+    consumer._dirty_latest = {}
+    consumer._catchup_mode = False
+    consumer._heartbeat_state = sc.ConsumerHeartbeatState(window_s=300.0)
+    consumer._scheduler = DummyScheduler()
+    consumer._model_ids_for = lambda _code, _period: []
+    consumer._maybe_trigger_backfill = lambda **_kwargs: False
+
+    consumer.handle_bar_close(
+        BarCloseEvent(
+            code="sh600104",
+            period="5min",
+            data={
+                "time": int(weekend_dt.timestamp()),
+                "open": 9.87,
+                "high": 10.11,
+                "low": 9.11,
+                "close": 10.1,
+                "volume": 160.0,
+                "amount": 160000.0,
+            },
+        )
+    )
+
+    assert calls == []
+    assert consumer._scheduler.updates == []
+
+
 def test_handle_bar_close_does_not_refresh_symbol_position_snapshot_on_1min(
     monkeypatch,
 ):
-    now_dt = datetime.now(tz=cfg.TZ).replace(second=0, microsecond=0)
+    now_dt = cfg.TZ.localize(datetime(2026, 7, 6, 9, 35, 0))
 
     class DummyScheduler:
         def update(self, _key, _meta) -> None:
@@ -544,3 +601,62 @@ def test_load_window_from_db_ignores_completed_day_realtime_overlap(monkeypatch)
     assert result["low"].tolist() == [0.518, 0.514]
     assert result["open"].tolist() == [0.518, 0.515]
     assert result["close"].tolist() == [0.519, 0.515]
+
+
+def test_load_window_from_db_filters_non_trading_day_realtime(monkeypatch):
+    _disable_quantaxis_import(monkeypatch)
+
+    now_dt = cfg.TZ.localize(datetime(2026, 7, 4, 10, 0, 0))
+    friday_bar = cfg.TZ.localize(datetime(2026, 7, 3, 15, 0, 0))
+    saturday_bar = cfg.TZ.localize(datetime(2026, 7, 4, 9, 35, 0))
+
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return now_dt
+            return now_dt.astimezone(tz)
+
+    monkeypatch.setattr(sc, "datetime", FrozenDateTime)
+    monkeypatch.setattr(
+        sc,
+        "DBQuantAxis",
+        FakeDatabase(
+            {
+                "stock_min": FakeCollection(
+                    [_make_bar_doc(friday_bar, code="600104", period="5min", open_=9.8)]
+                ),
+                "stock_adj": FakeCollection([]),
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        sc,
+        "DBfreshquant",
+        FakeDatabase(
+            {
+                "stock_realtime": FakeCollection(
+                    [
+                        {
+                            "code": "sh600104",
+                            "frequence": "5min",
+                            "datetime": saturday_bar,
+                            "open": 9.87,
+                            "high": 10.11,
+                            "low": 9.11,
+                            "close": 10.1,
+                            "volume": 160.0,
+                            "amount": 160000.0,
+                        }
+                    ]
+                )
+            }
+        ),
+    )
+
+    consumer = _make_consumer(is_index_like=False)
+    result = consumer._load_window_from_db(code="sh600104", period_backend="5min")
+
+    assert result["datetime"].dt.strftime("%Y-%m-%d %H:%M").tolist() == [
+        friday_bar.strftime("%Y-%m-%d %H:%M")
+    ]

--- a/freshquant/trading/trade_date_guard.py
+++ b/freshquant/trading/trade_date_guard.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from functools import lru_cache
+from typing import Any
+
+import pandas as pd
+
+from freshquant.runtime_constants import TZ
+from freshquant.trading.dt import fq_trading_fetch_trade_dates
+
+
+def _date_key(value: Any) -> str:
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, date):
+        return value.isoformat()
+    else:
+        dt = pd.Timestamp(value).to_pydatetime()
+
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(TZ)
+    return dt.date().isoformat()
+
+
+def _weekday_open(value: Any) -> bool:
+    try:
+        if isinstance(value, datetime):
+            dt = value.astimezone(TZ) if value.tzinfo is not None else value
+            return dt.weekday() < 5
+        if isinstance(value, date):
+            return value.weekday() < 5
+        ts = pd.Timestamp(value)
+        if ts.tzinfo is not None:
+            ts = ts.tz_convert(TZ)
+        return ts.weekday() < 5
+    except Exception:
+        return False
+
+
+@lru_cache(maxsize=1)
+def _trade_date_set() -> frozenset[str]:
+    frame = fq_trading_fetch_trade_dates()
+    if frame is None or "trade_date" not in frame.columns:
+        raise RuntimeError("trade calendar dataframe missing trade_date column")
+    values = pd.to_datetime(frame["trade_date"], errors="coerce")
+    if values.isna().any():
+        raise RuntimeError("trade calendar contains unparseable trade_date values")
+    return frozenset(value.date().isoformat() for value in values)
+
+
+def is_cn_a_trade_date(value: Any) -> bool:
+    if not _weekday_open(value):
+        return False
+    try:
+        return _date_key(value) in _trade_date_set()
+    except Exception:
+        return False
+
+
+def clear_trade_date_guard_cache() -> None:
+    cache_clear = getattr(_trade_date_set, "cache_clear", None)
+    if callable(cache_clear):
+        cache_clear()


### PR DESCRIPTION
## 背景

`/kline-slim` 展示了 `2026-07-04` 的分钟线。核查确认 `2026-07-04` 是周六且不在 A 股交易日历内；页面只是画出了 `/api/stock_data` 返回的时间轴，污染源是 `freshquant.stock_realtime/index_realtime` 中 `source=xtdata` 的非交易日 realtime bar。

## 目标

- 阻止 XTData 在周末/节假日生成和写入 realtime bar。
- API/consumer 合并窗口过滤历史遗留的非交易日 realtime 行。
- 清理已确认的 `2026-07-04` 脏数据和相关 Kline cache。

## 范围

- 新增 FreshQuant A 股交易日守卫，复用现有交易日历 Mongo/文件快照兜底。
- `OneMinuteBarGenerator` 在非交易日不生成 bar。
- `StrategyConsumer` 在非交易日不接受 `BAR_CLOSE` 入库，并在 prewarm/merge 时过滤 realtime 行。
- 股票分钟/日线 API 拼接 realtime 数据前过滤非交易日行。
- 更新 `docs/current/modules/market-data-xtdata.md` 与回归测试。

## 非目标

- 不改变前端图表渲染逻辑。
- 不改变 QuantAxis 历史库同步逻辑。
- 不改交易日历缓存刷新机制本身。

## 验收标准

- `2026-07-04` 这类非交易日 tick/BAR_CLOSE 不生成、不写入 realtime 表。
- `/api/stock_data` 不再返回 `2026-07-04` 的 `sh600104` 5 分钟 bar。
- 已确认脏数据清理后 `stock_realtime/index_realtime` 对应日期计数为 0。
- 相关单测通过。

## 本地验证

- `py -3.12 -m uv run pytest freshquant/tests/test_trade_date_guard.py freshquant/tests/test_xtdata_bar_generator.py freshquant/tests/test_xtdata_strategy_consumer_history.py freshquant/tests/test_stock_data_fetch.py freshquant/tests/test_stock_data_route_cache.py -q` -> `37 passed`
- `py -3.12 -m uv run black --check ...` -> passed
- `git diff --check` -> passed
- 脏数据清理备份：`D:\fqpack\runtime\artifacts\maintenance\non_trading_xtdata_realtime_20260704_backup_20260706T012912Z.json`
- 清理结果：`stock_realtime=1872`、`index_realtime=936` 删除；复查均为 `0`
- API 复查：`/api/stock_data?period=5m&symbol=sh600104&barCount=20000` 和 `realtimeCache=1` 最后一根均为 `2026-07-03 15:00`，`2026-07-04` 为 `0` 条

## 部署影响

部署计划识别影响面：`api`、`dagster`、`market_data`、`guardian`。

- Docker：重建/重启 `fq_apiserver`，重启 `fq_dagster_webserver`、`fq_dagster_daemon`
- 宿主机：重启 `fqnext_realtime_xtdata_producer`、`fqnext_realtime_xtdata_consumer`、`fqnext_xtdata_adj_refresh_worker`、`fqnext_guardian_event`
- 必要时重新 prewarm XTData consumer
