### PR TITLE
fix: filter ETF realtime bars by trade date

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -49,7 +49,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - `11:30:00` 与 `15:00:00` 这类交易时段结束边界快照会归入最后一个有效分钟 bar，而不是落到午休或收盘后的无效分钟桶。
 - `StrategyConsumer` 当前只允许“当天”的 realtime bar 参与 history/realtime merge；所有已完成交易日的分钟线都只信任盘后同步到 QuantAxis 的历史库，不再允许旧 `index_realtime/stock_realtime` 覆盖历史分钟线。
 - `OneMinuteBarGenerator` 和 `StrategyConsumer` 都会通过 FreshQuant A 股交易日历拦截非交易日 bar；周末/节假日 tick 不生成 bar，非交易日 `BAR_CLOSE` 不写入 `stock_realtime/index_realtime`。
-- consumer prewarm 与股票分钟线 API 拼接都会过滤非交易日 realtime 行，避免历史脏数据继续进入 Redis Kline cache 或 `/api/stock_data` 返回值。
+- consumer prewarm、股票分钟线 API 拼接与 ETF/index K 线查询都会过滤非交易日 realtime 行，避免历史脏数据继续进入 Redis Kline cache 或 `/api/stock_data` 返回值。
 
 ## 存储
 

--- a/freshquant/quote/etf.py
+++ b/freshquant/quote/etf.py
@@ -18,6 +18,7 @@ from freshquant.data.adj_intraday import (
 from freshquant.database.cache import in_memory_cache, redis_cache
 from freshquant.db import DBfreshquant
 from freshquant.quote.general import resample3min, resampleStockOrIndex120min
+from freshquant.trading.trade_date_guard import is_cn_a_trade_date
 from freshquant.util.code import fq_util_code_append_market_code, normalize_to_base_code
 
 
@@ -74,6 +75,13 @@ def _resolve_etf_history_days(period: str, bar_count=0):
     return default_days
 
 
+def _filter_trade_date_realtime_rows(rows: pd.DataFrame) -> pd.DataFrame:
+    if rows is None or len(rows) == 0 or "datetime" not in rows.columns:
+        return rows
+    mask = rows["datetime"].apply(is_cn_a_trade_date)
+    return rows.loc[mask].copy()
+
+
 @in_memory_cache.memoize(expiration=3)
 def queryEtfCandleSticks(code: str, period: str, endDate=None, bar_count=0):
     if endDate is None or endDate == "":
@@ -105,7 +113,7 @@ def queryEtfCandleSticks(code: str, period: str, endDate=None, bar_count=0):
     elif period == "1w":
         candleSticks = queryEtfCandleSticksDay(code, start, end)
         candleSticks = QA_data_day_resample(candleSticks, "w")
-        candleSticks['time_stamp'] = candleSticks.index.to_series().apply(
+        candleSticks["time_stamp"] = candleSticks.index.to_series().apply(
             lambda value: value[0].timestamp()
         )
     if candleSticks is not None and bar_count and len(candleSticks) > int(bar_count):
@@ -139,13 +147,13 @@ def queryEtfCandleSticksDay(code, start=None, end=None):
     data = data[
         ["datetime", "open", "close", "high", "low", "volume", "amount", "time_stamp"]
     ]
-    last_datetime = data["datetime"][-1]
+    last_datetime = data["datetime"].iloc[-1]
     realtime_data_list = (
         DBfreshquant["index_realtime"]
         .find(
             {
                 "code": fq_util_code_append_market_code(code, upper_case=False),
-                "frequence": '1d',
+                "frequence": "1d",
                 "datetime": {"$gt": last_datetime, "$lte": end_dt},
                 "open": {"$gt": 0},
                 "high": {"$gt": 0},
@@ -156,6 +164,7 @@ def queryEtfCandleSticksDay(code, start=None, end=None):
         .sort("datetime", pymongo.ASCENDING)
     )
     realtime_data_list = pd.DataFrame(realtime_data_list)
+    realtime_data_list = _filter_trade_date_realtime_rows(realtime_data_list)
     if len(realtime_data_list) > 0:
         realtime_data_list["time_stamp"] = realtime_data_list["datetime"].apply(
             lambda value: QA_util_time_stamp(value)
@@ -230,7 +239,7 @@ def queryEtfCandleSticksMin(code, frequence, start=None, end=None):
     data = data[
         ["datetime", "open", "close", "high", "low", "volume", "amount", "time_stamp"]
     ]
-    last_datetime = data["datetime"][-1]
+    last_datetime = data["datetime"].iloc[-1]
     realtime_data_list = (
         DBfreshquant["index_realtime"]
         .find(
@@ -247,6 +256,7 @@ def queryEtfCandleSticksMin(code, frequence, start=None, end=None):
         .sort("datetime", pymongo.ASCENDING)
     )
     realtime_data_list = pd.DataFrame(realtime_data_list)
+    realtime_data_list = _filter_trade_date_realtime_rows(realtime_data_list)
     if len(realtime_data_list) > 0:
         realtime_data_list["time_stamp"] = realtime_data_list["datetime"].apply(
             lambda value: QA_util_time_stamp(value)

--- a/freshquant/tests/test_etf_data_fetch.py
+++ b/freshquant/tests/test_etf_data_fetch.py
@@ -1,0 +1,208 @@
+import importlib
+import sys
+from datetime import date, datetime
+from types import ModuleType
+
+import pandas as pd
+
+
+class _FakeCursor:
+    def __init__(self, documents):
+        self._documents = [dict(item) for item in documents]
+
+    def sort(self, field, order):
+        reverse = int(order) < 0
+        return sorted(
+            self._documents, key=lambda item: item.get(field), reverse=reverse
+        )
+
+    def __iter__(self):
+        return iter(self._documents)
+
+
+class _FakeCollection:
+    def __init__(self, documents):
+        self.documents = [dict(item) for item in documents]
+        self.queries = []
+
+    def find(self, query):
+        self.queries.append(query)
+        return _FakeCursor(
+            [document for document in self.documents if _matches_query(document, query)]
+        )
+
+
+class _FakeDB:
+    def __init__(self, collection):
+        self._collection = collection
+
+    def __getitem__(self, name):
+        assert name == "index_realtime"
+        return self._collection
+
+
+def _matches_query(document, query):
+    for key, expected in query.items():
+        value = document.get(key)
+        if isinstance(expected, dict):
+            for op, boundary in expected.items():
+                if op == "$gt" and not (value is not None and value > boundary):
+                    return False
+                if op == "$gte" and not (value is not None and value >= boundary):
+                    return False
+                if op == "$lte" and not (value is not None and value <= boundary):
+                    return False
+            continue
+        if value != expected:
+            return False
+    return True
+
+
+def _load_etf_module(monkeypatch):
+    quantaxis_module = ModuleType("QUANTAXIS")
+    quantaxis_module.QA_fetch_index_day_adv = lambda *args, **kwargs: None
+    quantaxis_module.QA_fetch_index_min_adv = lambda *args, **kwargs: None
+
+    qa_data_module = ModuleType("QUANTAXIS.QAData")
+    qa_resample_module = ModuleType("QUANTAXIS.QAData.data_resample")
+    qa_resample_module.QA_data_day_resample = lambda data, freq: data
+
+    qa_util_module = ModuleType("QUANTAXIS.QAUtil")
+    qa_date_module = ModuleType("QUANTAXIS.QAUtil.QADate")
+    qa_date_module.QA_util_datetime_to_strdatetime = lambda value: value.isoformat(
+        sep=" "
+    )
+    qa_date_module.QA_util_time_stamp = lambda _: 0
+
+    monkeypatch.setitem(sys.modules, "QUANTAXIS", quantaxis_module)
+    monkeypatch.setitem(sys.modules, "QUANTAXIS.QAData", qa_data_module)
+    monkeypatch.setitem(
+        sys.modules, "QUANTAXIS.QAData.data_resample", qa_resample_module
+    )
+    monkeypatch.setitem(sys.modules, "QUANTAXIS.QAUtil", qa_util_module)
+    monkeypatch.setitem(sys.modules, "QUANTAXIS.QAUtil.QADate", qa_date_module)
+
+    sys.modules.pop("freshquant.quote.general", None)
+    sys.modules.pop("freshquant.quote.etf", None)
+    return importlib.import_module("freshquant.quote.etf")
+
+
+def _build_min_dataframe():
+    return pd.DataFrame(
+        {
+            "open": [1.0],
+            "close": [1.1],
+            "high": [1.2],
+            "low": [0.9],
+            "volume": [1000],
+            "amount": [10000],
+        },
+        index=pd.Index([datetime(2026, 7, 3, 15, 0)], name="datetime"),
+    )
+
+
+def _build_day_dataframe():
+    return pd.DataFrame(
+        {
+            "open": [1.0],
+            "close": [1.1],
+            "high": [1.2],
+            "low": [0.9],
+            "volume": [1000],
+            "amount": [10000],
+        },
+        index=pd.Index([date(2026, 7, 3)], name="date"),
+    )
+
+
+def _realtime_bar(dt, frequence, close):
+    return {
+        "code": "sh512000",
+        "frequence": frequence,
+        "datetime": dt,
+        "open": close - 0.01,
+        "close": close,
+        "high": close + 0.01,
+        "low": close - 0.02,
+        "volume": 2000,
+        "amount": 22000,
+    }
+
+
+def _patch_common(monkeypatch, etf_module, collection):
+    monkeypatch.setattr(etf_module, "DBfreshquant", _FakeDB(collection))
+    monkeypatch.setattr(etf_module, "_fetch_etf_adj", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        etf_module,
+        "fq_util_code_append_market_code",
+        lambda code, upper_case=False: code if code.startswith("sh") else f"sh{code}",
+    )
+    monkeypatch.setattr(etf_module, "QA_util_time_stamp", lambda _: 0)
+    monkeypatch.setattr(
+        etf_module,
+        "QA_util_datetime_to_strdatetime",
+        lambda value: value.isoformat(sep=" "),
+    )
+    monkeypatch.setattr(
+        etf_module,
+        "is_cn_a_trade_date",
+        lambda value: pd.Timestamp(value).weekday() < 5,
+    )
+    monkeypatch.setattr(
+        etf_module,
+        "normalize_to_base_code",
+        lambda code: code[-6:],
+    )
+
+
+def test_query_etf_min_filters_non_trade_date_realtime_rows(monkeypatch):
+    etf_module = _load_etf_module(monkeypatch)
+    collection = _FakeCollection(
+        [
+            _realtime_bar(datetime(2026, 7, 4, 9, 35), "5min", 1.2),
+            _realtime_bar(datetime(2026, 7, 6, 9, 35), "5min", 1.3),
+        ]
+    )
+    _patch_common(monkeypatch, etf_module, collection)
+    monkeypatch.setattr(
+        etf_module,
+        "queryEftCandleSticksMinAdv",
+        lambda code, start, end, frequence: _build_min_dataframe(),
+    )
+
+    result = etf_module.queryEtfCandleSticksMin(
+        "512000",
+        "5min",
+        datetime(2026, 7, 3, 9, 30),
+        datetime(2026, 7, 6, 15, 0),
+    )
+
+    bars = set(pd.to_datetime(result["datetime"]).dt.strftime("%Y-%m-%d %H:%M"))
+    assert "2026-07-04 09:35" not in bars
+    assert "2026-07-06 09:35" in bars
+
+
+def test_query_etf_day_filters_non_trade_date_realtime_rows(monkeypatch):
+    etf_module = _load_etf_module(monkeypatch)
+    collection = _FakeCollection(
+        [
+            _realtime_bar(datetime(2026, 7, 4, 15, 0), "1d", 1.2),
+            _realtime_bar(datetime(2026, 7, 6, 15, 0), "1d", 1.3),
+        ]
+    )
+    _patch_common(monkeypatch, etf_module, collection)
+    monkeypatch.setattr(
+        etf_module,
+        "queryEtfCandleSticksDayAdv",
+        lambda code, start, end: _build_day_dataframe(),
+    )
+
+    result = etf_module.queryEtfCandleSticksDay(
+        "sh512000",
+        datetime(2026, 7, 3, 9, 30),
+        datetime(2026, 7, 6, 15, 0),
+    )
+
+    dates = set(pd.to_datetime(result["datetime"]).dt.strftime("%Y-%m-%d"))
+    assert "2026-07-04" not in dates
+    assert "2026-07-06" in dates


### PR DESCRIPTION
## Background

`/kline-slim` can render 2026-07-04 weekend bars for ETF symbols such as `sh512000` when `/api/stock_data` falls back to the ETF history path. Latest `main` already guards future xtdata non-trading writes and stock realtime merges, but the ETF/index `index_realtime` merge path still needed the same read-side trade-date guard.

Refs #452.

## Changes

- Filter non-trading realtime rows before ETF/index day and minute K-line merges.
- Use `.iloc[-1]` for ETF day/minute last bar lookup to match the stock path and avoid pandas positional-index ambiguity.
- Add ETF day/minute regression tests for weekend realtime rows.
- Update current XTData docs to include ETF/index K-line read-side filtering.

## Runtime cleanup already performed

- Created issue: https://github.com/dao1oad/fqpack-next/issues/452
- Backup artifact: `D:\fqpack\runtime\artifacts\kline-non-trade-cleanup\issue-452-20260704-20260706-103853.json`
- Mongo cleanup scope: local date `2026-07-04`, `source=xtdata`, collections `freshquant.index_realtime` and `freshquant.stock_realtime`.
- Deleted rows: `index_realtime=1560`, `stock_realtime=1872`.
- Post-delete verification: both scoped counts are `0`.
- Cleared `44` affected `CACHE:KLINE:<code>:<period>` Redis keys for impacted codes and periods.

## Validation

- `.\.venv\Scripts\python.exe -m black --check freshquant\quote\etf.py freshquant\tests\test_etf_data_fetch.py`
- `.\.venv\Scripts\python.exe -m pytest freshquant\tests\test_etf_data_fetch.py freshquant\tests\test_trade_date_guard.py freshquant\tests\test_stock_data_fetch.py freshquant\tests\test_xtdata_strategy_consumer_history.py`
  - `15 passed`
  - Windows emitted the known ignored pytest temp symlink cleanup `PermissionError` after the passing result.
- `git diff --check`
- Direct runtime DB query with current branch code: `queryEtfCandleSticks('sh512000', '5m')` returned `0` bars on `2026-07-04`.
- Live API after data cleanup:
  - `/api/stock_data?period=5m&symbol=sh512000&barCount=20000`: `h0704=0`, last `2026-07-06 10:35`
  - same with `realtimeCache=1`: `h0704=0`, last `2026-07-06 10:35`

## Local validation gap

- `pre_commit` is not installed in the current `.venv`, so local pre-commit hook execution was not available. CI should run the formal hooks.

## Deployment impact

- API server redeploy is required after merge because `freshquant/quote/etf.py` changes `/api/stock_data` behavior for ETF/index symbols.
- No frontend build is required for this PR.
