### PR TITLE
fix: enforce Dagster market data integrity

### DIFF
--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -182,4 +182,6 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
 - `trade_calendar_postclose_refresh_schedule` runs at `15:10` Asia/Shanghai on weekdays.
 - A successful live Sina/AkShare refresh updates Mongo and the shared disk snapshot under `FQ_TRADE_CALENDAR_STATE_DIR`.
 - When a live refresh fails, FreshQuant falls back to Mongo last-known-good first, then the disk snapshot; the Dagster asset reports `refresh_status` and `degraded` so a cache-served refresh is visible without failing the run.
+- Dagster run monitoring allows two crash-resume attempts. `stock_data_job` and `etf_data_job` carry an eight-hour per-run limit because full daily/minute/xdxr recovery can exceed the global five-hour default, and each job limits automatic failed-run retries to two so a persistent upstream failure cannot create a long retry chain.
+- `stock_postclose_ready` is emitted only after the latest 15 trade dates pass a cross-collection audit between `stock_day` and all five `stock_min` frequencies for the current stock universe.
 - Stock, ETF, Gantt, and daily-screening date resolution read the shared FreshQuant trade calendar entry, which falls back to Mongo last-known-good data and then the disk snapshot when the live Sina/AkShare request fails.

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -562,13 +562,15 @@ docker exec fqnext_20260223-fq_mongodb-1 mongosh --quiet --eval 'const c=db.getS
 
 - 宿主机开启 sing-box/v2rayN 等 TUN 全局代理后，Docker 容器到 TDX 行情端口(7709)的流量被劫持出海外；部分 TDX 服务器直接拒绝(`head_buf is not 0x10`)，其余延迟升到 2~3 秒
 - 旧实现 ping 探活超时 0.7 秒且只测证券列表接口，坏服务器（列表接口正常、K 线接口损坏）会持续通过健康检查，好服务器全部被误判超时，永远切换不出去
-- `QA_SU_save_stock_day` / `QA_SU_save_stock_min` 把逐票异常吞进 `err` 列表只打印，asset 不失败，Dagster 呈现假成功
+- 旧版 `QA_SU_save_stock_day` / `QA_SU_save_stock_min` 把逐票异常吞进 `err` 列表只打印，asset 不失败，Dagster 呈现假成功
 
 处理：
 
-- TDX 行情服务器列表由仓库内 `freshquant/gateway/tdx_ip_pool.json` 人工维护（`QUANTAXIS.QAUtil.QAIPPool` 加载，优先于 `~/.quantaxis/setting/*_ip.json` 缓存）；服务器批量失效时更新该 JSON 即可
+- TDX 行情服务器列表由仓库内 `freshquant/gateway/tdx_ip_pool.json` 人工维护（`QUANTAXIS.QAUtil.QAIPPool` 加载，优先于 `~/.quantaxis/setting/*_ip.json` 缓存）；股票日线、分钟线与 ETF xdxr 都使用这份正式池，服务器批量失效时更新该 JSON 即可
 - 当前 `QATdx.ping` 已加 K 线接口探活并把连接超时放宽到 3 秒；`select_best_ip` 判定阈值同步放宽，坏 default 服务器会被自动淘汰重选
-- 当前 Dagster `stock_day` / `stock_min` asset 落库后会做数据新鲜度断言（样本蓝筹全部落后或当日文档数过低即 fail），行情停更时 run 会真实失败，不再假成功
+- 当前股票日线/分钟线逐票抓取会在首选 host 返回异常、`None` 或源侧空响应时切换仓库 IP 池；旧 QASU 即使继续收集逐票错误，最终 ready asset 的跨集合审计也会阻断假成功 marker
+- 当前 Dagster `stock_day` / `stock_min` asset 落库后仍做基础新鲜度断言；`stock_postclose_ready_asset` 写 marker 前还会交叉审计最近 15 个交易日的当前股票日线与 `1min/5min/15min/30min/60min` 覆盖，任一确定性缺口都会 fail
+- Dagster run monitoring 允许最多 2 次 crash resume；股票与 ETF 长任务通过 job tag 把单次最长运行时间设为 8 小时，并把自动失败重试限制为 2 次。容器重启后仍需确认 compute log 继续增长，不能只看 UI 的 `STARTED`
 - 宿主机代理软件建议启用"绕过中国大陆"分流或在使用系统链路时关闭 TUN 模式；即使代理未关，修复后的选点/超时也能在慢链路下工作
 - 补缺口：直接在 Dagster UI 手动 launch 一次 `stock_data_job`（增量逻辑按"库内最后日期 → 今天"自动回补），完成后核对 `stock_day` / `stock_min` 的 `max(date)`
 

--- a/freshquant/data/etf_adj_sync.py
+++ b/freshquant/data/etf_adj_sync.py
@@ -17,6 +17,7 @@ from pymongo.errors import (
 
 from freshquant.data.etf_adj import compute_etf_qfq_adj
 from freshquant.db import DBQuantAxis
+from freshquant.gateway.tdx_ip_pool import load_tdx_ip_pool
 
 _CATEGORY_MEANING = {
     1: "除权除息",
@@ -43,6 +44,19 @@ class TdxHqHost:
     port: int
 
 
+def _repo_hq_hosts() -> list[TdxHqHost]:
+    hosts = []
+    for item in load_tdx_ip_pool("stock") or []:
+        hosts.append(
+            TdxHqHost(
+                name=str(item.get("name") or "repo-pool"),
+                ip=str(item["ip"]),
+                port=int(item.get("port") or 7709),
+            )
+        )
+    return hosts
+
+
 def _import_pytdx():
     try:
         from pytdx.config.hosts import hq_hosts  # type: ignore
@@ -62,12 +76,18 @@ def _import_pytdx():
 
 
 def _pick_hq_host(
-    timeout: float = 0.7,
+    timeout: float = 3.0,
     *,
     exclude_hosts: Optional[set[tuple[str, int]]] = None,
 ) -> TdxHqHost:
-    TdxHq_API, hq_hosts = _import_pytdx()
+    TdxHq_API, pytdx_hq_hosts = _import_pytdx()
     api = TdxHq_API()
+    repo_hosts = _repo_hq_hosts()
+    hq_hosts = (
+        [(host.name, host.ip, host.port) for host in repo_hosts]
+        if repo_hosts
+        else pytdx_hq_hosts
+    )
     for name, ip, port in hq_hosts:
         if exclude_hosts and (ip, int(port)) in exclude_hosts:
             continue
@@ -78,7 +98,7 @@ def _pick_hq_host(
                 return TdxHqHost(name=name, ip=ip, port=int(port))
         except Exception:
             continue
-    raise RuntimeError("No reachable TDX HQ host found in pytdx.config.hosts.hq_hosts")
+    raise RuntimeError("No reachable TDX HQ host found in canonical host pool")
 
 
 def _market_from_sse_or_code(*, sse: str | None, code: str) -> int:
@@ -303,7 +323,7 @@ def sync_etf_xdxr_all(
     *,
     db=DBQuantAxis,
     codes: Optional[Iterable[str]] = None,
-    timeout: float = 0.7,
+    timeout: float = 3.0,
     preserve_on_empty: bool = True,
     reconnect_every: int = 200,
 ) -> dict:
@@ -468,7 +488,7 @@ def audit_recent_etf_xdxr_coverage(
     *,
     db=DBQuantAxis,
     codes: Optional[Iterable[str]] = None,
-    timeout: float = 0.7,
+    timeout: float = 3.0,
     reconnect_every: int = 200,
     recent_days: int = 120,
     as_of_date: str | None = None,

--- a/freshquant/gateway/tdx_ip_pool.py
+++ b/freshquant/gateway/tdx_ip_pool.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_DEFAULT_PORTS = {"stock": 7709, "future": 7727}
+_POOL_PATH = Path(__file__).with_name("tdx_ip_pool.json")
+
+
+def load_tdx_ip_pool(
+    kind: str, pool_path: str | Path | None = None
+) -> list[dict] | None:
+    path = Path(pool_path) if pool_path is not None else _POOL_PATH
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    default_port = _DEFAULT_PORTS.get(str(kind), 7709)
+    hosts = []
+    for item in payload.get(str(kind)) or []:
+        if not isinstance(item, dict):
+            continue
+        ip = str(item.get("ip") or "").strip()
+        if not ip:
+            continue
+        try:
+            port = int(item.get("port") or default_port)
+        except (TypeError, ValueError):
+            port = default_port
+        host = {"ip": ip, "port": port}
+        name = str(item.get("name") or "").strip()
+        if name:
+            host["name"] = name
+        hosts.append(host)
+    return hosts or None

--- a/freshquant/tests/test_etf_adj_sync.py
+++ b/freshquant/tests/test_etf_adj_sync.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import Any
 
 import pandas as pd
@@ -121,6 +120,9 @@ class FakeTdxApi:
             )
         return outcome
 
+    def disconnect(self):
+        return None
+
     def __enter__(self):
         return self
 
@@ -154,6 +156,40 @@ class FakeTdxApi:
         if not raw:
             return pd.DataFrame()
         return pd.DataFrame(raw)
+
+
+def test_repo_hq_hosts_use_canonical_tdx_ip_pool(monkeypatch):
+    monkeypatch.setattr(
+        etf_adj_sync,
+        "load_tdx_ip_pool",
+        lambda kind: [
+            {"ip": "10.0.0.1", "port": 7709, "name": "primary"},
+            {"ip": "10.0.0.2", "port": 7710},
+        ],
+    )
+
+    assert etf_adj_sync._repo_hq_hosts() == [
+        etf_adj_sync.TdxHqHost("primary", "10.0.0.1", 7709),
+        etf_adj_sync.TdxHqHost("repo-pool", "10.0.0.2", 7710),
+    ]
+
+
+def test_pick_hq_host_prefers_canonical_pool_over_pytdx_defaults(monkeypatch):
+    monkeypatch.setattr(
+        etf_adj_sync,
+        "load_tdx_ip_pool",
+        lambda kind: [{"ip": "10.0.0.2", "port": 7709, "name": "canonical"}],
+    )
+    monkeypatch.setattr(
+        etf_adj_sync,
+        "_import_pytdx",
+        lambda: (FakeTdxApi, [("legacy", "192.0.2.1", 7709)]),
+    )
+    FakeTdxApi.connect_outcome_by_endpoint = {}
+
+    assert etf_adj_sync._pick_hq_host() == etf_adj_sync.TdxHqHost(
+        "canonical", "10.0.0.2", 7709
+    )
 
 
 def test_sync_etf_xdxr_all_preserves_existing_docs_when_source_returns_empty(

--- a/freshquant/tests/test_market_data_assets.py
+++ b/freshquant/tests/test_market_data_assets.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -480,13 +481,42 @@ def test_stock_postclose_ready_asset_depends_on_quality_snapshot(monkeypatch):
     module = _import_market_data_module(monkeypatch)
 
     assert module.stock_postclose_ready_asset.dependency_names == [
-        "refresh_quality_stock_universe_snapshot"
+        "refresh_quality_stock_universe_snapshot",
+        "stock_day",
+        "stock_min",
     ]
+
+
+def test_stock_assets_raise_when_quantaxis_reports_partial_failures(monkeypatch):
+    module = _import_market_data_module(monkeypatch)
+    context = SimpleNamespace(log=FakeLog())
+
+    def report_failure(code, result):
+        def sync(*_):
+            logging.warning("ERROR CODE")
+            logging.warning([code])
+            return result
+
+        return sync
+
+    monkeypatch.setattr(module, "QA_SU_save_stock_day", report_failure("000065", True))
+    monkeypatch.setattr(module, "QA_SU_save_stock_min", report_failure("002390", None))
+
+    with pytest.raises(RuntimeError, match="stock_day sync failed.*000065"):
+        module.stock_day(context, "2026-07-20 16:00:00")
+    with pytest.raises(RuntimeError, match="stock_min sync failed.*002390"):
+        module.stock_min(context, "2026-07-20 16:00:00")
 
 
 def test_stock_postclose_ready_asset_writes_marker(monkeypatch):
     module = _import_market_data_module(monkeypatch)
     calls = []
+
+    monkeypatch.setattr(
+        module,
+        "assert_stock_market_data_consistent",
+        lambda: {"audited_dates": ["2026-03-19"]},
+    )
 
     monkeypatch.setattr(
         module,
@@ -513,6 +543,8 @@ def test_stock_postclose_ready_asset_writes_marker(monkeypatch):
             "source_version": "xgt_hot_blocks_v1",
             "count": 18,
         },
+        "2026-03-19 16:00:00",
+        "2026-03-19 16:05:00",
     )
 
     assert calls == [
@@ -523,6 +555,7 @@ def test_stock_postclose_ready_asset_writes_marker(monkeypatch):
             "payload": {
                 "count": 18,
                 "source_version": "xgt_hot_blocks_v1",
+                "integrity_audited_dates": ["2026-03-19"],
             },
         }
     ]

--- a/freshquant/tests/test_market_data_freshness.py
+++ b/freshquant/tests/test_market_data_freshness.py
@@ -134,6 +134,26 @@ def _complete_etf_min_counts() -> dict[str, int]:
     return {"1min": 240, "5min": 48, "15min": 16, "30min": 8, "60min": 4}
 
 
+class FakeIntegrityCollection:
+    def __init__(self, *, distinct_values=None, aggregate_rows=None):
+        self.distinct_values = distinct_values or {}
+        self.aggregate_rows = list(aggregate_rows or [])
+        self.aggregate_pipelines = []
+
+    def distinct(self, field, query=None):
+        key = (field, str((query or {}).get("date") or ""))
+        return list(self.distinct_values.get(key, self.distinct_values.get(field, [])))
+
+    def aggregate(self, pipeline, **kwargs):
+        self.aggregate_pipelines.append((pipeline, kwargs))
+        selected_codes = set(pipeline[0]["$match"]["code"]["$in"])
+        return [
+            row
+            for row in self.aggregate_rows
+            if str(row["_id"]["code"]) in selected_codes
+        ]
+
+
 def test_stock_day_fresh_passes():
     module = _load_module()
     collection = FakeDayCollection(
@@ -343,4 +363,85 @@ def test_etf_min_invalid_bar_count_raises():
             min_day_docs=1,
             min_real_codes=1,
             min_universe_codes=1,
+        )
+
+
+def test_stock_market_data_consistency_passes_for_all_frequencies():
+    module = _load_module()
+    dates = ["2026-07-17", "2026-07-20"]
+    codes = ["000001", "600000"]
+    day = FakeIntegrityCollection(
+        distinct_values={
+            "date": dates,
+            ("code", "2026-07-17"): codes,
+            ("code", "2026-07-20"): codes,
+        }
+    )
+    stock_list = FakeIntegrityCollection(distinct_values={"code": codes})
+    rows = []
+    for date in dates:
+        for code in codes:
+            for frequence in module.STOCK_MIN_FREQUENCIES:
+                rows.append({"_id": {"date": date, "code": code, "type": frequence}})
+    minute = FakeIntegrityCollection(aggregate_rows=rows)
+
+    result = module.assert_stock_market_data_consistent(
+        day_collection=day,
+        min_collection=minute,
+        stock_list_collection=stock_list,
+        expected_trade_date="2026-07-20",
+        trade_dates_provider=lambda: dates,
+    )
+
+    assert result["audited_dates"] == dates
+    assert result["day_codes"] == {"2026-07-17": 2, "2026-07-20": 2}
+    assert minute.aggregate_pipelines
+
+
+def test_stock_market_data_consistency_rejects_day_and_minute_holes():
+    module = _load_module()
+    date = "2026-07-20"
+    day = FakeIntegrityCollection(
+        distinct_values={"date": [date], ("code", date): ["000001", "600000"]}
+    )
+    stock_list = FakeIntegrityCollection(
+        distinct_values={"code": ["000001", "600000", "600519"]}
+    )
+    rows = []
+    for frequence in module.STOCK_MIN_FREQUENCIES:
+        rows.append({"_id": {"date": date, "code": "000001", "type": frequence}})
+        rows.append({"_id": {"date": date, "code": "600519", "type": frequence}})
+    rows.append({"_id": {"date": date, "code": "600000", "type": "1min"}})
+    minute = FakeIntegrityCollection(aggregate_rows=rows)
+
+    with pytest.raises(RuntimeError, match="missing_day=1.*missing_min"):
+        module.assert_stock_market_data_consistent(
+            day_collection=day,
+            min_collection=minute,
+            stock_list_collection=stock_list,
+            expected_trade_date=date,
+            trade_dates_provider=lambda: [date],
+        )
+
+
+def test_stock_market_data_consistency_rejects_fully_missing_trade_date():
+    module = _load_module()
+    dates = ["2026-07-17", "2026-07-20"]
+    codes = ["000001", "600000"]
+    day = FakeIntegrityCollection(distinct_values={("code", "2026-07-20"): codes})
+    stock_list = FakeIntegrityCollection(distinct_values={"code": codes})
+    rows = [
+        {"_id": {"date": "2026-07-20", "code": code, "type": frequence}}
+        for code in codes
+        for frequence in module.STOCK_MIN_FREQUENCIES
+    ]
+    minute = FakeIntegrityCollection(aggregate_rows=rows)
+
+    with pytest.raises(RuntimeError, match="missing_market_days=1"):
+        module.assert_stock_market_data_consistent(
+            day_collection=day,
+            min_collection=minute,
+            stock_list_collection=stock_list,
+            expected_trade_date="2026-07-20",
+            trade_dates_provider=lambda: dates,
         )

--- a/freshquant/tests/test_market_data_schedules.py
+++ b/freshquant/tests/test_market_data_schedules.py
@@ -1,0 +1,52 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+def _prepare_schedule_import(monkeypatch):
+    project_src = (
+        Path(__file__).resolve().parents[2] / "morningglory" / "fqdagster" / "src"
+    )
+    monkeypatch.syspath_prepend(str(project_src))
+
+    class FakeSelection:
+        @classmethod
+        def assets(cls, *assets):
+            return cls()
+
+        @classmethod
+        def groups(cls, *groups):
+            return cls()
+
+        def downstream(self):
+            return self
+
+        def __sub__(self, other):
+            return self
+
+    dagster = ModuleType("dagster")
+    dagster.AssetSelection = FakeSelection
+    dagster.DefaultScheduleStatus = SimpleNamespace(RUNNING="RUNNING")
+    dagster.ScheduleDefinition = lambda **kwargs: SimpleNamespace(**kwargs)
+    dagster.define_asset_job = lambda **kwargs: SimpleNamespace(**kwargs)
+    monkeypatch.setitem(sys.modules, "dagster", dagster)
+
+    assets = ModuleType("fqdagster.defs.assets.market_data")
+    for name in ("bond_list", "etf_list", "future_list", "index_list", "stock_list"):
+        setattr(assets, name, SimpleNamespace(name=name))
+    monkeypatch.setitem(sys.modules, "fqdagster.defs.assets.market_data", assets)
+    sys.modules.pop("fqdagster.defs.schedules.market_data", None)
+
+
+def test_stock_and_etf_jobs_bound_runtime_and_failed_run_retries(monkeypatch):
+    _prepare_schedule_import(monkeypatch)
+    module = importlib.import_module("fqdagster.defs.schedules.market_data")
+
+    expected_tags = {
+        "dagster/max_concurrent_runs": "1",
+        "dagster/max_retries": "2",
+        "dagster/max_runtime": "28800",
+    }
+    assert module.stock_data_job.tags == expected_tags
+    assert module.etf_data_job.tags == expected_tags

--- a/freshquant/tests/test_quantaxis_stock_sync_resilience.py
+++ b/freshquant/tests/test_quantaxis_stock_sync_resilience.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "sunflower"
+    / "QUANTAXIS"
+    / "QUANTAXIS"
+    / "QAFetch"
+    / "QATdx.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("save_tdx_under_test", _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stock_fetch_failover_moves_to_next_repo_host(monkeypatch):
+    module = _load_module()
+    monkeypatch.setattr(module, "get_mainmarket_ip", lambda *_: ("10.0.0.1", 7709))
+    monkeypatch.setattr(
+        module,
+        "stock_ip_list",
+        [
+            {"ip": "10.0.0.1", "port": 7709},
+            {"ip": "10.0.0.2", "port": 7709},
+        ],
+    )
+    calls = []
+
+    def fetcher(*args, ip=None, port=None, **kwargs):
+        calls.append((ip, port))
+        if ip == "10.0.0.1":
+            return None
+        return pd.DataFrame([{"code": "000001"}])
+
+    result = module._fetch_stock_bars_with_failover(fetcher, "000001")
+
+    assert len(result) == 1
+    assert calls == [("10.0.0.1", 7709), ("10.0.0.2", 7709)]
+
+
+def test_stock_fetch_failover_accepts_filtered_empty_result(monkeypatch):
+    module = _load_module()
+    monkeypatch.setattr(module, "get_mainmarket_ip", lambda *_: ("10.0.0.1", 7709))
+    monkeypatch.setattr(
+        module,
+        "stock_ip_list",
+        [{"ip": "10.0.0.1", "port": 7709}, {"ip": "10.0.0.2", "port": 7709}],
+    )
+    calls = []
+
+    def fetcher(*args, ip=None, port=None, **kwargs):
+        calls.append((ip, port))
+        return pd.DataFrame()
+
+    result = module._fetch_stock_bars_with_failover(fetcher, "000001")
+
+    assert result.empty
+    assert calls == [("10.0.0.1", 7709)]
+
+
+def test_stock_fetch_failover_raises_when_all_hosts_fail(monkeypatch):
+    module = _load_module()
+    monkeypatch.setattr(module, "get_mainmarket_ip", lambda *_: ("10.0.0.1", 7709))
+    monkeypatch.setattr(
+        module,
+        "stock_ip_list",
+        [{"ip": "10.0.0.1", "port": 7709}, {"ip": "10.0.0.2", "port": 7709}],
+    )
+
+    with pytest.raises(RuntimeError, match="all TDX stock hosts failed"):
+        module._fetch_stock_bars_with_failover(
+            lambda *args, **kwargs: (_ for _ in ()).throw(TimeoutError("timeout")),
+            "000001",
+        )

--- a/freshquant/tests/test_tdx_ip_pool.py
+++ b/freshquant/tests/test_tdx_ip_pool.py
@@ -14,10 +14,21 @@ _MODULE_PATH = (
     _REPO_ROOT / "sunflower" / "QUANTAXIS" / "QUANTAXIS" / "QAUtil" / "QAIPPool.py"
 )
 _POOL_PATH = _REPO_ROOT / "freshquant" / "gateway" / "tdx_ip_pool.json"
+_FRESHQUANT_MODULE_PATH = _REPO_ROOT / "freshquant" / "gateway" / "tdx_ip_pool.py"
 
 
 def _load_module():
     spec = importlib.util.spec_from_file_location("qa_ip_pool_under_test", _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_freshquant_module():
+    spec = importlib.util.spec_from_file_location(
+        "freshquant_tdx_ip_pool_under_test", _FRESHQUANT_MODULE_PATH
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -33,6 +44,16 @@ def test_repo_pool_file_exists_and_loads():
     for host in stock_hosts + future_hosts:
         assert host["ip"]
         assert isinstance(host["port"], int)
+
+
+def test_freshquant_loader_reads_same_canonical_pool():
+    module = _load_freshquant_module()
+
+    stock_hosts = module.load_tdx_ip_pool("stock")
+    future_hosts = module.load_tdx_ip_pool("future")
+
+    assert stock_hosts
+    assert future_hosts
 
 
 def test_locate_pool_file_resolves_repo_json():

--- a/morningglory/fqdagster/src/fqdagster/defs/assets/market_data.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/assets/market_data.py
@@ -4,6 +4,7 @@ This module replaces the traditional op/job pattern with assets that have clear 
 Each data type (stock, future, etf, bond, index) has its own set of assets with proper dependencies.
 """
 
+import logging
 import os
 import uuid
 from pathlib import Path
@@ -46,6 +47,7 @@ from .market_data_freshness import (
     assert_etf_day_fresh,
     assert_etf_min_fresh,
     assert_stock_day_fresh,
+    assert_stock_market_data_consistent,
     assert_stock_min_fresh,
 )
 from .postclose_ready import refresh_quality_stock_universe_snapshot
@@ -66,6 +68,38 @@ LOCAL_TDX_ROOT_CANDIDATES = (
     r"D:\通达信",
     r"C:\通达信",
 )
+
+
+class _QasuFailureCapture(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self._awaiting_codes = False
+        self.failed_codes: list[str] = []
+
+    def emit(self, record):
+        message = record.msg
+        if isinstance(message, str) and "ERROR CODE" in message:
+            self._awaiting_codes = True
+            return
+        if self._awaiting_codes and isinstance(message, list):
+            self.failed_codes.extend(str(code) for code in message)
+
+
+def _run_qasu_stock_sync(sync_name: str, sync_function) -> None:
+    capture = _QasuFailureCapture()
+    root_logger = logging.getLogger()
+    root_logger.addHandler(capture)
+    try:
+        sync_function("tdx")
+    finally:
+        root_logger.removeHandler(capture)
+
+    failed_codes = list(dict.fromkeys(capture.failed_codes))
+    if failed_codes:
+        raise RuntimeError(
+            f"{sync_name} sync failed for {len(failed_codes)} codes: "
+            f"{failed_codes[:20]}"
+        )
 
 
 def _normalize_stock_block_docs(documents, source: str):
@@ -388,9 +422,8 @@ def stock_day(context: AssetExecutionContext, stock_list: str) -> str:
     context.log.info(
         f"Saving stock daily data, triggered after stock_list at {stock_list}"
     )
-    QA_SU_save_stock_day("tdx")
-    # QA_SU_save_stock_day 会吞掉逐票抓取异常; 这里直接断言库内数据已覆盖
-    # 最新交易日, 上游 TDX 故障时让 asset 真实失败, 不再假成功
+    _run_qasu_stock_sync("stock_day", QA_SU_save_stock_day)
+    # 采集入口会抛出逐票失败; 这里再断言库内数据已覆盖最新交易日。
     freshness = assert_stock_day_fresh()
     context.log.info(f"stock_day freshness check passed: {freshness}")
     market_data_alert.send(
@@ -409,7 +442,7 @@ def stock_min(context: AssetExecutionContext, stock_list: str) -> str:
     context.log.info(
         f"Saving stock minute data, triggered after stock_list at {stock_list}"
     )
-    QA_SU_save_stock_min("tdx")
+    _run_qasu_stock_sync("stock_min", QA_SU_save_stock_min)
     # 与 stock_day 相同: 断言分钟线已覆盖最新交易日, 消灭假成功
     freshness = assert_stock_min_fresh()
     context.log.info(f"stock_min freshness check passed: {freshness}")
@@ -444,16 +477,21 @@ def stock_xdxr(context: AssetExecutionContext, stock_day: str) -> str:
 def stock_postclose_ready_asset(
     context: AssetExecutionContext,
     refresh_quality_stock_universe_snapshot: dict,
+    stock_day: str,
+    stock_min: str,
 ) -> dict:
     trade_date = (
         str(refresh_quality_stock_universe_snapshot.get("trade_date") or "")
         or resolve_latest_completed_trade_date()
     )
+    integrity = assert_stock_market_data_consistent()
+    context.log.info(f"stock market integrity check passed: {integrity}")
     payload = {
         "count": int(refresh_quality_stock_universe_snapshot.get("count") or 0),
         "source_version": str(
             refresh_quality_stock_universe_snapshot.get("source_version") or ""
         ).strip(),
+        "integrity_audited_dates": list(integrity.get("audited_dates") or []),
     }
     upsert_postclose_marker(
         "stock_postclose_ready",

--- a/morningglory/fqdagster/src/fqdagster/defs/assets/market_data_freshness.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/assets/market_data_freshness.py
@@ -17,16 +17,26 @@ QUANTAXIS 的 ``QA_SU_save_stock_day`` / ``QA_SU_save_stock_min`` 会把逐票�
 
 from __future__ import annotations
 
+import datetime as dt
 from collections import Counter
 from datetime import datetime, timedelta
 from types import MappingProxyType
-from typing import Mapping, Sequence
+from typing import Callable, Mapping, Sequence
 from zoneinfo import ZoneInfo
 
 # 大盘蓝筹样本: 平安银行 / 浦发银行 / 贵州茅台
 FRESHNESS_SAMPLE_CODES: tuple[str, ...] = ("000001", "600000", "600519")
 # 全市场约 5200 只, 正常交易日 stock_day 当日文档数约 5190(停牌股无 bar)
 STOCK_DAY_MIN_DOCS = 3000
+STOCK_MIN_FREQUENCIES: tuple[str, ...] = (
+    "1min",
+    "5min",
+    "15min",
+    "30min",
+    "60min",
+)
+STOCK_INTEGRITY_LOOKBACK_TRADE_DAYS = 15
+STOCK_INTEGRITY_CODE_CHUNK_SIZE = 250
 
 # ETF 全市场约 1675 只, 正常交易日 index_day 当日文档数约 1650。
 ETF_DAY_MIN_DOCS = 1000
@@ -363,4 +373,161 @@ def assert_etf_min_fresh(
         "placeholder_sample": placeholder_codes[:10],
         "frequencies": list(requested_frequencies),
         "checked_groups": checked_groups,
+    }
+
+
+def _date_start_stamp(value: str) -> int:
+    parsed = dt.date.fromisoformat(str(value)[:10])
+    midnight = dt.datetime.combine(
+        parsed,
+        dt.time.min,
+        tzinfo=ZoneInfo("Asia/Shanghai"),
+    )
+    return int(midnight.timestamp())
+
+
+def _chunks(values: Sequence[str], size: int):
+    for start in range(0, len(values), size):
+        yield values[start : start + size]
+
+
+def _default_stock_integrity_trade_dates() -> Sequence[object]:
+    from freshquant.data.trade_date_hist import tool_trade_date_hist_sina
+
+    return list(tool_trade_date_hist_sina()["trade_date"])
+
+
+def assert_stock_market_data_consistent(
+    day_collection=None,
+    min_collection=None,
+    stock_list_collection=None,
+    *,
+    expected_trade_date: str | None = None,
+    lookback_trade_days: int = STOCK_INTEGRITY_LOOKBACK_TRADE_DAYS,
+    frequencies: Sequence[str] = STOCK_MIN_FREQUENCIES,
+    code_chunk_size: int = STOCK_INTEGRITY_CODE_CHUNK_SIZE,
+    trade_dates_provider: Callable[[], Sequence[object]] | None = None,
+) -> dict:
+    """Cross-check recent stock daily bars against every minute frequency.
+
+    ``stock_min`` is intentionally queried through its existing
+    ``(code, time_stamp, date_stamp)`` index in bounded code chunks. This keeps
+    the audit proportional to the recent window instead of scanning the full
+    collection.
+    """
+    day_coll = (
+        day_collection
+        if day_collection is not None
+        else _default_collection("stock_day")
+    )
+    min_coll = (
+        min_collection
+        if min_collection is not None
+        else _default_collection("stock_min")
+    )
+    list_coll = (
+        stock_list_collection
+        if stock_list_collection is not None
+        else _default_collection("stock_list")
+    )
+    expected = expected_trade_date or resolve_expected_trade_date()
+
+    provider = trade_dates_provider or _default_stock_integrity_trade_dates
+    calendar_dates = sorted(
+        {str(value)[:10] for value in provider() if str(value)[:10] <= expected}
+    )
+    audited_dates = calendar_dates[-max(int(lookback_trade_days), 1) :]
+    if not audited_dates or audited_dates[-1] != expected:
+        raise RuntimeError(
+            f"stock market integrity audit has no daily data for {expected}"
+        )
+
+    universe = sorted(
+        {str(code) for code in list_coll.distinct("code") if str(code).strip()}
+    )
+    if not universe:
+        raise RuntimeError("stock market integrity audit found an empty stock_list")
+
+    day_codes_by_date = {
+        trade_date: {
+            str(code)
+            for code in day_coll.distinct(
+                "code",
+                {"date": trade_date, "code": {"$in": universe}},
+            )
+        }
+        for trade_date in audited_dates
+    }
+    minute_codes_by_date: dict[str, dict[str, set[str]]] = {
+        trade_date: {str(frequence): set() for frequence in frequencies}
+        for trade_date in audited_dates
+    }
+    start_stamp = _date_start_stamp(audited_dates[0])
+    end_stamp = _date_start_stamp(expected) + 86400
+
+    for code_chunk in _chunks(universe, max(int(code_chunk_size), 1)):
+        pipeline = [
+            {
+                "$match": {
+                    "code": {"$in": list(code_chunk)},
+                    "time_stamp": {"$gte": start_stamp, "$lt": end_stamp},
+                    "type": {"$in": list(frequencies)},
+                }
+            },
+            {"$group": {"_id": {"date": "$date", "code": "$code", "type": "$type"}}},
+        ]
+        for row in min_coll.aggregate(pipeline, allowDiskUse=True):
+            identity = row.get("_id") or {}
+            trade_date = str(identity.get("date") or "")[:10]
+            code = str(identity.get("code") or "")
+            frequence = str(identity.get("type") or "")
+            date_frequencies = minute_codes_by_date.get(trade_date)
+            if date_frequencies is not None and frequence in date_frequencies:
+                date_frequencies[frequence].add(code)
+
+    issues = []
+    missing_market_day_total = 0
+    missing_day_total = 0
+    missing_min_total = 0
+    for trade_date in audited_dates:
+        day_codes = day_codes_by_date[trade_date]
+        minute_by_frequency = minute_codes_by_date[trade_date]
+        minute_union = set().union(*minute_by_frequency.values())
+        missing_market_day = not day_codes and not minute_union
+        missing_day = sorted(minute_union - day_codes)
+        missing_min = {
+            frequence: sorted(day_codes - minute_by_frequency[str(frequence)])
+            for frequence in frequencies
+            if day_codes - minute_by_frequency[str(frequence)]
+        }
+        missing_market_day_total += int(missing_market_day)
+        missing_day_total += len(missing_day)
+        missing_min_total += sum(len(codes) for codes in missing_min.values())
+        if missing_market_day or missing_day or missing_min:
+            issues.append(
+                {
+                    "date": trade_date,
+                    "missing_market_day": missing_market_day,
+                    "missing_day": missing_day[:20],
+                    "missing_min": {
+                        key: value[:20] for key, value in missing_min.items()
+                    },
+                }
+            )
+
+    if issues:
+        raise RuntimeError(
+            "stock market integrity audit failed: "
+            f"missing_market_days={missing_market_day_total} "
+            f"missing_day={missing_day_total} missing_min={missing_min_total}; "
+            f"issues={issues[:5]}"
+        )
+
+    return {
+        "expected_trade_date": expected,
+        "audited_dates": audited_dates,
+        "universe_codes": len(universe),
+        "day_codes": {
+            trade_date: len(codes) for trade_date, codes in day_codes_by_date.items()
+        },
     }

--- a/morningglory/fqdagster/src/fqdagster/defs/schedules/market_data.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/schedules/market_data.py
@@ -32,7 +32,11 @@ stock_data_job = define_asset_job(
         AssetSelection.assets(stock_list).downstream()
         - AssetSelection.groups("cjsd_data")
     ),
-    tags={"dagster/max_concurrent_runs": "1"},
+    tags={
+        "dagster/max_concurrent_runs": "1",
+        "dagster/max_retries": "2",
+        "dagster/max_runtime": "28800",
+    },
 )
 
 future_data_job = define_asset_job(
@@ -46,7 +50,11 @@ etf_data_job = define_asset_job(
     name="etf_data_job",
     description="Materialize ETF data assets starting from etf_list",
     selection=AssetSelection.assets(etf_list).downstream(),
-    tags={"dagster/max_concurrent_runs": "1"},
+    tags={
+        "dagster/max_concurrent_runs": "1",
+        "dagster/max_retries": "2",
+        "dagster/max_runtime": "28800",
+    },
 )
 
 bond_data_job = define_asset_job(

--- a/morningglory/fqdagsterconfig/dagster.yaml
+++ b/morningglory/fqdagsterconfig/dagster.yaml
@@ -50,6 +50,6 @@ run_monitoring:
   enabled: true
   start_timeout_seconds: 1800
   cancel_timeout_seconds: 1800
-  max_resume_run_attempts: 0
+  max_resume_run_attempts: 2
   poll_interval_seconds: 120
   max_runtime_seconds: 18000

--- a/sunflower/QUANTAXIS/QUANTAXIS/QAFetch/QATdx.py
+++ b/sunflower/QUANTAXIS/QUANTAXIS/QAFetch/QATdx.py
@@ -371,8 +371,55 @@ def QA_fetch_get_security_bars(code, _type, lens, ip=None, port=None):
             return None
 
 
-@retry(stop_max_attempt_number=3, wait_random_min=50, wait_random_max=100)
-def QA_fetch_get_stock_day(
+def _stock_hq_endpoints(ip=None, port=None):
+    endpoints = []
+    try:
+        preferred_ip, preferred_port = get_mainmarket_ip(ip, port)
+        if preferred_ip and preferred_port:
+            endpoints.append((str(preferred_ip), int(preferred_port)))
+    except Exception:
+        pass
+
+    for item in stock_ip_list or []:
+        host = str(item.get('ip') or '').strip()
+        if not host:
+            continue
+        endpoint = (host, int(item.get('port') or 7709))
+        if endpoint not in endpoints:
+            endpoints.append(endpoint)
+    return endpoints
+
+
+def _fetch_stock_bars_with_failover(fetcher, *args, ip=None, port=None, **kwargs):
+    endpoints = _stock_hq_endpoints(ip, port)
+    if not endpoints:
+        raise RuntimeError('TDX stock host pool is empty')
+
+    source_empty = None
+    failures = []
+    for host, host_port in endpoints:
+        try:
+            result = fetcher(*args, ip=host, port=host_port, **kwargs)
+        except Exception as exc:
+            failures.append(f'{host}:{host_port} {exc}')
+            continue
+        if result is None:
+            failures.append(f'{host}:{host_port} returned None')
+            continue
+        if bool(getattr(result, 'attrs', {}).get('_tdx_source_empty')):
+            source_empty = result
+            failures.append(f'{host}:{host_port} returned no source bars')
+            continue
+        return result
+
+    if source_empty is not None:
+        return source_empty
+    raise RuntimeError(
+        'all TDX stock hosts failed: {}'.format('; '.join(failures[-5:]))
+    )
+
+
+def _fetch_get_stock_day_from_endpoint(
     code, start_date, end_date, if_fq='00', frequence='day', ip=None, port=None
 ):
     """获取日线及以上级别的数据
@@ -393,7 +440,10 @@ def QA_fetch_get_stock_day(
     ip, port = get_mainmarket_ip(ip, port)
     api = TdxHq_API()
     try:
-        with api.connect(ip, port, time_out=TDX_CONNECT_TIMEOUT):
+        connection = api.connect(ip, port, time_out=TDX_CONNECT_TIMEOUT)
+        if not connection:
+            raise ConnectionError(f'TDX HQ connect failed: {ip}:{port}')
+        with connection:
 
             if frequence in ['day', 'd', 'D', 'DAY', 'Day']:
                 frequence = 9
@@ -409,26 +459,25 @@ def QA_fetch_get_stock_day(
             today_ = datetime.date.today()
             lens = QA_util_get_trade_gap(start_date, today_)
 
-            data = pd.concat(
-                [
-                    api.to_df(
-                        api.get_security_bars(
-                            frequence,
-                            _select_market_code(code),
-                            code,
-                            (int(lens / 800) - i) * 800,
-                            800,
-                        )
-                    )
-                    for i in range(int(lens / 800) + 1)
-                ],
-                axis=0,
-                sort=False,
-            )
+            frames = []
+            for i in range(int(lens / 800) + 1):
+                raw = api.get_security_bars(
+                    frequence,
+                    _select_market_code(code),
+                    code,
+                    (int(lens / 800) - i) * 800,
+                    800,
+                )
+                if raw:
+                    frame = api.to_df(raw)
+                    if frame is not None and len(frame) > 0:
+                        frames.append(frame)
 
-            # 这里的问题是: 如果只取了一天的股票,而当天停牌, 那么就直接返回None了
-            if len(data) < 1:
-                return None
+            if not frames:
+                empty = pd.DataFrame()
+                empty.attrs['_tdx_source_empty'] = True
+                return empty
+            data = pd.concat(frames, axis=0, sort=False)
             data = data[data['open'] != 0]
 
             data = data.assign(
@@ -464,8 +513,24 @@ def QA_fetch_get_stock_day(
             print(e)
 
 
-@retry(stop_max_attempt_number=3, wait_random_min=50, wait_random_max=100)
-def QA_fetch_get_stock_min(code, start, end, frequence='1min', ip=None, port=None):
+def QA_fetch_get_stock_day(
+    code, start_date, end_date, if_fq='00', frequence='day', ip=None, port=None
+):
+    return _fetch_stock_bars_with_failover(
+        _fetch_get_stock_day_from_endpoint,
+        code,
+        start_date,
+        end_date,
+        if_fq,
+        frequence,
+        ip=ip,
+        port=port,
+    )
+
+
+def _fetch_get_stock_min_from_endpoint(
+    code, start, end, frequence='1min', ip=None, port=None
+):
     ip, port = get_mainmarket_ip(ip, port)
     api = TdxHq_API()
     type_ = ''
@@ -489,24 +554,28 @@ def QA_fetch_get_stock_min(code, start, end, frequence='1min', ip=None, port=Non
         lens = 4 * lens
     if lens > 20800:
         lens = 20800
-    with api.connect(ip, port):
-
-        data = pd.concat(
-            [
-                api.to_df(
-                    api.get_security_bars(
-                        frequence,
-                        _select_market_code(str(code)),
-                        str(code),
-                        (int(lens / 800) - i) * 800,
-                        800,
-                    )
-                )
-                for i in range(int(lens / 800) + 1)
-            ],
-            axis=0,
-            sort=False,
-        )
+    connection = api.connect(ip, port, time_out=TDX_CONNECT_TIMEOUT)
+    if not connection:
+        raise ConnectionError(f'TDX HQ connect failed: {ip}:{port}')
+    with connection:
+        frames = []
+        for i in range(int(lens / 800) + 1):
+            raw = api.get_security_bars(
+                frequence,
+                _select_market_code(str(code)),
+                str(code),
+                (int(lens / 800) - i) * 800,
+                800,
+            )
+            if raw:
+                frame = api.to_df(raw)
+                if frame is not None and len(frame) > 0:
+                    frames.append(frame)
+        if not frames:
+            empty = pd.DataFrame()
+            empty.attrs['_tdx_source_empty'] = True
+            return empty
+        data = pd.concat(frames, axis=0, sort=False)
         data = (
             data.drop(['year', 'month', 'day', 'hour', 'minute'], axis=1, inplace=False)
             .assign(
@@ -520,6 +589,18 @@ def QA_fetch_get_stock_min(code, start, end, frequence='1min', ip=None, port=Non
             .set_index('datetime', drop=False, inplace=False)[start:end]
         )
         return data.assign(datetime=data['datetime'].apply(lambda x: str(x)))
+
+
+def QA_fetch_get_stock_min(code, start, end, frequence='1min', ip=None, port=None):
+    return _fetch_stock_bars_with_failover(
+        _fetch_get_stock_min_from_endpoint,
+        code,
+        start,
+        end,
+        frequence,
+        ip=ip,
+        port=port,
+    )
 
 
 @retry(stop_max_attempt_number=3, wait_random_min=50, wait_random_max=100)


### PR DESCRIPTION
## 背景

TDX 服务器地址失效后，QUANTAXIS 股票日线/分钟线采集会吞掉逐票错误，导致 Dagster run 显示成功但 Mongo 行情未更新。生产审计已确认 2026-07-07 后同时存在日线和分钟线缺口。

Closes #456

## 变更

- 股票日线/分钟线抓取增加跨正式 TDX IP 池 failover，区分空响应与请求区间无 bar。
- Dagster 资产边界捕获 legacy QASU 的逐票 `ERROR CODE` 日志并转为真实失败。
- ETF xdxr 通过 FreshQuant 轻量 loader 使用正式 TDX IP 池并提高连接超时，避免导入 QUANTAXIS 触发 xdist 初始化竞态。
- `stock_postclose_ready` 按共享交易日历审计最近 15 个交易日的 `stock_day` 与五种 `stock_min` 周期，包含整日双空检测。
- 股票/ETF Dagster job 最长运行时间调整为 8 小时，crash resume 与自动失败重试都限制为 2 次。
- 同步更新当前运行与排障文档。

## 影响

行情源整体或部分失效时，Dagster 将真实失败并阻止 post-close ready marker，不再产生假成功。持续上游故障也不会再形成 9 至 10 次的长重试链。部署后需重跑股票和 ETF 行情任务并复核历史缺口。

## 验证

- 目标测试：47 passed
- ETF/IP pool CI 风格 xdist：15 passed
- changed-files pre-commit：全部通过
- Dagster definitions validate：通过
- `script/fq_local_preflight.ps1 -Mode Ensure`：通过
- 真实 TDX failover 探针：坏首选 host 后自动切换并返回 2026-07-08 至 2026-07-20 日线
- 生产 Mongo 只读审计：能准确识别 `missing_day=1386`、`missing_min=839`
- 最近 Dagster 日志：确认旧配置产生 ETF 第 9 次自动重试，补充 job 级 `dagster/max_retries=2`
- Codex review 两项 P1 已修复并解决 thread

## 部署

合并后必须基于最新远程 `main` 执行 formal deploy，重跑 `stock_data_job` 与 `etf_data_job`，再执行最近 15 个交易日完整性审计。