### PR TITLE
fix: ignore TDX no-turnover placeholder days

### DIFF
--- a/docs/current/reference/market-data.md
+++ b/docs/current/reference/market-data.md
@@ -41,6 +41,8 @@ Dagster 盘后桥接口径当前新增两条 ready asset：
 
 - `stock_postclose_ready_asset`
   - 依赖股票日线与 `quality_stock_universe` 快照刷新
+  - 对最近 15 个已收盘交易日交叉核验日线与 1/5/15/30/60 分钟线
+  - TDX 成交量和成交额均为浮点哨兵值的零成交占位日线不要求分钟线，避免为停牌/无效占位记录伪造 bar
   - 成功后写入 `dagster_pipeline_markers.stock_postclose_ready`
 - `etf_postclose_ready_asset`
   - 依赖 `etf_adj` 和通过日线/五周期完整性门禁的 `etf_min`

--- a/freshquant/tests/test_market_data_freshness.py
+++ b/freshquant/tests/test_market_data_freshness.py
@@ -135,9 +135,10 @@ def _complete_etf_min_counts() -> dict[str, int]:
 
 
 class FakeIntegrityCollection:
-    def __init__(self, *, distinct_values=None, aggregate_rows=None):
+    def __init__(self, *, distinct_values=None, aggregate_rows=None, documents=None):
         self.distinct_values = distinct_values or {}
         self.aggregate_rows = list(aggregate_rows or [])
+        self.documents = list(documents or [])
         self.aggregate_pipelines = []
 
     def distinct(self, field, query=None):
@@ -151,6 +152,28 @@ class FakeIntegrityCollection:
             row
             for row in self.aggregate_rows
             if str(row["_id"]["code"]) in selected_codes
+        ]
+
+    def find(self, query, projection=None):
+        selected_dates = set(query.get("date", {}).get("$in", []))
+        selected_codes = set(query.get("code", {}).get("$in", []))
+        documents = self.documents
+        if not documents:
+            documents = [
+                {
+                    "date": date,
+                    "code": code,
+                    "vol": 1000,
+                    "amount": 10000,
+                }
+                for date in selected_dates
+                for code in self.distinct_values.get(("code", date), [])
+            ]
+        return [
+            document
+            for document in documents
+            if document.get("date") in selected_dates
+            and document.get("code") in selected_codes
         ]
 
 
@@ -396,6 +419,57 @@ def test_stock_market_data_consistency_passes_for_all_frequencies():
     assert result["audited_dates"] == dates
     assert result["day_codes"] == {"2026-07-17": 2, "2026-07-20": 2}
     assert minute.aggregate_pipelines
+
+
+def test_stock_market_data_consistency_ignores_tdx_no_turnover_placeholders():
+    module = _load_module()
+    date = "2026-06-30"
+    real_code = "000001"
+    placeholder_code = "002729"
+    day = FakeIntegrityCollection(
+        documents=[
+            {
+                "date": date,
+                "code": real_code,
+                "vol": 1000,
+                "amount": 10000,
+            },
+            {
+                "date": date,
+                "code": placeholder_code,
+                "vol": 5.877471754e-39,
+                "amount": 5.877471754e-39,
+            },
+        ]
+    )
+    stock_list = FakeIntegrityCollection(
+        distinct_values={"code": [real_code, placeholder_code]}
+    )
+    rows = [
+        {"_id": {"date": date, "code": real_code, "type": frequence}}
+        for frequence in module.STOCK_MIN_FREQUENCIES
+    ]
+    # Neighboring TDX snapshots can contain sentinel minute rows too. They do
+    # not turn a non-trading placeholder day into a real coverage obligation.
+    rows.append({"_id": {"date": date, "code": placeholder_code, "type": "1min"}})
+    minute = FakeIntegrityCollection(aggregate_rows=rows)
+
+    result = module.assert_stock_market_data_consistent(
+        day_collection=day,
+        min_collection=minute,
+        stock_list_collection=stock_list,
+        expected_trade_date=date,
+        trade_dates_provider=lambda: [date],
+    )
+
+    assert result["day_codes"] == {date: 1}
+    assert result["placeholder_codes"] == {date: 1}
+
+
+def test_tdx_no_turnover_placeholder_requires_both_turnover_fields():
+    module = _load_module()
+
+    assert not module._is_tdx_no_turnover_day({"vol": 5.877471754e-39})
 
 
 def test_stock_market_data_consistency_rejects_day_and_minute_holes():

--- a/morningglory/fqdagster/src/fqdagster/defs/assets/market_data_freshness.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/assets/market_data_freshness.py
@@ -37,6 +37,7 @@ STOCK_MIN_FREQUENCIES: tuple[str, ...] = (
 )
 STOCK_INTEGRITY_LOOKBACK_TRADE_DAYS = 15
 STOCK_INTEGRITY_CODE_CHUNK_SIZE = 250
+TDX_NO_TURNOVER_SENTINEL_ABS_LIMIT = 1e-30
 
 # ETF 全市场约 1675 只, 正常交易日 index_day 当日文档数约 1650。
 ETF_DAY_MIN_DOCS = 1000
@@ -175,6 +176,26 @@ def _is_etf_placeholder_day(document: Mapping[str, object]) -> bool:
     except (TypeError, ValueError):
         return False
     return ohlc_placeholder and no_turnover
+
+
+def _is_tdx_no_turnover_day(document: Mapping[str, object]) -> bool:
+    """Return whether a TDX day row is a non-trading sentinel.
+
+    Some inactive securities are represented by flat OHLC rows whose volume
+    and amount are both the float sentinel ``5.877e-39``. TDX has no minute
+    bars for those rows, so they must not create a minute-coverage obligation.
+    Malformed turnover values remain in scope so the integrity gate fails
+    closed instead of silently ignoring bad data.
+    """
+    if any(field not in document for field in ("vol", "amount")):
+        return False
+    try:
+        return all(
+            abs(float(str(document.get(field, 0)))) < TDX_NO_TURNOVER_SENTINEL_ABS_LIMIT
+            for field in ("vol", "amount")
+        )
+    except (TypeError, ValueError):
+        return False
 
 
 def _trade_date_timestamp_bounds(trade_date: str) -> tuple[float, float]:
@@ -448,16 +469,34 @@ def assert_stock_market_data_consistent(
     if not universe:
         raise RuntimeError("stock market integrity audit found an empty stock_list")
 
-    day_codes_by_date = {
-        trade_date: {
-            str(code)
-            for code in day_coll.distinct(
-                "code",
-                {"date": trade_date, "code": {"$in": universe}},
-            )
-        }
-        for trade_date in audited_dates
+    day_codes_by_date: dict[str, set[str]] = {
+        trade_date: set() for trade_date in audited_dates
     }
+    placeholder_codes_by_date: dict[str, set[str]] = {
+        trade_date: set() for trade_date in audited_dates
+    }
+    for code_chunk in _chunks(universe, max(int(code_chunk_size), 1)):
+        for document in day_coll.find(
+            {
+                "date": {"$in": audited_dates},
+                "code": {"$in": list(code_chunk)},
+            },
+            {
+                "_id": 0,
+                "date": 1,
+                "code": 1,
+                "vol": 1,
+                "amount": 1,
+            },
+        ):
+            trade_date = str(document.get("date") or "")[:10]
+            code = str(document.get("code") or "")
+            if trade_date not in day_codes_by_date or not code:
+                continue
+            if _is_tdx_no_turnover_day(document):
+                placeholder_codes_by_date[trade_date].add(code)
+            else:
+                day_codes_by_date[trade_date].add(code)
     minute_codes_by_date: dict[str, dict[str, set[str]]] = {
         trade_date: {str(frequence): set() for frequence in frequencies}
         for trade_date in audited_dates
@@ -492,7 +531,8 @@ def assert_stock_market_data_consistent(
     for trade_date in audited_dates:
         day_codes = day_codes_by_date[trade_date]
         minute_by_frequency = minute_codes_by_date[trade_date]
-        minute_union = set().union(*minute_by_frequency.values())
+        placeholder_codes = placeholder_codes_by_date[trade_date]
+        minute_union = set().union(*minute_by_frequency.values()) - placeholder_codes
         missing_market_day = not day_codes and not minute_union
         missing_day = sorted(minute_union - day_codes)
         missing_min = {
@@ -529,5 +569,9 @@ def assert_stock_market_data_consistent(
         "universe_codes": len(universe),
         "day_codes": {
             trade_date: len(codes) for trade_date, codes in day_codes_by_date.items()
+        },
+        "placeholder_codes": {
+            trade_date: len(codes)
+            for trade_date, codes in placeholder_codes_by_date.items()
         },
     }


### PR DESCRIPTION
## 背景

生产 Mongo 的 15 交易日交叉审计在 2026-06-30 报 4 只股票、5 个分钟周期缺失。逐条核查发现这些股票的日线 `vol`/`amount` 均为 TDX 浮点哨兵值 `5.877471754e-39`，TDX 对该日也返回 0 根分钟线；它们属于零成交占位记录，不应伪造分钟 bar。

## 修复

- 股票日线/分钟线一致性门禁按批读取日线成交字段。
- `vol` 和 `amount` 同时小于 `1e-30` 的 TDX 零成交占位日不建立分钟覆盖义务。
- 同日可能存在的哨兵分钟行也从 `missing_day` 比较中排除。
- 缺字段或不可解析成交字段仍按真实数据处理，保持 fail-closed。
- 更新当前行情口径文档和回归测试。

## 验证

- 相关测试集：49 passed；新增边界用例后 freshness 单测：18 passed。
- 生产 Mongo 只读实测：`missing_min` 从 839 降至 819，仅剔除 6 月 30 日 4×5 个占位组；7 月 8 日起真实缺口仍为 `missing_day=1386`、`missing_min=819`，未被掩盖。
- `black --check` 与 `git diff --check` 通过。

## 部署影响

合并后需重部署 Dagster，再运行股票/ETF 盘后补数任务并复核 15 日完整性。