### PR TITLE
fix: ignore expected prelisting TDX empty results

### DIFF
--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -574,6 +574,7 @@ docker exec fqnext_20260223-fq_mongodb-1 mongosh --quiet --eval 'const c=db.getS
 - 当前股票日线/分钟线逐票抓取会在首选 host 返回异常、`None` 或源侧空响应时切换仓库 IP 池；旧 QASU 即使继续收集逐票错误，最终 ready asset 的跨集合审计也会阻断假成功 marker
 - 当前 Dagster `stock_day` / `stock_min` asset 落库后仍做基础新鲜度断言；`stock_postclose_ready_asset` 写 marker 前还会交叉审计最近 15 个交易日的当前股票日线与 `1min/5min/15min/30min/60min` 覆盖，任一确定性缺口都会 fail
 - 全市场交叉审计会豁免 OHLC 同值且成交量/额为 TDX 浮点哨兵的停牌占位日线；这类日期源侧没有分钟 bar，不要伪造数据
+- TDX 会在首个历史 bar 出现前把发行期证券放进 `stock_list`。QASU 对这类空结果打印 `ERROR CODE`；Dagster 仅在代码没有任何历史日线且仍为 TDX 发行期占位（或盘中当天 `N` 股）时豁免，已有历史或应有数据的代码仍会令任务失败
 - 当前默认 run launcher 不支持 crash resume，因此 run worker 崩溃后由 monitoring 将该 run 标记为失败；股票与 ETF 长任务通过 job tag 把单次最长运行时间设为 8 小时，并把自动失败重试限制为 2 次。容器重启后应确认失败 run 已结束、后续重试 run 的 compute log 继续增长，不能只看 UI 的 `STARTED`
 - 宿主机代理软件建议启用"绕过中国大陆"分流或在使用系统链路时关闭 TUN 模式；即使代理未关，修复后的选点/超时也能在慢链路下工作
 - 补缺口：直接在 Dagster UI 手动 launch 一次 `stock_data_job`（增量逻辑按"库内最后日期 → 今天"自动回补），完成后核对 `stock_day` / `stock_min` 的 `max(date)`

--- a/freshquant/tests/test_market_data_assets.py
+++ b/freshquant/tests/test_market_data_assets.py
@@ -490,6 +490,11 @@ def test_stock_postclose_ready_asset_depends_on_quality_snapshot(monkeypatch):
 def test_stock_assets_raise_when_quantaxis_reports_partial_failures(monkeypatch):
     module = _import_market_data_module(monkeypatch)
     context = SimpleNamespace(log=FakeLog())
+    monkeypatch.setattr(
+        module,
+        "_is_expected_prelisting_qasu_failure",
+        lambda _code: False,
+    )
 
     def report_failure(code, result):
         def sync(*_):
@@ -506,6 +511,115 @@ def test_stock_assets_raise_when_quantaxis_reports_partial_failures(monkeypatch)
         module.stock_day(context, "2026-07-20 16:00:00")
     with pytest.raises(RuntimeError, match="stock_min sync failed.*002390"):
         module.stock_min(context, "2026-07-20 16:00:00")
+
+
+def test_stock_assets_ignore_only_expected_prelisting_empty_results(monkeypatch):
+    module = _import_market_data_module(monkeypatch)
+    context = SimpleNamespace(log=FakeLog())
+
+    def report_failures(*_):
+        logging.warning("ERROR CODE")
+        logging.warning(["001232", "000065"])
+
+    monkeypatch.setattr(module, "QA_SU_save_stock_day", report_failures)
+    monkeypatch.setattr(
+        module,
+        "_is_expected_prelisting_qasu_failure",
+        lambda code: code == "001232",
+    )
+
+    with pytest.raises(RuntimeError, match="stock_day sync failed.*000065") as error:
+        module.stock_day(context, "2026-07-20 16:00:00")
+
+    assert "001232" not in str(error.value)
+
+
+def test_stock_assets_allow_run_when_all_failures_are_prelisting(monkeypatch):
+    module = _import_market_data_module(monkeypatch)
+    context = SimpleNamespace(log=FakeLog())
+
+    def report_failure(*_):
+        logging.warning("ERROR CODE")
+        logging.warning(["001232", "688806"])
+
+    monkeypatch.setattr(module, "QA_SU_save_stock_day", report_failure)
+    monkeypatch.setattr(
+        module,
+        "_is_expected_prelisting_qasu_failure",
+        lambda _code: True,
+    )
+    monkeypatch.setattr(
+        module,
+        "assert_stock_day_fresh",
+        lambda: {"expected_trade_date": "2026-07-20"},
+    )
+    result = module.stock_day(context, "2026-07-20 16:00:00")
+
+    assert isinstance(result, str)
+
+
+def test_prelisting_qasu_failure_requires_no_existing_history(monkeypatch):
+    module = _import_market_data_module(monkeypatch)
+
+    class FindOneCollection:
+        def __init__(self, document):
+            self.document = document
+
+        def find_one(self, *_args, **_kwargs):
+            return self.document
+
+    monkeypatch.setattr(
+        module,
+        "DBQuantAxis",
+        {
+            "stock_day": FindOneCollection(None),
+            "stock_list": FindOneCollection(
+                {"name": "嘉立创", "pre_close": 5.877471754e-39}
+            ),
+        },
+    )
+    assert module._is_expected_prelisting_qasu_failure("001232") is True
+
+    module.DBQuantAxis["stock_day"] = FindOneCollection({"_id": "historical"})
+    assert module._is_expected_prelisting_qasu_failure("001232") is False
+
+
+def test_same_day_ipo_empty_result_is_ignored_only_before_close(monkeypatch):
+    module = _import_market_data_module(monkeypatch)
+
+    class FindOneCollection:
+        def __init__(self, document):
+            self.document = document
+
+        def find_one(self, *_args, **_kwargs):
+            return self.document
+
+    monkeypatch.setattr(
+        module,
+        "DBQuantAxis",
+        {
+            "stock_day": FindOneCollection(None),
+            "stock_list": FindOneCollection({"name": "N泰诺", "pre_close": 1656.0225}),
+        },
+    )
+    monkeypatch.setattr(
+        module.pendulum,
+        "now",
+        lambda _timezone: SimpleNamespace(to_date_string=lambda: "2026-07-21"),
+    )
+    monkeypatch.setattr(
+        module,
+        "resolve_latest_completed_trade_date",
+        lambda: "2026-07-20",
+    )
+    assert module._is_expected_prelisting_qasu_failure("688806") is True
+
+    monkeypatch.setattr(
+        module,
+        "resolve_latest_completed_trade_date",
+        lambda: "2026-07-21",
+    )
+    assert module._is_expected_prelisting_qasu_failure("688806") is False
 
 
 def test_stock_postclose_ready_asset_writes_marker(monkeypatch):

--- a/morningglory/fqdagster/src/fqdagster/defs/assets/market_data.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/assets/market_data.py
@@ -85,6 +85,42 @@ class _QasuFailureCapture(logging.Handler):
             self.failed_codes.extend(str(code) for code in message)
 
 
+def _is_expected_prelisting_qasu_failure(code: str) -> bool:
+    """Return whether an empty QASU result is expected before a stock lists.
+
+    TDX exposes issuance-stage securities in ``stock_list`` before their first
+    historical bar exists. QASU calls ``insert_many([])`` for those codes and
+    reports them through ``ERROR CODE`` even though the upstream request did
+    not fail. Existing securities are never exempted: any prior daily bar
+    keeps the failure actionable.
+    """
+    normalized_code = str(code).strip().zfill(6)
+    if DBQuantAxis["stock_day"].find_one({"code": normalized_code}, {"_id": 1}):
+        return False
+
+    document = DBQuantAxis["stock_list"].find_one(
+        {"code": normalized_code},
+        {"_id": 0, "name": 1, "pre_close": 1},
+    )
+    if not document:
+        return False
+
+    try:
+        if abs(float(document.get("pre_close", 0))) < 1e-30:
+            return True
+    except (TypeError, ValueError):
+        pass
+
+    # Before the close, QASU intentionally ends at the previous completed
+    # trade date. A same-day IPO (TDX name prefix ``N``) therefore has no bar
+    # in the requested range yet and must not turn the historical sync red.
+    today = pendulum.now("Asia/Shanghai").to_date_string()
+    return (
+        str(document.get("name") or "").strip().upper().startswith("N")
+        and resolve_latest_completed_trade_date() < today
+    )
+
+
 def _run_qasu_stock_sync(sync_name: str, sync_function) -> None:
     capture = _QasuFailureCapture()
     root_logger = logging.getLogger()
@@ -94,7 +130,17 @@ def _run_qasu_stock_sync(sync_name: str, sync_function) -> None:
     finally:
         root_logger.removeHandler(capture)
 
-    failed_codes = list(dict.fromkeys(capture.failed_codes))
+    reported_codes = list(dict.fromkeys(capture.failed_codes))
+    ignored_codes = [
+        code for code in reported_codes if _is_expected_prelisting_qasu_failure(code)
+    ]
+    if ignored_codes:
+        logging.getLogger(__name__).warning(
+            "%s ignored expected pre-listing empty results for: %s",
+            sync_name,
+            ignored_codes[:20],
+        )
+    failed_codes = [code for code in reported_codes if code not in ignored_codes]
     if failed_codes:
         raise RuntimeError(
             f"{sync_name} sync failed for {len(failed_codes)} codes: "


### PR DESCRIPTION
## 背景
生产补跑在新完整性门禁下识别出 5 个 QASU `ERROR CODE`。核验发现它们均无历史日线：4 个为 TDX 发行期浮点占位，1 个为盘中当天首发 `N` 股；QASU 对预期空结果执行 `insert_many([])` 后误报错误。

## 目标
保留已上市/已有历史代码的严格失败语义，仅豁免能够证明为发行期、且没有任何历史日线的预期空结果。

## 范围
- 根据 `stock_day` 历史、`stock_list.pre_close` 发行期哨兵与盘中 `N` 股状态过滤预期空结果
- 混合错误列表中仍保留真实失败代码并使 Dagster 失败
- 增加回归测试并同步 `docs/current/troubleshooting.md`

## 非目标
- 不放宽最新交易日新鲜度或 15 日全市场日线/分钟线交叉审计
- 不伪造发行期、停牌期分钟行情

## 验收标准
- 发行期无历史代码不再令 `stock_day` / `stock_min` 误失败
- 已有历史代码、未知代码和收盘后应有首日数据的 `N` 股仍严格失败
- 本地 preflight、Black、35 个相关测试通过

## 部署影响
影响 `morningglory/fqdagster/**`，合并后需正式重部署 Dagster 并重跑股票数据任务。