### PR TITLE
fix: skip empty QASU stock day inserts

### DIFF
--- a/docs/current/reference/market-data.md
+++ b/docs/current/reference/market-data.md
@@ -36,6 +36,7 @@ FreshQuant 当前同时使用三类行情来源：
 - `get_data_v2` 使用 QuantAxis 历史数据
 - endDate 为空时，可优先命中 Redis realtime cache
 - 指定 `endDate` 时，以历史查询为准
+- TDX 股票日线对未上市/暂无源数据代码返回空结果时按 no-op 处理，不执行空批量写入；连接、抓取或真实写库异常仍由 Dagster 标记为失败
 
 Dagster 盘后桥接口径当前新增两条 ready asset：
 

--- a/freshquant/tests/test_quantaxis_stock_sync_resilience.py
+++ b/freshquant/tests/test_quantaxis_stock_sync_resilience.py
@@ -14,10 +14,28 @@ _MODULE_PATH = (
     / "QAFetch"
     / "QATdx.py"
 )
+_SAVE_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "sunflower"
+    / "QUANTAXIS"
+    / "QUANTAXIS"
+    / "QASU"
+    / "save_tdx.py"
+)
 
 
 def _load_module():
     spec = importlib.util.spec_from_file_location("save_tdx_under_test", _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_save_module():
+    spec = importlib.util.spec_from_file_location(
+        "qasu_save_tdx_under_test", _SAVE_MODULE_PATH
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -83,3 +101,62 @@ def test_stock_fetch_failover_raises_when_all_hosts_fail(monkeypatch):
             lambda *args, **kwargs: (_ for _ in ()).throw(TimeoutError("timeout")),
             "000001",
         )
+
+
+def test_stock_day_empty_source_is_a_noop():
+    module = _load_save_module()
+
+    class Collection:
+        def insert_many(self, documents):
+            raise AssertionError(f"unexpected empty insert: {documents}")
+
+    assert module._insert_stock_day_rows(Collection(), pd.DataFrame()) == 0
+    assert module._insert_stock_day_rows(Collection(), None) == 0
+
+
+def test_full_stock_day_sync_accepts_unlisted_empty_source(monkeypatch):
+    module = _load_save_module()
+
+    class Collection:
+        def create_index(self, keys):
+            return keys
+
+        def find_one(self, query, sort=None):
+            return None
+
+        def insert_many(self, documents):
+            raise AssertionError(f"unexpected empty insert: {documents}")
+
+    class Client:
+        stock_day = Collection()
+
+    monkeypatch.setattr(
+        module,
+        "QA_fetch_get_stock_list",
+        lambda: pd.DataFrame([{"code": "001232"}]),
+    )
+    monkeypatch.setattr(module, "QA_fetch_get_stock_day", lambda *args: pd.DataFrame())
+    monkeypatch.setattr(module, "now_time", lambda: "2026-07-20 15:00:00")
+
+    module.QA_SU_save_stock_day(client=Client())
+
+
+def test_stock_day_nonempty_source_is_inserted(monkeypatch):
+    module = _load_save_module()
+    inserted = []
+
+    class Collection:
+        def insert_many(self, documents):
+            inserted.extend(documents)
+
+    monkeypatch.setattr(
+        module,
+        "QA_util_to_json_from_pandas",
+        lambda data: [{"code": str(data.iloc[0]["code"])}],
+    )
+
+    assert (
+        module._insert_stock_day_rows(Collection(), pd.DataFrame([{"code": "000001"}]))
+        == 1
+    )
+    assert inserted == [{"code": "000001"}]

--- a/sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py
+++ b/sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py
@@ -1,4 +1,7 @@
 # coding:utf-8
+# mypy: ignore-errors
+# isort: skip_file
+# fmt: off
 #
 # The MIT License (MIT)
 #
@@ -97,6 +100,17 @@ def now_time():
            ' 17:00:00' if datetime.datetime.now().hour < 15 else str(QA_util_get_real_date(
         str(datetime.date.today()), trade_date_sse, -1)) + ' 15:00:00'
 
+
+def _insert_stock_day_rows(collection, data):
+    """Insert fetched daily rows, treating an empty TDX result as a no-op."""
+    if data is None or getattr(data, 'empty', False):
+        return 0
+    documents = QA_util_to_json_from_pandas(data)
+    if not documents:
+        return 0
+    collection.insert_many(documents)
+    return len(documents)
+
 def QA_SU_save_single_stock_day(code : str, client= DATABASE, ui_log=None):
     '''
      save single stock_day
@@ -142,14 +156,13 @@ def QA_SU_save_single_stock_day(code : str, client= DATABASE, ui_log=None):
                     ui_log
                 )
                 if start_date != end_date:
-                    coll_stock_day.insert_many(
-                        QA_util_to_json_from_pandas(
-                            QA_fetch_get_stock_day(
-                                str(code),
-                                QA_util_get_next_day(start_date),
-                                end_date,
-                                '00'
-                            )
+                    _insert_stock_day_rows(
+                        coll_stock_day,
+                        QA_fetch_get_stock_day(
+                            str(code),
+                            QA_util_get_next_day(start_date),
+                            end_date,
+                            '00'
                         )
                     )
 
@@ -164,14 +177,13 @@ def QA_SU_save_single_stock_day(code : str, client= DATABASE, ui_log=None):
                     ui_log
                 )
                 if start_date != end_date:
-                    coll_stock_day.insert_many(
-                        QA_util_to_json_from_pandas(
-                            QA_fetch_get_stock_day(
-                                str(code),
-                                start_date,
-                                end_date,
-                                '00'
-                            )
+                    _insert_stock_day_rows(
+                        coll_stock_day,
+                        QA_fetch_get_stock_day(
+                            str(code),
+                            start_date,
+                            end_date,
+                            '00'
                         )
                     )
         except Exception as error0:
@@ -232,14 +244,13 @@ def QA_SU_save_stock_day(client=DATABASE, ui_log=None, ui_progress=None):
                     ui_log
                 )
                 if start_date != end_date:
-                    coll_stock_day.insert_many(
-                        QA_util_to_json_from_pandas(
-                            QA_fetch_get_stock_day(
-                                str(code),
-                                QA_util_get_next_day(start_date),
-                                end_date,
-                                '00'
-                            )
+                    _insert_stock_day_rows(
+                        coll_stock_day,
+                        QA_fetch_get_stock_day(
+                            str(code),
+                            QA_util_get_next_day(start_date),
+                            end_date,
+                            '00'
                         )
                     )
 
@@ -254,14 +265,13 @@ def QA_SU_save_stock_day(client=DATABASE, ui_log=None, ui_progress=None):
                     ui_log
                 )
                 if start_date != end_date:
-                    coll_stock_day.insert_many(
-                        QA_util_to_json_from_pandas(
-                            QA_fetch_get_stock_day(
-                                str(code),
-                                start_date,
-                                end_date,
-                                '00'
-                            )
+                    _insert_stock_day_rows(
+                        coll_stock_day,
+                        QA_fetch_get_stock_day(
+                            str(code),
+                            start_date,
+                            end_date,
+                            '00'
                         )
                     )
         except Exception as error0:


### PR DESCRIPTION
## 背景

部署 TDX 故障切换和逐代码失败捕获后，生产 `stock_data_job` 正确失败并报告 5 个代码：`001232`、`301707`、`603468`、`688806`、`688825`。核查确认前 4 个是未上市占位代码；`688806` 为当日首发，而盘前/盘中补历史的正式截止日仍是上一已收盘日。它们对截止日均合法返回空 DataFrame。

旧 `QA_SU_save_stock_day` 会继续调用 `insert_many([])`，把“暂无源数据”错误记录成逐代码失败。

## 修复

- 新增 `_insert_stock_day_rows`，`None`/空 DataFrame/空文档列表均按 no-op 处理。
- 全市场与单股票日线同步统一使用该入口。
- 非空数据仍正常批量写入；连接、抓取和真实写库异常不吞掉，继续由 Dagster 失败捕获。
- 更新当前行情数据口径。

## 验证

- 增加 helper 空/非空结果测试。
- 增加 `QA_SU_save_stock_day` 全流程未上市代码空结果回归测试，断言不会执行空批量写入。
- 相关 QASU/行情 asset 测试：18 passed；扩展相关集：36 passed。
- `black --check` 与 `git diff --check` 通过。

## 生产证据

本轮 Dagster 已实际回填日线/分钟线；该修复用于让包含合法未上市代码的重跑最终能真实 SUCCESS，而不是放松任何数据完整性门禁。