### PR TITLE
fix: tolerate migrated QUANTAXIS index options

### DIFF
--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -579,6 +579,20 @@ docker exec fqnext_20260223-fq_mongodb-1 mongosh --quiet --eval 'const c=db.getS
 - 宿主机代理软件建议启用"绕过中国大陆"分流或在使用系统链路时关闭 TUN 模式；即使代理未关，修复后的选点/超时也能在慢链路下工作
 - 补缺口：直接在 Dagster UI 手动 launch 一次 `stock_data_job`（增量逻辑按"库内最后日期 → 今天"自动回补），完成后核对 `stock_day` / `stock_min` 的 `max(date)`
 
+## ETF 日线启动时报 `IndexKeySpecsConflict`
+
+现象：
+
+- `etf_data_job` 在 `etf_day` 刚启动时失败，Mongo 返回 `codeName=IndexKeySpecsConflict`
+- 报错同时列出 `quantaxis.index_day` 的 `code_1_date_stamp_1` 已有唯一索引，以及 QASU 请求创建的同名非唯一索引
+- `etf_adj`、`etf_min` 与 `etf_postclose_ready_asset` 因依赖失败而跳过
+
+处理：
+
+- 先用 `db.index_day.getIndexes()` 确认已有索引的 key pattern；`(code, date_stamp)` 的唯一或非唯一索引都满足 QASU 的查询要求
+- 当前 vendored QASU 在创建 `index_day` 索引前会复用相同 key pattern 的已有索引，不再因数据迁移保留的 `unique` 选项不同而重复创建同名索引
+- 重新部署 Dagster 使用的 rear 镜像后重跑 `etf_data_job`，确认 `etf_day` 已越过索引初始化并继续执行 freshness check
+
 ## ETF 日线/分钟线停更但 Dagster run 显示成功
 
 现象：

--- a/freshquant/tests/test_order_management_read_service.py
+++ b/freshquant/tests/test_order_management_read_service.py
@@ -6,6 +6,9 @@ from datetime import datetime, timezone
 
 import pytest
 
+_original_instrument_general = sys.modules.get("freshquant.instrument.general")
+_original_util_code = sys.modules.get("freshquant.util.code")
+
 instrument_general_stub = types.ModuleType("freshquant.instrument.general")
 setattr(instrument_general_stub, "query_instrument_info", lambda symbol: None)
 sys.modules.setdefault("freshquant.instrument.general", instrument_general_stub)
@@ -33,10 +36,21 @@ setattr(
 )
 sys.modules.setdefault("freshquant.util.code", code_stub)
 
-from freshquant.order_management.read_service import (
-    OrderManagementReadService,
-    _parse_filter_datetime,
-)
+try:
+    from freshquant.order_management.read_service import (
+        OrderManagementReadService,
+        _parse_filter_datetime,
+    )
+finally:
+    if _original_instrument_general is None:
+        sys.modules.pop("freshquant.instrument.general", None)
+    else:
+        sys.modules["freshquant.instrument.general"] = _original_instrument_general
+
+    if _original_util_code is None:
+        sys.modules.pop("freshquant.util.code", None)
+    else:
+        sys.modules["freshquant.util.code"] = _original_util_code
 
 
 class InMemoryOrderManagementRepository:

--- a/freshquant/tests/test_quantaxis_index_compat.py
+++ b/freshquant/tests/test_quantaxis_index_compat.py
@@ -7,15 +7,15 @@ _SOURCE_PATH = (
     / "QUANTAXIS"
     / "QUANTAXIS"
     / "QASU"
-    / "save_tdx.py"
+    / "index_compat.py"
 )
 _SPEC = importlib.util.spec_from_file_location(
-    "freshquant_vendor_save_tdx", _SOURCE_PATH
+    "freshquant_vendor_index_compat", _SOURCE_PATH
 )
 assert _SPEC is not None and _SPEC.loader is not None
 _MODULE = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MODULE)
-_ensure_compatible_index = _MODULE._ensure_compatible_index
+_ensure_compatible_index = _MODULE.ensure_compatible_index
 
 
 class _FakeCollection:

--- a/freshquant/tests/test_quantaxis_index_compat.py
+++ b/freshquant/tests/test_quantaxis_index_compat.py
@@ -1,0 +1,55 @@
+import importlib.util
+from pathlib import Path
+
+_SOURCE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "sunflower"
+    / "QUANTAXIS"
+    / "QUANTAXIS"
+    / "QASU"
+    / "save_tdx.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "freshquant_vendor_save_tdx", _SOURCE_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+_ensure_compatible_index = _MODULE._ensure_compatible_index
+
+
+class _FakeCollection:
+    def __init__(self, indexes):
+        self._indexes = indexes
+        self.created = []
+
+    def index_information(self):
+        return self._indexes
+
+    def create_index(self, fields):
+        self.created.append(list(fields))
+
+
+def test_ensure_compatible_index_reuses_unique_index_with_same_keys():
+    fields = [("code", 1), ("date_stamp", 1)]
+    collection = _FakeCollection(
+        {
+            "code_1_date_stamp_1": {
+                "key": fields,
+                "unique": True,
+            }
+        }
+    )
+
+    _ensure_compatible_index(collection, fields)
+
+    assert collection.created == []
+
+
+def test_ensure_compatible_index_creates_missing_key_pattern():
+    fields = [("code", 1), ("date_stamp", 1)]
+    collection = _FakeCollection({"_id_": {"key": [("_id", 1)]}})
+
+    _ensure_compatible_index(collection, fields)
+
+    assert collection.created == [fields]

--- a/sunflower/QUANTAXIS/QUANTAXIS/QASU/index_compat.py
+++ b/sunflower/QUANTAXIS/QUANTAXIS/QASU/index_compat.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+
+def ensure_compatible_index(collection: Any, fields: list[tuple[str, int]]) -> None:
+    """Reuse an existing index with the same key pattern, regardless of options."""
+    normalized_fields = list(fields)
+    for spec in collection.index_information().values():
+        if list(spec.get("key") or []) == normalized_fields:
+            return
+    collection.create_index(normalized_fields)

--- a/sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py
+++ b/sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py
@@ -92,6 +92,15 @@ from QUANTAXIS.QAFetch.QATdx import ping, get_ip_list_by_multi_process_ping, sto
 from multiprocessing import cpu_count
 
 
+def _ensure_compatible_index(collection, fields):
+    """Reuse an existing index with the same key pattern, regardless of options."""
+    normalized_fields = list(fields)
+    for spec in collection.index_information().values():
+        if list(spec.get("key") or []) == normalized_fields:
+            return
+    collection.create_index(normalized_fields)
+
+
 # ip=select_best_ip()
 
 
@@ -968,11 +977,12 @@ def QA_SU_save_single_index_day(code : str, client=DATABASE, ui_log=None):
 
     #__index_list = QA_fetch_get_stock_list('index')
     coll = client.index_day
-    coll.create_index(
+    _ensure_compatible_index(
+        coll,
         [('code',
           pymongo.ASCENDING),
          ('date_stamp',
-          pymongo.ASCENDING)]
+           pymongo.ASCENDING)]
     )
     err = []
 
@@ -1061,11 +1071,12 @@ def QA_SU_save_index_day(client=DATABASE, ui_log=None, ui_progress=None):
 
     __index_list = QA_fetch_get_stock_list('index')
     coll = client.index_day
-    coll.create_index(
+    _ensure_compatible_index(
+        coll,
         [('code',
           pymongo.ASCENDING),
          ('date_stamp',
-          pymongo.ASCENDING)]
+           pymongo.ASCENDING)]
     )
     err = []
 
@@ -1425,11 +1436,12 @@ def QA_SU_save_single_etf_day(code : str, client=DATABASE, ui_log=None):
 
     #__index_list = QA_fetch_get_stock_list('etf')
     coll = client.index_day
-    coll.create_index(
+    _ensure_compatible_index(
+        coll,
         [('code',
           pymongo.ASCENDING),
          ('date_stamp',
-          pymongo.ASCENDING)]
+           pymongo.ASCENDING)]
     )
     err = []
 
@@ -1499,11 +1511,12 @@ def QA_SU_save_etf_day(client=DATABASE, ui_log=None, ui_progress=None):
 
     __index_list = QA_fetch_get_stock_list('etf')
     coll = client.index_day
-    coll.create_index(
+    _ensure_compatible_index(
+        coll,
         [('code',
           pymongo.ASCENDING),
          ('date_stamp',
-          pymongo.ASCENDING)]
+           pymongo.ASCENDING)]
     )
     err = []
 

--- a/sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py
+++ b/sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py
@@ -89,16 +89,8 @@ from QUANTAXIS.QAData.data_fq import _QA_data_stock_to_fq
 from QUANTAXIS.QAFetch.QAQuery import QA_fetch_stock_day
 from QUANTAXIS.QAUtil import Parallelism
 from QUANTAXIS.QAFetch.QATdx import ping, get_ip_list_by_multi_process_ping, stock_ip_list
+from QUANTAXIS.QASU.index_compat import ensure_compatible_index as _ensure_compatible_index
 from multiprocessing import cpu_count
-
-
-def _ensure_compatible_index(collection, fields):
-    """Reuse an existing index with the same key pattern, regardless of options."""
-    normalized_fields = list(fields)
-    for spec in collection.index_information().values():
-        if list(spec.get("key") or []) == normalized_fields:
-            return
-    collection.create_index(normalized_fields)
 
 
 # ip=select_best_ip()


### PR DESCRIPTION
## 背景
Docker Mongo 数据迁移后，`quantaxis.index_day` 保留了 `(code, date_stamp)` 唯一索引。Vendored QASU 在 ETF/指数日线启动时重复请求同名非唯一索引，导致 `IndexKeySpecsConflict`，阻断 `etf_data_job`。

## 目标
复用具有相同 key pattern 的现有索引，不因 unique 等选项差异重复创建同名索引。

## 范围
- 为 vendored QASU 增加兼容索引检查
- 覆盖单标的/全量 index day 与 ETF day 四条入口
- 增加唯一索引复用与缺失索引创建测试
- 更新当前排障文档

## 非目标
- 不变更现有 Mongo 索引规格
- 不迁移或删除行情数据
- 不改变 ETF freshness 阈值

## 验收标准
- 已有同 key pattern 唯一索引时初始化通过
- 缺失对应 key pattern 时仍创建索引
- 相关 market-data/ETF 测试通过
- CI 全绿

## 部署影响
需重建 rear 镜像并重启 Dagster webserver/daemon，之后重跑 `etf_data_job`。

## 验证
- `pytest ...test_quantaxis_index_compat.py ...test_market_data_assets.py ...test_market_data_freshness.py ...test_market_data_schedules.py ...test_etf_adj_sync.py -q`：47 passed
- changed-files pre-commit：passed