### PR TITLE
feat: add three-layer CLX18 signals to TongdaXin charts

### DIFF
--- a/docs/current/reference/signal-clxs.md
+++ b/docs/current/reference/signal-clxs.md
@@ -65,6 +65,46 @@ python -m freshquant.cli stock screening --model clxs
   - 止损价
   - 标签或中枢数量
 
+## 通达信 CLX18 插件接口
+
+32 位通达信插件由 `morningglory/fqcopilot` 的 `tdx` target 构建。
+现有函数槽位 `1～4` 保持兼容，其中 CLX18 专家回测继续使用：
+
+```text
+TDXDLL7(3,HIGH,LOW,CLOSE)
+```
+
+它返回选定模型唯一的主触发编码，交易规则不读取并发掩码。
+
+CLX18 三层主图使用：
+
+```text
+TDXDLL7(5,HIGH,LOW,CLOSE)
+```
+
+5 号函数只计算 `PARAM_MODEL_OPT` 指定的一个模型，同时返回主信号和完整并发触发
+掩码：
+
+```text
+packed = sign(signal) * (abs(signal) * 128 + trigger_mask)
+```
+
+- `trigger_mask` 的 `1/2/4/8/16/32/64` 分别表示
+  `模型结构/Pin Bar/吞没/强分型/MA5拐头/量价齐升/MACD金叉`。
+- 完整掩码等于方向基础掩码与主触发位按位或，因此主触发位始终存在。
+- 最大 packed 值小于 `2^24`，在通达信 float32 插件协议中可精确往返。
+- 主图在信号后的可执行开盘 K 线上区分“原始未增强”和“增强”，并把同 K 线
+  全部触发按固定顺序纵向显示；专家回测仍只使用增强入场条件。
+
+当前通达信运行 DLL 路径是：
+
+```text
+D:\new_tdx\T0002\dlls\fqcopilot.dll
+```
+
+部署时先关闭 `D:\new_tdx\tdxw.exe`，备份旧 DLL 和公式数据库，再替换 DLL、重新
+登记 18 个主图公式并执行逐 K 线 parity 与公式编译检查。
+
 ## 当前排查
 
 ### CLXS 结果总是空

--- a/morningglory/fqcopilot/cpp/TCalcFuncSets.cpp
+++ b/morningglory/fqcopilot/cpp/TCalcFuncSets.cpp
@@ -1,6 +1,7 @@
 ﻿#include "stdafx.h"
 #include "TCalcFuncSets.h"
 #include "copilot/copilot.h"
+#include "copilot/signal_encoding.h"
 #include "common/log.h"
 #include "func_set.h"
 #include <thread>
@@ -47,7 +48,7 @@ void Func3(int count, float *out, float *high, float *low, float *close)
         if (calcTypeMap.find(modelOptInt) != calcTypeMap.end())
         {
             modelOpt = calcTypeMap[modelOptInt];
-        }  
+        }
     }
 
     std::vector<int> result = copilotProxy.Calc(modelOpt);
@@ -92,7 +93,7 @@ void Func4(int count, float *out_values, float *high_values, float *low_values, 
         if (tailoredCalcTypeMap.find(modelOptInt) != tailoredCalcTypeMap.end())
         {
             modelOpt = tailoredCalcTypeMap[modelOptInt];
-        }  
+        }
     }
 
     std::vector<int> result = copilotProxy.TailoredCalc(modelOpt);
@@ -116,11 +117,90 @@ void Func4(int count, float *out_values, float *high_values, float *low_values, 
     copilotProxy.Reset();
 }
 
+//=============================================================================
+// 输出函数5号：单模型信号 + 完整并发触发掩码（通达信主图）
+//
+// packed = sign(signal) * (abs(signal) * 128 + trigger_mask)
+// trigger_mask bits 0..6 correspond to entrypoints 1..7 and always include
+// the selected model's primary entrypoint bit.
+//=============================================================================
+void Func5(int count, float *out, float *high, float *low, float *close)
+{
+    if (count == 0) return;
+    memset(out, 0, count * sizeof(float));
+    CopilotProxy &copilotProxy = CopilotProxy::GetInstance();
+
+    std::vector<float> open =
+        copilotProxy.ExistParam(ParamType::PARAM_OPEN)
+            ? copilotProxy.GetParam(ParamType::PARAM_OPEN)
+            : std::vector<float>();
+    std::vector<float> volume =
+        copilotProxy.ExistParam(ParamType::PARAM_VOLUME)
+            ? copilotProxy.GetParam(ParamType::PARAM_VOLUME)
+            : std::vector<float>();
+    if (open.size() != static_cast<size_t>(count) ||
+        volume.size() != static_cast<size_t>(count))
+    {
+        copilotProxy.Reset();
+        return;
+    }
+
+    const int waveOpt =
+        copilotProxy.ExistParam(ParamType::PARAM_WAVE_OPT)
+            ? static_cast<int>(
+                  copilotProxy.GetParam(ParamType::PARAM_WAVE_OPT)[0])
+            : 0;
+    const int stretchOpt =
+        copilotProxy.ExistParam(ParamType::PARAM_STRETCH_OPT)
+            ? static_cast<int>(
+                  copilotProxy.GetParam(ParamType::PARAM_STRETCH_OPT)[0])
+            : 0;
+    const int extOpt =
+        copilotProxy.ExistParam(ParamType::PARAM_EXT_OPT)
+            ? static_cast<int>(
+                  copilotProxy.GetParam(ParamType::PARAM_EXT_OPT)[0])
+            : 0;
+    const int modelOpt =
+        copilotProxy.ExistParam(ParamType::PARAM_MODEL_OPT)
+            ? static_cast<int>(
+                  copilotProxy.GetParam(ParamType::PARAM_MODEL_OPT)[0])
+            : static_cast<int>(CalcType::CALC_S0001);
+
+    std::vector<float> highValues(high, high + count);
+    std::vector<float> lowValues(low, low + count);
+    std::vector<float> closeValues(close, close + count);
+    DetailedModelResult detailed = clxs_model_detailed(
+        count, highValues, lowValues, open, closeValues, volume,
+        waveOpt, stretchOpt, extOpt, modelOpt);
+
+    const int length = (std::min)(
+        count, static_cast<int>(detailed.signals.size()));
+    for (int i = 0; i < length; ++i)
+    {
+        const int signal = detailed.signals[i];
+        if (signal == 0)
+        {
+            continue;
+        }
+        const std::vector<int> &masks =
+            signal > 0
+                ? detailed.buy_base_trigger_masks
+                : detailed.sell_base_trigger_masks;
+        const int baseMask =
+            i < static_cast<int>(masks.size()) ? masks[i] : 0;
+        out[i] = static_cast<float>(
+            ClxSignalEncoding::pack_tdx_signal_and_base_mask(
+                signal, baseMask));
+    }
+    copilotProxy.Reset();
+}
+
 PluginTCalcFuncInfo g_CalcFuncSets[] = {
     {1, (pPluginFUNC)&Func1},
     {2, (pPluginFUNC)&Func2},
     {3, (pPluginFUNC)&Func3},
     {4, (pPluginFUNC)&Func4},
+    {5, (pPluginFUNC)&Func5},
     {0, NULL},
 };
 

--- a/morningglory/fqcopilot/cpp/copilot/batch_calculator.cpp
+++ b/morningglory/fqcopilot/cpp/copilot/batch_calculator.cpp
@@ -82,10 +82,48 @@ std::vector<std::vector<int>> BatchCalculator::calc_all()
     return results;
 }
 
+std::vector<int> BatchCalculator::calc_model(int model_id)
+{
+    switch (model_id)
+    {
+    case 0: return F_S0000_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 1: return F_S0001_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 2: return F_S0002_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 3: return F_S0003_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 4: return F_S0004_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 5: return F_S0005_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 6: return F_S0006_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 7: return F_S0007_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 8: return F_S0008_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 9: return F_S0009_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 10: return F_S0010_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 11: return F_S0011_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 12: return F_S0012_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 13: return F_S0013_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 14: return F_S0014_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 15: return F_S0015_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 16: return F_S0016_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    case 17: return F_S0017_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    default: return F_S0001_ctx(high, low, open, close, vol, switch_opt, options, ctx);
+    }
+}
+
 DetailedBatchResult BatchCalculator::calc_all_detailed()
 {
     DetailedBatchResult result;
     result.signals = calc_all();
+    std::tie(result.buy_base_trigger_masks, result.sell_base_trigger_masks) =
+        SignalUtils::calc_base_trigger_masks(
+            high, low, open, close, vol,
+            ctx.ma5, ctx.macd, ctx.strong_factors);
+
+    return result;
+}
+
+DetailedModelResult BatchCalculator::calc_model_detailed(int model_id)
+{
+    DetailedModelResult result;
+    result.signals = calc_model(model_id);
     std::tie(result.buy_base_trigger_masks, result.sell_base_trigger_masks) =
         SignalUtils::calc_base_trigger_masks(
             high, low, open, close, vol,

--- a/morningglory/fqcopilot/cpp/copilot/batch_calculator.h
+++ b/morningglory/fqcopilot/cpp/copilot/batch_calculator.h
@@ -11,6 +11,13 @@ struct DetailedBatchResult
     std::vector<int> sell_base_trigger_masks;
 };
 
+struct DetailedModelResult
+{
+    std::vector<int> signals;
+    std::vector<int> buy_base_trigger_masks;
+    std::vector<int> sell_base_trigger_masks;
+};
+
 class BatchCalculator
 {
 public:
@@ -23,8 +30,14 @@ public:
     // 一次缠论分析 + 18 个模型计算，按 model_id (0~17) 索引
     std::vector<std::vector<int>> calc_all();
 
+    // 复用已计算的 ChanContext，只计算一个模型。
+    std::vector<int> calc_model(int model_id);
+
     // 复用同一个 ChanContext，同时返回模型原始信号和逐 bar 基础触发掩码。
     DetailedBatchResult calc_all_detailed();
+
+    // 通达信主图使用：一次计算选定模型及逐 bar 基础触发掩码。
+    DetailedModelResult calc_model_detailed(int model_id);
 
 private:
     ChanContext ctx;

--- a/morningglory/fqcopilot/cpp/copilot/signal_encoding.h
+++ b/morningglory/fqcopilot/cpp/copilot/signal_encoding.h
@@ -4,6 +4,8 @@ namespace ClxSignalEncoding
 {
     constexpr int MIN_OCCURRENCE = 1;
     constexpr int MAX_OCCURRENCE = 99;
+    constexpr int TDX_TRIGGER_MASK_BASE = 1 << 7;
+    constexpr int TDX_TRIGGER_MASK_LIMIT = TDX_TRIGGER_MASK_BASE - 1;
 
     // occurrence <= 0 is invalid and produces no signal. Values above the
     // two-digit wire limit saturate at 99; 99 therefore means "99 or more".
@@ -50,4 +52,43 @@ namespace ClxSignalEncoding
             occurrence_for_model(signal, source_model_id),
             signed_entrypoint);
     }
+
+    // Float32 exactly represents every packed CLX value:
+    // max abs(signal)=26907, so max packed value is 3,444,223 (<2^24).
+    constexpr int pack_tdx_signal_and_base_mask(int signal, int base_mask)
+    {
+        if (signal == 0)
+        {
+            return 0;
+        }
+        const int primary_entrypoint = magnitude(signal) % 100;
+        const int primary_bit =
+            primary_entrypoint >= 1 && primary_entrypoint <= 7
+                ? 1 << (primary_entrypoint - 1)
+                : 0;
+        const int completed_mask =
+            (base_mask | primary_bit) & TDX_TRIGGER_MASK_LIMIT;
+        const int packed_magnitude =
+            magnitude(signal) * TDX_TRIGGER_MASK_BASE + completed_mask;
+        return signal > 0 ? packed_magnitude : -packed_magnitude;
+    }
+
+    constexpr int unpack_tdx_signal(int packed)
+    {
+        const int unpacked =
+            magnitude(packed) / TDX_TRIGGER_MASK_BASE;
+        return packed >= 0 ? unpacked : -unpacked;
+    }
+
+    constexpr int unpack_tdx_trigger_mask(int packed)
+    {
+        return magnitude(packed) % TDX_TRIGGER_MASK_BASE;
+    }
+
+    static_assert(
+        unpack_tdx_signal(pack_tdx_signal_and_base_mask(104, 4)) == 104,
+        "TDX packed signal must round-trip");
+    static_assert(
+        unpack_tdx_trigger_mask(pack_tdx_signal_and_base_mask(104, 4)) == 12,
+        "TDX packed mask must include the primary trigger bit");
 }

--- a/morningglory/fqcopilot/cpp/func_set.cpp
+++ b/morningglory/fqcopilot/cpp/func_set.cpp
@@ -106,3 +106,26 @@ std::vector<std::vector<int>> clxs_all_detailed(
     result[19] = std::move(detailed.sell_base_trigger_masks);
     return result;
 }
+
+DetailedModelResult clxs_model_detailed(
+    int length,
+    std::vector<float> &high, std::vector<float> &low,
+    std::vector<float> &open, std::vector<float> &close,
+    std::vector<float> &vol,
+    int wave_opt, int stretch_opt, int trend_opt, int model_opt)
+{
+    DetailedModelResult result;
+    if (length == 0) return result;
+
+    ChanOptions options;
+    options.bi_mode = wave_opt / 10 % 10;
+    options.force_wave_stick_count = wave_opt / 100 % 100;
+    options.merge_non_complehensive_wave = wave_opt / 10000 % 10;
+    options.ext_opt = trend_opt;
+
+    const int model_id = model_opt % 10000;
+    const int switch_opt = model_opt / 10000;
+    BatchCalculator batch(
+        high, low, open, close, vol, switch_opt, options);
+    return batch.calc_model_detailed(model_id);
+}

--- a/morningglory/fqcopilot/cpp/func_set.h
+++ b/morningglory/fqcopilot/cpp/func_set.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include "copilot/batch_calculator.h"
 
 std::vector<float> clxs(
     int length,
@@ -24,3 +25,11 @@ std::vector<std::vector<int>> clxs_all_detailed(
     std::vector<float> &open, std::vector<float> &close,
     std::vector<float> &vol,
     int wave_opt, int stretch_opt, int trend_opt);
+
+// 通达信主图接口：只计算一个模型，同时返回方向基础触发掩码。
+DetailedModelResult clxs_model_detailed(
+    int length,
+    std::vector<float> &high, std::vector<float> &low,
+    std::vector<float> &open, std::vector<float> &close,
+    std::vector<float> &vol,
+    int wave_opt, int stretch_opt, int trend_opt, int model_opt);

--- a/morningglory/fqcopilot/tests/tdx_trigger_pack_test.cpp
+++ b/morningglory/fqcopilot/tests/tdx_trigger_pack_test.cpp
@@ -1,0 +1,28 @@
+#include "../cpp/copilot/signal_encoding.h"
+
+int main()
+{
+    using namespace ClxSignalEncoding;
+
+    const int buy = pack_tdx_signal_and_base_mask(104, 4);
+    if (unpack_tdx_signal(buy) != 104 ||
+        unpack_tdx_trigger_mask(buy) != 12)
+    {
+        return 1;
+    }
+
+    const int sell = pack_tdx_signal_and_base_mask(-17007, 2);
+    if (unpack_tdx_signal(sell) != -17007 ||
+        unpack_tdx_trigger_mask(sell) != 66)
+    {
+        return 2;
+    }
+
+    const int maximum = pack_tdx_signal_and_base_mask(26907, 127);
+    if (maximum >= (1 << 24) ||
+        static_cast<int>(static_cast<float>(maximum)) != maximum)
+    {
+        return 3;
+    }
+    return 0;
+}

--- a/morningglory/fqcopilot/xmake.lua
+++ b/morningglory/fqcopilot/xmake.lua
@@ -177,3 +177,11 @@ target("fullcalc_py")
 
     add_defines("MAKE_X64")
     add_cxflags("/EHsc", "/d2SSAOptimizer-", "/Od")
+
+-- 通达信 packed signal/mask wire contract.
+target("tdx_trigger_pack_test")
+    set_kind("binary")
+    set_default(false)
+    set_languages("cxx17")
+    set_targetdir("build/tests")
+    add_files("tests/tdx_trigger_pack_test.cpp")


### PR DESCRIPTION
Closes #473

## 背景

现有 18 个通达信专家公式只输出唯一主触发，主图因此不能同时区分原始/增强信号，也不能展示同一根 K 线上的全部并发触发；旧主图还使用了多层叠加的三倍箭头。

## 目标

在不改变 18 个专家回测交易语义的前提下，为 CLX18 主图提供原始未增强、增强和完整并发触发三层显示。

## 范围

- 新增 `TDXDLL7(5,...)` 单模型接口，按 `sign(signal) * (abs(signal) * 128 + trigger_mask)` 打包主信号与 7 bit 触发掩码。
- 完整掩码自动补入唯一主触发位，支持构/针/吞/强/拐/量/叉同时展示。
- 复用一次 `ChanContext`，只计算指定模型及基础触发掩码。
- 增加 packed wire contract C++ 测试。
- 更新 `docs/current/reference/signal-clxs.md`，记录接口、部署和验收合同。

## 非目标

- 不修改 `TDXDLL7(3,...)` 及 18 个专家公式的建仓/退出规则。
- 不重算或改写既有通达信回测报告、BLK 分组和研究 HOLDOUT 结果。
- 不修改增强过滤参数。

## 验收结果

- `xmake build -vD tdx_trigger_pack_test` + executable：通过。
- `xmake build -vD tdx`：32 位 DLL 构建通过。
- 新 DLL Func3 与旧安装 DLL：20只股票 × 18模型，360组信号零差异。
- 新 DLL Func5 解包信号与 Func3：360组零差异。
- Func5 掩码与 Python `fq_clxs_all_detailed`：360组零差异，主触发位缺失为0。
- 通达信公式登记/编译：专家18/18、主图18/18；输出验证 `ok=true`。
- 仓库 preflight：docs-current-guard、pre-commit 通过；pytest `1680 passed, 51 skipped`。

## 部署影响

合并后仅基于最新远程 `main`：

1. 重新构建 32 位 `fqcopilot.dll`，在通达信关闭时备份并替换 `D:\new_tdx\T0002\dlls\fqcopilot.dll`；
2. 重新生成/登记 18 个主图公式并做 GUI 抽查；
3. 按部署矩阵重建 `fq_apiserver` 与 `fq_clx_backtest_worker`，验证 CLX API、worker 心跳和既有 immutable artifact；
4. 保留部署前 DLL、`PriGS.dat`、`PriLoc.dat` 回滚备份。