### PR TITLE
research(clx): complete full-trigger 30m F1-F6 backtest pipeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,5 @@ morningglory/fqwebui/web/index.html text eol=lf
 
 script/clx_backtest/research/results/2026-07-26-clx-regime-trigger-v1/*.csv text eol=lf
 script/clx_backtest/research/results/2026-07-26-clx-regime-trigger-v1/*.json text eol=lf
+
+/freshquant/tests/clx_backtest/fixtures/clx_engine_golden.json text eol=lf

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -572,6 +572,7 @@ docker exec fqnext_20260223-fq_mongodb-1 mongosh --quiet --eval 'const c=db.getS
 - TDX 行情服务器列表由仓库内 `freshquant/gateway/tdx_ip_pool.json` 人工维护（`QUANTAXIS.QAUtil.QAIPPool` 加载，优先于 `~/.quantaxis/setting/*_ip.json` 缓存）；股票日线、分钟线与 ETF xdxr 都使用这份正式池，服务器批量失效时更新该 JSON 即可
 - 当前 `QATdx.ping` 已加 K 线接口探活并把连接超时放宽到 3 秒；`select_best_ip` 判定阈值同步放宽，坏 default 服务器会被自动淘汰重选
 - 当前股票日线/分钟线逐票抓取会在首选 host 返回异常、`None` 或源侧空响应时切换仓库 IP 池；旧 QASU 即使继续收集逐票错误，最终 ready asset 的跨集合审计也会阻断假成功 marker
+- 股票分钟线增量落库按 `datetime` 严格大于 Mongo 中该代码、该周期的高水位筛选，不再按位置无条件丢弃 TDX 返回的首行；因此源侧没有回传旧高水位 bar（例如库内最后一条是发行期占位）时，第一根真实新 bar 仍会保留，首次仅返回一根有效 bar 时也会正常写入
 - 当前 Dagster `stock_day` / `stock_min` asset 落库后仍做基础新鲜度断言；`stock_postclose_ready_asset` 写 marker 前还会交叉审计最近 15 个交易日的当前股票日线与 `1min/5min/15min/30min/60min` 覆盖，任一确定性缺口都会 fail
 - 全市场交叉审计会豁免 OHLC 同值且成交量/额为 TDX 浮点哨兵的停牌占位日线；这类日期源侧没有分钟 bar，不要伪造数据
 - TDX 会在首个历史 bar 出现前把发行期证券放进 `stock_list`。QASU 对这类空结果打印 `ERROR CODE`；Dagster 仅在代码没有任何历史日线且仍为 TDX 发行期占位（或盘中当天 `N` 股）时豁免，已有历史或应有数据的代码仍会令任务失败

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -572,7 +572,7 @@ docker exec fqnext_20260223-fq_mongodb-1 mongosh --quiet --eval 'const c=db.getS
 - TDX 行情服务器列表由仓库内 `freshquant/gateway/tdx_ip_pool.json` 人工维护（`QUANTAXIS.QAUtil.QAIPPool` 加载，优先于 `~/.quantaxis/setting/*_ip.json` 缓存）；股票日线、分钟线与 ETF xdxr 都使用这份正式池，服务器批量失效时更新该 JSON 即可
 - 当前 `QATdx.ping` 已加 K 线接口探活并把连接超时放宽到 3 秒；`select_best_ip` 判定阈值同步放宽，坏 default 服务器会被自动淘汰重选
 - 当前股票日线/分钟线逐票抓取会在首选 host 返回异常、`None` 或源侧空响应时切换仓库 IP 池；旧 QASU 即使继续收集逐票错误，最终 ready asset 的跨集合审计也会阻断假成功 marker
-- 股票分钟线增量落库按 `datetime` 严格大于 Mongo 中该代码、该周期的高水位筛选，不再按位置无条件丢弃 TDX 返回的首行；因此源侧没有回传旧高水位 bar（例如库内最后一条是发行期占位）时，第一根真实新 bar 仍会保留，首次仅返回一根有效 bar 时也会正常写入
+- 股票分钟线增量落库按 `datetime` 严格大于 Mongo 中该代码、该周期的高水位筛选，不再按位置无条件丢弃 TDX 返回的首行；因此源侧没有回传旧高水位 bar（例如库内最后一条是发行期占位）时，第一根真实新 bar 仍会保留，首次仅返回一根有效 bar 时也会正常写入；批内固定按 `code`、`type` 和规范化后的 `datetime` 去重，不依赖可能缺列或为空的 `time_stamp`
 - 当前 Dagster `stock_day` / `stock_min` asset 落库后仍做基础新鲜度断言；`stock_postclose_ready_asset` 写 marker 前还会交叉审计最近 15 个交易日的当前股票日线与 `1min/5min/15min/30min/60min` 覆盖，任一确定性缺口都会 fail
 - 全市场交叉审计会豁免 OHLC 同值且成交量/额为 TDX 浮点哨兵的停牌占位日线；这类日期源侧没有分钟 bar，不要伪造数据
 - TDX 会在首个历史 bar 出现前把发行期证券放进 `stock_list`。QASU 对这类空结果打印 `ERROR CODE`；Dagster 仅在代码没有任何历史日线且仍为 TDX 发行期占位（或盘中当天 `N` 股）时豁免，已有历史或应有数据的代码仍会令任务失败

--- a/freshquant/runtime/memory/refresh.py
+++ b/freshquant/runtime/memory/refresh.py
@@ -37,6 +37,7 @@ def _run_git(
         cwd=repo_root,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
 

--- a/freshquant/tests/clx_backtest/test_clx_30m_f1_f6_matrix.py
+++ b/freshquant/tests/clx_backtest/test_clx_30m_f1_f6_matrix.py
@@ -14,6 +14,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 from script.clx_backtest.research.clx_30m_f1_f6_matrix import (
     FILTER_SUBSET_COUNT,
     TRIGGER_SELECTORS,
+    _development_identity,
+    _index_source_label,
+    _iter_model_candidate_groups,
+    _load_lock_for_reveal,
+    _study_config,
+    _validate_reveal_lineage,
     attach_index_benchmark,
     build_exact_detail_tables,
     build_matrix_chunk,
@@ -31,6 +37,129 @@ SPLITS = {
     "VALIDATION": ["2024-04-01", "2024-06-30"],
     "AUDIT": ["2024-07-01", "2024-12-31"],
 }
+
+
+def _write_index_snapshot_contract(root: Path) -> tuple[Path, Path, Path]:
+    snapshot_dir = root / "snapshot"
+    audit_dir = root / "audit"
+    snapshot_dir.mkdir(parents=True)
+    audit_dir.mkdir(parents=True)
+    index_path = snapshot_dir / "index_day.parquet"
+    pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-03", "2024-01-08"]),
+            "close": [100.0, 110.0],
+        }
+    ).to_parquet(index_path, index=False)
+    index_identity = {
+        "source_kind": "SHANGHAI_COMPOSITE_ETF_PROXY",
+        "source_code": "510980",
+        "source_name": "上证综合",
+        "logical_path": "snapshot/index_day.parquet",
+        "file_size": index_path.stat().st_size,
+        "file_sha256": sha256_file(index_path),
+        "rows": 2,
+    }
+    snapshot_manifest_path = snapshot_dir / "manifest.json"
+    write_json_atomic(
+        snapshot_manifest_path,
+        {
+            "snapshot_id": "sha256:fixture",
+            "index": dict(index_identity),
+        },
+    )
+    config_path = audit_dir / "study_config.json"
+    write_json_atomic(
+        config_path,
+        {
+            "index_source": dict(index_identity),
+            "time_splits": SPLITS,
+        },
+    )
+    return config_path, snapshot_manifest_path, index_path
+
+
+def _write_reveal_lineage_fixture(root: Path) -> tuple[Path, dict[str, object]]:
+    config_path, snapshot_manifest_path, index_path = _write_index_snapshot_contract(
+        root
+    )
+    features_path = root / "features" / "candidate_events.parquet"
+    features_path.parent.mkdir()
+    features_path.write_bytes(b"candidate-events-fixture")
+    matrix_dir = root / "matrix"
+    matrix_dir.mkdir()
+    candidates_path = matrix_dir / "development_lock_candidates.parquet"
+    common = {
+        "model_code": "S0016",
+        "trigger_id": "ALL",
+        "trigger_selector_kind": "ALL",
+        "trigger_selector_value": pd.NA,
+        "trigger_selector_name": "all non-zero trigger masks",
+        "filter_mask": 3,
+        "filter_names": "F1+F2",
+        "filter_count": 2,
+        "eligible_for_lock": True,
+        "development_score": 0.60,
+        "train_sample_count": 100,
+        "train_net_win_rate": 0.55,
+        "train_net_win_rate_ci_low": 0.50,
+        "train_net_win_rate_ci_high": 0.60,
+        "train_mean_net_return": 0.02,
+        "train_profit_factor": 1.2,
+        "train_mean_net_excess_return": 0.01,
+        "validation_sample_count": 80,
+        "validation_net_win_rate": 0.54,
+        "validation_net_win_rate_ci_low": 0.48,
+        "validation_net_win_rate_ci_high": 0.60,
+        "validation_mean_net_return": 0.01,
+        "validation_profit_factor": 1.1,
+        "validation_mean_net_excess_return": 0.005,
+    }
+    pd.DataFrame(
+        [
+            {
+                **common,
+                "horizon_trading_days": horizon,
+            }
+            for horizon in HORIZONS
+        ]
+    ).to_parquet(candidates_path, index=False)
+    development_stage_id, development_identity = _development_identity(
+        features_path=features_path,
+        config_path=config_path,
+        index_path=index_path,
+        snapshot_manifest_path=snapshot_manifest_path,
+        min_train_samples=1,
+        min_validation_samples=1,
+        top_per_model=1,
+    )
+    development_manifest_path = matrix_dir / "development_manifest.json"
+    write_json_atomic(
+        development_manifest_path,
+        {
+            "study_id": "clx-30m-full-trigger-f1-f6-v1",
+            "stage": "development",
+            "stage_id": development_stage_id,
+            "identity": development_identity,
+            "data_access_contract": {
+                "candidate_event_scopes_physically_read": [
+                    "TRAIN",
+                    "VALIDATION",
+                ],
+                "audit_used_in_score": False,
+            },
+            "outputs": {
+                "lock_candidates": {
+                    "path": str(candidates_path.resolve()),
+                    "file_size": candidates_path.stat().st_size,
+                    "file_sha256": sha256_file(candidates_path),
+                }
+            },
+        },
+    )
+    run_lock(argparse.Namespace(root=root, force=False))
+    lock_path, locked = _load_lock_for_reveal(root)
+    return lock_path, locked
 
 
 def _event(
@@ -81,6 +210,26 @@ def test_trigger_contract_covers_every_requested_population() -> None:
     }
     assert sum(selector.kind == "SINGLE_BIT" for selector in TRIGGER_SELECTORS) == 7
     assert sum(selector.kind == "EXACT_MASK" for selector in TRIGGER_SELECTORS) == 127
+
+
+def test_detailed_candidate_grouping_preserves_every_retained_row() -> None:
+    candidates = pd.DataFrame(
+        {
+            "candidate_id": ["a", "b", "c", "d", "e"],
+            "model_code": ["S0001", "S0000", "S0001", "S0000", "S0000"],
+            "horizon_trading_days": [5, 5, 30, 30, 30],
+        }
+    )
+
+    groups = list(_iter_model_candidate_groups(candidates))
+    grouped_rows = pd.concat(
+        [model_candidates for _, model_candidates in groups],
+        ignore_index=True,
+    )
+
+    assert [model_code for model_code, _ in groups] == ["S0000", "S0001"]
+    assert len(grouped_rows) == len(candidates)
+    assert set(grouped_rows["candidate_id"]) == set(candidates["candidate_id"])
 
 
 def test_matrix_has_64_subsets_and_masks_away_the_seventh_source_bit() -> None:
@@ -166,6 +315,148 @@ def test_index_benchmark_is_strictly_prior_and_uses_exit_day_close() -> None:
     assert audit["future_or_same_day_feature_count"] == 0
 
 
+def test_index_benchmark_labels_default_and_etf_proxy_sources() -> None:
+    assert _index_source_label() == "上证指数（000001）"
+
+    proxy = {
+        "source_kind": "SHANGHAI_COMPOSITE_ETF_PROXY",
+        "source_code": "510980",
+        "source_name": "上证综合",
+    }
+    assert _index_source_label(proxy) == "510980上证综合ETF代理"
+
+    events = pd.DataFrame([_event(code="600000", trigger_mask=1, filter_pass_mask=0)])
+    index = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-03", "2024-01-08"]),
+            "close": [100.0, 110.0],
+        }
+    )
+    _, audit = attach_index_benchmark(events, index, index_source=proxy)
+
+    assert audit["index_source"] == {
+        **proxy,
+        "source_label": "510980上证综合ETF代理",
+        "is_proxy": True,
+    }
+    assert audit["formula"].startswith("510980上证综合ETF代理 close")
+
+
+def test_study_config_accepts_bound_index_snapshot_and_manifest_changes_stage_id(
+    tmp_path: Path,
+) -> None:
+    config_path, snapshot_manifest_path, index_path = _write_index_snapshot_contract(
+        tmp_path
+    )
+    features_path = tmp_path / "candidate_events.parquet"
+    features_path.write_bytes(b"fixture")
+
+    _, config = _study_config(tmp_path)
+    first_stage_id, first_identity = _development_identity(
+        features_path=features_path,
+        config_path=config_path,
+        index_path=index_path,
+        snapshot_manifest_path=snapshot_manifest_path,
+        min_train_samples=1,
+        min_validation_samples=1,
+        top_per_model=1,
+    )
+    snapshot_manifest = json.loads(snapshot_manifest_path.read_text(encoding="utf-8"))
+    snapshot_manifest["snapshot_id"] = "sha256:changed"
+    write_json_atomic(snapshot_manifest_path, snapshot_manifest)
+    _study_config(tmp_path)
+    second_stage_id, second_identity = _development_identity(
+        features_path=features_path,
+        config_path=config_path,
+        index_path=index_path,
+        snapshot_manifest_path=snapshot_manifest_path,
+        min_train_samples=1,
+        min_validation_samples=1,
+        top_per_model=1,
+    )
+
+    assert config["index_source"]["source_code"] == "510980"
+    assert first_stage_id != second_stage_id
+    assert (
+        first_identity["snapshot_manifest_sha256"]
+        != second_identity["snapshot_manifest_sha256"]
+    )
+
+
+def test_study_config_rejects_index_identity_drift_in_snapshot_manifest(
+    tmp_path: Path,
+) -> None:
+    _, snapshot_manifest_path, _ = _write_index_snapshot_contract(tmp_path)
+    snapshot_manifest = json.loads(snapshot_manifest_path.read_text(encoding="utf-8"))
+    snapshot_manifest["index"]["source_code"] = "000001"
+    write_json_atomic(snapshot_manifest_path, snapshot_manifest)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"index_source\.source_code disagrees",
+    ):
+        _study_config(tmp_path)
+
+
+def test_study_config_rejects_index_parquet_file_drift(tmp_path: Path) -> None:
+    _, _, index_path = _write_index_snapshot_contract(tmp_path)
+    with index_path.open("ab") as stream:
+        stream.write(b"drift")
+
+    with pytest.raises(RuntimeError, match="file size disagrees"):
+        _study_config(tmp_path)
+
+
+def test_reveal_lineage_accepts_lock_bound_to_current_inputs(tmp_path: Path) -> None:
+    lock_path, locked = _write_reveal_lineage_fixture(tmp_path)
+
+    config_path, config = _validate_reveal_lineage(
+        tmp_path,
+        lock_path=lock_path,
+        locked=locked,
+    )
+
+    assert config_path == tmp_path / "audit" / "study_config.json"
+    assert config["index_source"]["source_code"] == "510980"
+
+
+def test_reveal_lineage_rejects_stale_lock_after_development_manifest_drift(
+    tmp_path: Path,
+) -> None:
+    lock_path, locked = _write_reveal_lineage_fixture(tmp_path)
+    development_manifest_path = tmp_path / "matrix" / "development_manifest.json"
+    development_manifest = json.loads(
+        development_manifest_path.read_text(encoding="utf-8")
+    )
+    development_manifest["drift"] = True
+    write_json_atomic(development_manifest_path, development_manifest)
+
+    with pytest.raises(RuntimeError, match="stale lock"):
+        _validate_reveal_lineage(
+            tmp_path,
+            lock_path=lock_path,
+            locked=locked,
+        )
+
+
+def test_reveal_lineage_rejects_current_candidate_event_input_drift(
+    tmp_path: Path,
+) -> None:
+    lock_path, locked = _write_reveal_lineage_fixture(tmp_path)
+    features_path = tmp_path / "features" / "candidate_events.parquet"
+    features_path.write_bytes(features_path.read_bytes() + b"-drift")
+
+    with pytest.raises(
+        RuntimeError,
+        match="stale lock/input drift.*candidate_events_sha256",
+    ):
+        _validate_reveal_lineage(
+            tmp_path,
+            lock_path=lock_path,
+            locked=locked,
+        )
+
+
 def test_available_matched90_and_purged_use_frozen_maturity_status() -> None:
     event = _event(code="600000", trigger_mask=1, filter_pass_mask=0)
     event["h5_exit_trade_date"] = pd.Timestamp("2024-04-01")
@@ -205,6 +496,48 @@ def test_available_matched90_and_purged_use_frozen_maturity_status() -> None:
             time_splits=SPLITS,
             hypothesis_family_size=100,
             min_train_samples=1,
+        )
+
+
+def test_available_boundary_status_must_exactly_match_recomputed_maturity() -> None:
+    valid = _event(code="600000", trigger_mask=1, filter_pass_mask=0)
+
+    matrix = build_matrix_chunk(
+        pd.DataFrame([valid]),
+        model_code="S0000",
+        horizon=5,
+        scope="AVAILABLE",
+        time_splits=SPLITS,
+        hypothesis_family_size=100,
+        min_reveal_samples=1,
+    )
+    selected = matrix.loc[matrix["trigger_id"].eq("ALL") & matrix["filter_mask"].eq(0)]
+    assert int(selected.iloc[0]["sample_count"]) == 1
+
+    missing_maturity = dict(valid)
+    missing_maturity["h5_result_maturity_at"] = pd.NaT
+    with pytest.raises(RuntimeError, match="AVAILABLE.*maturity"):
+        build_matrix_chunk(
+            pd.DataFrame([missing_maturity]),
+            model_code="S0000",
+            horizon=5,
+            scope="AVAILABLE",
+            time_splits=SPLITS,
+            hypothesis_family_size=100,
+            min_reveal_samples=1,
+        )
+
+    incorrectly_unavailable = dict(valid)
+    incorrectly_unavailable["h5_split_boundary_status"] = "UNAVAILABLE"
+    with pytest.raises(RuntimeError, match="AVAILABLE.*maturity"):
+        build_matrix_chunk(
+            pd.DataFrame([incorrectly_unavailable]),
+            model_code="S0000",
+            horizon=5,
+            scope="AVAILABLE",
+            time_splits=SPLITS,
+            hypothesis_family_size=100,
+            min_reveal_samples=1,
         )
 
 

--- a/freshquant/tests/clx_backtest/test_clx_30m_f1_f6_matrix.py
+++ b/freshquant/tests/clx_backtest/test_clx_30m_f1_f6_matrix.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from script.clx_backtest.research.clx_30m_f1_f6_matrix import (
+    FILTER_SUBSET_COUNT,
+    TRIGGER_SELECTORS,
+    attach_index_benchmark,
+    build_exact_detail_tables,
+    build_matrix_chunk,
+    load_feature_events,
+    run_lock,
+    run_reveal,
+    select_locked_config,
+    sha256_file,
+    write_json_atomic,
+)
+
+HORIZONS = (5, 30, 60, 90)
+SPLITS = {
+    "TRAIN": ["2024-01-01", "2024-03-31"],
+    "VALIDATION": ["2024-04-01", "2024-06-30"],
+    "AUDIT": ["2024-07-01", "2024-12-31"],
+}
+
+
+def _event(
+    *,
+    code: str,
+    trigger_mask: int,
+    filter_pass_mask: int,
+    split_id: str = "TRAIN",
+    net_return: float = 0.10,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "code": code,
+        "model_code": "S0000",
+        "concurrent_trigger_mask": trigger_mask,
+        "filter_pass_mask": filter_pass_mask,
+        "split_id": split_id,
+        "reveal_at": pd.Timestamp("2024-01-04 10:00", tz="Asia/Shanghai"),
+        "entry_trade_date": pd.Timestamp("2024-01-04"),
+        "index_feature_date": pd.Timestamp("2024-01-03"),
+        "market_regime": "SIDEWAYS",
+    }
+    for horizon in HORIZONS:
+        row.update(
+            {
+                f"h{horizon}_status": "OK",
+                f"h{horizon}_gross_return": net_return + 0.0004,
+                f"h{horizon}_net_return": net_return,
+                f"h{horizon}_exit_trade_date": pd.Timestamp("2024-01-08"),
+                f"h{horizon}_result_maturity_at": pd.Timestamp(
+                    "2024-01-08 10:00", tz="Asia/Shanghai"
+                ),
+                f"h{horizon}_split_boundary_status": "AVAILABLE",
+                f"h{horizon}_index_return": 0.02,
+                f"h{horizon}_net_excess_return": net_return - 0.02,
+            }
+        )
+    return row
+
+
+def test_trigger_contract_covers_every_requested_population() -> None:
+    assert len(TRIGGER_SELECTORS) == 7 + 127 + 3
+    assert {selector.kind for selector in TRIGGER_SELECTORS} == {
+        "SINGLE_BIT",
+        "EXACT_MASK",
+        "COUNT_EQ",
+        "COUNT_GTE",
+        "ALL",
+    }
+    assert sum(selector.kind == "SINGLE_BIT" for selector in TRIGGER_SELECTORS) == 7
+    assert sum(selector.kind == "EXACT_MASK" for selector in TRIGGER_SELECTORS) == 127
+
+
+def test_matrix_has_64_subsets_and_masks_away_the_seventh_source_bit() -> None:
+    events = pd.DataFrame(
+        [
+            # Source bit 6 (64) is ignored; only F1 remains in this matrix.
+            _event(code="600000", trigger_mask=0x01, filter_pass_mask=0x01 | 0x40),
+            _event(
+                code="600001",
+                trigger_mask=0x01 | 0x02,
+                filter_pass_mask=0x01 | 0x02,
+                net_return=-0.05,
+            ),
+        ]
+    )
+
+    actual = build_matrix_chunk(
+        events,
+        model_code="S0000",
+        horizon=5,
+        scope="TRAIN",
+        time_splits=SPLITS,
+        hypothesis_family_size=100,
+        min_train_samples=1,
+    )
+
+    assert len(actual) == len(TRIGGER_SELECTORS) * FILTER_SUBSET_COUNT
+    assert actual["filter_mask"].nunique() == 64
+    assert actual["filter_mask"].min() == 0
+    assert actual["filter_mask"].max() == 63
+    assert set(actual["filter_names"].str.split("+").explode()) <= {
+        "NONE",
+        "F1",
+        "F2",
+        "F3",
+        "F4",
+        "F5",
+        "F6",
+    }
+
+    def sample(trigger_id: str, filter_mask: int) -> int:
+        row = actual.loc[
+            actual["trigger_id"].eq(trigger_id) & actual["filter_mask"].eq(filter_mask)
+        ]
+        assert len(row) == 1
+        return int(row.iloc[0]["sample_count"])
+
+    assert sample("ALL", 0) == 2
+    assert sample("SINGLE_MODEL_STRUCTURAL", 0) == 2
+    assert sample("EXACT_MASK_001", 0) == 1
+    assert sample("EXACTLY_2", 0) == 1
+    assert sample("ALL", 0x01) == 2
+    assert sample("ALL", 0x02) == 1
+    assert sample("ALL", 0x03) == 1
+    assert sample("ALL", 0x3F) == 0
+
+
+def test_index_benchmark_is_strictly_prior_and_uses_exit_day_close() -> None:
+    events = pd.DataFrame(
+        [_event(code="600000", trigger_mask=1, filter_pass_mask=0)]
+    ).drop(
+        columns=[
+            *(f"h{horizon}_index_return" for horizon in HORIZONS),
+            *(f"h{horizon}_net_excess_return" for horizon in HORIZONS),
+        ]
+    )
+    index = pd.DataFrame(
+        {
+            "date": pd.to_datetime(
+                ["2024-01-02", "2024-01-03", "2024-01-05", "2024-01-08"]
+            ),
+            "close": [100.0, 101.0, 102.0, 111.1],
+        }
+    )
+
+    actual, audit = attach_index_benchmark(events, index)
+
+    assert actual.loc[0, "benchmark_entry_index_date"] == pd.Timestamp("2024-01-03")
+    assert actual.loc[0, "h5_benchmark_exit_index_date"] == pd.Timestamp("2024-01-08")
+    assert math.isclose(actual.loc[0, "h5_index_return"], 0.10)
+    assert math.isclose(actual.loc[0, "h5_net_excess_return"], 0.0, abs_tol=1e-12)
+    assert audit["future_or_same_day_entry_base_count"] == 0
+    assert audit["future_or_same_day_feature_count"] == 0
+
+
+def test_available_matched90_and_purged_use_frozen_maturity_status() -> None:
+    event = _event(code="600000", trigger_mask=1, filter_pass_mask=0)
+    event["h5_exit_trade_date"] = pd.Timestamp("2024-04-01")
+    event["h5_result_maturity_at"] = pd.Timestamp(
+        "2024-04-01 10:00", tz="Asia/Shanghai"
+    )
+    event["h5_split_boundary_status"] = "PURGED"
+    events = pd.DataFrame([event])
+
+    def count(scope: str) -> int:
+        matrix = build_matrix_chunk(
+            events,
+            model_code="S0000",
+            horizon=5,
+            scope=scope,
+            time_splits=SPLITS,
+            hypothesis_family_size=100,
+            min_train_samples=1,
+            min_reveal_samples=1,
+        )
+        row = matrix.loc[matrix["trigger_id"].eq("ALL") & matrix["filter_mask"].eq(0)]
+        assert len(row) == 1
+        return int(row.iloc[0]["sample_count"])
+
+    assert count("TRAIN") == 0
+    assert count("AVAILABLE") == 0
+    assert count("MATCHED90") == 0
+    assert count("PURGED") == 1
+
+    events.loc[0, "h5_split_boundary_status"] = "AVAILABLE"
+    with pytest.raises(RuntimeError, match="disagrees with maturity"):
+        build_matrix_chunk(
+            events,
+            model_code="S0000",
+            horizon=5,
+            scope="TRAIN",
+            time_splits=SPLITS,
+            hypothesis_family_size=100,
+            min_train_samples=1,
+        )
+
+
+def test_exact_shortlist_details_cover_weightings_and_time_groups() -> None:
+    first = _event(code="600000", trigger_mask=1, filter_pass_mask=0)
+    second = _event(
+        code="600000",
+        trigger_mask=1,
+        filter_pass_mask=0,
+        net_return=-0.05,
+    )
+    second["model_code"] = "S0001"
+    events = pd.DataFrame([first, second])
+    selection = {
+        "selection_id": "sha256:fixture",
+        "horizon_trading_days": 5,
+        "model_code": "S0000",
+        "trigger_id": "ALL",
+        "trigger_selector": {
+            "kind": "ALL",
+            "value": None,
+            "name": "all non-zero trigger masks",
+        },
+        "filter_mask": 0,
+        "filter_names": [],
+    }
+
+    overview, groups = build_exact_detail_tables(
+        events,
+        selection=selection,
+        scopes=("TRAIN",),
+        time_splits=SPLITS,
+        model_populations=("SELECTED_MODEL", "ALL_MODELS_SAME_RULE"),
+        minimum_sample=1,
+        source_kind="FIXTURE",
+    )
+
+    all_models = overview.loc[
+        overview["model_population"].eq("ALL_MODELS_SAME_RULE")
+    ].set_index("aggregation")
+    assert all_models.loc["EVENT", "sample_count"] == 2
+    assert all_models.loc["UNION", "sample_count"] == 1
+    assert all_models.loc["MACRO", "sample_count"] == 2
+    assert all_models.loc["DATE_BALANCED", "sample_count"] == 1
+    assert set(groups["group_dimension"]) == {
+        "YEAR",
+        "QUARTER",
+        "MARKET_REGIME",
+    }
+    assert {
+        "median_net_return",
+        "p05_net_return",
+        "p95_net_return",
+        "cvar5_net_return",
+        "max_consecutive_losses",
+        "positive_pnl_top10pct_concentration",
+        "peak_same_day_signal_crowding",
+    }.issubset(overview.columns)
+
+
+def test_development_parquet_pushdown_excludes_audit_rows(tmp_path: Path) -> None:
+    path = tmp_path / "candidate_events.parquet"
+    pd.DataFrame(
+        [
+            _event(
+                code="600000",
+                trigger_mask=1,
+                filter_pass_mask=0,
+                split_id="TRAIN",
+            ),
+            _event(
+                code="600001",
+                trigger_mask=1,
+                filter_pass_mask=0,
+                split_id="AUDIT",
+            ),
+        ]
+    ).drop(
+        columns=[
+            *(f"h{horizon}_index_return" for horizon in HORIZONS),
+            *(f"h{horizon}_net_excess_return" for horizon in HORIZONS),
+        ]
+    ).to_parquet(
+        path, index=False
+    )
+
+    actual = load_feature_events(
+        path,
+        split_filter=("TRAIN", "VALIDATION"),
+    )
+
+    assert list(actual["split_id"]) == ["TRAIN"]
+    assert list(actual["code"]) == ["600000"]
+    assert actual.loc[0, "filter_pass_mask"] == 0
+
+
+def test_lock_selects_one_development_champion_without_reveal_columns() -> None:
+    common = {
+        "horizon_trading_days": 5,
+        "trigger_selector_kind": "ALL",
+        "trigger_selector_value": pd.NA,
+        "trigger_selector_name": "all non-zero trigger masks",
+        "filter_names": "NONE",
+        "filter_count": 0,
+        "eligible_for_lock": True,
+        "train_sample_count": 100,
+        "train_net_win_rate": 0.55,
+        "train_net_win_rate_ci_low": 0.50,
+        "train_net_win_rate_ci_high": 0.60,
+        "train_mean_net_return": 0.02,
+        "train_profit_factor": 1.2,
+        "train_mean_net_excess_return": 0.01,
+        "validation_sample_count": 80,
+        "validation_net_win_rate": 0.54,
+        "validation_net_win_rate_ci_low": 0.48,
+        "validation_net_win_rate_ci_high": 0.60,
+        "validation_mean_net_return": 0.01,
+        "validation_profit_factor": 1.1,
+        "validation_mean_net_excess_return": 0.005,
+    }
+    candidates = pd.DataFrame(
+        [
+            {
+                **common,
+                "model_code": "S0000",
+                "trigger_id": "ALL",
+                "filter_mask": 0,
+                "development_score": 0.50,
+            },
+            {
+                **common,
+                "model_code": "S0016",
+                "trigger_id": "ALL",
+                "filter_mask": 3,
+                "filter_names": "F1+F2",
+                "filter_count": 2,
+                "development_score": 0.60,
+            },
+        ]
+    )
+
+    selections = select_locked_config(candidates, horizons=(5,))
+
+    assert len(selections) == 1
+    assert selections[0]["model_code"] == "S0016"
+    assert selections[0]["filter_mask"] == 3
+    assert selections[0]["filter_names"] == ["F1", "F2"]
+    assert selections[0]["trigger_selector"]["kind"] == "ALL"
+
+    with pytest.raises(RuntimeError, match="leaks reveal columns"):
+        select_locked_config(
+            candidates.assign(audit_win_rate=0.99),
+            horizons=(5,),
+        )
+
+
+def test_reveal_fails_on_missing_lock_before_opening_inputs(tmp_path: Path) -> None:
+    args = argparse.Namespace(
+        root=tmp_path,
+        min_reveal_samples=1,
+        progress_every=0,
+        force=False,
+    )
+
+    with pytest.raises(FileNotFoundError) as error:
+        run_reveal(args)
+
+    assert (
+        error.value.filename is None
+        or str(error.value).endswith("matrix\\locked_config.json")
+        or str(error.value).endswith("matrix/locked_config.json")
+    )
+
+
+def test_lock_artifact_has_four_f1_f6_selections_and_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    matrix_dir = tmp_path / "matrix"
+    matrix_dir.mkdir()
+    rows = []
+    for horizon in HORIZONS:
+        rows.append(
+            {
+                "horizon_trading_days": horizon,
+                "model_code": "S0016",
+                "trigger_id": "ALL",
+                "trigger_selector_kind": "ALL",
+                "trigger_selector_value": pd.NA,
+                "trigger_selector_name": "all non-zero trigger masks",
+                "filter_mask": 3,
+                "filter_names": "F1+F2",
+                "filter_count": 2,
+                "eligible_for_lock": True,
+                "development_score": 0.60,
+                "train_sample_count": 100,
+                "train_net_win_rate": 0.55,
+                "train_net_win_rate_ci_low": 0.50,
+                "train_net_win_rate_ci_high": 0.60,
+                "train_mean_net_return": 0.02,
+                "train_profit_factor": 1.2,
+                "train_mean_net_excess_return": 0.01,
+                "validation_sample_count": 80,
+                "validation_net_win_rate": 0.54,
+                "validation_net_win_rate_ci_low": 0.48,
+                "validation_net_win_rate_ci_high": 0.60,
+                "validation_mean_net_return": 0.01,
+                "validation_profit_factor": 1.1,
+                "validation_mean_net_excess_return": 0.005,
+            }
+        )
+    candidates_path = matrix_dir / "development_lock_candidates.parquet"
+    pd.DataFrame(rows).to_parquet(candidates_path, index=False)
+    development_manifest_path = matrix_dir / "development_manifest.json"
+    write_json_atomic(
+        development_manifest_path,
+        {
+            "stage_id": "sha256:development-fixture",
+            "data_access_contract": {
+                "candidate_event_scopes_physically_read": [
+                    "TRAIN",
+                    "VALIDATION",
+                ],
+                "audit_used_in_score": False,
+            },
+            "outputs": {
+                "lock_candidates": {
+                    "path": str(candidates_path.resolve()),
+                    "file_sha256": sha256_file(candidates_path),
+                }
+            },
+        },
+    )
+    args = argparse.Namespace(root=tmp_path, force=False)
+
+    first = run_lock(args)
+    second = run_lock(args)
+    locked = json.loads((matrix_dir / "locked_config.json").read_text(encoding="utf-8"))
+
+    assert first["reused"] is False
+    assert second["reused"] is True
+    assert len(locked["selections"]) == 4
+    assert {item["horizon_trading_days"] for item in locked["selections"]} == set(
+        HORIZONS
+    )
+    assert all(0 <= item["filter_mask"] <= 63 for item in locked["selections"])
+    assert locked["study_id"] == "clx-30m-full-trigger-f1-f6-v1"
+    assert locked["filter_contract"] == {
+        "filters": ["F1", "F2", "F3", "F4", "F5", "F6"],
+        "mask_range": [0, 63],
+        "subset_count": 64,
+    }

--- a/freshquant/tests/clx_backtest/test_intraday_f1_f6_portfolio.py
+++ b/freshquant/tests/clx_backtest/test_intraday_f1_f6_portfolio.py
@@ -1,31 +1,74 @@
 from __future__ import annotations
 
+import argparse
 import json
 import math
+import subprocess
 import sys
 from pathlib import Path
 
 import pandas as pd
 import pytest
+from openpyxl import load_workbook
+from openpyxl.utils import get_column_letter
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
+from script.clx_backtest.research.clx_30m_f1_f6_matrix import (
+    _development_identity,
+    _reveal_identity,
+    run_lock,
+    write_json_atomic,
+)
 from script.clx_backtest.research.clx_30m_f1_f6_portfolio import (
     FEE_PER_SIDE,
     INITIAL_CAPITAL,
+    REPRODUCE_SCRIPT,
+    REQUIRED_LOGICAL_OUTPUTS,
     MarkStore,
     PortfolioContractError,
+    _checkpoint_key,
+    _completed_result,
+    _parse_locked_selections,
+    _portfolio_quality_statement,
+    _stability_statement,
+    _write_excel,
     build_simulation_clock,
     load_locked_selections,
+    rebuild_report,
     run_portfolios,
     select_locked_candidates,
+    sha256_file,
     simulate_portfolio,
+    validate_snapshot_inputs,
 )
+
+
+def test_direct_script_cli_help_from_repo_root() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = (
+        repo_root
+        / "script"
+        / "clx_backtest"
+        / "research"
+        / "clx_30m_f1_f6_portfolio.py"
+    )
+    completed = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "usage:" in completed.stdout.lower()
 
 
 def _locked_payload(filter_mask: int = 0) -> dict[str, object]:
     return {
-        "study_id": "fixture",
+        "lock_id": "sha256:fixture-lock",
+        "study_id": "clx-30m-full-trigger-f1-f6-v1",
         "selections": [
             {
                 "selection_id": f"h{horizon}-fixture",
@@ -90,11 +133,125 @@ def _event(
         row[f"h{horizon}_status"] = "OK"
         row[f"h{horizon}_exit_at"] = exit_at
         row[f"h{horizon}_gross_return"] = gross_return
+        row[f"h{horizon}_split_boundary_status"] = "AVAILABLE"
     return row
 
 
-def _write_fixture(root: Path) -> pd.DataFrame:
+def _finalize_matrix_lineage(root: Path) -> None:
+    matrix_dir = root / "matrix"
+    candidates_path = matrix_dir / "development_lock_candidates.parquet"
+    common = {
+        "model_code": "S0000",
+        "trigger_id": "ALL",
+        "trigger_selector_kind": "ALL",
+        "trigger_selector_value": pd.NA,
+        "trigger_selector_name": "all non-zero trigger masks",
+        "filter_mask": 0,
+        "filter_names": "NONE",
+        "filter_count": 0,
+        "eligible_for_lock": True,
+        "development_score": 0.60,
+        "train_sample_count": 100,
+        "train_net_win_rate": 0.55,
+        "train_net_win_rate_ci_low": 0.50,
+        "train_net_win_rate_ci_high": 0.60,
+        "train_mean_net_return": 0.02,
+        "train_profit_factor": 1.2,
+        "train_mean_net_excess_return": 0.01,
+        "validation_sample_count": 80,
+        "validation_net_win_rate": 0.54,
+        "validation_net_win_rate_ci_low": 0.48,
+        "validation_net_win_rate_ci_high": 0.60,
+        "validation_mean_net_return": 0.01,
+        "validation_profit_factor": 1.1,
+        "validation_mean_net_excess_return": 0.005,
+    }
+    pd.DataFrame(
+        [
+            {
+                **common,
+                "horizon_trading_days": horizon,
+            }
+            for horizon in (5, 30, 60, 90)
+        ]
+    ).to_parquet(candidates_path, index=False)
+    features_path = root / "features" / "candidate_events.parquet"
+    config_path = root / "audit" / "study_config.json"
+    index_path = root / "snapshot" / "index_day.parquet"
+    snapshot_manifest_path = root / "snapshot" / "manifest.json"
+    development_stage_id, development_identity = _development_identity(
+        features_path=features_path,
+        config_path=config_path,
+        index_path=index_path,
+        snapshot_manifest_path=snapshot_manifest_path,
+        min_train_samples=1,
+        min_validation_samples=1,
+        top_per_model=1,
+    )
+    development_manifest_path = matrix_dir / "development_manifest.json"
+    write_json_atomic(
+        development_manifest_path,
+        {
+            "study_id": "clx-30m-full-trigger-f1-f6-v1",
+            "stage": "development",
+            "stage_id": development_stage_id,
+            "identity": development_identity,
+            "data_access_contract": {
+                "candidate_event_scopes_physically_read": [
+                    "TRAIN",
+                    "VALIDATION",
+                ],
+                "audit_used_in_score": False,
+            },
+            "outputs": {
+                "lock_candidates": {
+                    "path": str(candidates_path.resolve()),
+                    "file_size": candidates_path.stat().st_size,
+                    "file_sha256": sha256_file(candidates_path),
+                }
+            },
+        },
+    )
+    run_lock(argparse.Namespace(root=root, force=True))
+    lock_path = matrix_dir / "locked_config.json"
+    locked = json.loads(lock_path.read_text(encoding="utf-8"))
+    reveal_stage_id, reveal_identity = _reveal_identity(
+        lock_path=lock_path,
+        features_path=features_path,
+        config_path=config_path,
+        index_path=index_path,
+        snapshot_manifest_path=snapshot_manifest_path,
+        min_reveal_samples=1,
+    )
+    reveal_outputs = {
+        "matrix": matrix_dir / "reveal_matrix.parquet",
+        "summary": matrix_dir / "reveal_summary.csv",
+        "locked_detailed": matrix_dir / "reveal_locked_detailed.parquet",
+        "group_detail": matrix_dir / "reveal_locked_group_detail.parquet",
+    }
+    write_json_atomic(
+        matrix_dir / "reveal_manifest.json",
+        {
+            "study_id": "clx-30m-full-trigger-f1-f6-v1",
+            "stage": "reveal",
+            "stage_id": reveal_stage_id,
+            "lock_id": locked["lock_id"],
+            "identity": reveal_identity,
+            "outputs": {
+                name: {
+                    "path": str(path.resolve()),
+                    "file_size": path.stat().st_size,
+                    "file_sha256": sha256_file(path),
+                }
+                for name, path in reveal_outputs.items()
+            },
+        },
+    )
+
+
+def _write_fixture(root: Path, *, split_id: str = "TRAIN") -> pd.DataFrame:
     _write_lock(root)
+    reveal_path = root / "matrix" / "reveal_summary.csv"
     pd.DataFrame(
         [
             {
@@ -113,10 +270,70 @@ def _write_fixture(root: Path) -> pd.DataFrame:
             }
             for horizon in (5, 30, 60, 90)
         ]
-    ).to_csv(
-        root / "matrix" / "reveal_summary.csv",
+    ).to_csv(reveal_path, index=False, encoding="utf-8-sig")
+    reveal_detailed_path = root / "matrix" / "reveal_locked_detailed.parquet"
+    pd.DataFrame(
+        [
+            {
+                "scope": "AUDIT",
+                "horizon_trading_days": horizon,
+                "model_population": "SELECTED_MODEL",
+                "aggregation": aggregation,
+                "sample_count": 40,
+                "net_win_rate": 0.55,
+                "mean_net_return": 0.02,
+                "mean_net_excess_return": 0.01,
+            }
+            for horizon in (5, 30, 60, 90)
+            for aggregation in ("EVENT", "UNION", "MACRO", "DATE_BALANCED")
+        ]
+    ).to_parquet(reveal_detailed_path, index=False)
+    reveal_group_path = root / "matrix" / "reveal_locked_group_detail.parquet"
+    pd.DataFrame(
+        [
+            {
+                "scope": "AUDIT",
+                "horizon_trading_days": horizon,
+                "model_population": "SELECTED_MODEL",
+                "aggregation": "EVENT",
+                "group_type": "YEAR",
+                "group_value": "2024",
+                "sample_count": 40,
+                "net_win_rate": 0.55,
+            }
+            for horizon in (5, 30, 60, 90)
+        ]
+    ).to_parquet(reveal_group_path, index=False)
+    pd.DataFrame({"fixture": [1]}).to_parquet(
+        root / "matrix" / "reveal_matrix.parquet",
         index=False,
-        encoding="utf-8-sig",
+    )
+    (root / "matrix" / "reveal_manifest.json").write_text(
+        json.dumps(
+            {
+                "study_id": "clx-30m-full-trigger-f1-f6-v1",
+                "stage": "reveal",
+                "lock_id": "sha256:fixture-lock",
+                "outputs": {
+                    "summary": {
+                        "path": str(reveal_path),
+                        "file_size": reveal_path.stat().st_size,
+                        "file_sha256": sha256_file(reveal_path),
+                    },
+                    "locked_detailed": {
+                        "path": str(reveal_detailed_path),
+                        "file_size": reveal_detailed_path.stat().st_size,
+                        "file_sha256": sha256_file(reveal_detailed_path),
+                    },
+                    "group_detail": {
+                        "path": str(reveal_group_path),
+                        "file_size": reveal_group_path.stat().st_size,
+                        "file_sha256": sha256_file(reveal_group_path),
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
     )
     sessions = pd.bdate_range("2024-07-01", periods=12)
     index = pd.DataFrame(
@@ -130,10 +347,12 @@ def _write_fixture(root: Path) -> pd.DataFrame:
     )
     snapshot = root / "snapshot"
     snapshot.mkdir(parents=True)
-    index.to_parquet(snapshot / "index_day.parquet", index=False)
+    index_path = snapshot / "index_day.parquet"
+    index.to_parquet(index_path, index=False)
     bars_dir = snapshot / "bars"
     bars_dir.mkdir()
     clocks = ("10:00", "10:30", "11:00", "11:30", "13:30", "14:00", "14:30", "15:00")
+    bar_files = []
     for code, drift in (("600000", 0.02), ("600001", -0.01)):
         bars = pd.DataFrame(
             [
@@ -154,7 +373,57 @@ def _write_fixture(root: Path) -> pd.DataFrame:
                 for slot, clock in enumerate(clocks)
             ]
         )
-        bars.to_parquet(bars_dir / f"{code}.parquet", index=False)
+        bar_path = bars_dir / f"{code}.parquet"
+        bars.to_parquet(bar_path, index=False)
+        bar_files.append(
+            {
+                "code": code,
+                "rows": len(bars),
+                "file_size": bar_path.stat().st_size,
+                "file_sha256": sha256_file(bar_path),
+            }
+        )
+    index_source = {
+        "source_code": "510980",
+        "source_kind": "SHANGHAI_COMPOSITE_ETF_PROXY",
+        "source_name": "上证综合ETF",
+    }
+    index_identity = {
+        **index_source,
+        "logical_path": "snapshot/index_day.parquet",
+        "file_size": index_path.stat().st_size,
+        "file_sha256": sha256_file(index_path),
+        "rows": len(index),
+    }
+    audit = root / "audit"
+    audit.mkdir()
+    (audit / "study_config.json").write_text(
+        json.dumps(
+            {
+                "study_id": "clx-30m-full-trigger-f1-f6-v1",
+                "index_source": index_identity,
+                "time_splits": {
+                    "TRAIN": ["2024-01-01", "2024-07-04"],
+                    "VALIDATION": ["2024-07-05", "2024-07-10"],
+                    "AUDIT": ["2024-07-11", "2024-12-31"],
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    (snapshot / "manifest.json").write_text(
+        json.dumps(
+            {
+                "study_id": "clx-30m-full-trigger-f1-f6-v1",
+                "snapshot_id": "sha256:fixture-snapshot",
+                "index": index_identity,
+                "code_files": bar_files,
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
     entry = pd.Timestamp("2024-07-02 10:30", tz="Asia/Shanghai")
     events = pd.DataFrame(
         [
@@ -162,10 +431,12 @@ def _write_fixture(root: Path) -> pd.DataFrame:
             _event("600001", entry, gross_return=-0.05, event_no=2),
         ]
     )
+    events["split_id"] = split_id
     events.loc[events["code"].eq("600000"), "amount_median_20d"] = 2_000_000.0
     features = root / "features"
     features.mkdir()
-    events.to_parquet(features / "candidate_events.parquet", index=False)
+    event_path = features / "candidate_events.parquet"
+    events.to_parquet(event_path, index=False)
     pd.DataFrame(
         [
             {
@@ -180,29 +451,80 @@ def _write_fixture(root: Path) -> pd.DataFrame:
             }
         ]
     ).to_csv(features / "market_segments.csv", index=False, encoding="utf-8-sig")
+    feature_summary = {
+        "study_id": "clx-30m-full-trigger-f1-f6-v1",
+        "candidate_event_rows": 2,
+        "unique_union_signals": 2,
+        "unique_stocks": 2,
+        "output": {
+            "path": str(event_path.resolve()),
+            "file_size": event_path.stat().st_size,
+            "file_sha256": sha256_file(event_path),
+        },
+    }
     (features / "summary.json").write_text(
+        json.dumps(feature_summary),
+        encoding="utf-8",
+    )
+    signal_set_id = "sha256:" + "1" * 64
+    (features / "manifest.json").write_text(
         json.dumps(
             {
-                "candidate_event_rows": 2,
-                "unique_union_signals": 2,
-                "unique_stocks": 2,
+                "study_id": "clx-30m-full-trigger-f1-f6-v1",
+                "snapshot_id": "sha256:fixture-snapshot",
+                "signal_set_id": signal_set_id,
+                "summary": feature_summary,
             }
         ),
         encoding="utf-8",
     )
+    replay = root / "replay"
+    replay.mkdir()
+    (replay / "manifest.json").write_text(
+        json.dumps(
+            {
+                "study_id": "clx-30m-full-trigger-f1-f6-v1",
+                "snapshot_id": "sha256:fixture-snapshot",
+                "signal_set_id": signal_set_id,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _finalize_matrix_lineage(root)
     return events
 
 
 def test_lock_rejects_filter_mask_outside_six_bits(tmp_path: Path) -> None:
-    _write_lock(tmp_path, filter_mask=64)
-
     with pytest.raises(PortfolioContractError, match="0..63"):
-        load_locked_selections(tmp_path / "matrix" / "locked_config.json")
+        _parse_locked_selections(_locked_payload(filter_mask=64))
+
+
+def test_lock_rejects_another_study_identity(tmp_path: Path) -> None:
+    payload = _locked_payload()
+    payload["study_id"] = "another-study"
+    path = tmp_path / "matrix" / "locked_config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(PortfolioContractError, match="study_id mismatch"):
+        load_locked_selections(path)
+
+
+def test_load_lock_rejects_tampered_selection_with_old_lock_id(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    path = tmp_path / "matrix" / "locked_config.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["selections"][0]["model_code"] = "S0001"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(PortfolioContractError, match="lock_id mismatch"):
+        load_locked_selections(path)
 
 
 def test_selection_applies_single_trigger_and_f1_f6_mask(tmp_path: Path) -> None:
-    _write_lock(tmp_path)
-    selection = load_locked_selections(tmp_path / "matrix" / "locked_config.json")[0]
+    selection = _parse_locked_selections(_locked_payload())[0]
     selection = selection.__class__(
         **{
             **selection.__dict__,
@@ -225,6 +547,309 @@ def test_selection_applies_single_trigger_and_f1_f6_mask(tmp_path: Path) -> None
 
     assert actual["code"].tolist() == ["600000"]
     assert math.isclose(actual.loc[0, "qfq_exit_open"], 11.0)
+
+
+@pytest.mark.parametrize("horizon", (5, 30, 60, 90))
+def test_selection_scope_contract_is_fail_closed_for_every_horizon(
+    tmp_path: Path,
+    horizon: int,
+) -> None:
+    selection = next(
+        item
+        for item in _parse_locked_selections(_locked_payload())
+        if item.horizon == horizon
+    )
+    entry = pd.Timestamp("2024-07-02 10:30", tz="Asia/Shanghai")
+    train_available = _event("600000", entry, gross_return=0.1, event_no=1)
+    validation_available = _event("600001", entry, gross_return=0.1, event_no=2)
+    validation_available["split_id"] = "VALIDATION"
+    audit_available = _event("600002", entry, gross_return=0.1, event_no=3)
+    audit_available["split_id"] = "AUDIT"
+    train_purged = _event("600003", entry, gross_return=0.1, event_no=4)
+    train_purged[f"h{horizon}_split_boundary_status"] = "PURGED"
+    audit_purged = _event("600004", entry, gross_return=0.1, event_no=5)
+    audit_purged["split_id"] = "AUDIT"
+    audit_purged[f"h{horizon}_split_boundary_status"] = "PURGED"
+    missing_boundary = _event("600005", entry, gross_return=0.1, event_no=6)
+    missing_boundary[f"h{horizon}_split_boundary_status"] = pd.NA
+    unknown_boundary = _event("600006", entry, gross_return=0.1, event_no=7)
+    unknown_boundary[f"h{horizon}_split_boundary_status"] = "UNKNOWN"
+    unknown_split = _event("600007", entry, gross_return=0.1, event_no=8)
+    unknown_split["split_id"] = "UNKNOWN"
+    missing_split = _event("600008", entry, gross_return=0.1, event_no=9)
+    missing_split["split_id"] = pd.NA
+    events = pd.DataFrame(
+        [
+            train_available,
+            validation_available,
+            audit_available,
+            train_purged,
+            audit_purged,
+            missing_boundary,
+            unknown_boundary,
+            unknown_split,
+            missing_split,
+        ]
+    )
+
+    available = select_locked_candidates(events, selection, scope="AVAILABLE")
+    audit = select_locked_candidates(events, selection, scope="AUDIT")
+
+    assert set(available["code"]) == {"600000", "600001", "600002"}
+    assert audit["code"].tolist() == ["600002"]
+
+    with pytest.raises(PortfolioContractError, match="split_id"):
+        select_locked_candidates(
+            events.drop(columns="split_id"),
+            selection,
+            scope="AVAILABLE",
+        )
+    with pytest.raises(
+        PortfolioContractError,
+        match=f"h{horizon}_split_boundary_status",
+    ):
+        select_locked_candidates(
+            events.drop(columns=f"h{horizon}_split_boundary_status"),
+            selection,
+            scope="AVAILABLE",
+        )
+
+
+def test_checkpoint_keys_isolate_available_audit_and_matched90(
+    tmp_path: Path,
+) -> None:
+    selection = _parse_locked_selections(_locked_payload())[0]
+
+    keys = {
+        scope: _checkpoint_key(
+            selection=selection,
+            scope=scope,
+            daily_entry_limit=5,
+            ranking_policy="quality",
+            random_seed=None,
+        )
+        for scope in ("AVAILABLE", "AUDIT", "MATCHED90")
+    }
+
+    assert len(set(keys.values())) == 3
+    assert "_available_" in keys["AVAILABLE"]
+    assert "_audit_" in keys["AUDIT"]
+    assert "_matched90_" in keys["MATCHED90"]
+    with pytest.raises(PortfolioContractError, match="unsupported checkpoint scope"):
+        _checkpoint_key(
+            selection=selection,
+            scope="UNKNOWN",
+            daily_entry_limit=5,
+            ranking_policy="quality",
+            random_seed=None,
+        )
+
+
+def test_run_rejects_reveal_artifact_changed_after_manifest(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    path = tmp_path / "matrix" / "reveal_summary.csv"
+    path.write_text(path.read_text(encoding="utf-8-sig") + "\n", encoding="utf-8-sig")
+
+    with pytest.raises(PortfolioContractError, match="summary identity mismatch"):
+        run_portfolios(
+            root=tmp_path,
+            random_seeds=1,
+            include_audit_scope=False,
+        )
+
+
+def test_run_rejects_old_reveal_manifest_mixed_with_current_lock(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    path = tmp_path / "matrix" / "reveal_manifest.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["lock_id"] = "sha256:" + "0" * 64
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(PortfolioContractError, match="reveal identity mismatch"):
+        run_portfolios(
+            root=tmp_path,
+            random_seeds=0,
+            include_audit_scope=False,
+        )
+
+
+def test_snapshot_contract_verifies_every_declared_file_and_identity(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path)
+    benchmark = {
+        "source_code": "510980",
+        "source_kind": "SHANGHAI_COMPOSITE_ETF_PROXY",
+        "source_name": "上证综合ETF",
+    }
+
+    verified = validate_snapshot_inputs(
+        tmp_path,
+        index_benchmark=benchmark,
+    )
+
+    assert verified["status"] == "VERIFIED"
+    assert verified["all_declared_files_verified"] is True
+    assert verified["verified_bar_file_count"] == 2
+    assert verified["verified_file_count"] == 3
+
+    for relative_path in (
+        "snapshot/index_day.parquet",
+        "snapshot/bars/600000.parquet",
+    ):
+        path = tmp_path / relative_path
+        original = path.read_bytes()
+        path.write_bytes(original + b"x")
+        with pytest.raises(PortfolioContractError, match="size mismatch"):
+            validate_snapshot_inputs(tmp_path, index_benchmark=benchmark)
+        path.write_bytes(original)
+
+
+def test_snapshot_contract_rejects_declared_bar_rows_drift(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    path = tmp_path / "snapshot" / "manifest.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["code_files"][0]["rows"] += 1
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(PortfolioContractError, match="Parquet row count mismatch"):
+        validate_snapshot_inputs(
+            tmp_path,
+            index_benchmark={
+                "source_code": "510980",
+                "source_kind": "SHANGHAI_COMPOSITE_ETF_PROXY",
+                "source_name": "上证综合ETF",
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    (
+        ("study", "study_id mismatch"),
+        ("index_path", "index logical_path"),
+        ("bar_path", "path mismatch"),
+        ("duplicate_code", "duplicate code"),
+    ),
+)
+def test_snapshot_contract_rejects_ambiguous_manifest_identity(
+    tmp_path: Path,
+    mutation: str,
+    message: str,
+) -> None:
+    _write_fixture(tmp_path)
+    path = tmp_path / "snapshot" / "manifest.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if mutation == "study":
+        payload["study_id"] = "another-study"
+    elif mutation == "index_path":
+        payload["index"]["logical_path"] = "../index_day.parquet"
+    elif mutation == "bar_path":
+        payload["code_files"][0]["path"] = "../600000.parquet"
+    else:
+        payload["code_files"].append(dict(payload["code_files"][0]))
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(PortfolioContractError, match=message):
+        validate_snapshot_inputs(
+            tmp_path,
+            index_benchmark={
+                "source_code": "510980",
+                "source_kind": "SHANGHAI_COMPOSITE_ETF_PROXY",
+                "source_name": "上证综合ETF",
+            },
+        )
+
+
+def test_run_requires_feature_summary_identity(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    (tmp_path / "features" / "summary.json").unlink()
+
+    with pytest.raises(
+        PortfolioContractError,
+        match="summary.json",
+    ):
+        run_portfolios(
+            root=tmp_path,
+            random_seeds=0,
+            include_audit_scope=False,
+        )
+
+
+def test_run_rejects_features_manifest_signal_set_drift(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    path = tmp_path / "features" / "manifest.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["signal_set_id"] = "sha256:" + "2" * 64
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(PortfolioContractError, match="signal_set_id lineage mismatch"):
+        run_portfolios(
+            root=tmp_path,
+            random_seeds=0,
+            include_audit_scope=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ("features/market_segments.csv",),
+)
+def test_run_id_changes_when_bound_input_changes(
+    tmp_path: Path,
+    relative_path: str,
+) -> None:
+    _write_fixture(tmp_path)
+    first = run_portfolios(
+        root=tmp_path,
+        random_seeds=0,
+        include_audit_scope=False,
+    )
+    path = tmp_path / relative_path
+    path.write_bytes(path.read_bytes() + b"\n")
+
+    second = run_portfolios(
+        root=tmp_path,
+        random_seeds=0,
+        include_audit_scope=False,
+    )
+
+    assert second["reused"] is False
+    assert second["run_id"] != first["run_id"]
+
+
+def test_run_rejects_snapshot_manifest_drift_from_matrix_lock(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    path = tmp_path / "snapshot" / "manifest.json"
+    path.write_bytes(path.read_bytes() + b"\n")
+
+    with pytest.raises(PortfolioContractError, match="matrix lock lineage mismatch"):
+        run_portfolios(
+            root=tmp_path,
+            random_seeds=0,
+            include_audit_scope=False,
+        )
+
+
+def test_rebuild_report_rejects_external_input_drift(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+    run_portfolios(
+        root=tmp_path,
+        random_seeds=0,
+        include_audit_scope=False,
+    )
+    path = tmp_path / "features" / "market_segments.csv"
+    path.write_bytes(path.read_bytes() + b"\n")
+
+    with pytest.raises(
+        PortfolioContractError,
+        match="frozen run_contract external input drift: market_segments",
+    ):
+        rebuild_report(tmp_path)
 
 
 def test_simulator_limits_daily_entries_and_charges_both_sides(
@@ -270,6 +895,7 @@ def test_smoke_run_writes_machine_report_and_excel(tmp_path: Path) -> None:
     random_runs = pd.read_parquet(output / "random_order_runs.parquet")
     report = (output / "report.md").read_text(encoding="utf-8")
     manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+    config = json.loads((output / "portfolio_config.json").read_text(encoding="utf-8"))
     assert len(summary) == 4 * 6
     assert len(random_runs) == 4 * 6 * 3
     assert set(summary["daily_entry_limit"]) == {
@@ -282,8 +908,272 @@ def test_smoke_run_writes_machine_report_and_excel(tmp_path: Path) -> None:
     }
     assert "F1-F6 共64个子集" in report
     assert "样本外 AUDIT 一次性揭示" in report
+    assert "AUDIT多聚合口径" in report
     assert "|5|40|55.00%|" in report
     assert "滑点、印花税、最低佣金、100股取整" in report
-    assert (output / "clx_30m_portfolio_report.xlsx").is_file()
+    workbook_path = output / "clx_30m_portfolio_report.xlsx"
+    assert workbook_path.is_file()
+    workbook = load_workbook(workbook_path)
+    assert "Charts" in workbook.sheetnames
+    assert "RevealDetailed" in workbook.sheetnames
+    assert "RevealByPeriod" in workbook.sheetnames
+    assert len(workbook["Charts"]._charts) == 2
+    portfolio_sheet = workbook["Portfolio"]
+    headers = {cell.value: cell.column for cell in portfolio_sheet[1]}
+    assert portfolio_sheet.freeze_panes == "A2"
+    assert portfolio_sheet.auto_filter.ref == portfolio_sheet.dimensions
+    assert portfolio_sheet["A1"].fill.fgColor.rgb.endswith("1F4E78")
+    assert portfolio_sheet["A1"].font.bold is True
+    assert portfolio_sheet["A1"].font.color.rgb.endswith("FFFFFF")
+    assert portfolio_sheet.column_dimensions["A"].width == 24
+    assert all(
+        dimension.width <= 42
+        for dimension in portfolio_sheet.column_dimensions.values()
+        if dimension.width is not None
+    )
+    assert portfolio_sheet.cell(2, headers["total_return"]).number_format == "0.00%"
+    assert (
+        portfolio_sheet.cell(2, headers["initial_capital"]).number_format
+        == '"¥"#,##0.00'
+    )
+    assert (
+        portfolio_sheet.cell(2, headers["candidate_signals"]).number_format == "#,##0"
+    )
+    assert portfolio_sheet.cell(2, headers["average_positions"]).number_format == "0.00"
+    assert portfolio_sheet.cell(2, headers["average_win"]).number_format == "0.00%"
+    assert (
+        portfolio_sheet.cell(2, headers["start_at"]).number_format == "yyyy-mm-dd hh:mm"
+    )
+    for chart in workbook["Charts"]._charts:
+        assert chart.y_axis.numFmt.formatCode == "0.00%"
+        assert [series.tx.v for series in chart.series] == [
+            "5日",
+            "30日",
+            "60日",
+            "90日",
+        ]
+    chart_data_sheet = workbook["ChartData"]
+    chart_data_headers = {cell.value: cell.column for cell in chart_data_sheet[1]}
+    assert chart_data_sheet["B2"].number_format == "0.00%"
+    for horizon in (5, 30, 60, 90):
+        column = chart_data_headers[f"h{horizon}_normalized_equity"]
+        assert chart_data_sheet.cell(2, column).number_format == "0.00%"
+    date_label_column = chart_data_headers["trade_date_label"]
+    trade_date_column = chart_data_headers["trade_date"]
+    assert chart_data_sheet.cell(2, date_label_column).value == pd.Timestamp(
+        chart_data_sheet.cell(2, trade_date_column).value
+    ).strftime("%Y-%m-%d")
+    date_label_letter = get_column_letter(date_label_column)
+    expected_categories = (
+        f"'ChartData'!${date_label_letter}$2:"
+        f"${date_label_letter}${chart_data_sheet.max_row}"
+    )
+    for chart in workbook["Charts"]._charts:
+        for series in chart.series:
+            assert series.cat.strRef is not None
+            assert series.cat.strRef.f == expected_categories
+            assert series.cat.numRef is None
+    assert workbook["Charts"].sheet_view.showGridLines is False
+    contract_sheet = workbook["Contract"]
+    assert contract_sheet.column_dimensions["B"].width <= 42
+    for row in range(2, 8):
+        contract_cell = contract_sheet.cell(row, 2)
+        assert contract_cell.alignment.wrap_text is True
+        assert contract_cell.alignment.vertical == "top"
+        assert contract_sheet.row_dimensions[row].height >= 30
+    assert "冻结配置的资金 AUDIT" in report
+    assert "3组敏感性" in report
+    assert "3组SHA随机排序分位数" in report
+    assert "100组" not in report
     assert manifest["selection_count"] == 4
     assert manifest["random_portfolios"] == 72
+    assert "510980上证综合ETF代理" in report
+    assert "相对510980上证综合ETF代理平均超额" in report
+    assert "相对上证平均超额" not in report
+    assert config["index_benchmark"] == manifest["index_benchmark"]
+    assert config["index_benchmark"]["benchmark_label"] == "510980上证综合ETF代理"
+    assert config["filter_descriptions"]["F6"].startswith("510980上证综合ETF代理")
+    assert config["snapshot_verification"] == manifest["snapshot_verification"]
+    assert config["snapshot_verification"]["all_declared_files_verified"] is True
+    assert {
+        item["logical_path"] for item in manifest["outputs"]
+    } == REQUIRED_LOGICAL_OUTPUTS
+    reproduce_command = (output / "reproduce_command.txt").read_text(encoding="utf-8")
+    assert "--no-audit-scope" in reproduce_command
+    assert f'"{REPRODUCE_SCRIPT}"' in reproduce_command
+    assert str(Path(__file__).resolve().parents[3]) not in reproduce_command
+    assert (
+        manifest["portfolio_logic_sha256"]
+        == config["run_contract"]["portfolio_logic_sha256"]
+        == sha256_file(
+            Path(__file__).resolve().parents[3]
+            / "script"
+            / "clx_backtest"
+            / "research"
+            / "clx_30m_f1_f6_portfolio.py"
+        )
+    )
+    assert str(manifest["portfolio_logic_sha256"]) in report
+    for name in (
+        "snapshot_manifest",
+        "market_segments",
+        "feature_summary",
+        "study_config",
+    ):
+        assert set(config["run_contract"][name]) == {
+            "logical_path",
+            "file_size",
+            "sha256",
+        }
+        assert manifest["input"][name] == config["run_contract"][name]
+    bar_path = tmp_path / "snapshot" / "bars" / "600000.parquet"
+    original_bar = bar_path.read_bytes()
+    bar_path.write_bytes(original_bar + b"x")
+    with pytest.raises(PortfolioContractError, match="size mismatch"):
+        run_portfolios(
+            root=tmp_path,
+            random_seeds=3,
+            include_audit_scope=False,
+        )
+    bar_path.write_bytes(original_bar)
+    reused = run_portfolios(
+        root=tmp_path,
+        random_seeds=3,
+        include_audit_scope=False,
+    )
+    assert reused["reused"] is True
+    assert reused["run_id"] == manifest["run_id"]
+
+    manifest_path = output / "manifest.json"
+    original_manifest = manifest_path.read_bytes()
+    original_outputs = manifest["outputs"]
+    invalid_outputs: tuple[list[dict[str, object]], ...] = (
+        [],
+        original_outputs[:-1],
+        [*original_outputs, dict(original_outputs[0])],
+    )
+    for outputs in invalid_outputs:
+        invalid_manifest = {**manifest, "outputs": outputs}
+        manifest_path.write_text(json.dumps(invalid_manifest), encoding="utf-8")
+        with pytest.raises(PortfolioContractError, match="outputs"):
+            _completed_result(tmp_path, run_id=manifest["run_id"])
+    manifest_path.write_bytes(original_manifest)
+    invalid_manifest = {**manifest, "portfolio_logic_sha256": "0" * 64}
+    manifest_path.write_text(json.dumps(invalid_manifest), encoding="utf-8")
+    with pytest.raises(PortfolioContractError, match="logic SHA256 mismatch"):
+        _completed_result(tmp_path, run_id=manifest["run_id"])
+    manifest_path.write_bytes(original_manifest)
+
+    config_path = output / "portfolio_config.json"
+    original_config = config_path.read_bytes()
+    invalid_config = json.loads(original_config.decode("utf-8"))
+    invalid_config["run_contract"]["portfolio_logic_sha256"] = "0" * 64
+    config_path.write_text(json.dumps(invalid_config), encoding="utf-8")
+    with pytest.raises(PortfolioContractError, match="logic SHA256 mismatch"):
+        rebuild_report(tmp_path)
+    config_path.write_bytes(original_config)
+    assert Path(rebuild_report(tmp_path)["report"]).is_file()
+
+    checkpoint = next((output / "ckpt").rglob("complete.json"))
+    checkpoint_mtime = checkpoint.stat().st_mtime_ns
+    (output / "manifest.json").unlink()
+    resumed = run_portfolios(
+        root=tmp_path,
+        random_seeds=3,
+        include_audit_scope=False,
+    )
+    assert resumed["reused"] is False
+    assert checkpoint.stat().st_mtime_ns == checkpoint_mtime
+
+
+def test_audit_report_uses_current_metrics_without_frozen_conclusions(
+    tmp_path: Path,
+) -> None:
+    _write_fixture(tmp_path, split_id="AUDIT")
+
+    result = run_portfolios(
+        root=tmp_path,
+        random_seeds=0,
+        include_audit_scope=True,
+    )
+
+    output = Path(result["portfolio_dir"])
+    report = (output / "report.md").read_text(encoding="utf-8")
+    summary = pd.read_parquet(output / "portfolio_summary.parquet")
+    audit_five = summary[
+        summary["scope"].eq("AUDIT")
+        & summary["horizon_trading_days"].eq(5)
+        & summary["daily_entry_limit"].eq("5")
+        & summary["ranking_policy"].eq("quality")
+    ].iloc[0]
+    assert f"{audit_five.total_return:.2%}" in report
+    assert "35%" not in report
+    assert "2026Q2" not in report
+    assert "收益集中于震荡段" not in report
+    assert "仅覆盖2026年" not in report
+    assert "2024年以来短样本" not in report
+
+
+def test_audit_interpretation_switches_with_current_metrics() -> None:
+    positive = pd.Series(
+        {
+            "total_return": 0.12,
+            "profit_factor": 1.4,
+            "closed_win_rate": 0.58,
+        }
+    )
+    negative = pd.Series(
+        {
+            "total_return": -0.08,
+            "profit_factor": 0.7,
+            "closed_win_rate": 0.42,
+        }
+    )
+    negative_high_pf = pd.Series(
+        {
+            "total_return": -0.04,
+            "profit_factor": 1.3,
+            "closed_win_rate": 0.47,
+        }
+    )
+
+    assert "总收益与PF均高于各自基准" in _portfolio_quality_statement(positive)
+    assert "总收益与PF均未高于各自基准" in _portfolio_quality_statement(negative)
+    assert "资金方向一致" in _stability_statement(positive, positive)
+    assert "资金方向不一致" in _stability_statement(positive, negative)
+    both_negative = _stability_statement(negative, negative_high_pf)
+    assert "两段总收益均为负" in both_negative
+    assert "AUDIT PF高于1" in both_negative
+    assert "AUDIT PF未高于1" not in both_negative
+
+
+def test_excel_temporary_file_is_removed_when_replace_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_replace(_source: Path, _destination: Path) -> None:
+        raise OSError("fixture replace failure")
+
+    monkeypatch.setattr(
+        "script.clx_backtest.research.clx_30m_f1_f6_portfolio.os.replace",
+        fail_replace,
+    )
+    path = tmp_path / "report.xlsx"
+    empty = pd.DataFrame()
+
+    with pytest.raises(OSError, match="fixture replace failure"):
+        _write_excel(
+            path,
+            summary=empty,
+            random_summary=empty,
+            period_metrics=empty,
+            daily_curves=empty,
+            chart_data=empty,
+            locked=empty,
+            baseline=empty,
+            reveal=empty,
+            reveal_detailed=empty,
+            reveal_groups=empty,
+        )
+
+    assert not path.with_name(".report.tmp.xlsx").exists()

--- a/freshquant/tests/clx_backtest/test_intraday_f1_f6_portfolio.py
+++ b/freshquant/tests/clx_backtest/test_intraday_f1_f6_portfolio.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from script.clx_backtest.research.clx_30m_f1_f6_portfolio import (
+    FEE_PER_SIDE,
+    INITIAL_CAPITAL,
+    MarkStore,
+    PortfolioContractError,
+    build_simulation_clock,
+    load_locked_selections,
+    run_portfolios,
+    select_locked_candidates,
+    simulate_portfolio,
+)
+
+
+def _locked_payload(filter_mask: int = 0) -> dict[str, object]:
+    return {
+        "study_id": "fixture",
+        "selections": [
+            {
+                "selection_id": f"h{horizon}-fixture",
+                "horizon_trading_days": horizon,
+                "model_code": "S0000",
+                "trigger_id": "ALL",
+                "trigger_selector": {
+                    "kind": "ALL",
+                    "value": None,
+                    "name": "全部触发",
+                },
+                "filter_mask": filter_mask,
+                "filter_names": (["F1"] if filter_mask == 1 else []),
+                "development_score": 1.0,
+                "train_metrics": {"sample_count": 100, "win_rate": 0.55},
+                "validation_metrics": {"sample_count": 50, "win_rate": 0.54},
+            }
+            for horizon in (5, 30, 60, 90)
+        ],
+    }
+
+
+def _write_lock(root: Path, filter_mask: int = 0) -> None:
+    path = root / "matrix" / "locked_config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(_locked_payload(filter_mask), ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _event(
+    code: str,
+    entry_at: pd.Timestamp,
+    *,
+    gross_return: float,
+    event_no: int,
+) -> dict[str, object]:
+    exit_at = entry_at + pd.Timedelta(days=7)
+    row: dict[str, object] = {
+        "signal_fact_id": f"sha256:signal-{event_no}",
+        "union_signal_id": f"sha256:union-{event_no}",
+        "code": code,
+        "model_code": "S0000",
+        "reveal_at": entry_at - pd.Timedelta(minutes=30),
+        "entry_at": entry_at,
+        "entry_trade_date": entry_at.date(),
+        "qfq_entry_open": 10.0,
+        "entry_executable": True,
+        "entry_status": "OK",
+        "concurrent_trigger_mask": 0x04,
+        "concurrent_trigger_count": 1,
+        "filter_pass_mask": 63,
+        "same_code_reveal_model_count": 1,
+        "same_reveal_event_count": 2,
+        "amount_median_20d": 1_000_000.0 + event_no,
+        "raw_entry_gap": 0.0,
+        "market_regime": "UP",
+        "split_id": "TRAIN",
+    }
+    for horizon in (5, 30, 60, 90):
+        row[f"h{horizon}_status"] = "OK"
+        row[f"h{horizon}_exit_at"] = exit_at
+        row[f"h{horizon}_gross_return"] = gross_return
+    return row
+
+
+def _write_fixture(root: Path) -> pd.DataFrame:
+    _write_lock(root)
+    pd.DataFrame(
+        [
+            {
+                "selection_id": f"h{horizon}-fixture",
+                "scope": "AUDIT",
+                "horizon_trading_days": horizon,
+                "sample_count": 40,
+                "net_win_rate": 0.55,
+                "net_win_rate_ci_low": 0.40,
+                "net_win_rate_ci_high": 0.69,
+                "mean_net_return": 0.02,
+                "median_net_return": 0.01,
+                "profit_factor": 1.2,
+                "mean_net_excess_return": 0.01,
+                "small_sample_warning": False,
+            }
+            for horizon in (5, 30, 60, 90)
+        ]
+    ).to_csv(
+        root / "matrix" / "reveal_summary.csv",
+        index=False,
+        encoding="utf-8-sig",
+    )
+    sessions = pd.bdate_range("2024-07-01", periods=12)
+    index = pd.DataFrame(
+        {
+            "date": sessions,
+            "open": 3000.0,
+            "high": 3010.0,
+            "low": 2990.0,
+            "close": 3000.0,
+        }
+    )
+    snapshot = root / "snapshot"
+    snapshot.mkdir(parents=True)
+    index.to_parquet(snapshot / "index_day.parquet", index=False)
+    bars_dir = snapshot / "bars"
+    bars_dir.mkdir()
+    clocks = ("10:00", "10:30", "11:00", "11:30", "13:30", "14:00", "14:30", "15:00")
+    for code, drift in (("600000", 0.02), ("600001", -0.01)):
+        bars = pd.DataFrame(
+            [
+                {
+                    "bar_at": pd.Timestamp(
+                        f"{day.date().isoformat()} {clock}",
+                        tz="Asia/Shanghai",
+                    ),
+                    "qfq_close": 10.0
+                    * (
+                        1
+                        + drift
+                        * (session_no * len(clocks) + slot)
+                        / (len(sessions) * len(clocks))
+                    ),
+                }
+                for session_no, day in enumerate(sessions)
+                for slot, clock in enumerate(clocks)
+            ]
+        )
+        bars.to_parquet(bars_dir / f"{code}.parquet", index=False)
+    entry = pd.Timestamp("2024-07-02 10:30", tz="Asia/Shanghai")
+    events = pd.DataFrame(
+        [
+            _event("600000", entry, gross_return=0.10, event_no=1),
+            _event("600001", entry, gross_return=-0.05, event_no=2),
+        ]
+    )
+    events.loc[events["code"].eq("600000"), "amount_median_20d"] = 2_000_000.0
+    features = root / "features"
+    features.mkdir()
+    events.to_parquet(features / "candidate_events.parquet", index=False)
+    pd.DataFrame(
+        [
+            {
+                "segment_id": "UP-0001",
+                "regime": "UP",
+                "start_date": sessions[0].date().isoformat(),
+                "end_date": sessions[-1].date().isoformat(),
+                "sessions": len(sessions),
+                "start_close": 3000,
+                "end_close": 3100,
+                "segment_return": 0.033,
+            }
+        ]
+    ).to_csv(features / "market_segments.csv", index=False, encoding="utf-8-sig")
+    (features / "summary.json").write_text(
+        json.dumps(
+            {
+                "candidate_event_rows": 2,
+                "unique_union_signals": 2,
+                "unique_stocks": 2,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return events
+
+
+def test_lock_rejects_filter_mask_outside_six_bits(tmp_path: Path) -> None:
+    _write_lock(tmp_path, filter_mask=64)
+
+    with pytest.raises(PortfolioContractError, match="0..63"):
+        load_locked_selections(tmp_path / "matrix" / "locked_config.json")
+
+
+def test_selection_applies_single_trigger_and_f1_f6_mask(tmp_path: Path) -> None:
+    _write_lock(tmp_path)
+    selection = load_locked_selections(tmp_path / "matrix" / "locked_config.json")[0]
+    selection = selection.__class__(
+        **{
+            **selection.__dict__,
+            "trigger_kind": "SINGLE_BIT",
+            "trigger_value": 0x04,
+            "filter_mask": 0b100001,
+            "filter_names": (
+                "F1",
+                "F6",
+            ),
+        }
+    )
+    entry = pd.Timestamp("2024-07-02 10:30", tz="Asia/Shanghai")
+    passing = _event("600000", entry, gross_return=0.1, event_no=1)
+    failing = _event("600001", entry, gross_return=0.1, event_no=2)
+    failing["concurrent_trigger_mask"] = 0x02
+    frame = pd.DataFrame([passing, failing])
+
+    actual = select_locked_candidates(frame, selection)
+
+    assert actual["code"].tolist() == ["600000"]
+    assert math.isclose(actual.loc[0, "qfq_exit_open"], 11.0)
+
+
+def test_simulator_limits_daily_entries_and_charges_both_sides(
+    tmp_path: Path,
+) -> None:
+    events = _write_fixture(tmp_path)
+    selection = load_locked_selections(tmp_path / "matrix" / "locked_config.json")[0]
+    candidates = select_locked_candidates(events, selection)
+    marks = MarkStore(tmp_path)
+    marks.load(candidates["code"])
+    clock = build_simulation_clock(tmp_path, [candidates], marks)
+
+    actual = simulate_portfolio(
+        candidates,
+        selection=selection,
+        scope="AVAILABLE",
+        clock=clock,
+        marks=marks,
+        daily_entry_limit=1,
+        ranking_policy="quality",
+    )
+
+    assert actual.summary["closed_trades"] == 1
+    assert actual.summary["rejected_daily_limit"] == 1
+    assert actual.summary["final_equity"] > INITIAL_CAPITAL
+    trade = actual.trades.iloc[0]
+    expected = (1 + 0.10) * (1 - FEE_PER_SIDE) / (1 + FEE_PER_SIDE) - 1
+    assert math.isclose(trade["net_return"], expected)
+    assert actual.summary["total_fees"] > 0
+
+
+def test_smoke_run_writes_machine_report_and_excel(tmp_path: Path) -> None:
+    _write_fixture(tmp_path)
+
+    result = run_portfolios(
+        root=tmp_path,
+        random_seeds=3,
+        include_audit_scope=False,
+    )
+
+    output = Path(result["portfolio_dir"])
+    summary = pd.read_parquet(output / "portfolio_summary.parquet")
+    random_runs = pd.read_parquet(output / "random_order_runs.parquet")
+    report = (output / "report.md").read_text(encoding="utf-8")
+    manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+    assert len(summary) == 4 * 6
+    assert len(random_runs) == 4 * 6 * 3
+    assert set(summary["daily_entry_limit"]) == {
+        "1",
+        "3",
+        "5",
+        "10",
+        "20",
+        "UNLIMITED",
+    }
+    assert "F1-F6 共64个子集" in report
+    assert "样本外 AUDIT 一次性揭示" in report
+    assert "|5|40|55.00%|" in report
+    assert "滑点、印花税、最低佣金、100股取整" in report
+    assert (output / "clx_30m_portfolio_report.xlsx").is_file()
+    assert manifest["selection_count"] == 4
+    assert manifest["random_portfolios"] == 72

--- a/freshquant/tests/clx_backtest/test_intraday_full_trigger_f1_f6_study.py
+++ b/freshquant/tests/clx_backtest/test_intraday_full_trigger_f1_f6_study.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from script.clx_backtest.research.clx_30m_full_trigger_f1_f6_study import (
+    FEE_PER_SIDE,
+    STUDY_ID,
+    TRIGGER_BITS,
+    _attach_index_features,
+    _filter_pass_mask,
+    _freeze_splits,
+    _select_joinable_session_documents,
+    _select_usable_session_documents,
+    build_full_candidate_frame,
+    compute_code_outcome_map,
+)
+
+CLOCKS = (
+    "10:00",
+    "10:30",
+    "11:00",
+    "11:30",
+    "13:30",
+    "14:00",
+    "14:30",
+    "15:00",
+)
+
+
+def _bars(
+    session_dates: list[pd.Timestamp] | None = None,
+    *,
+    session_count: int = 100,
+) -> pd.DataFrame:
+    dates = (
+        session_dates
+        if session_dates is not None
+        else list(pd.bdate_range("2024-07-01", periods=session_count))
+    )
+    rows: list[dict[str, object]] = []
+    for session_no, session_day in enumerate(dates, start=1):
+        for slot, clock in enumerate(CLOCKS):
+            bar_at = pd.Timestamp(
+                f"{session_day.date().isoformat()} {clock}",
+                tz="Asia/Shanghai",
+            )
+            raw_open = 2.0 + session_no / 100.0 + slot / 1000.0
+            rows.append(
+                {
+                    "code": "600000",
+                    "bar_at": bar_at,
+                    "trade_date": session_day.date(),
+                    "bar_slot": slot,
+                    "raw_open": raw_open,
+                    "raw_high": raw_open + 0.2,
+                    "raw_low": raw_open - 0.2,
+                    "raw_close": raw_open + 0.1,
+                    "raw_volume": 1000.0,
+                    "raw_amount": 10_000_000.0,
+                    "qfq_open": raw_open,
+                    "qfq_high": raw_open + 0.2,
+                    "qfq_low": raw_open - 0.2,
+                    "qfq_close": raw_open + 0.1,
+                    "prior_raw_daily_close": 2.0,
+                    "source_duplicate_count": 1,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _event(
+    *,
+    mask: int,
+    signal_at: pd.Timestamp,
+    reveal_at: pd.Timestamp,
+    fact_id: str = "sha256:fixture",
+) -> dict[str, object]:
+    return {
+        "signal_set_id": "sha256:set",
+        "signal_fact_id": fact_id,
+        "code": "600000",
+        "expected_model_id": 8,
+        "model_id": 8,
+        "model_code": "S0008",
+        "signal_at": signal_at,
+        "signal_trade_date": signal_at.date(),
+        "as_of_at": reveal_at,
+        "reveal_at": reveal_at,
+        "reveal_trade_date": reveal_at.date(),
+        "revision_no": 1,
+        "event_kind": "ADD",
+        "previous_raw_signal": 0,
+        "current_raw_signal": 8102,
+        "previous_concurrent_trigger_mask": None,
+        "concurrent_trigger_mask": mask,
+        "direction": 1,
+        "occurrence": 1,
+        "primary_entrypoint": 2,
+        "actionable": True,
+    }
+
+
+def test_study_contract_has_only_six_enhanced_filters() -> None:
+    assert STUDY_ID == "clx-30m-full-trigger-f1-f6-v1"
+    frame = pd.DataFrame(
+        {
+            "f1_raw_open_1_to_6": [True],
+            "f2_return_20d_le_0": [True],
+            "f3_drawdown_20d_ge_10pct": [True],
+            "f4_volatility_20d_ge_3pct": [True],
+            "f5_close_le_ma60d_equivalent": [True],
+            "f6_index_return_20d_le_0": [True],
+        }
+    )
+
+    assert _filter_pass_mask(frame).tolist() == [0b11_1111]
+
+
+def test_outcomes_count_frozen_stock_day_even_when_intraday_day_is_absent() -> None:
+    calendar = list(pd.bdate_range("2024-07-01", periods=5))
+    bars = _bars([calendar[0], calendar[1], calendar[3], calendar[4]])
+    reveal = pd.Timestamp("2024-07-01 10:00", tz="Asia/Shanghai")
+
+    actual = compute_code_outcome_map(
+        bars,
+        [reveal],
+        horizons=(2,),
+        stock_trading_dates=calendar,
+    )[reveal.value]
+
+    assert actual["entry_at"] == pd.Timestamp("2024-07-01 10:30", tz="Asia/Shanghai")
+    assert actual["h2_target_trade_date"] == calendar[2].date()
+    assert actual["h2_exit_at"] == pd.Timestamp("2024-07-04 10:00", tz="Asia/Shanghai")
+    assert actual["h2_exit_delay"] == 7
+    assert actual["h2_exit_fallback_used"] is True
+    assert actual["h2_exit_fallback_reason"] == "TARGET_SLOT_OR_SESSION_MISSING"
+
+
+def test_partial_session_keeps_real_standard_bars_without_fabrication() -> None:
+    def document(
+        trade_date: str,
+        clock: str,
+        *,
+        volume: float = 100.0,
+    ) -> dict[str, object]:
+        timestamp = pd.Timestamp(
+            f"{trade_date} {clock}",
+            tz="Asia/Shanghai",
+        )
+        return {
+            "code": "600000",
+            "type": "30min",
+            "date": trade_date,
+            "datetime": timestamp.isoformat(),
+            "time_stamp": timestamp.timestamp(),
+            "vol": volume,
+            "amount": volume * 10,
+        }
+
+    partial = [
+        document("2024-07-01", "10:00"),
+        document("2024-07-01", "11:00"),
+    ]
+    nonstandard = [document("2024-07-02", "13:00")]
+    placeholder = [
+        document("2024-07-03", "10:00", volume=0),
+        document("2024-07-03", "10:30", volume=0),
+    ]
+
+    selected, quality = _select_usable_session_documents(
+        partial + nonstandard + placeholder
+    )
+    joinable, joined_quality = _select_joinable_session_documents(
+        selected,
+        adj_docs=[{"code": "600000", "date": "2024-07-01", "adj": 1.0}],
+        daily_docs=[{"code": "600000", "date": "2024-07-01", "close": 2.0}],
+        quality=quality,
+    )
+
+    assert [row["datetime"] for row in joinable] == [
+        partial[0]["datetime"],
+        partial[1]["datetime"],
+    ]
+    assert joined_quality["partial_session_count"] == 1
+    assert joined_quality["joinable_partial_session_count"] == 1
+    assert joined_quality["partial_missing_slot_count"] == 6
+    assert joined_quality["excluded_session_count"] == 2
+
+
+def test_exit_uses_later_real_bar_when_target_slot_is_missing() -> None:
+    calendar = list(pd.bdate_range("2024-07-01", periods=3))
+    bars = _bars(calendar)
+    target_at = pd.Timestamp("2024-07-03 10:30", tz="Asia/Shanghai")
+    bars = bars[bars["bar_at"].ne(target_at)].reset_index(drop=True)
+    reveal = pd.Timestamp("2024-07-01 10:00", tz="Asia/Shanghai")
+
+    actual = compute_code_outcome_map(
+        bars,
+        [reveal],
+        horizons=(2,),
+        stock_trading_dates=calendar,
+    )[reveal.value]
+
+    assert actual["h2_target_at"] == target_at
+    assert actual["h2_exit_at"] == pd.Timestamp("2024-07-03 11:00", tz="Asia/Shanghai")
+    assert actual["h2_exit_delay"] == 1
+    assert actual["h2_exit_fallback_used"] is True
+
+
+def test_outcomes_include_all_horizons_and_exact_fee_formula() -> None:
+    bars = _bars()
+    reveal = pd.Timestamp("2024-07-01 10:00", tz="Asia/Shanghai")
+
+    actual = compute_code_outcome_map(bars, [reveal])[reveal.value]
+
+    for horizon in (5, 30, 60, 90):
+        assert actual[f"h{horizon}_status"] == "OK"
+        expected = (1 + actual[f"h{horizon}_gross_return"]) * (1 - FEE_PER_SIDE) / (
+            1 + FEE_PER_SIDE
+        ) - 1
+        assert math.isclose(actual[f"h{horizon}_net_return"], expected)
+
+
+def test_candidate_keeps_all_seven_native_trigger_bits_and_duplicate_audit() -> None:
+    bars = _bars()
+    signal_at = pd.Timestamp("2024-07-01 10:00", tz="Asia/Shanghai")
+    reveal_at = pd.Timestamp("2024-07-01 10:30", tz="Asia/Shanghai")
+    duplicate = _event(
+        mask=sum(TRIGGER_BITS.values()),
+        signal_at=reveal_at,
+        reveal_at=reveal_at,
+        fact_id="sha256:latest",
+    )
+    splits = {
+        "TRAIN": ["2024-07-01", "2024-12-31"],
+        "VALIDATION": ["2025-01-01", "2025-06-30"],
+        "AUDIT": ["2025-07-01", "2025-12-31"],
+    }
+
+    actual = build_full_candidate_frame(
+        events=[
+            _event(
+                mask=TRIGGER_BITS["PIN_BAR"],
+                signal_at=signal_at,
+                reveal_at=reveal_at,
+                fact_id="sha256:older",
+            ),
+            duplicate,
+        ],
+        bars=bars,
+        splits=splits,
+    )
+
+    assert len(actual) == 1
+    assert actual.loc[0, "concurrent_trigger_count"] == 7
+    assert actual.loc[0, "same_model_reveal_fact_count"] == 2
+    assert actual.loc[0, "same_model_reveal_collapsed_fact_count"] == 1
+    assert all(bool(actual.loc[0, f"trigger_{name.lower()}"]) for name in TRIGGER_BITS)
+
+
+def test_candidate_rejects_unpublished_native_trigger_bits() -> None:
+    bars = _bars()
+    signal_at = pd.Timestamp("2024-07-01 10:00", tz="Asia/Shanghai")
+
+    with pytest.raises(RuntimeError, match="unknown trigger bits"):
+        build_full_candidate_frame(
+            events=[
+                _event(
+                    mask=0x80,
+                    signal_at=signal_at,
+                    reveal_at=signal_at,
+                )
+            ],
+            bars=bars,
+            splits={"TRAIN": ["2024-07-01", "2024-12-31"]},
+        )
+
+
+def test_candidate_marks_outcomes_maturing_after_split_end_as_purged() -> None:
+    dates = list(pd.bdate_range("2024-12-02", periods=100))
+    bars = _bars(dates)
+    reveal_at = pd.Timestamp("2024-12-02 10:00", tz="Asia/Shanghai")
+
+    actual = build_full_candidate_frame(
+        events=[
+            _event(
+                mask=TRIGGER_BITS["ENGULFING"],
+                signal_at=reveal_at,
+                reveal_at=reveal_at,
+            )
+        ],
+        bars=bars,
+        splits={"TRAIN": ["2024-01-01", "2024-12-31"]},
+        stock_trading_dates=dates,
+    )
+
+    assert actual.loc[0, "h5_split_boundary_status"] == "AVAILABLE"
+    assert actual.loc[0, "h30_split_boundary_status"] == "PURGED"
+    assert actual.loc[0, "h30_result_maturity_at"] == actual.loc[0, "h30_exit_at"]
+
+
+def test_time_splits_prefer_calendar_year_contract_then_fall_back() -> None:
+    full_dates = [
+        value.date().isoformat() for value in pd.bdate_range("2015-01-01", "2024-03-31")
+    ]
+    preferred = _freeze_splits(
+        full_dates,
+        signal_start=full_dates[0],
+        end_date=full_dates[-1],
+    )
+    assert preferred["TRAIN"][1] == "2019-12-31"
+    assert preferred["VALIDATION"] == ["2020-01-01", "2023-12-29"]
+    assert preferred["AUDIT"][0] == "2024-01-01"
+
+    short_dates = [
+        value.date().isoformat() for value in pd.bdate_range("2024-01-01", periods=100)
+    ]
+    proportional = _freeze_splits(
+        short_dates,
+        signal_start=short_dates[0],
+        end_date=short_dates[-1],
+    )
+    assert proportional["TRAIN"] == [short_dates[0], short_dates[49]]
+    assert proportional["VALIDATION"] == [short_dates[50], short_dates[79]]
+    assert proportional["AUDIT"] == [short_dates[80], short_dates[-1]]
+
+
+def test_index_features_use_only_the_previous_completed_session() -> None:
+    dates = pd.bdate_range("2024-01-01", periods=30)
+    index = pd.DataFrame(
+        {
+            "code": "000001",
+            "date": dates,
+            "open": range(100, 130),
+            "high": range(101, 131),
+            "low": range(99, 129),
+            "close": range(100, 130),
+            "vol": 1_000,
+            "amount": 1_000_000,
+        }
+    )
+    events = pd.DataFrame(
+        {
+            "code": ["600000"],
+            "reveal_at": [
+                pd.Timestamp(
+                    f"{dates[-1].date().isoformat()} 10:00",
+                    tz="Asia/Shanghai",
+                )
+            ],
+        }
+    )
+
+    actual = _attach_index_features(events, index)
+
+    assert actual.loc[0, "code"] == "600000"
+    assert actual.loc[0, "index_feature_date"].date() == dates[-2].date()
+    expected_return = (
+        index.loc[len(index) - 2, "close"] / index.loc[len(index) - 22, "close"] - 1
+    )
+    assert math.isclose(actual.loc[0, "index_return_20"], expected_return)

--- a/freshquant/tests/test_quantaxis_stock_min_incremental.py
+++ b/freshquant/tests/test_quantaxis_stock_min_incremental.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pandas as pd
+from QUANTAXIS.QASU.save_tdx import _select_strictly_new_minute_rows
+
+
+def _bars(*datetimes: str) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "datetime": list(datetimes),
+            "code": ["301234"] * len(datetimes),
+            "type": ["30min"] * len(datetimes),
+            "time_stamp": [pd.Timestamp(value).timestamp() for value in datetimes],
+        }
+    )
+
+
+def test_incremental_minute_rows_keep_first_real_bar_when_source_omits_cutoff():
+    frame = _bars(
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:30:00",
+    )
+
+    selected = _select_strictly_new_minute_rows(
+        frame,
+        "2026-07-21 15:00:00",
+    )
+
+    assert selected["datetime"].tolist() == [
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:30:00",
+    ]
+
+
+def test_incremental_minute_rows_drop_only_the_actual_cutoff_bar():
+    frame = _bars(
+        "2026-07-21 15:00:00",
+        "2026-07-22 10:00:00",
+    )
+
+    selected = _select_strictly_new_minute_rows(
+        frame,
+        "2026-07-21 15:00:00",
+    )
+
+    assert selected["datetime"].tolist() == ["2026-07-22 10:00:00"]
+
+
+def test_incremental_minute_rows_keep_a_single_new_bar():
+    frame = _bars("2026-07-22 10:00:00")
+
+    selected = _select_strictly_new_minute_rows(
+        frame,
+        "2026-07-21 15:00:00",
+    )
+
+    assert len(selected) == 1
+
+
+def test_initial_minute_rows_keep_a_single_valid_bar():
+    frame = _bars("2026-07-22 10:00:00")
+
+    selected = _select_strictly_new_minute_rows(frame, None)
+
+    assert selected["datetime"].tolist() == ["2026-07-22 10:00:00"]
+
+
+def test_incremental_minute_rows_fall_back_to_datetime_for_deduplication():
+    frame = _bars(
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:30:00",
+    ).drop(columns=["time_stamp"])
+
+    selected = _select_strictly_new_minute_rows(
+        frame,
+        "2026-07-21 15:00:00",
+    )
+
+    assert selected["datetime"].tolist() == [
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:30:00",
+    ]

--- a/freshquant/tests/test_quantaxis_stock_min_incremental.py
+++ b/freshquant/tests/test_quantaxis_stock_min_incremental.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
 import pandas as pd
-from QUANTAXIS.QASU.save_tdx import _select_strictly_new_minute_rows
+from QUANTAXIS.QASU.save_tdx import (
+    _insert_new_minute_rows,
+    _select_strictly_new_minute_rows,
+)
+
+
+class _RecordingCollection:
+    def __init__(self) -> None:
+        self.documents: list[dict] = []
+
+    def insert_many(self, documents: list[dict]) -> None:
+        self.documents.extend(documents)
 
 
 def _bars(*datetimes: str) -> pd.DataFrame:
@@ -65,12 +76,64 @@ def test_initial_minute_rows_keep_a_single_valid_bar():
     assert selected["datetime"].tolist() == ["2026-07-22 10:00:00"]
 
 
+def test_initial_minute_rows_insert_a_single_valid_bar():
+    collection = _RecordingCollection()
+
+    inserted = _insert_new_minute_rows(
+        collection,
+        _bars("2026-07-22 10:00:00"),
+        None,
+    )
+
+    assert inserted == 1
+    assert len(collection.documents) == 1
+    assert collection.documents[0]["datetime"] == "2026-07-22 10:00:00"
+
+
 def test_incremental_minute_rows_fall_back_to_datetime_for_deduplication():
     frame = _bars(
         "2026-07-22 10:00:00",
         "2026-07-22 10:00:00",
         "2026-07-22 10:30:00",
     ).drop(columns=["time_stamp"])
+
+    selected = _select_strictly_new_minute_rows(
+        frame,
+        "2026-07-21 15:00:00",
+    )
+
+    assert selected["datetime"].tolist() == [
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:30:00",
+    ]
+
+
+def test_incremental_minute_rows_ignore_null_time_stamp_for_deduplication():
+    frame = _bars(
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:30:00",
+    )
+    frame["time_stamp"] = pd.NA
+
+    selected = _select_strictly_new_minute_rows(
+        frame,
+        "2026-07-21 15:00:00",
+    )
+
+    assert selected["datetime"].tolist() == [
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:30:00",
+    ]
+
+
+def test_incremental_minute_rows_handle_duplicate_datetime_index_by_position():
+    frame = _bars(
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:00:00",
+        "2026-07-22 10:30:00",
+    )
+    frame.index = pd.DatetimeIndex(frame["datetime"])
 
     selected = _select_strictly_new_minute_rows(
         frame,

--- a/runtime/memory/scripts/bootstrap_freshquant_memory.py
+++ b/runtime/memory/scripts/bootstrap_freshquant_memory.py
@@ -25,6 +25,7 @@ def _git_output(repo_root: Path, *args: str) -> str:
         cwd=repo_root,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
     if result.returncode != 0:

--- a/script/clx_backtest/research/clx_30m_f1_f6_matrix.py
+++ b/script/clx_backtest/research/clx_30m_f1_f6_matrix.py
@@ -1,0 +1,2498 @@
+"""Build, lock, and reveal the CLX18 30-minute F1-F6 research matrix.
+
+The module deliberately separates model development from holdout disclosure:
+
+* ``development`` physically reads only TRAIN and VALIDATION event rows;
+* ``lock`` reads only the compact development candidate artifact;
+* ``reveal`` validates the immutable lock before opening candidate events.
+
+The six filters are represented by the low six bits of ``filter_pass_mask``.
+Every one of the 64 required subsets is evaluated.  Trigger selectors cover
+the seven inclusive native bits, all 127 exact masks, exactly two concurrent
+bits, at least three concurrent bits, and the complete signal population.
+
+Returns relative to the Shanghai index use an explicitly approximate daily
+benchmark: the last completed index close before entry to the index close on
+the stock exit trade date (backward-asof only when that date is absent).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from statistics import NormalDist
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+STUDY_ID = "clx-30m-full-trigger-f1-f6-v1"
+MATRIX_CONTRACT_VERSION = 1
+MODEL_CODES = tuple(f"S{model_id:04d}" for model_id in range(18))
+HORIZONS = (5, 30, 60, 90)
+DEVELOPMENT_SCOPES = ("TRAIN", "VALIDATION")
+REVEAL_SCOPES = ("AUDIT", "AVAILABLE", "MATCHED90", "PURGED")
+
+TRIGGER_BITS = {
+    "MODEL_STRUCTURAL": 0x01,
+    "PIN_BAR": 0x02,
+    "ENGULFING": 0x04,
+    "STRONG_FRACTAL": 0x08,
+    "MA5_TURN": 0x10,
+    "PRICE_VOLUME_CONFIRMATION": 0x20,
+    "MACD_CROSS": 0x40,
+}
+TRIGGER_MASK = 0x7F
+
+FILTER_COLUMNS = (
+    "f1_raw_open_1_to_6",
+    "f2_return_20d_le_0",
+    "f3_drawdown_20d_ge_10pct",
+    "f4_volatility_20d_ge_3pct",
+    "f5_close_le_ma60d_equivalent",
+    "f6_index_return_20d_le_0",
+)
+FILTER_NAMES = tuple(f"F{offset}" for offset in range(1, 7))
+FILTER_MASK = 0x3F
+FILTER_SUBSET_COUNT = 64
+
+DEFAULT_ROOT = Path("D:/fqpack/runtime/clx-backtest/studies/" + STUDY_ID)
+DEFAULT_MIN_TRAIN_SAMPLES = 60
+DEFAULT_MIN_VALIDATION_SAMPLES = 30
+DEFAULT_MIN_REVEAL_SAMPLES = 30
+DEFAULT_TOP_PER_MODEL = 5
+NOMINAL_ALPHA = 0.05
+
+
+@dataclass(frozen=True)
+class TriggerSelector:
+    """One auditable trigger population."""
+
+    trigger_id: str
+    kind: str
+    value: int | None
+    name: str
+
+
+def build_trigger_selectors() -> tuple[TriggerSelector, ...]:
+    selectors: list[TriggerSelector] = []
+    for name, bit in TRIGGER_BITS.items():
+        selectors.append(
+            TriggerSelector(
+                trigger_id=f"SINGLE_{name}",
+                kind="SINGLE_BIT",
+                value=bit,
+                name=name,
+            )
+        )
+    for mask in range(1, TRIGGER_MASK + 1):
+        selectors.append(
+            TriggerSelector(
+                trigger_id=f"EXACT_MASK_{mask:03d}",
+                kind="EXACT_MASK",
+                value=mask,
+                name=f"EXACT_MASK_{mask:03d}",
+            )
+        )
+    selectors.extend(
+        (
+            TriggerSelector(
+                trigger_id="EXACTLY_2",
+                kind="COUNT_EQ",
+                value=2,
+                name="exactly two concurrent triggers",
+            ),
+            TriggerSelector(
+                trigger_id="AT_LEAST_3",
+                kind="COUNT_GTE",
+                value=3,
+                name="at least three concurrent triggers",
+            ),
+            TriggerSelector(
+                trigger_id="ALL",
+                kind="ALL",
+                value=None,
+                name="all non-zero trigger masks",
+            ),
+        )
+    )
+    return tuple(selectors)
+
+
+TRIGGER_SELECTORS = build_trigger_selectors()
+TRIGGER_SELECTOR_SEMANTICS = {
+    "SINGLE_BIT": (
+        "inclusive membership: the named bit is set; concurrent masks also qualify"
+    ),
+    "EXACT_MASK": "the complete seven-bit native mask equals value",
+    "COUNT_EQ": "native mask bit count equals value",
+    "COUNT_GTE": "native mask bit count is at least value",
+    "ALL": "all non-zero native masks",
+}
+EXACT_AGGREGATION_CONTRACT = {
+    "EVENT": "one observation per model event",
+    "UNION": "deduplicate by stock code and reveal timestamp",
+    "MACRO": "one equal-weight observation per model mean",
+    "DATE_BALANCED": "one equal-weight observation per reveal-date mean",
+}
+
+
+def trigger_selector_matches(selector: TriggerSelector, trigger_mask: int) -> bool:
+    """Return the frozen selector semantics for one exact native mask."""
+
+    mask = int(trigger_mask) & TRIGGER_MASK
+    if mask == 0:
+        return False
+    if selector.kind == "SINGLE_BIT":
+        return bool(mask & int(selector.value or 0))
+    if selector.kind == "EXACT_MASK":
+        return mask == int(selector.value or 0)
+    if selector.kind == "COUNT_EQ":
+        return mask.bit_count() == int(selector.value or 0)
+    if selector.kind == "COUNT_GTE":
+        return mask.bit_count() >= int(selector.value or 0)
+    if selector.kind == "ALL":
+        return True
+    raise ValueError(f"unknown trigger selector kind: {selector.kind}")
+
+
+SELECTOR_MEMBERSHIP = np.asarray(
+    [
+        [
+            float(trigger_selector_matches(selector, exact_mask))
+            for exact_mask in range(TRIGGER_MASK + 1)
+        ]
+        for selector in TRIGGER_SELECTORS
+    ],
+    dtype=np.float64,
+)
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+    ).encode("utf-8")
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if isinstance(value, (np.floating,)):
+        numeric = float(value)
+        return None if not math.isfinite(numeric) else numeric
+    if isinstance(value, (pd.Timestamp,)):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return str(value)
+    raise TypeError(f"not JSON serialisable: {type(value)!r}")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError(f"{path} must contain a JSON object")
+    return value
+
+
+def write_json_atomic(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+    temporary.write_bytes(canonical_json_bytes(value) + b"\n")
+    os.replace(temporary, path)
+
+
+def write_frame_atomic(frame: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+    if path.suffix.lower() == ".parquet":
+        frame.to_parquet(temporary, index=False)
+    elif path.suffix.lower() == ".csv":
+        frame.to_csv(temporary, index=False, encoding="utf-8-sig")
+    else:
+        raise ValueError(f"unsupported frame path: {path}")
+    os.replace(temporary, path)
+
+
+class AtomicParquetWriter:
+    """Stream homogeneous DataFrame chunks into one atomically replaced file."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.temporary = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+        self.writer: pq.ParquetWriter | None = None
+        self.rows = 0
+
+    def write(self, frame: pd.DataFrame) -> None:
+        if frame.empty:
+            return
+        table = pa.Table.from_pandas(frame, preserve_index=False)
+        if self.writer is None:
+            self.writer = pq.ParquetWriter(
+                self.temporary,
+                table.schema,
+                compression="zstd",
+                use_dictionary=True,
+            )
+        else:
+            table = table.cast(self.writer.schema, safe=False)
+        self.writer.write_table(table)
+        self.rows += len(frame)
+
+    def close(self) -> None:
+        if self.writer is None:
+            raise RuntimeError(f"no rows were written to {self.path}")
+        self.writer.close()
+        self.writer = None
+        os.replace(self.temporary, self.path)
+
+    def abort(self) -> None:
+        if self.writer is not None:
+            self.writer.close()
+            self.writer = None
+        if self.temporary.exists():
+            self.temporary.unlink()
+
+
+def _filter_names(mask: int) -> str:
+    names = [
+        name for offset, name in enumerate(FILTER_NAMES) if int(mask) & (1 << offset)
+    ]
+    return "+".join(names) if names else "NONE"
+
+
+def _selector_contract() -> list[dict[str, Any]]:
+    return [asdict(selector) for selector in TRIGGER_SELECTORS]
+
+
+def _logic_sha256() -> str:
+    return sha256_file(Path(__file__).resolve())
+
+
+def _artifact(path: Path) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "file_size": path.stat().st_size,
+        "file_sha256": sha256_file(path),
+    }
+
+
+def _manifest_reusable(
+    manifest_path: Path,
+    *,
+    stage_id: str,
+    output_keys: Sequence[str],
+) -> bool:
+    if not manifest_path.is_file():
+        return False
+    try:
+        manifest = read_json(manifest_path)
+        if manifest.get("stage_id") != stage_id:
+            return False
+        outputs = manifest["outputs"]
+        for key in output_keys:
+            meta = outputs[key]
+            path = Path(str(meta["path"]))
+            if not path.is_file() or sha256_file(path) != meta["file_sha256"]:
+                return False
+        return True
+    except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def _required_event_columns(horizons: Sequence[int]) -> list[str]:
+    columns = [
+        "code",
+        "model_code",
+        "concurrent_trigger_mask",
+        "filter_pass_mask",
+        "split_id",
+        "reveal_at",
+        "entry_trade_date",
+        "index_feature_date",
+        "market_regime",
+    ]
+    for horizon in horizons:
+        columns.extend(
+            (
+                f"h{horizon}_status",
+                f"h{horizon}_gross_return",
+                f"h{horizon}_net_return",
+                f"h{horizon}_exit_trade_date",
+                f"h{horizon}_result_maturity_at",
+                f"h{horizon}_split_boundary_status",
+            )
+        )
+    return columns
+
+
+def load_feature_events(
+    path: Path,
+    *,
+    horizons: Sequence[int] = HORIZONS,
+    split_filter: Sequence[str] | None = None,
+) -> pd.DataFrame:
+    """Read only columns required by the matrix, optionally with pushdown."""
+
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    filters = (
+        [("split_id", "in", list(split_filter))] if split_filter is not None else None
+    )
+    frame = pd.read_parquet(
+        path,
+        columns=_required_event_columns(horizons),
+        filters=filters,
+    )
+    missing = sorted(set(_required_event_columns(horizons)) - set(frame.columns))
+    if missing:
+        raise RuntimeError(f"candidate events miss columns: {missing}")
+    frame["model_code"] = frame["model_code"].astype(str)
+    frame["split_id"] = frame["split_id"].astype(str)
+    frame["concurrent_trigger_mask"] = (
+        pd.to_numeric(frame["concurrent_trigger_mask"], errors="raise")
+        .astype("int16")
+        .map(lambda value: int(value) & TRIGGER_MASK)
+    )
+    if frame["concurrent_trigger_mask"].eq(0).any():
+        raise RuntimeError("candidate events contain zero trigger masks")
+    frame["filter_pass_mask"] = (
+        pd.to_numeric(frame["filter_pass_mask"], errors="raise")
+        .astype("int16")
+        .map(lambda value: int(value) & FILTER_MASK)
+    )
+    if split_filter is not None:
+        unexpected = set(frame["split_id"].unique()) - set(split_filter)
+        if unexpected:
+            raise RuntimeError(
+                f"Parquet split pushdown leaked rows: {sorted(unexpected)}"
+            )
+    return frame.reset_index(drop=True)
+
+
+def _to_day_array(values: Iterable[object]) -> np.ndarray:
+    parsed = pd.to_datetime(pd.Series(values), errors="coerce", utc=True)
+    return parsed.to_numpy(dtype="datetime64[ns]").astype("datetime64[D]")
+
+
+def _reveal_day_array(values: Iterable[object]) -> np.ndarray:
+    parsed = pd.to_datetime(pd.Series(values), errors="coerce", utc=True)
+    local = parsed.dt.tz_convert("Asia/Shanghai").dt.tz_localize(None)
+    return local.to_numpy(dtype="datetime64[ns]").astype("datetime64[D]")
+
+
+def _asof_index_close(
+    targets: np.ndarray,
+    index_dates: np.ndarray,
+    index_closes: np.ndarray,
+    *,
+    strict: bool,
+) -> tuple[np.ndarray, np.ndarray]:
+    side = "left" if strict else "right"
+    positions = np.searchsorted(index_dates, targets, side=side) - 1
+    valid_target = ~np.isnat(targets)
+    valid = valid_target & (positions >= 0)
+    closes = np.full(len(targets), np.nan, dtype=float)
+    mapped_dates = np.full(len(targets), np.datetime64("NaT"), dtype="datetime64[D]")
+    closes[valid] = index_closes[positions[valid]]
+    mapped_dates[valid] = index_dates[positions[valid]]
+    return closes, mapped_dates
+
+
+def attach_index_benchmark(
+    events: pd.DataFrame,
+    index: pd.DataFrame,
+    *,
+    horizons: Sequence[int] = HORIZONS,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    """Attach causal daily close-to-close index returns to stock outcomes."""
+
+    frame = events.copy()
+    required_index = {"date", "close"}
+    if not required_index.issubset(index.columns):
+        raise RuntimeError("index snapshot must contain date and close")
+    market = index.loc[:, ["date", "close"]].copy()
+    market["date"] = pd.to_datetime(market["date"], errors="coerce")
+    market["close"] = pd.to_numeric(market["close"], errors="coerce")
+    market = (
+        market.dropna(subset=["date", "close"])
+        .loc[lambda value: value["close"].gt(0)]
+        .sort_values("date", kind="stable")
+        .drop_duplicates("date", keep="last")
+    )
+    if market.empty:
+        raise RuntimeError("index snapshot has no valid close")
+    index_dates = (
+        market["date"].to_numpy(dtype="datetime64[ns]").astype("datetime64[D]")
+    )
+    index_closes = market["close"].to_numpy(dtype=float)
+
+    reveal_days = _reveal_day_array(frame["reveal_at"])
+    entry_days = _to_day_array(frame["entry_trade_date"])
+    base_close, base_date = _asof_index_close(
+        entry_days,
+        index_dates,
+        index_closes,
+        strict=True,
+    )
+    # A non-executable early event can lack entry_trade_date.  The fallback is
+    # still causal because exact reveal dates are disallowed.
+    missing_base = ~np.isfinite(base_close)
+    fallback_close, fallback_date = _asof_index_close(
+        reveal_days,
+        index_dates,
+        index_closes,
+        strict=True,
+    )
+    base_close[missing_base] = fallback_close[missing_base]
+    base_date[missing_base] = fallback_date[missing_base]
+    future_or_same_entry = (
+        ~np.isnat(base_date) & ~np.isnat(entry_days) & (base_date >= entry_days)
+    )
+    if future_or_same_entry.any():
+        raise RuntimeError("index benchmark base must be before entry date")
+    source_days = _to_day_array(frame["index_feature_date"])
+    future_or_same_feature = (
+        ~np.isnat(source_days) & ~np.isnat(reveal_days) & (source_days >= reveal_days)
+    )
+    if future_or_same_feature.any():
+        raise RuntimeError("index feature date must be before reveal date")
+
+    frame["benchmark_entry_index_date"] = pd.to_datetime(base_date)
+    frame["benchmark_entry_index_close"] = base_close
+    audit: dict[str, Any] = {
+        "formula": (
+            "Shanghai index close on the last completed day before entry "
+            "to close on stock exit trade date; arithmetic excess="
+            "stock net return-index return"
+        ),
+        "frequency": "daily close-to-close approximation",
+        "base_missing_before_fallback": int(missing_base.sum()),
+        "base_missing_after_fallback": int((~np.isfinite(base_close)).sum()),
+        "future_or_same_day_entry_base_count": int(future_or_same_entry.sum()),
+        "future_or_same_day_feature_count": int(future_or_same_feature.sum()),
+        "horizons": {},
+    }
+    for horizon in horizons:
+        exit_days = _to_day_array(frame[f"h{horizon}_exit_trade_date"])
+        exit_close, mapped_exit_date = _asof_index_close(
+            exit_days,
+            index_dates,
+            index_closes,
+            strict=False,
+        )
+        status_ok = frame[f"h{horizon}_status"].eq("OK").to_numpy(dtype=bool)
+        benchmark_valid = (
+            status_ok
+            & np.isfinite(base_close)
+            & np.isfinite(exit_close)
+            & (base_close > 0)
+        )
+        index_return = np.full(len(frame), np.nan, dtype=float)
+        index_return[benchmark_valid] = (
+            exit_close[benchmark_valid] / base_close[benchmark_valid] - 1
+        )
+        stock_net = pd.to_numeric(
+            frame[f"h{horizon}_net_return"], errors="coerce"
+        ).to_numpy(dtype=float)
+        frame[f"h{horizon}_benchmark_exit_index_date"] = pd.to_datetime(
+            mapped_exit_date
+        )
+        frame[f"h{horizon}_index_return"] = index_return
+        frame[f"h{horizon}_net_excess_return"] = stock_net - index_return
+        lag = exit_days.astype("int64") - mapped_exit_date.astype("int64")
+        backward = benchmark_valid & (lag > 0)
+        audit["horizons"][str(horizon)] = {
+            "status_ok_rows": int(status_ok.sum()),
+            "mapped_rows": int(benchmark_valid.sum()),
+            "missing_rows": int((status_ok & ~benchmark_valid).sum()),
+            "backward_asof_exit_rows": int(backward.sum()),
+            "maximum_exit_mapping_lag_calendar_days": (
+                int(lag[backward].max()) if backward.any() else 0
+            ),
+        }
+    return frame, audit
+
+
+def _scope_masks(
+    frame: pd.DataFrame,
+    *,
+    horizon: int,
+    scope: str,
+    time_splits: Mapping[str, Sequence[str]],
+    horizons: Sequence[int] = HORIZONS,
+) -> dict[str, np.ndarray]:
+    split_ids = frame["split_id"].astype(str).to_numpy()
+    research_split_ids = tuple(
+        split_id
+        for split_id in ("TRAIN", "VALIDATION", "AUDIT")
+        if split_id in time_splits
+    )
+    research = np.isin(split_ids, research_split_ids)
+    status_ok = frame[f"h{horizon}_status"].eq("OK").to_numpy(dtype=bool)
+    maturity_days = _to_day_array(frame[f"h{horizon}_result_maturity_at"])
+    split_end = np.full(len(frame), np.datetime64("NaT"), dtype="datetime64[D]")
+    for split_id in research_split_ids:
+        split_end[split_ids == split_id] = np.datetime64(
+            str(time_splits[split_id][1]), "D"
+        )
+    recomputed_purged = (
+        research
+        & status_ok
+        & ~np.isnat(maturity_days)
+        & ~np.isnat(split_end)
+        & (maturity_days > split_end)
+    )
+    declared_boundary = (
+        frame[f"h{horizon}_split_boundary_status"].fillna("").astype(str)
+    )
+    unknown_declared = ~declared_boundary.isin(
+        ("AVAILABLE", "PURGED", "UNAVAILABLE", "OUT_OF_SCOPE")
+    )
+    if unknown_declared.any():
+        raise RuntimeError(
+            f"h{horizon} has unknown split boundary statuses: "
+            f"{sorted(declared_boundary.loc[unknown_declared].unique())}"
+        )
+    declared_purged = declared_boundary.eq("PURGED").to_numpy(dtype=bool)
+    declared_available = declared_boundary.eq("AVAILABLE").to_numpy(dtype=bool)
+    if not np.array_equal(recomputed_purged, declared_purged):
+        raise RuntimeError(
+            f"h{horizon} split boundary status disagrees with maturity timestamp"
+        )
+
+    if scope in ("TRAIN", "VALIDATION", "AUDIT"):
+        if scope not in time_splits:
+            raise RuntimeError(f"study config misses {scope} split")
+        candidate = split_ids == scope
+        sample = candidate & declared_available
+    elif scope == "AVAILABLE":
+        candidate = research
+        sample = candidate & declared_available
+    elif scope == "MATCHED90":
+        candidate = research
+        jointly_mature = candidate.copy()
+        for candidate_horizon in horizons:
+            jointly_mature &= (
+                frame[f"h{candidate_horizon}_split_boundary_status"]
+                .eq("AVAILABLE")
+                .to_numpy(dtype=bool)
+            )
+        sample = jointly_mature
+    elif scope == "PURGED":
+        candidate = research
+        sample = declared_purged
+    else:
+        raise ValueError(f"unknown matrix scope: {scope}")
+
+    return {
+        "candidate": candidate,
+        "status_ok": candidate & status_ok,
+        "sample": sample,
+        "boundary_purged": candidate & declared_purged,
+    }
+
+
+def _bincount_cube(
+    exact_masks: np.ndarray,
+    pass_masks: np.ndarray,
+    selected: np.ndarray,
+    *,
+    weights: np.ndarray | None = None,
+) -> np.ndarray:
+    chosen = np.asarray(selected, dtype=bool)
+    if not chosen.any():
+        return np.zeros((TRIGGER_MASK + 1, FILTER_SUBSET_COUNT), dtype=np.float64)
+    indexes = exact_masks[chosen].astype(np.int64) * FILTER_SUBSET_COUNT + pass_masks[
+        chosen
+    ].astype(np.int64)
+    selected_weights = None if weights is None else weights[chosen]
+    return np.bincount(
+        indexes,
+        weights=selected_weights,
+        minlength=(TRIGGER_MASK + 1) * FILTER_SUBSET_COUNT,
+    ).reshape(TRIGGER_MASK + 1, FILTER_SUBSET_COUNT)
+
+
+def _superset_zeta(cube: np.ndarray) -> np.ndarray:
+    """Convert exact pass masks to totals satisfying each required subset."""
+
+    transformed = np.asarray(cube, dtype=np.float64).copy()
+    for offset in range(len(FILTER_NAMES)):
+        bit = 1 << offset
+        for required_mask in range(FILTER_SUBSET_COUNT):
+            if not required_mask & bit:
+                transformed[:, required_mask] += transformed[:, required_mask | bit]
+    return transformed
+
+
+def _project_metric(
+    exact_masks: np.ndarray,
+    pass_masks: np.ndarray,
+    selected: np.ndarray,
+    *,
+    weights: np.ndarray | None = None,
+) -> np.ndarray:
+    cube = _bincount_cube(
+        exact_masks,
+        pass_masks,
+        selected,
+        weights=weights,
+    )
+    return SELECTOR_MEMBERSHIP @ _superset_zeta(cube)
+
+
+def _safe_divide(
+    numerator: np.ndarray,
+    denominator: np.ndarray,
+) -> np.ndarray:
+    result = np.full(np.broadcast_shapes(numerator.shape, denominator.shape), np.nan)
+    np.divide(
+        numerator,
+        denominator,
+        out=result,
+        where=np.asarray(denominator) != 0,
+    )
+    return result
+
+
+def _wilson_bounds(
+    wins: np.ndarray,
+    counts: np.ndarray,
+    *,
+    z: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    rates = _safe_divide(wins, counts)
+    denominator = 1 + z * z / np.where(counts > 0, counts, 1)
+    center = (rates + z * z / (2 * np.where(counts > 0, counts, 1))) / denominator
+    radius = (
+        z
+        * np.sqrt(
+            rates * (1 - rates) / np.where(counts > 0, counts, 1)
+            + z
+            * z
+            / (4 * np.where(counts > 0, counts, 1) * np.where(counts > 0, counts, 1))
+        )
+        / denominator
+    )
+    lower = center - radius
+    upper = center + radius
+    lower[counts <= 0] = np.nan
+    upper[counts <= 0] = np.nan
+    return lower, upper
+
+
+def _minimum_for_scope(
+    scope: str,
+    *,
+    min_train_samples: int,
+    min_validation_samples: int,
+    min_reveal_samples: int,
+) -> int:
+    if scope == "TRAIN":
+        return int(min_train_samples)
+    if scope == "VALIDATION":
+        return int(min_validation_samples)
+    return int(min_reveal_samples)
+
+
+def build_matrix_chunk(
+    frame: pd.DataFrame,
+    *,
+    model_code: str,
+    horizon: int,
+    scope: str,
+    time_splits: Mapping[str, Sequence[str]],
+    hypothesis_family_size: int,
+    min_train_samples: int = DEFAULT_MIN_TRAIN_SAMPLES,
+    min_validation_samples: int = DEFAULT_MIN_VALIDATION_SAMPLES,
+    min_reveal_samples: int = DEFAULT_MIN_REVEAL_SAMPLES,
+    horizons: Sequence[int] = HORIZONS,
+) -> pd.DataFrame:
+    """Build one model × horizon × scope matrix using exact subset transforms."""
+
+    if hypothesis_family_size <= 0:
+        raise ValueError("hypothesis_family_size must be positive")
+    subset = frame.loc[frame["model_code"].eq(model_code)].reset_index(drop=True)
+    exact_masks = (
+        subset["concurrent_trigger_mask"].to_numpy(dtype=np.int16)
+        if len(subset)
+        else np.empty(0, dtype=np.int16)
+    )
+    pass_masks = (
+        (subset["filter_pass_mask"].to_numpy(dtype=np.int16) & FILTER_MASK)
+        if len(subset)
+        else np.empty(0, dtype=np.int16)
+    )
+    scope_masks = _scope_masks(
+        subset,
+        horizon=horizon,
+        scope=scope,
+        time_splits=time_splits,
+        horizons=horizons,
+    )
+
+    gross = pd.to_numeric(subset[f"h{horizon}_gross_return"], errors="coerce").to_numpy(
+        dtype=float
+    )
+    net = pd.to_numeric(subset[f"h{horizon}_net_return"], errors="coerce").to_numpy(
+        dtype=float
+    )
+    index_return = pd.to_numeric(
+        subset[f"h{horizon}_index_return"], errors="coerce"
+    ).to_numpy(dtype=float)
+    excess = pd.to_numeric(
+        subset[f"h{horizon}_net_excess_return"], errors="coerce"
+    ).to_numpy(dtype=float)
+    finite_returns = np.isfinite(gross) & np.isfinite(net)
+    sample = scope_masks["sample"] & finite_returns
+    benchmark_sample = sample & np.isfinite(index_return) & np.isfinite(excess)
+    projected: dict[str, np.ndarray] = {
+        "candidate_count": _project_metric(
+            exact_masks, pass_masks, scope_masks["candidate"]
+        ),
+        "status_ok_count": _project_metric(
+            exact_masks, pass_masks, scope_masks["status_ok"]
+        ),
+        "sample_count": _project_metric(exact_masks, pass_masks, sample),
+        "boundary_purged_count": _project_metric(
+            exact_masks, pass_masks, scope_masks["boundary_purged"]
+        ),
+        "gross_win_count": _project_metric(
+            exact_masks, pass_masks, sample & (gross > 0)
+        ),
+        "net_win_count": _project_metric(exact_masks, pass_masks, sample & (net > 0)),
+        "gross_return_sum": _project_metric(
+            exact_masks, pass_masks, sample, weights=gross
+        ),
+        "net_return_sum": _project_metric(exact_masks, pass_masks, sample, weights=net),
+        "net_return_square_sum": _project_metric(
+            exact_masks, pass_masks, sample, weights=net * net
+        ),
+        "net_profit_count": _project_metric(
+            exact_masks, pass_masks, sample & (net > 0)
+        ),
+        "net_profit_sum": _project_metric(
+            exact_masks,
+            pass_masks,
+            sample & (net > 0),
+            weights=net,
+        ),
+        "net_loss_count": _project_metric(exact_masks, pass_masks, sample & (net < 0)),
+        "net_loss_abs_sum": _project_metric(
+            exact_masks,
+            pass_masks,
+            sample & (net < 0),
+            weights=-net,
+        ),
+        "benchmark_sample_count": _project_metric(
+            exact_masks, pass_masks, benchmark_sample
+        ),
+        "index_return_sum": _project_metric(
+            exact_masks,
+            pass_masks,
+            benchmark_sample,
+            weights=index_return,
+        ),
+        "net_excess_return_sum": _project_metric(
+            exact_masks,
+            pass_masks,
+            benchmark_sample,
+            weights=excess,
+        ),
+    }
+
+    selector_count = len(TRIGGER_SELECTORS)
+    selector_indexes = np.repeat(np.arange(selector_count), FILTER_SUBSET_COUNT)
+    required_masks = np.tile(
+        np.arange(FILTER_SUBSET_COUNT, dtype=np.int16), selector_count
+    )
+    flattened = {name: values.reshape(-1) for name, values in projected.items()}
+    sample_count = flattened["sample_count"]
+    candidate_count = flattened["candidate_count"]
+    status_ok_count = flattened["status_ok_count"]
+    net_win_count = flattened["net_win_count"]
+    gross_win_count = flattened["gross_win_count"]
+    net_profit_count = flattened["net_profit_count"]
+    net_loss_count = flattened["net_loss_count"]
+    benchmark_count = flattened["benchmark_sample_count"]
+
+    nominal_z = NormalDist().inv_cdf(1 - NOMINAL_ALPHA / 2)
+    corrected_alpha = NOMINAL_ALPHA / hypothesis_family_size
+    corrected_z = NormalDist().inv_cdf(1 - corrected_alpha / 2)
+    net_ci_low, net_ci_high = _wilson_bounds(net_win_count, sample_count, z=nominal_z)
+    corrected_low, corrected_high = _wilson_bounds(
+        net_win_count, sample_count, z=corrected_z
+    )
+    gross_ci_low, gross_ci_high = _wilson_bounds(
+        gross_win_count, sample_count, z=nominal_z
+    )
+    mean_net = _safe_divide(flattened["net_return_sum"], sample_count)
+    net_variance = (
+        _safe_divide(flattened["net_return_square_sum"], sample_count)
+        - mean_net * mean_net
+    )
+    net_variance = np.where(net_variance < 0, 0, net_variance)
+    minimum = _minimum_for_scope(
+        scope,
+        min_train_samples=min_train_samples,
+        min_validation_samples=min_validation_samples,
+        min_reveal_samples=min_reveal_samples,
+    )
+
+    selector_values = pd.array(
+        [TRIGGER_SELECTORS[index].value for index in selector_indexes],
+        dtype="Int16",
+    )
+    result = pd.DataFrame(
+        {
+            "scope": scope,
+            "model_code": model_code,
+            "trigger_id": [
+                TRIGGER_SELECTORS[index].trigger_id for index in selector_indexes
+            ],
+            "trigger_selector_kind": [
+                TRIGGER_SELECTORS[index].kind for index in selector_indexes
+            ],
+            "trigger_selector_value": selector_values,
+            "trigger_selector_name": [
+                TRIGGER_SELECTORS[index].name for index in selector_indexes
+            ],
+            "filter_mask": required_masks.astype(np.int16),
+            "filter_names": [_filter_names(mask) for mask in required_masks],
+            "filter_count": np.fromiter(
+                (int(mask).bit_count() for mask in required_masks),
+                dtype=np.int8,
+                count=len(required_masks),
+            ),
+            "horizon_trading_days": int(horizon),
+            "candidate_count": np.rint(candidate_count).astype(np.int64),
+            "status_ok_count": np.rint(status_ok_count).astype(np.int64),
+            "sample_count": np.rint(sample_count).astype(np.int64),
+            "unavailable_count": np.rint(candidate_count - status_ok_count).astype(
+                np.int64
+            ),
+            "boundary_purged_count": np.rint(flattened["boundary_purged_count"]).astype(
+                np.int64
+            ),
+            "sample_retention_rate": _safe_divide(sample_count, candidate_count),
+            "gross_win_count": np.rint(gross_win_count).astype(np.int64),
+            "gross_win_rate": _safe_divide(gross_win_count, sample_count),
+            "gross_win_rate_ci_low": gross_ci_low,
+            "gross_win_rate_ci_high": gross_ci_high,
+            "net_win_count": np.rint(net_win_count).astype(np.int64),
+            "net_win_rate": _safe_divide(net_win_count, sample_count),
+            "net_win_rate_ci_low": net_ci_low,
+            "net_win_rate_ci_high": net_ci_high,
+            "net_win_rate_bonferroni_ci_low": corrected_low,
+            "net_win_rate_bonferroni_ci_high": corrected_high,
+            "mean_gross_return": _safe_divide(
+                flattened["gross_return_sum"], sample_count
+            ),
+            "mean_net_return": mean_net,
+            "net_return_std": np.sqrt(net_variance),
+            "average_net_win": _safe_divide(
+                flattened["net_profit_sum"], net_profit_count
+            ),
+            "average_net_loss_abs": _safe_divide(
+                flattened["net_loss_abs_sum"], net_loss_count
+            ),
+            "payoff_ratio": _safe_divide(
+                _safe_divide(flattened["net_profit_sum"], net_profit_count),
+                _safe_divide(flattened["net_loss_abs_sum"], net_loss_count),
+            ),
+            "profit_factor": _safe_divide(
+                flattened["net_profit_sum"],
+                flattened["net_loss_abs_sum"],
+            ),
+            "benchmark_sample_count": np.rint(benchmark_count).astype(np.int64),
+            "mean_index_return": _safe_divide(
+                flattened["index_return_sum"], benchmark_count
+            ),
+            "mean_net_excess_return": _safe_divide(
+                flattened["net_excess_return_sum"], benchmark_count
+            ),
+            "minimum_sample_required": minimum,
+            "minimum_sample_pass": sample_count >= minimum,
+            "small_sample_warning": sample_count < minimum,
+            "nominal_confidence_level": 1 - NOMINAL_ALPHA,
+            "multiple_comparison_family_size": int(hypothesis_family_size),
+            "bonferroni_alpha": corrected_alpha,
+            "multiple_testing_warning": True,
+        }
+    )
+    return result
+
+
+def build_development_candidates(
+    train: pd.DataFrame,
+    validation: pd.DataFrame,
+    *,
+    min_train_samples: int = DEFAULT_MIN_TRAIN_SAMPLES,
+    min_validation_samples: int = DEFAULT_MIN_VALIDATION_SAMPLES,
+) -> pd.DataFrame:
+    """Join development scopes and calculate the deterministic lock score."""
+
+    keys = (
+        "model_code",
+        "trigger_id",
+        "trigger_selector_kind",
+        "trigger_selector_value",
+        "trigger_selector_name",
+        "filter_mask",
+        "filter_names",
+        "filter_count",
+        "horizon_trading_days",
+    )
+    metric_columns = (
+        "candidate_count",
+        "sample_count",
+        "sample_retention_rate",
+        "net_win_rate",
+        "net_win_rate_ci_low",
+        "net_win_rate_ci_high",
+        "mean_net_return",
+        "profit_factor",
+        "mean_net_excess_return",
+    )
+    left = train.loc[:, [*keys, *metric_columns]].rename(
+        columns={name: f"train_{name}" for name in metric_columns}
+    )
+    right = validation.loc[:, [*keys, *metric_columns]].rename(
+        columns={name: f"validation_{name}" for name in metric_columns}
+    )
+    joined = left.merge(right, on=list(keys), how="inner", validate="one_to_one")
+    eligible = (
+        joined["train_sample_count"].ge(min_train_samples)
+        & joined["validation_sample_count"].ge(min_validation_samples)
+        & joined["train_net_win_rate_ci_low"].notna()
+        & joined["validation_net_win_rate_ci_low"].notna()
+        & joined["train_mean_net_return"].notna()
+        & joined["validation_mean_net_return"].notna()
+    )
+    joined["eligible_for_lock"] = eligible
+    joined["development_score"] = (
+        0.30 * joined["train_net_win_rate_ci_low"]
+        + 0.40 * joined["validation_net_win_rate_ci_low"]
+        + 0.15 * joined[["train_net_win_rate", "validation_net_win_rate"]].min(axis=1)
+        + 0.075 * joined["train_mean_net_return"].clip(-0.10, 0.10)
+        + 0.075 * joined["validation_mean_net_return"].clip(-0.10, 0.10)
+        - 0.002 * joined["filter_count"]
+    )
+    joined.loc[~eligible, "development_score"] = np.nan
+    joined["selection_uses_audit"] = False
+    return joined
+
+
+def _candidate_sort(frame: pd.DataFrame) -> pd.DataFrame:
+    return frame.sort_values(
+        [
+            "development_score",
+            "validation_net_win_rate_ci_low",
+            "validation_mean_net_return",
+            "validation_sample_count",
+            "filter_count",
+            "model_code",
+            "trigger_id",
+            "filter_mask",
+        ],
+        ascending=[False, False, False, False, True, True, True, True],
+        kind="stable",
+    )
+
+
+def select_locked_config(
+    candidates: pd.DataFrame,
+    *,
+    horizons: Sequence[int] = HORIZONS,
+) -> list[dict[str, Any]]:
+    """Select one global champion per horizon from development facts only."""
+
+    prohibited = [
+        column
+        for column in candidates.columns
+        if column.lower().startswith(("audit_", "available_", "matched90_", "purged_"))
+    ]
+    if prohibited:
+        raise RuntimeError(
+            f"development candidate artifact leaks reveal columns: {prohibited}"
+        )
+    selections: list[dict[str, Any]] = []
+    for horizon in horizons:
+        eligible = candidates.loc[
+            candidates["horizon_trading_days"].eq(horizon)
+            & candidates["eligible_for_lock"].eq(True)
+            & candidates["development_score"].notna()
+        ]
+        if eligible.empty:
+            raise RuntimeError(
+                f"no development candidate satisfies minimum samples for h{horizon}"
+            )
+        winner = _candidate_sort(eligible).iloc[0].to_dict()
+        selector_value = winner["trigger_selector_value"]
+        if pd.isna(selector_value):
+            selector_value = None
+        else:
+            selector_value = int(selector_value)
+        core = {
+            "horizon_trading_days": int(horizon),
+            "model_code": str(winner["model_code"]),
+            "trigger_id": str(winner["trigger_id"]),
+            "trigger_selector": {
+                "kind": str(winner["trigger_selector_kind"]),
+                "value": selector_value,
+                "name": str(winner["trigger_selector_name"]),
+            },
+            "filter_mask": int(winner["filter_mask"]),
+            "filter_names": (
+                []
+                if str(winner["filter_names"]) == "NONE"
+                else str(winner["filter_names"]).split("+")
+            ),
+        }
+        selection_id = "sha256:" + sha256_bytes(canonical_json_bytes(core))
+        selections.append(
+            {
+                "selection_id": selection_id,
+                **core,
+                "development_score": float(winner["development_score"]),
+                "train_metrics": {
+                    "sample_count": int(winner["train_sample_count"]),
+                    "win_rate": float(winner["train_net_win_rate"]),
+                    "win_rate_ci_low": float(winner["train_net_win_rate_ci_low"]),
+                    "win_rate_ci_high": float(winner["train_net_win_rate_ci_high"]),
+                    "mean_net_return": float(winner["train_mean_net_return"]),
+                    "profit_factor": (
+                        float(winner["train_profit_factor"])
+                        if pd.notna(winner["train_profit_factor"])
+                        else None
+                    ),
+                    "mean_net_excess_return": (
+                        float(winner["train_mean_net_excess_return"])
+                        if pd.notna(winner["train_mean_net_excess_return"])
+                        else None
+                    ),
+                },
+                "validation_metrics": {
+                    "sample_count": int(winner["validation_sample_count"]),
+                    "win_rate": float(winner["validation_net_win_rate"]),
+                    "win_rate_ci_low": float(winner["validation_net_win_rate_ci_low"]),
+                    "win_rate_ci_high": float(
+                        winner["validation_net_win_rate_ci_high"]
+                    ),
+                    "mean_net_return": float(winner["validation_mean_net_return"]),
+                    "profit_factor": (
+                        float(winner["validation_profit_factor"])
+                        if pd.notna(winner["validation_profit_factor"])
+                        else None
+                    ),
+                    "mean_net_excess_return": (
+                        float(winner["validation_mean_net_excess_return"])
+                        if pd.notna(winner["validation_mean_net_excess_return"])
+                        else None
+                    ),
+                },
+            }
+        )
+    return selections
+
+
+def _study_config(root: Path) -> tuple[Path, dict[str, Any]]:
+    path = root / "audit" / "study_config.json"
+    config = read_json(path)
+    time_splits = config.get("time_splits")
+    if not isinstance(time_splits, dict):
+        raise TypeError("study_config.json misses time_splits")
+    for split_id in ("TRAIN", "VALIDATION", "AUDIT"):
+        bounds = time_splits.get(split_id)
+        if (
+            not isinstance(bounds, list)
+            or len(bounds) != 2
+            or str(bounds[0]) > str(bounds[1])
+        ):
+            raise RuntimeError(f"invalid {split_id} time split")
+    return path, config
+
+
+def _stage_identity(payload: Mapping[str, Any]) -> str:
+    return "sha256:" + sha256_bytes(canonical_json_bytes(payload))
+
+
+def _development_identity(
+    *,
+    features_path: Path,
+    config_path: Path,
+    index_path: Path,
+    min_train_samples: int,
+    min_validation_samples: int,
+    top_per_model: int,
+) -> tuple[str, dict[str, Any]]:
+    payload = {
+        "matrix_contract_version": MATRIX_CONTRACT_VERSION,
+        "logic_sha256": _logic_sha256(),
+        "candidate_events_sha256": sha256_file(features_path),
+        "study_config_sha256": sha256_file(config_path),
+        "index_snapshot_sha256": sha256_file(index_path),
+        "scopes": list(DEVELOPMENT_SCOPES),
+        "models": list(MODEL_CODES),
+        "horizons": list(HORIZONS),
+        "trigger_selector_contract": _selector_contract(),
+        "filter_contract": {
+            "columns": list(FILTER_COLUMNS),
+            "subsets": FILTER_SUBSET_COUNT,
+            "source_mask_applied": FILTER_MASK,
+        },
+        "minimum_samples": {
+            "TRAIN": min_train_samples,
+            "VALIDATION": min_validation_samples,
+        },
+        "top_per_model": top_per_model,
+    }
+    return _stage_identity(payload), payload
+
+
+def _top_development_rows(
+    candidates: pd.DataFrame,
+    *,
+    limit: int,
+) -> pd.DataFrame:
+    eligible = candidates.loc[candidates["eligible_for_lock"].eq(True)]
+    if eligible.empty:
+        return eligible
+    return _candidate_sort(eligible).head(limit).reset_index(drop=True)
+
+
+def run_development(args: argparse.Namespace) -> dict[str, Any]:
+    root = Path(args.root).resolve()
+    matrix_dir = root / "matrix"
+    matrix_dir.mkdir(parents=True, exist_ok=True)
+    features_path = root / "features" / "candidate_events.parquet"
+    index_path = root / "snapshot" / "index_day.parquet"
+    config_path, config = _study_config(root)
+    if not features_path.is_file():
+        raise FileNotFoundError(features_path)
+    if not index_path.is_file():
+        raise FileNotFoundError(index_path)
+
+    stage_id, identity = _development_identity(
+        features_path=features_path,
+        config_path=config_path,
+        index_path=index_path,
+        min_train_samples=args.min_train_samples,
+        min_validation_samples=args.min_validation_samples,
+        top_per_model=args.top_per_model,
+    )
+    matrix_path = matrix_dir / "development_matrix.parquet"
+    candidates_path = matrix_dir / "development_lock_candidates.parquet"
+    summary_path = matrix_dir / "development_summary.csv"
+    detailed_path = matrix_dir / "development_top_detailed.parquet"
+    detailed_csv_path = matrix_dir / "development_top_detailed.csv"
+    group_detail_path = matrix_dir / "development_top_group_detail.parquet"
+    manifest_path = matrix_dir / "development_manifest.json"
+    if not args.force and _manifest_reusable(
+        manifest_path,
+        stage_id=stage_id,
+        output_keys=(
+            "matrix",
+            "lock_candidates",
+            "summary",
+            "top_detailed",
+            "top_detailed_csv",
+            "top_group_detail",
+        ),
+    ):
+        result = {
+            "stage": "development",
+            "stage_id": stage_id,
+            "reused": True,
+            "manifest_path": str(manifest_path),
+        }
+        print(json.dumps(result, ensure_ascii=False), flush=True)
+        return result
+
+    # Parquet predicate pushdown is a hard anti-leakage property of this stage.
+    events = load_feature_events(
+        features_path,
+        split_filter=DEVELOPMENT_SCOPES,
+    )
+    if set(events["split_id"].unique()) - set(DEVELOPMENT_SCOPES):
+        raise RuntimeError("development input contains non-development rows")
+    index = pd.read_parquet(index_path, columns=["date", "close"])
+    events, benchmark_audit = attach_index_benchmark(events, index)
+    time_splits = config["time_splits"]
+    family_size = len(MODEL_CODES) * len(TRIGGER_SELECTORS) * FILTER_SUBSET_COUNT
+
+    writer = AtomicParquetWriter(matrix_path)
+    retained: list[pd.DataFrame] = []
+    try:
+        for model_no, model_code in enumerate(MODEL_CODES, start=1):
+            model_events = events.loc[events["model_code"].eq(model_code)]
+            for horizon in HORIZONS:
+                train = build_matrix_chunk(
+                    model_events,
+                    model_code=model_code,
+                    horizon=horizon,
+                    scope="TRAIN",
+                    time_splits=time_splits,
+                    hypothesis_family_size=family_size,
+                    min_train_samples=args.min_train_samples,
+                    min_validation_samples=args.min_validation_samples,
+                )
+                validation = build_matrix_chunk(
+                    model_events,
+                    model_code=model_code,
+                    horizon=horizon,
+                    scope="VALIDATION",
+                    time_splits=time_splits,
+                    hypothesis_family_size=family_size,
+                    min_train_samples=args.min_train_samples,
+                    min_validation_samples=args.min_validation_samples,
+                )
+                writer.write(train)
+                writer.write(validation)
+                development = build_development_candidates(
+                    train,
+                    validation,
+                    min_train_samples=args.min_train_samples,
+                    min_validation_samples=args.min_validation_samples,
+                )
+                top = _top_development_rows(
+                    development,
+                    limit=args.top_per_model,
+                )
+                if not top.empty:
+                    retained.append(top)
+            if args.progress_every and model_no % args.progress_every == 0:
+                print(
+                    json.dumps(
+                        {
+                            "stage": "development",
+                            "models_complete": model_no,
+                            "models_total": len(MODEL_CODES),
+                            "matrix_rows": writer.rows,
+                        },
+                        ensure_ascii=False,
+                    ),
+                    flush=True,
+                )
+        writer.close()
+    except BaseException:
+        writer.abort()
+        raise
+
+    if not retained:
+        raise RuntimeError(
+            "no TRAIN/VALIDATION candidate satisfies the minimum sample contract"
+        )
+    lock_candidates = pd.concat(retained, ignore_index=True)
+    lock_candidates = _candidate_sort(lock_candidates).reset_index(drop=True)
+    write_frame_atomic(lock_candidates, candidates_path)
+    write_frame_atomic(lock_candidates, summary_path)
+
+    detailed_frames: list[pd.DataFrame] = []
+    group_frames: list[pd.DataFrame] = []
+    for row in lock_candidates.to_dict(orient="records"):
+        selection = _development_row_selection(row)
+        model_events = events.loc[events["model_code"].eq(selection["model_code"])]
+        overview, groups = build_exact_detail_tables(
+            model_events,
+            selection=selection,
+            scopes=DEVELOPMENT_SCOPES,
+            time_splits=time_splits,
+            model_populations=("SELECTED_MODEL",),
+            minimum_sample={
+                "TRAIN": args.min_train_samples,
+                "VALIDATION": args.min_validation_samples,
+            },
+            source_kind="DEVELOPMENT_TOP",
+        )
+        overview["development_score"] = float(row["development_score"])
+        groups["development_score"] = float(row["development_score"])
+        detailed_frames.append(overview)
+        if not groups.empty:
+            group_frames.append(groups)
+
+    # Preserve a meaningful 18-model Macro/Union view for the eventual global
+    # champion of each horizon without opening the sealed AUDIT rows.
+    for horizon in HORIZONS:
+        winner = _candidate_sort(
+            lock_candidates.loc[lock_candidates["horizon_trading_days"].eq(horizon)]
+        ).iloc[0]
+        selection = _development_row_selection(winner.to_dict())
+        overview, groups = build_exact_detail_tables(
+            events,
+            selection=selection,
+            scopes=DEVELOPMENT_SCOPES,
+            time_splits=time_splits,
+            model_populations=("ALL_MODELS_SAME_RULE",),
+            minimum_sample={
+                "TRAIN": args.min_train_samples,
+                "VALIDATION": args.min_validation_samples,
+            },
+            source_kind="DEVELOPMENT_GLOBAL_TOP_ALL_MODELS",
+        )
+        overview["development_score"] = float(winner["development_score"])
+        groups["development_score"] = float(winner["development_score"])
+        detailed_frames.append(overview)
+        if not groups.empty:
+            group_frames.append(groups)
+    exact_detailed = pd.concat(detailed_frames, ignore_index=True)
+    exact_groups = (
+        pd.concat(group_frames, ignore_index=True) if group_frames else pd.DataFrame()
+    )
+    write_frame_atomic(exact_detailed, detailed_path)
+    write_frame_atomic(exact_detailed, detailed_csv_path)
+    write_frame_atomic(exact_groups, group_detail_path)
+    output_rows_expected = (
+        len(MODEL_CODES)
+        * len(HORIZONS)
+        * len(DEVELOPMENT_SCOPES)
+        * len(TRIGGER_SELECTORS)
+        * FILTER_SUBSET_COUNT
+    )
+    if writer.rows != output_rows_expected:
+        raise RuntimeError(
+            f"development matrix rows {writer.rows} != {output_rows_expected}"
+        )
+
+    manifest = {
+        "study_id": STUDY_ID,
+        "stage": "development",
+        "stage_id": stage_id,
+        "matrix_contract_version": MATRIX_CONTRACT_VERSION,
+        "identity": identity,
+        "data_access_contract": {
+            "candidate_event_scopes_physically_read": list(DEVELOPMENT_SCOPES),
+            "reveal_scopes_read": [],
+            "audit_used_in_score": False,
+        },
+        "row_contract": {
+            "matrix_rows": writer.rows,
+            "trigger_selectors": len(TRIGGER_SELECTORS),
+            "trigger_selector_semantics": TRIGGER_SELECTOR_SEMANTICS,
+            "filter_subsets": FILTER_SUBSET_COUNT,
+            "filter_subset_semantics": (
+                "event qualifies when (filter_pass_mask & required_mask) "
+                "equals required_mask"
+            ),
+            "models": len(MODEL_CODES),
+            "horizons": len(HORIZONS),
+            "scopes": list(DEVELOPMENT_SCOPES),
+        },
+        "selection_contract": {
+            "score": (
+                "0.30*TRAIN Wilson95 lower + 0.40*VALIDATION Wilson95 lower "
+                "+ 0.15*min(TRAIN,VALIDATION win rate) "
+                "+ 0.075*clipped TRAIN mean net return "
+                "+ 0.075*clipped VALIDATION mean net return "
+                "- 0.002*filter count"
+            ),
+            "minimum_samples": {
+                "TRAIN": args.min_train_samples,
+                "VALIDATION": args.min_validation_samples,
+            },
+            "multiple_testing": {
+                "family_size_per_horizon": family_size,
+                "nominal_alpha": NOMINAL_ALPHA,
+                "bonferroni_alpha": NOMINAL_ALPHA / family_size,
+                "warning": (
+                    "Many correlated model/trigger/filter hypotheses are tested; "
+                    "unadjusted rankings are exploratory."
+                ),
+            },
+            "per_model_top_rows_retained": args.top_per_model,
+            "global_maximum_preserved": True,
+        },
+        "statistics_layering": {
+            "exhaustive_matrix": (
+                "additive exact counts, rates, means, standard deviation, "
+                "payoff ratio, profit factor, confidence intervals, and "
+                "daily benchmark excess for every cell"
+            ),
+            "development_top_exact": (
+                "exact median, P05/P25/P50/P75/P95, CVaR5, distinct stocks "
+                "and dates, loss streak, PnL concentration, crowding, "
+                "Event/Union/Macro/DateBalanced, year/quarter/regime groups"
+            ),
+            "aggregation_contract": EXACT_AGGREGATION_CONTRACT,
+            "reason": (
+                "non-additive order statistics are materialized for the "
+                "development shortlist rather than approximated across the "
+                "entire exhaustive matrix"
+            ),
+            "audit_rows_used": False,
+        },
+        "benchmark_audit": benchmark_audit,
+        "outputs": {
+            "matrix": _artifact(matrix_path),
+            "lock_candidates": _artifact(candidates_path),
+            "summary": _artifact(summary_path),
+            "top_detailed": _artifact(detailed_path),
+            "top_detailed_csv": _artifact(detailed_csv_path),
+            "top_group_detail": _artifact(group_detail_path),
+        },
+    }
+    write_json_atomic(manifest_path, manifest)
+    result = {
+        "stage": "development",
+        "stage_id": stage_id,
+        "reused": False,
+        "matrix_rows": writer.rows,
+        "lock_candidate_rows": len(lock_candidates),
+        "top_detailed_rows": len(exact_detailed),
+        "top_group_detail_rows": len(exact_groups),
+        "manifest_path": str(manifest_path),
+    }
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return result
+
+
+def _lock_identity(
+    development_manifest_path: Path,
+    candidates_path: Path,
+) -> tuple[str, dict[str, Any]]:
+    payload = {
+        "matrix_contract_version": MATRIX_CONTRACT_VERSION,
+        "logic_sha256": _logic_sha256(),
+        "development_manifest_sha256": sha256_file(development_manifest_path),
+        "development_candidates_sha256": sha256_file(candidates_path),
+        "horizons": list(HORIZONS),
+        "selection_count": len(HORIZONS),
+    }
+    return _stage_identity(payload), payload
+
+
+def run_lock(args: argparse.Namespace) -> dict[str, Any]:
+    """Lock without opening candidate_events or any holdout artifact."""
+
+    root = Path(args.root).resolve()
+    matrix_dir = root / "matrix"
+    development_manifest_path = matrix_dir / "development_manifest.json"
+    candidates_path = matrix_dir / "development_lock_candidates.parquet"
+    development_manifest = read_json(development_manifest_path)
+    access = development_manifest.get("data_access_contract", {})
+    if access.get("candidate_event_scopes_physically_read") != list(DEVELOPMENT_SCOPES):
+        raise RuntimeError(
+            "development manifest does not prove TRAIN/VALIDATION isolation"
+        )
+    if access.get("audit_used_in_score") is not False:
+        raise RuntimeError("development manifest does not prove AUDIT exclusion")
+    expected_candidates = development_manifest["outputs"]["lock_candidates"]
+    if (
+        expected_candidates["file_sha256"] != sha256_file(candidates_path)
+        or Path(str(expected_candidates["path"])).resolve() != candidates_path.resolve()
+    ):
+        raise RuntimeError("development lock candidate identity mismatch")
+
+    stage_id, identity = _lock_identity(
+        development_manifest_path,
+        candidates_path,
+    )
+    locked_path = matrix_dir / "locked_config.json"
+    summary_path = matrix_dir / "locked_config.csv"
+    manifest_path = matrix_dir / "lock_manifest.json"
+    if not args.force and _manifest_reusable(
+        manifest_path,
+        stage_id=stage_id,
+        output_keys=("locked_config", "summary"),
+    ):
+        result = {
+            "stage": "lock",
+            "stage_id": stage_id,
+            "reused": True,
+            "manifest_path": str(manifest_path),
+        }
+        print(json.dumps(result, ensure_ascii=False), flush=True)
+        return result
+
+    candidates = pd.read_parquet(candidates_path)
+    selections = select_locked_config(candidates)
+    if len(selections) != len(HORIZONS):
+        raise RuntimeError("lock must contain exactly one selection per horizon")
+    lock_payload = {
+        "study_id": STUDY_ID,
+        "matrix_contract_version": MATRIX_CONTRACT_VERSION,
+        "development_stage_id": development_manifest["stage_id"],
+        "lock_stage_id": stage_id,
+        "selection_policy": (
+            "one deterministic global champion per horizon using TRAIN and "
+            "VALIDATION only; holdout remains sealed"
+        ),
+        "filter_contract": {
+            "filters": list(FILTER_NAMES),
+            "subset_count": FILTER_SUBSET_COUNT,
+            "mask_range": [0, FILTER_MASK],
+        },
+        "selections": selections,
+    }
+    lock_id = "sha256:" + sha256_bytes(canonical_json_bytes(lock_payload))
+    locked = {"lock_id": lock_id, **lock_payload}
+    write_json_atomic(locked_path, locked)
+    flat_rows = []
+    for selection in selections:
+        flat_rows.append(
+            {
+                "lock_id": lock_id,
+                "selection_id": selection["selection_id"],
+                "horizon_trading_days": selection["horizon_trading_days"],
+                "model_code": selection["model_code"],
+                "trigger_id": selection["trigger_id"],
+                "trigger_selector_kind": selection["trigger_selector"]["kind"],
+                "trigger_selector_value": selection["trigger_selector"]["value"],
+                "filter_mask": selection["filter_mask"],
+                "filter_names": "+".join(selection["filter_names"]) or "NONE",
+                "development_score": selection["development_score"],
+                "train_sample_count": selection["train_metrics"]["sample_count"],
+                "train_win_rate": selection["train_metrics"]["win_rate"],
+                "validation_sample_count": selection["validation_metrics"][
+                    "sample_count"
+                ],
+                "validation_win_rate": selection["validation_metrics"]["win_rate"],
+            }
+        )
+    write_frame_atomic(pd.DataFrame(flat_rows), summary_path)
+    manifest = {
+        "study_id": STUDY_ID,
+        "stage": "lock",
+        "stage_id": stage_id,
+        "lock_id": lock_id,
+        "identity": identity,
+        "data_access_contract": {
+            "read": [
+                "matrix/development_manifest.json",
+                "matrix/development_lock_candidates.parquet",
+            ],
+            "candidate_events_read": False,
+            "audit_or_reveal_metrics_read": False,
+        },
+        "outputs": {
+            "locked_config": _artifact(locked_path),
+            "summary": _artifact(summary_path),
+        },
+    }
+    write_json_atomic(manifest_path, manifest)
+    result = {
+        "stage": "lock",
+        "stage_id": stage_id,
+        "lock_id": lock_id,
+        "reused": False,
+        "selections": len(selections),
+        "manifest_path": str(manifest_path),
+    }
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return result
+
+
+def _load_lock_for_reveal(root: Path) -> tuple[Path, dict[str, Any]]:
+    """The first reveal read: fail closed before any event or index access."""
+
+    path = root / "matrix" / "locked_config.json"
+    locked = read_json(path)
+    if locked.get("study_id") != STUDY_ID:
+        raise RuntimeError("locked_config study_id mismatch")
+    selections = locked.get("selections")
+    if not isinstance(selections, list) or len(selections) != len(HORIZONS):
+        raise RuntimeError("locked_config must contain four horizon selections")
+    observed_horizons: list[int] = []
+    for selection in selections:
+        horizon = int(selection["horizon_trading_days"])
+        observed_horizons.append(horizon)
+        model_code = str(selection["model_code"])
+        if model_code not in MODEL_CODES:
+            raise RuntimeError(f"lock contains unknown model: {model_code}")
+        filter_mask = int(selection["filter_mask"])
+        if not 0 <= filter_mask <= FILTER_MASK:
+            raise RuntimeError(f"lock contains invalid filter mask: {filter_mask}")
+        selector = TriggerSelector(
+            trigger_id=str(selection["trigger_id"]),
+            kind=str(selection["trigger_selector"]["kind"]),
+            value=(
+                None
+                if selection["trigger_selector"].get("value") is None
+                else int(selection["trigger_selector"]["value"])
+            ),
+            name=str(selection["trigger_selector"].get("name") or ""),
+        )
+        if selector.trigger_id not in {
+            candidate.trigger_id for candidate in TRIGGER_SELECTORS
+        }:
+            raise RuntimeError(
+                f"lock contains unknown trigger selector: {selector.trigger_id}"
+            )
+        expected = next(
+            candidate
+            for candidate in TRIGGER_SELECTORS
+            if candidate.trigger_id == selector.trigger_id
+        )
+        if selector.kind != expected.kind or selector.value != expected.value:
+            raise RuntimeError(
+                f"lock trigger selector contract mismatch: {selector.trigger_id}"
+            )
+    if sorted(observed_horizons) != sorted(HORIZONS):
+        raise RuntimeError("locked_config horizons are incomplete or duplicated")
+    payload = {key: value for key, value in locked.items() if key != "lock_id"}
+    expected_lock_id = "sha256:" + sha256_bytes(canonical_json_bytes(payload))
+    if locked.get("lock_id") != expected_lock_id:
+        raise RuntimeError("locked_config lock_id mismatch")
+    return path, locked
+
+
+def _reveal_identity(
+    *,
+    lock_path: Path,
+    features_path: Path,
+    config_path: Path,
+    index_path: Path,
+    min_reveal_samples: int,
+) -> tuple[str, dict[str, Any]]:
+    payload = {
+        "matrix_contract_version": MATRIX_CONTRACT_VERSION,
+        "logic_sha256": _logic_sha256(),
+        "locked_config_sha256": sha256_file(lock_path),
+        "candidate_events_sha256": sha256_file(features_path),
+        "study_config_sha256": sha256_file(config_path),
+        "index_snapshot_sha256": sha256_file(index_path),
+        "scopes": list(REVEAL_SCOPES),
+        "models": list(MODEL_CODES),
+        "horizons": list(HORIZONS),
+        "trigger_selector_contract": _selector_contract(),
+        "filter_contract": {
+            "columns": list(FILTER_COLUMNS),
+            "subsets": FILTER_SUBSET_COUNT,
+            "source_mask_applied": FILTER_MASK,
+        },
+        "minimum_reveal_samples": min_reveal_samples,
+    }
+    return _stage_identity(payload), payload
+
+
+def _selection_event_mask(
+    frame: pd.DataFrame,
+    selection: Mapping[str, Any],
+    *,
+    all_models: bool = False,
+) -> np.ndarray:
+    selector_contract = selection["trigger_selector"]
+    selector = TriggerSelector(
+        trigger_id=str(selection["trigger_id"]),
+        kind=str(selector_contract["kind"]),
+        value=(
+            None
+            if selector_contract.get("value") is None
+            else int(selector_contract["value"])
+        ),
+        name=str(selector_contract.get("name") or ""),
+    )
+    exact_masks = frame["concurrent_trigger_mask"].to_numpy(dtype=np.int16)
+    trigger = np.fromiter(
+        (trigger_selector_matches(selector, int(mask)) for mask in exact_masks),
+        dtype=bool,
+        count=len(frame),
+    )
+    required_filter = int(selection["filter_mask"])
+    pass_masks = frame["filter_pass_mask"].to_numpy(dtype=np.int16) & FILTER_MASK
+    filters = (pass_masks & required_filter) == required_filter
+    model = (
+        np.ones(len(frame), dtype=bool)
+        if all_models
+        else frame["model_code"].eq(str(selection["model_code"])).to_numpy(dtype=bool)
+    )
+    return model & trigger & filters
+
+
+def _longest_loss_streak(values: np.ndarray) -> int:
+    longest = 0
+    current = 0
+    for value in values:
+        if value < 0:
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def _selected_detailed_metrics(
+    frame: pd.DataFrame,
+    *,
+    selection: Mapping[str, Any],
+    scope: str,
+    time_splits: Mapping[str, Sequence[str]],
+) -> dict[str, Any]:
+    horizon = int(selection["horizon_trading_days"])
+    configuration = _selection_event_mask(frame, selection)
+    scope_masks = _scope_masks(
+        frame,
+        horizon=horizon,
+        scope=scope,
+        time_splits=time_splits,
+    )
+    gross = pd.to_numeric(frame[f"h{horizon}_gross_return"], errors="coerce").to_numpy(
+        dtype=float
+    )
+    net = pd.to_numeric(frame[f"h{horizon}_net_return"], errors="coerce").to_numpy(
+        dtype=float
+    )
+    index_return = pd.to_numeric(
+        frame[f"h{horizon}_index_return"], errors="coerce"
+    ).to_numpy(dtype=float)
+    excess = pd.to_numeric(
+        frame[f"h{horizon}_net_excess_return"], errors="coerce"
+    ).to_numpy(dtype=float)
+    sample = (
+        configuration & scope_masks["sample"] & np.isfinite(gross) & np.isfinite(net)
+    )
+    sample_frame = frame.loc[sample].copy()
+    sample_frame["_net"] = net[sample]
+    sample_frame = sample_frame.sort_values(["reveal_at", "code"], kind="stable")
+    net_values = sample_frame["_net"].to_numpy(dtype=float)
+    gross_values = gross[sample]
+    benchmark = sample & np.isfinite(index_return) & np.isfinite(excess)
+    candidate_count = int((configuration & scope_masks["candidate"]).sum())
+    status_ok_count = int((configuration & scope_masks["status_ok"]).sum())
+    boundary_count = int((configuration & scope_masks["boundary_purged"]).sum())
+    count = len(net_values)
+    wins = int((net_values > 0).sum())
+    ci_low, ci_high = _wilson_bounds(
+        np.asarray([wins], dtype=float),
+        np.asarray([count], dtype=float),
+        z=NormalDist().inv_cdf(1 - NOMINAL_ALPHA / 2),
+    )
+    positive = net_values[net_values > 0]
+    negative = net_values[net_values < 0]
+    reveal_dates = (
+        pd.to_datetime(sample_frame["reveal_at"], utc=True)
+        .dt.tz_convert("Asia/Shanghai")
+        .dt.date
+        if count
+        else pd.Series(dtype=object)
+    )
+    daily_counts = reveal_dates.value_counts() if count else pd.Series(dtype=int)
+    positive_total = float(positive.sum()) if len(positive) else 0.0
+    top_count = max(1, math.ceil(len(positive) * 0.10)) if len(positive) else 0
+    concentration = (
+        float(np.sort(positive)[-top_count:].sum() / positive_total)
+        if positive_total > 0 and top_count
+        else np.nan
+    )
+    result: dict[str, Any] = {
+        "lock_id": "",
+        "selection_id": str(selection["selection_id"]),
+        "scope": scope,
+        "horizon_trading_days": horizon,
+        "model_code": str(selection["model_code"]),
+        "trigger_id": str(selection["trigger_id"]),
+        "trigger_selector_kind": str(selection["trigger_selector"]["kind"]),
+        "trigger_selector_value": selection["trigger_selector"].get("value"),
+        "filter_mask": int(selection["filter_mask"]),
+        "filter_names": "+".join(selection["filter_names"]) or "NONE",
+        "candidate_count": candidate_count,
+        "status_ok_count": status_ok_count,
+        "sample_count": count,
+        "unavailable_count": candidate_count - status_ok_count,
+        "boundary_purged_count": boundary_count,
+        "unique_stock_count": (
+            int(sample_frame["code"].astype(str).nunique()) if count else 0
+        ),
+        "unique_signal_date_count": int(reveal_dates.nunique()) if count else 0,
+        "gross_win_rate": float((gross_values > 0).mean()) if count else np.nan,
+        "net_win_rate": wins / count if count else np.nan,
+        "net_win_rate_ci_low": float(ci_low[0]) if count else np.nan,
+        "net_win_rate_ci_high": float(ci_high[0]) if count else np.nan,
+        "mean_gross_return": float(gross_values.mean()) if count else np.nan,
+        "mean_net_return": float(net_values.mean()) if count else np.nan,
+        "median_net_return": float(np.median(net_values)) if count else np.nan,
+        "average_net_win": (float(positive.mean()) if len(positive) else np.nan),
+        "average_net_loss_abs": (float(-negative.mean()) if len(negative) else np.nan),
+        "payoff_ratio": (
+            float(positive.mean() / -negative.mean())
+            if len(positive) and len(negative)
+            else np.nan
+        ),
+        "profit_factor": (
+            float(positive.sum() / -negative.sum())
+            if len(negative) and -negative.sum() > 0
+            else np.nan
+        ),
+        "p05_net_return": (float(np.quantile(net_values, 0.05)) if count else np.nan),
+        "p25_net_return": (float(np.quantile(net_values, 0.25)) if count else np.nan),
+        "p50_net_return": (float(np.quantile(net_values, 0.50)) if count else np.nan),
+        "p75_net_return": (float(np.quantile(net_values, 0.75)) if count else np.nan),
+        "p95_net_return": (float(np.quantile(net_values, 0.95)) if count else np.nan),
+        "cvar5_net_return": (
+            float(net_values[net_values <= np.quantile(net_values, 0.05)].mean())
+            if count
+            else np.nan
+        ),
+        "mean_index_return": (
+            float(index_return[benchmark].mean()) if benchmark.any() else np.nan
+        ),
+        "mean_net_excess_return": (
+            float(excess[benchmark].mean()) if benchmark.any() else np.nan
+        ),
+        "max_consecutive_losses": _longest_loss_streak(net_values),
+        "positive_pnl_top10pct_concentration": concentration,
+        "mean_same_day_signal_crowding": (
+            float(daily_counts.mean()) if len(daily_counts) else np.nan
+        ),
+        "peak_same_day_signal_crowding": (
+            int(daily_counts.max()) if len(daily_counts) else 0
+        ),
+    }
+    return result
+
+
+def _development_row_selection(row: Mapping[str, Any]) -> dict[str, Any]:
+    selector_value = row["trigger_selector_value"]
+    selector_value = None if pd.isna(selector_value) else int(selector_value)
+    filter_names = (
+        []
+        if str(row["filter_names"]) == "NONE"
+        else str(row["filter_names"]).split("+")
+    )
+    core = {
+        "horizon_trading_days": int(row["horizon_trading_days"]),
+        "model_code": str(row["model_code"]),
+        "trigger_id": str(row["trigger_id"]),
+        "trigger_selector": {
+            "kind": str(row["trigger_selector_kind"]),
+            "value": selector_value,
+            "name": str(row["trigger_selector_name"]),
+        },
+        "filter_mask": int(row["filter_mask"]),
+        "filter_names": filter_names,
+    }
+    return {
+        "selection_id": "sha256:" + sha256_bytes(canonical_json_bytes(core)),
+        **core,
+    }
+
+
+def _prepared_selection_sample(
+    frame: pd.DataFrame,
+    *,
+    selection: Mapping[str, Any],
+    scope: str,
+    time_splits: Mapping[str, Sequence[str]],
+    all_models: bool,
+) -> tuple[pd.DataFrame, dict[str, int]]:
+    horizon = int(selection["horizon_trading_days"])
+    configuration = _selection_event_mask(
+        frame,
+        selection,
+        all_models=all_models,
+    )
+    scope_masks = _scope_masks(
+        frame,
+        horizon=horizon,
+        scope=scope,
+        time_splits=time_splits,
+    )
+    gross = pd.to_numeric(frame[f"h{horizon}_gross_return"], errors="coerce").to_numpy(
+        dtype=float
+    )
+    net = pd.to_numeric(frame[f"h{horizon}_net_return"], errors="coerce").to_numpy(
+        dtype=float
+    )
+    index_return = pd.to_numeric(
+        frame[f"h{horizon}_index_return"], errors="coerce"
+    ).to_numpy(dtype=float)
+    excess = pd.to_numeric(
+        frame[f"h{horizon}_net_excess_return"], errors="coerce"
+    ).to_numpy(dtype=float)
+    sample_mask = (
+        configuration & scope_masks["sample"] & np.isfinite(gross) & np.isfinite(net)
+    )
+    sample = frame.loc[
+        sample_mask,
+        ["code", "model_code", "reveal_at", "market_regime"],
+    ].copy()
+    sample["_gross"] = gross[sample_mask]
+    sample["_net"] = net[sample_mask]
+    sample["_index"] = index_return[sample_mask]
+    sample["_excess"] = excess[sample_mask]
+    local_reveal = pd.to_datetime(sample["reveal_at"], utc=True).dt.tz_convert(
+        "Asia/Shanghai"
+    )
+    sample["_reveal_date"] = local_reveal.dt.date
+    sample["_year"] = local_reveal.dt.year.astype(str)
+    sample["_quarter"] = (
+        local_reveal.dt.year.astype(str) + "Q" + local_reveal.dt.quarter.astype(str)
+    )
+    sample["_regime"] = sample["market_regime"].fillna("UNKNOWN").astype(str)
+    sample = sample.sort_values(
+        ["reveal_at", "code", "model_code"], kind="stable"
+    ).reset_index(drop=True)
+    counts = {
+        "candidate_count": int((configuration & scope_masks["candidate"]).sum()),
+        "status_ok_count": int((configuration & scope_masks["status_ok"]).sum()),
+        "boundary_purged_count": int(
+            (configuration & scope_masks["boundary_purged"]).sum()
+        ),
+    }
+    return sample, counts
+
+
+def _aggregation_observations(
+    sample: pd.DataFrame,
+    aggregation: str,
+) -> pd.DataFrame:
+    value_columns = ["_gross", "_net", "_index", "_excess"]
+    if aggregation == "EVENT":
+        return sample.loc[:, value_columns].copy()
+    if aggregation == "UNION":
+        return (
+            sample.drop_duplicates(["code", "reveal_at"], keep="first")
+            .loc[:, value_columns]
+            .reset_index(drop=True)
+        )
+    if aggregation == "DATE_BALANCED":
+        return (
+            sample.groupby("_reveal_date", sort=True, observed=True)[value_columns]
+            .mean()
+            .reset_index(drop=True)
+        )
+    if aggregation == "MACRO":
+        return (
+            sample.groupby("model_code", sort=True, observed=True)[value_columns]
+            .mean()
+            .reset_index(drop=True)
+        )
+    raise ValueError(f"unknown exact aggregation: {aggregation}")
+
+
+def _exact_observation_metrics(
+    observations: pd.DataFrame,
+    *,
+    underlying: pd.DataFrame,
+    counts: Mapping[str, int],
+) -> dict[str, Any]:
+    gross = observations["_gross"].to_numpy(dtype=float)
+    net = observations["_net"].to_numpy(dtype=float)
+    finite = np.isfinite(gross) & np.isfinite(net)
+    gross = gross[finite]
+    net = net[finite]
+    index_return = observations["_index"].to_numpy(dtype=float)[finite]
+    excess = observations["_excess"].to_numpy(dtype=float)[finite]
+    count = len(net)
+    wins = int((net > 0).sum())
+    ci_low, ci_high = _wilson_bounds(
+        np.asarray([wins], dtype=float),
+        np.asarray([count], dtype=float),
+        z=NormalDist().inv_cdf(1 - NOMINAL_ALPHA / 2),
+    )
+    positive = net[net > 0]
+    negative = net[net < 0]
+    benchmark = np.isfinite(index_return) & np.isfinite(excess)
+    daily_counts = (
+        underlying.groupby("_reveal_date", observed=True).size()
+        if len(underlying)
+        else pd.Series(dtype=int)
+    )
+    positive_total = float(positive.sum()) if len(positive) else 0.0
+    top_count = max(1, math.ceil(len(positive) * 0.10)) if len(positive) else 0
+    concentration = (
+        float(np.sort(positive)[-top_count:].sum() / positive_total)
+        if positive_total > 0 and top_count
+        else np.nan
+    )
+    return {
+        **{name: int(value) for name, value in counts.items()},
+        "unavailable_count": int(counts["candidate_count"] - counts["status_ok_count"]),
+        "underlying_event_count": len(underlying),
+        "sample_count": count,
+        "unique_stock_count": int(underlying["code"].astype(str).nunique()),
+        "unique_signal_date_count": int(underlying["_reveal_date"].nunique()),
+        "unique_model_count": int(underlying["model_code"].astype(str).nunique()),
+        "gross_win_rate": float((gross > 0).mean()) if count else np.nan,
+        "net_win_rate": wins / count if count else np.nan,
+        "net_win_rate_ci_low": float(ci_low[0]) if count else np.nan,
+        "net_win_rate_ci_high": float(ci_high[0]) if count else np.nan,
+        "mean_gross_return": float(gross.mean()) if count else np.nan,
+        "mean_net_return": float(net.mean()) if count else np.nan,
+        "median_net_return": float(np.median(net)) if count else np.nan,
+        "average_net_win": (float(positive.mean()) if len(positive) else np.nan),
+        "average_net_loss_abs": (float(-negative.mean()) if len(negative) else np.nan),
+        "payoff_ratio": (
+            float(positive.mean() / -negative.mean())
+            if len(positive) and len(negative)
+            else np.nan
+        ),
+        "profit_factor": (
+            float(positive.sum() / -negative.sum())
+            if len(negative) and -negative.sum() > 0
+            else np.nan
+        ),
+        "p05_net_return": (float(np.quantile(net, 0.05)) if count else np.nan),
+        "p25_net_return": (float(np.quantile(net, 0.25)) if count else np.nan),
+        "p50_net_return": (float(np.quantile(net, 0.50)) if count else np.nan),
+        "p75_net_return": (float(np.quantile(net, 0.75)) if count else np.nan),
+        "p95_net_return": (float(np.quantile(net, 0.95)) if count else np.nan),
+        "cvar5_net_return": (
+            float(net[net <= np.quantile(net, 0.05)].mean()) if count else np.nan
+        ),
+        "mean_index_return": (
+            float(index_return[benchmark].mean()) if benchmark.any() else np.nan
+        ),
+        "mean_net_excess_return": (
+            float(excess[benchmark].mean()) if benchmark.any() else np.nan
+        ),
+        "max_consecutive_losses": _longest_loss_streak(net),
+        "positive_pnl_top10pct_concentration": concentration,
+        "mean_same_day_signal_crowding": (
+            float(daily_counts.mean()) if len(daily_counts) else np.nan
+        ),
+        "peak_same_day_signal_crowding": (
+            int(daily_counts.max()) if len(daily_counts) else 0
+        ),
+    }
+
+
+def build_exact_detail_tables(
+    frame: pd.DataFrame,
+    *,
+    selection: Mapping[str, Any],
+    scopes: Sequence[str],
+    time_splits: Mapping[str, Sequence[str]],
+    model_populations: Sequence[str],
+    minimum_sample: int | Mapping[str, int],
+    source_kind: str,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Exact, non-additive statistics for shortlisted or locked configs."""
+
+    overview_rows: list[dict[str, Any]] = []
+    group_rows: list[dict[str, Any]] = []
+    for scope in scopes:
+        required_sample = (
+            int(minimum_sample[scope])
+            if isinstance(minimum_sample, Mapping)
+            else int(minimum_sample)
+        )
+        for population in model_populations:
+            if population not in (
+                "SELECTED_MODEL",
+                "ALL_MODELS_SAME_RULE",
+            ):
+                raise ValueError(f"unknown model population: {population}")
+            sample, counts = _prepared_selection_sample(
+                frame,
+                selection=selection,
+                scope=scope,
+                time_splits=time_splits,
+                all_models=population == "ALL_MODELS_SAME_RULE",
+            )
+            metadata = {
+                "source_kind": source_kind,
+                "selection_id": str(selection["selection_id"]),
+                "scope": scope,
+                "model_population": population,
+                "horizon_trading_days": int(selection["horizon_trading_days"]),
+                "selected_model_code": str(selection["model_code"]),
+                "trigger_id": str(selection["trigger_id"]),
+                "trigger_selector_kind": str(selection["trigger_selector"]["kind"]),
+                "trigger_selector_value": selection["trigger_selector"].get("value"),
+                "filter_mask": int(selection["filter_mask"]),
+                "filter_names": "+".join(selection["filter_names"]) or "NONE",
+            }
+            for aggregation in ("EVENT", "UNION", "MACRO", "DATE_BALANCED"):
+                observations = _aggregation_observations(sample, aggregation)
+                metrics = _exact_observation_metrics(
+                    observations,
+                    underlying=sample,
+                    counts=counts,
+                )
+                overview_rows.append(
+                    {
+                        **metadata,
+                        "aggregation": aggregation,
+                        **metrics,
+                        "minimum_sample_required": required_sample,
+                        "minimum_sample_pass": len(sample) >= required_sample,
+                        "small_sample_warning": len(sample) < required_sample,
+                        "multiple_testing_warning": True,
+                    }
+                )
+
+            group_contracts = (
+                ("YEAR", "_year"),
+                ("QUARTER", "_quarter"),
+                ("MARKET_REGIME", "_regime"),
+            )
+            for group_dimension, group_column in group_contracts:
+                for group_value, grouped in sample.groupby(
+                    group_column,
+                    sort=True,
+                    observed=True,
+                ):
+                    for aggregation in (
+                        "EVENT",
+                        "UNION",
+                        "MACRO",
+                        "DATE_BALANCED",
+                    ):
+                        observations = _aggregation_observations(
+                            grouped,
+                            aggregation,
+                        )
+                        metrics = _exact_observation_metrics(
+                            observations,
+                            underlying=grouped,
+                            counts={
+                                "candidate_count": len(grouped),
+                                "status_ok_count": len(grouped),
+                                "boundary_purged_count": 0,
+                            },
+                        )
+                        group_rows.append(
+                            {
+                                **metadata,
+                                "group_dimension": group_dimension,
+                                "group_value": str(group_value),
+                                "aggregation": aggregation,
+                                **metrics,
+                                "minimum_sample_required": required_sample,
+                                "minimum_sample_pass": (
+                                    len(grouped) >= required_sample
+                                ),
+                                "small_sample_warning": (
+                                    len(grouped) < required_sample
+                                ),
+                                "multiple_testing_warning": True,
+                            }
+                        )
+    return pd.DataFrame(overview_rows), pd.DataFrame(group_rows)
+
+
+def run_reveal(args: argparse.Namespace) -> dict[str, Any]:
+    root = Path(args.root).resolve()
+
+    # Keep this before _study_config, hashing, index reads, and event reads.
+    lock_path, locked = _load_lock_for_reveal(root)
+
+    matrix_dir = root / "matrix"
+    features_path = root / "features" / "candidate_events.parquet"
+    index_path = root / "snapshot" / "index_day.parquet"
+    config_path, config = _study_config(root)
+    if not features_path.is_file():
+        raise FileNotFoundError(features_path)
+    if not index_path.is_file():
+        raise FileNotFoundError(index_path)
+    stage_id, identity = _reveal_identity(
+        lock_path=lock_path,
+        features_path=features_path,
+        config_path=config_path,
+        index_path=index_path,
+        min_reveal_samples=args.min_reveal_samples,
+    )
+    matrix_path = matrix_dir / "reveal_matrix.parquet"
+    summary_path = matrix_dir / "reveal_summary.csv"
+    detailed_path = matrix_dir / "reveal_locked_detailed.parquet"
+    group_detail_path = matrix_dir / "reveal_locked_group_detail.parquet"
+    manifest_path = matrix_dir / "reveal_manifest.json"
+    if not args.force and _manifest_reusable(
+        manifest_path,
+        stage_id=stage_id,
+        output_keys=("matrix", "summary", "locked_detailed", "group_detail"),
+    ):
+        result = {
+            "stage": "reveal",
+            "stage_id": stage_id,
+            "lock_id": locked["lock_id"],
+            "reused": True,
+            "manifest_path": str(manifest_path),
+        }
+        print(json.dumps(result, ensure_ascii=False), flush=True)
+        return result
+
+    events = load_feature_events(features_path)
+    index = pd.read_parquet(index_path, columns=["date", "close"])
+    events, benchmark_audit = attach_index_benchmark(events, index)
+    time_splits = config["time_splits"]
+    family_size = len(MODEL_CODES) * len(TRIGGER_SELECTORS) * FILTER_SUBSET_COUNT
+    writer = AtomicParquetWriter(matrix_path)
+    try:
+        for model_no, model_code in enumerate(MODEL_CODES, start=1):
+            model_events = events.loc[events["model_code"].eq(model_code)]
+            for horizon in HORIZONS:
+                for scope in REVEAL_SCOPES:
+                    chunk = build_matrix_chunk(
+                        model_events,
+                        model_code=model_code,
+                        horizon=horizon,
+                        scope=scope,
+                        time_splits=time_splits,
+                        hypothesis_family_size=family_size,
+                        min_reveal_samples=args.min_reveal_samples,
+                    )
+                    writer.write(chunk)
+            if args.progress_every and model_no % args.progress_every == 0:
+                print(
+                    json.dumps(
+                        {
+                            "stage": "reveal",
+                            "models_complete": model_no,
+                            "models_total": len(MODEL_CODES),
+                            "matrix_rows": writer.rows,
+                        },
+                        ensure_ascii=False,
+                    ),
+                    flush=True,
+                )
+        writer.close()
+    except BaseException:
+        writer.abort()
+        raise
+
+    expected_rows = (
+        len(MODEL_CODES)
+        * len(HORIZONS)
+        * len(REVEAL_SCOPES)
+        * len(TRIGGER_SELECTORS)
+        * FILTER_SUBSET_COUNT
+    )
+    if writer.rows != expected_rows:
+        raise RuntimeError(f"reveal matrix rows {writer.rows} != {expected_rows}")
+
+    detailed_rows: list[dict[str, Any]] = []
+    for selection in locked["selections"]:
+        for scope in REVEAL_SCOPES:
+            row = _selected_detailed_metrics(
+                events,
+                selection=selection,
+                scope=scope,
+                time_splits=time_splits,
+            )
+            row["lock_id"] = locked["lock_id"]
+            detailed_rows.append(row)
+    detailed = pd.DataFrame(detailed_rows).sort_values(
+        ["horizon_trading_days", "scope"], kind="stable"
+    )
+    detailed["minimum_sample_required"] = int(args.min_reveal_samples)
+    detailed["minimum_sample_pass"] = detailed["sample_count"].ge(
+        args.min_reveal_samples
+    )
+    detailed["small_sample_warning"] = ~detailed["minimum_sample_pass"]
+    detailed["multiple_testing_warning"] = True
+    write_frame_atomic(detailed, summary_path)
+
+    exact_frames: list[pd.DataFrame] = []
+    exact_group_frames: list[pd.DataFrame] = []
+    for selection in locked["selections"]:
+        overview, groups = build_exact_detail_tables(
+            events,
+            selection=selection,
+            scopes=REVEAL_SCOPES,
+            time_splits=time_splits,
+            model_populations=(
+                "SELECTED_MODEL",
+                "ALL_MODELS_SAME_RULE",
+            ),
+            minimum_sample=args.min_reveal_samples,
+            source_kind="LOCKED_AFTER_REVEAL",
+        )
+        overview["lock_id"] = locked["lock_id"]
+        groups["lock_id"] = locked["lock_id"]
+        exact_frames.append(overview)
+        if not groups.empty:
+            exact_group_frames.append(groups)
+    exact_detailed = pd.concat(exact_frames, ignore_index=True)
+    exact_groups = (
+        pd.concat(exact_group_frames, ignore_index=True)
+        if exact_group_frames
+        else pd.DataFrame()
+    )
+    write_frame_atomic(exact_detailed, detailed_path)
+    write_frame_atomic(exact_groups, group_detail_path)
+
+    manifest = {
+        "study_id": STUDY_ID,
+        "stage": "reveal",
+        "stage_id": stage_id,
+        "lock_id": locked["lock_id"],
+        "matrix_contract_version": MATRIX_CONTRACT_VERSION,
+        "identity": identity,
+        "data_access_contract": {
+            "locked_config_validated_before_candidate_events_read": True,
+            "revealed_scopes": list(REVEAL_SCOPES),
+            "development_selection_recomputed_after_reveal": False,
+        },
+        "scope_definitions": {
+            "AUDIT": (
+                "AUDIT reveal rows with OK outcome whose exit trade date does "
+                "not cross the frozen AUDIT end"
+            ),
+            "AVAILABLE": (
+                "all TRAIN/VALIDATION/AUDIT outcomes whose frozen "
+                "split_boundary_status is AVAILABLE"
+            ),
+            "MATCHED90": (
+                "common rows whose frozen split_boundary_status is AVAILABLE "
+                "for all 5/30/60/90 horizons"
+            ),
+            "PURGED": (
+                "otherwise valid outcomes excluded only because their exit "
+                "crosses the originating frozen split boundary"
+            ),
+        },
+        "benchmark_audit": benchmark_audit,
+        "statistical_cautions": {
+            "minimum_reveal_samples": args.min_reveal_samples,
+            "multiple_comparison_family_size_per_horizon": family_size,
+            "bonferroni_alpha": NOMINAL_ALPHA / family_size,
+            "warning": (
+                "The exhaustive reveal matrix is descriptive after lock; "
+                "AUDIT must not be used to reselect the champions."
+            ),
+        },
+        "statistics_layering": {
+            "exhaustive_matrix": (
+                "additive exact statistics for every model/trigger/filter cell"
+            ),
+            "locked_exact": (
+                "exact median, P05/P25/P50/P75/P95, CVaR5, distinct stocks "
+                "and dates, loss streak, PnL concentration, crowding, "
+                "Event/Union/Macro/DateBalanced, year/quarter/regime groups"
+            ),
+            "aggregation_contract": EXACT_AGGREGATION_CONTRACT,
+            "non_additive_full_matrix_policy": (
+                "order statistics are not approximated for all exhaustive "
+                "cells; exact values are materialized for locked selections"
+            ),
+            "audit_reselection_permitted": False,
+        },
+        "row_contract": {
+            "matrix_rows": writer.rows,
+            "locked_summary_rows": len(detailed),
+            "locked_detailed_rows": len(exact_detailed),
+            "locked_group_detail_rows": len(exact_groups),
+            "trigger_selectors": len(TRIGGER_SELECTORS),
+            "trigger_selector_semantics": TRIGGER_SELECTOR_SEMANTICS,
+            "filter_subsets": FILTER_SUBSET_COUNT,
+            "filter_subset_semantics": (
+                "event qualifies when (filter_pass_mask & required_mask) "
+                "equals required_mask"
+            ),
+            "scopes": list(REVEAL_SCOPES),
+        },
+        "outputs": {
+            "matrix": _artifact(matrix_path),
+            "summary": _artifact(summary_path),
+            "locked_detailed": _artifact(detailed_path),
+            "group_detail": _artifact(group_detail_path),
+        },
+    }
+    write_json_atomic(manifest_path, manifest)
+    result = {
+        "stage": "reveal",
+        "stage_id": stage_id,
+        "lock_id": locked["lock_id"],
+        "reused": False,
+        "matrix_rows": writer.rows,
+        "locked_summary_rows": len(detailed),
+        "locked_detailed_rows": len(exact_detailed),
+        "locked_group_detail_rows": len(exact_groups),
+        "manifest_path": str(manifest_path),
+    }
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return result
+
+
+def run_status(args: argparse.Namespace) -> dict[str, Any]:
+    root = Path(args.root).resolve()
+    matrix_dir = root / "matrix"
+    result = {
+        "study_id": STUDY_ID,
+        "root": str(root),
+        "development_complete": (matrix_dir / "development_manifest.json").is_file(),
+        "lock_complete": (matrix_dir / "locked_config.json").is_file(),
+        "reveal_complete": (matrix_dir / "reveal_manifest.json").is_file(),
+    }
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return result
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    development = subparsers.add_parser("development")
+    development.add_argument(
+        "--min-train-samples",
+        type=_positive_int,
+        default=DEFAULT_MIN_TRAIN_SAMPLES,
+    )
+    development.add_argument(
+        "--min-validation-samples",
+        type=_positive_int,
+        default=DEFAULT_MIN_VALIDATION_SAMPLES,
+    )
+    development.add_argument(
+        "--top-per-model",
+        type=_positive_int,
+        default=DEFAULT_TOP_PER_MODEL,
+    )
+    development.add_argument("--progress-every", type=int, default=1)
+    development.add_argument("--force", action="store_true")
+    development.set_defaults(handler=run_development)
+
+    lock = subparsers.add_parser("lock")
+    lock.add_argument("--force", action="store_true")
+    lock.set_defaults(handler=run_lock)
+
+    reveal = subparsers.add_parser("reveal")
+    reveal.add_argument(
+        "--min-reveal-samples",
+        type=_positive_int,
+        default=DEFAULT_MIN_REVEAL_SAMPLES,
+    )
+    reveal.add_argument("--progress-every", type=int, default=1)
+    reveal.add_argument("--force", action="store_true")
+    reveal.set_defaults(handler=run_reveal)
+
+    status = subparsers.add_parser("status")
+    status.set_defaults(handler=run_status)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    args.handler(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/clx_backtest/research/clx_30m_f1_f6_matrix.py
+++ b/script/clx_backtest/research/clx_30m_f1_f6_matrix.py
@@ -11,9 +11,11 @@ Every one of the 64 required subsets is evaluated.  Trigger selectors cover
 the seven inclusive native bits, all 127 exact masks, exactly two concurrent
 bits, at least three concurrent bits, and the complete signal population.
 
-Returns relative to the Shanghai index use an explicitly approximate daily
-benchmark: the last completed index close before entry to the index close on
-the stock exit trade date (backward-asof only when that date is absent).
+Returns relative to the configured market benchmark use an explicitly
+approximate daily close-to-close calculation: the last completed benchmark
+close before entry to the benchmark close on the stock exit trade date
+(backward-asof only when that date is absent).  The benchmark identity is
+frozen in ``audit/study_config.json`` and may be an explicitly labelled proxy.
 """
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from statistics import NormalDist
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -70,6 +72,17 @@ DEFAULT_MIN_VALIDATION_SAMPLES = 30
 DEFAULT_MIN_REVEAL_SAMPLES = 30
 DEFAULT_TOP_PER_MODEL = 5
 NOMINAL_ALPHA = 0.05
+DEFAULT_INDEX_SOURCE = {
+    "source_kind": "SHANGHAI_COMPOSITE",
+    "source_code": "000001",
+    "source_name": "上证指数",
+}
+SUPPORTED_INDEX_SOURCE_KINDS = frozenset(
+    {
+        "SHANGHAI_COMPOSITE",
+        "SHANGHAI_COMPOSITE_ETF_PROXY",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -414,7 +427,7 @@ def _asof_index_close(
     *,
     strict: bool,
 ) -> tuple[np.ndarray, np.ndarray]:
-    side = "left" if strict else "right"
+    side: Literal["left", "right"] = "left" if strict else "right"
     positions = np.searchsorted(index_dates, targets, side=side) - 1
     valid_target = ~np.isnat(targets)
     valid = valid_target & (positions >= 0)
@@ -425,15 +438,155 @@ def _asof_index_close(
     return closes, mapped_dates
 
 
+def _validated_index_source(
+    index_source: Mapping[str, Any] | None = None,
+) -> dict[str, str]:
+    """Return the frozen benchmark identity or the direct-call default."""
+
+    raw: Mapping[str, Any] = (
+        DEFAULT_INDEX_SOURCE if index_source is None else index_source
+    )
+    validated: dict[str, str] = {}
+    for field in ("source_kind", "source_code", "source_name"):
+        value = raw.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise RuntimeError(f"index_source.{field} must be a non-empty string")
+        validated[field] = value.strip()
+    if validated["source_kind"] not in SUPPORTED_INDEX_SOURCE_KINDS:
+        raise RuntimeError(
+            f"unsupported index_source.source_kind: {validated['source_kind']}"
+        )
+    source_code = validated["source_code"]
+    if len(source_code) != 6 or not source_code.isdigit():
+        raise RuntimeError("index_source.source_code must be a six-digit code")
+    if (
+        validated["source_kind"] == "SHANGHAI_COMPOSITE"
+        and source_code != DEFAULT_INDEX_SOURCE["source_code"]
+    ):
+        raise RuntimeError(
+            "SHANGHAI_COMPOSITE index_source must use source_code 000001"
+        )
+    return validated
+
+
+def _index_source_label(index_source: Mapping[str, Any] | None = None) -> str:
+    """Build an audit label that never presents a proxy as the real index."""
+
+    source = _validated_index_source(index_source)
+    if source["source_kind"] == "SHANGHAI_COMPOSITE_ETF_PROXY":
+        proxy_name = source["source_name"]
+        if "ETF" not in proxy_name.upper():
+            proxy_name += "ETF"
+        return f"{source['source_code']}{proxy_name}代理"
+    return f"{source['source_name']}（{source['source_code']}）"
+
+
+def _validate_index_snapshot_contract(
+    root: Path,
+    index_source: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Fail closed unless config, snapshot manifest, and Parquet identities agree."""
+
+    snapshot_manifest_path = root / "snapshot" / "manifest.json"
+    snapshot_manifest = read_json(snapshot_manifest_path)
+    manifest_index = snapshot_manifest.get("index")
+    if not isinstance(manifest_index, Mapping):
+        raise TypeError("snapshot/manifest.json index must be an object")
+
+    config_identity = _validated_index_source(index_source)
+    manifest_identity = _validated_index_source(manifest_index)
+    for field in ("source_kind", "source_code", "source_name"):
+        if config_identity[field] != manifest_identity[field]:
+            raise RuntimeError(f"index_source.{field} disagrees with snapshot manifest")
+
+    for field in ("logical_path", "file_sha256", "rows"):
+        if field not in index_source or field not in manifest_index:
+            raise RuntimeError(
+                f"index_source.{field} must exist in config and snapshot manifest"
+            )
+        if index_source[field] != manifest_index[field]:
+            raise RuntimeError(f"index_source.{field} disagrees with snapshot manifest")
+
+    logical_path = index_source["logical_path"]
+    if not isinstance(logical_path, str) or logical_path != (
+        "snapshot/index_day.parquet"
+    ):
+        raise RuntimeError(
+            "index_source.logical_path must be snapshot/index_day.parquet"
+        )
+    declared_sha256 = index_source["file_sha256"]
+    if (
+        not isinstance(declared_sha256, str)
+        or len(declared_sha256) != 64
+        or any(character not in "0123456789abcdef" for character in declared_sha256)
+    ):
+        raise RuntimeError("index_source.file_sha256 must be lowercase SHA-256")
+    declared_rows = index_source["rows"]
+    if (
+        not isinstance(declared_rows, int)
+        or isinstance(declared_rows, bool)
+        or declared_rows < 0
+    ):
+        raise RuntimeError("index_source.rows must be a non-negative integer")
+
+    config_has_size = "file_size" in index_source
+    manifest_has_size = "file_size" in manifest_index
+    if config_has_size != manifest_has_size:
+        raise RuntimeError(
+            "index_source.file_size presence disagrees with snapshot manifest"
+        )
+    declared_size: int | None = None
+    if config_has_size:
+        raw_size = index_source["file_size"]
+        if not isinstance(raw_size, int) or isinstance(raw_size, bool) or raw_size < 0:
+            raise RuntimeError("index_source.file_size must be a non-negative integer")
+        if raw_size != manifest_index["file_size"]:
+            raise RuntimeError(
+                "index_source.file_size disagrees with snapshot manifest"
+            )
+        declared_size = raw_size
+
+    index_path = (root / logical_path).resolve()
+    expected_index_path = (root / "snapshot" / "index_day.parquet").resolve()
+    if index_path != expected_index_path:
+        raise RuntimeError("index snapshot resolved outside its frozen logical path")
+    if not index_path.is_file():
+        raise FileNotFoundError(index_path)
+    actual_size = index_path.stat().st_size
+    if declared_size is not None and actual_size != declared_size:
+        raise RuntimeError("index snapshot file size disagrees with declared identity")
+    actual_sha256 = sha256_file(index_path)
+    if actual_sha256 != declared_sha256:
+        raise RuntimeError("index snapshot SHA-256 disagrees with declared identity")
+    parquet_metadata = pq.ParquetFile(index_path).metadata
+    actual_rows = parquet_metadata.num_rows
+    if actual_rows != declared_rows:
+        raise RuntimeError("index snapshot row count disagrees with declared identity")
+
+    return {
+        "snapshot_manifest_path": snapshot_manifest_path,
+        "snapshot_manifest_sha256": sha256_file(snapshot_manifest_path),
+        "index_path": index_path,
+        "logical_path": logical_path,
+        "file_size": actual_size,
+        "file_sha256": actual_sha256,
+        "rows": actual_rows,
+        **config_identity,
+    }
+
+
 def attach_index_benchmark(
     events: pd.DataFrame,
     index: pd.DataFrame,
     *,
     horizons: Sequence[int] = HORIZONS,
+    index_source: Mapping[str, Any] | None = None,
 ) -> tuple[pd.DataFrame, dict[str, Any]]:
-    """Attach causal daily close-to-close index returns to stock outcomes."""
+    """Attach causal daily returns for the configured index or labelled proxy."""
 
     frame = events.copy()
+    benchmark_source = _validated_index_source(index_source)
+    benchmark_label = _index_source_label(benchmark_source)
     required_index = {"date", "close"}
     if not required_index.issubset(index.columns):
         raise RuntimeError("index snapshot must contain date and close")
@@ -487,9 +640,17 @@ def attach_index_benchmark(
     frame["benchmark_entry_index_date"] = pd.to_datetime(base_date)
     frame["benchmark_entry_index_close"] = base_close
     audit: dict[str, Any] = {
+        "index_source": {
+            **benchmark_source,
+            "source_label": benchmark_label,
+            "is_proxy": (
+                benchmark_source["source_kind"] == "SHANGHAI_COMPOSITE_ETF_PROXY"
+            ),
+        },
         "formula": (
-            "Shanghai index close on the last completed day before entry "
-            "to close on stock exit trade date; arithmetic excess="
+            f"{benchmark_label} close on the last completed day before entry "
+            "to the same benchmark close on stock exit trade date; "
+            "arithmetic excess="
             "stock net return-index return"
         ),
         "frequency": "daily close-to-close approximation",
@@ -569,6 +730,13 @@ def _scope_masks(
         & ~np.isnat(split_end)
         & (maturity_days > split_end)
     )
+    expected_available = (
+        research
+        & status_ok
+        & ~np.isnat(maturity_days)
+        & ~np.isnat(split_end)
+        & (maturity_days <= split_end)
+    )
     declared_boundary = (
         frame[f"h{horizon}_split_boundary_status"].fillna("").astype(str)
     )
@@ -585,6 +753,11 @@ def _scope_masks(
     if not np.array_equal(recomputed_purged, declared_purged):
         raise RuntimeError(
             f"h{horizon} split boundary status disagrees with maturity timestamp"
+        )
+    if not np.array_equal(expected_available, declared_available):
+        raise RuntimeError(
+            f"h{horizon} AVAILABLE split boundary status disagrees with "
+            "maturity timestamp"
         )
 
     if scope in ("TRAIN", "VALIDATION", "AUDIT"):
@@ -1126,6 +1299,12 @@ def select_locked_config(
 def _study_config(root: Path) -> tuple[Path, dict[str, Any]]:
     path = root / "audit" / "study_config.json"
     config = read_json(path)
+    if "index_source" not in config:
+        raise TypeError("study_config.json misses index_source")
+    if not isinstance(config["index_source"], Mapping):
+        raise TypeError("study_config.json index_source must be an object")
+    _validated_index_source(config["index_source"])
+    _validate_index_snapshot_contract(root, config["index_source"])
     time_splits = config.get("time_splits")
     if not isinstance(time_splits, dict):
         raise TypeError("study_config.json misses time_splits")
@@ -1149,6 +1328,7 @@ def _development_identity(
     features_path: Path,
     config_path: Path,
     index_path: Path,
+    snapshot_manifest_path: Path,
     min_train_samples: int,
     min_validation_samples: int,
     top_per_model: int,
@@ -1159,6 +1339,7 @@ def _development_identity(
         "candidate_events_sha256": sha256_file(features_path),
         "study_config_sha256": sha256_file(config_path),
         "index_snapshot_sha256": sha256_file(index_path),
+        "snapshot_manifest_sha256": sha256_file(snapshot_manifest_path),
         "scopes": list(DEVELOPMENT_SCOPES),
         "models": list(MODEL_CODES),
         "horizons": list(HORIZONS),
@@ -1188,12 +1369,26 @@ def _top_development_rows(
     return _candidate_sort(eligible).head(limit).reset_index(drop=True)
 
 
+def _iter_model_candidate_groups(
+    candidates: pd.DataFrame,
+) -> Iterable[tuple[str, pd.DataFrame]]:
+    """Yield every retained candidate while reusing each model's event slice."""
+
+    for model_code, model_candidates in candidates.groupby(
+        "model_code",
+        sort=True,
+        observed=True,
+    ):
+        yield str(model_code), model_candidates
+
+
 def run_development(args: argparse.Namespace) -> dict[str, Any]:
     root = Path(args.root).resolve()
     matrix_dir = root / "matrix"
     matrix_dir.mkdir(parents=True, exist_ok=True)
     features_path = root / "features" / "candidate_events.parquet"
     index_path = root / "snapshot" / "index_day.parquet"
+    snapshot_manifest_path = root / "snapshot" / "manifest.json"
     config_path, config = _study_config(root)
     if not features_path.is_file():
         raise FileNotFoundError(features_path)
@@ -1204,6 +1399,7 @@ def run_development(args: argparse.Namespace) -> dict[str, Any]:
         features_path=features_path,
         config_path=config_path,
         index_path=index_path,
+        snapshot_manifest_path=snapshot_manifest_path,
         min_train_samples=args.min_train_samples,
         min_validation_samples=args.min_validation_samples,
         top_per_model=args.top_per_model,
@@ -1244,7 +1440,11 @@ def run_development(args: argparse.Namespace) -> dict[str, Any]:
     if set(events["split_id"].unique()) - set(DEVELOPMENT_SCOPES):
         raise RuntimeError("development input contains non-development rows")
     index = pd.read_parquet(index_path, columns=["date", "close"])
-    events, benchmark_audit = attach_index_benchmark(events, index)
+    events, benchmark_audit = attach_index_benchmark(
+        events,
+        index,
+        index_source=config["index_source"],
+    )
     time_splits = config["time_splits"]
     family_size = len(MODEL_CODES) * len(TRIGGER_SELECTORS) * FILTER_SUBSET_COUNT
 
@@ -1317,26 +1517,27 @@ def run_development(args: argparse.Namespace) -> dict[str, Any]:
 
     detailed_frames: list[pd.DataFrame] = []
     group_frames: list[pd.DataFrame] = []
-    for row in lock_candidates.to_dict(orient="records"):
-        selection = _development_row_selection(row)
-        model_events = events.loc[events["model_code"].eq(selection["model_code"])]
-        overview, groups = build_exact_detail_tables(
-            model_events,
-            selection=selection,
-            scopes=DEVELOPMENT_SCOPES,
-            time_splits=time_splits,
-            model_populations=("SELECTED_MODEL",),
-            minimum_sample={
-                "TRAIN": args.min_train_samples,
-                "VALIDATION": args.min_validation_samples,
-            },
-            source_kind="DEVELOPMENT_TOP",
-        )
-        overview["development_score"] = float(row["development_score"])
-        groups["development_score"] = float(row["development_score"])
-        detailed_frames.append(overview)
-        if not groups.empty:
-            group_frames.append(groups)
+    for model_code, model_candidates in _iter_model_candidate_groups(lock_candidates):
+        model_events = events.loc[events["model_code"].eq(model_code)]
+        for row in model_candidates.to_dict(orient="records"):
+            selection = _development_row_selection(row)
+            overview, groups = build_exact_detail_tables(
+                model_events,
+                selection=selection,
+                scopes=DEVELOPMENT_SCOPES,
+                time_splits=time_splits,
+                model_populations=("SELECTED_MODEL",),
+                minimum_sample={
+                    "TRAIN": args.min_train_samples,
+                    "VALIDATION": args.min_validation_samples,
+                },
+                source_kind="DEVELOPMENT_TOP",
+            )
+            overview["development_score"] = float(row["development_score"])
+            groups["development_score"] = float(row["development_score"])
+            detailed_frames.append(overview)
+            if not groups.empty:
+                group_frames.append(groups)
 
     # Preserve a meaningful 18-model Macro/Union view for the eventual global
     # champion of each horizon without opening the sealed AUDIT rows.
@@ -1663,12 +1864,152 @@ def _load_lock_for_reveal(root: Path) -> tuple[Path, dict[str, Any]]:
     return path, locked
 
 
+def _validate_manifest_artifact(
+    metadata: object,
+    expected_path: Path,
+    *,
+    label: str,
+) -> None:
+    if not isinstance(metadata, Mapping):
+        raise TypeError(f"{label} artifact metadata is missing")
+    declared_path = Path(str(metadata.get("path", ""))).resolve()
+    if declared_path != expected_path.resolve():
+        raise RuntimeError(f"{label} artifact path mismatch")
+    if not expected_path.is_file():
+        raise FileNotFoundError(expected_path)
+    if metadata.get("file_sha256") != sha256_file(expected_path):
+        raise RuntimeError(f"{label} artifact SHA-256 mismatch")
+    if (
+        "file_size" in metadata
+        and metadata["file_size"] != expected_path.stat().st_size
+    ):
+        raise RuntimeError(f"{label} artifact file size mismatch")
+
+
+def _validate_reveal_lineage(
+    root: Path,
+    *,
+    lock_path: Path,
+    locked: Mapping[str, Any],
+) -> tuple[Path, dict[str, Any]]:
+    """Bind the sealed lock to its development stage and every current input."""
+
+    matrix_dir = root / "matrix"
+    lock_manifest_path = matrix_dir / "lock_manifest.json"
+    development_manifest_path = matrix_dir / "development_manifest.json"
+    candidates_path = matrix_dir / "development_lock_candidates.parquet"
+    features_path = root / "features" / "candidate_events.parquet"
+    index_path = root / "snapshot" / "index_day.parquet"
+    snapshot_manifest_path = root / "snapshot" / "manifest.json"
+
+    lock_manifest = read_json(lock_manifest_path)
+    if (
+        lock_manifest.get("study_id") != STUDY_ID
+        or lock_manifest.get("stage") != "lock"
+    ):
+        raise RuntimeError("lock manifest study/stage mismatch")
+    lock_identity = lock_manifest.get("identity")
+    if not isinstance(lock_identity, Mapping):
+        raise TypeError("lock manifest identity is missing")
+    if lock_manifest.get("stage_id") != _stage_identity(lock_identity):
+        raise RuntimeError("lock manifest stage identity mismatch")
+    if lock_manifest.get("lock_id") != locked.get("lock_id"):
+        raise RuntimeError("lock manifest lock_id mismatch")
+    if lock_manifest.get("stage_id") != locked.get("lock_stage_id"):
+        raise RuntimeError("locked_config lock stage mismatch")
+    lock_outputs = lock_manifest.get("outputs")
+    if not isinstance(lock_outputs, Mapping):
+        raise TypeError("lock manifest outputs are missing")
+    _validate_manifest_artifact(
+        lock_outputs.get("locked_config"),
+        lock_path,
+        label="locked_config",
+    )
+
+    development_manifest = read_json(development_manifest_path)
+    if (
+        development_manifest.get("study_id") != STUDY_ID
+        or development_manifest.get("stage") != "development"
+    ):
+        raise RuntimeError("development manifest study/stage mismatch")
+    development_identity = development_manifest.get("identity")
+    if not isinstance(development_identity, Mapping):
+        raise TypeError("development manifest identity is missing")
+    development_stage_id = development_manifest.get("stage_id")
+    if development_stage_id != _stage_identity(development_identity):
+        raise RuntimeError("development manifest stage identity mismatch")
+    if locked.get("development_stage_id") != development_stage_id:
+        raise RuntimeError("stale lock: development stage reference mismatch")
+    if lock_identity.get("development_manifest_sha256") != sha256_file(
+        development_manifest_path
+    ):
+        raise RuntimeError("stale lock: development manifest identity drift")
+
+    development_outputs = development_manifest.get("outputs")
+    if not isinstance(development_outputs, Mapping):
+        raise TypeError("development manifest outputs are missing")
+    _validate_manifest_artifact(
+        development_outputs.get("lock_candidates"),
+        candidates_path,
+        label="development lock candidates",
+    )
+    candidates_sha256 = sha256_file(candidates_path)
+    if lock_identity.get("development_candidates_sha256") != candidates_sha256:
+        raise RuntimeError("stale lock: development candidate identity drift")
+
+    current_lock_stage_id, current_lock_identity = _lock_identity(
+        development_manifest_path,
+        candidates_path,
+    )
+    if (
+        dict(lock_identity) != current_lock_identity
+        or lock_manifest.get("stage_id") != current_lock_stage_id
+    ):
+        raise RuntimeError("stale lock: current lock identity drift")
+
+    config_path, config = _study_config(root)
+    if not features_path.is_file():
+        raise FileNotFoundError(features_path)
+    minimum_samples = development_identity.get("minimum_samples")
+    if not isinstance(minimum_samples, Mapping):
+        raise TypeError("development identity minimum_samples is missing")
+    try:
+        min_train_samples = int(minimum_samples["TRAIN"])
+        min_validation_samples = int(minimum_samples["VALIDATION"])
+        top_per_model = int(development_identity["top_per_model"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError("development identity selection inputs are invalid") from exc
+    current_development_stage_id, current_development_identity = _development_identity(
+        features_path=features_path,
+        config_path=config_path,
+        index_path=index_path,
+        snapshot_manifest_path=snapshot_manifest_path,
+        min_train_samples=min_train_samples,
+        min_validation_samples=min_validation_samples,
+        top_per_model=top_per_model,
+    )
+    if (
+        dict(development_identity) != current_development_identity
+        or development_stage_id != current_development_stage_id
+    ):
+        drift_fields = sorted(
+            key
+            for key in set(development_identity) | set(current_development_identity)
+            if development_identity.get(key) != current_development_identity.get(key)
+        )
+        raise RuntimeError(
+            "stale lock/input drift in development lineage: " + ",".join(drift_fields)
+        )
+    return config_path, config
+
+
 def _reveal_identity(
     *,
     lock_path: Path,
     features_path: Path,
     config_path: Path,
     index_path: Path,
+    snapshot_manifest_path: Path,
     min_reveal_samples: int,
 ) -> tuple[str, dict[str, Any]]:
     payload = {
@@ -1678,6 +2019,7 @@ def _reveal_identity(
         "candidate_events_sha256": sha256_file(features_path),
         "study_config_sha256": sha256_file(config_path),
         "index_snapshot_sha256": sha256_file(index_path),
+        "snapshot_manifest_sha256": sha256_file(snapshot_manifest_path),
         "scopes": list(REVEAL_SCOPES),
         "models": list(MODEL_CODES),
         "horizons": list(HORIZONS),
@@ -2192,22 +2534,24 @@ def build_exact_detail_tables(
 def run_reveal(args: argparse.Namespace) -> dict[str, Any]:
     root = Path(args.root).resolve()
 
-    # Keep this before _study_config, hashing, index reads, and event reads.
+    # Validate the lock itself before opening any current research input.
     lock_path, locked = _load_lock_for_reveal(root)
 
     matrix_dir = root / "matrix"
     features_path = root / "features" / "candidate_events.parquet"
     index_path = root / "snapshot" / "index_day.parquet"
-    config_path, config = _study_config(root)
-    if not features_path.is_file():
-        raise FileNotFoundError(features_path)
-    if not index_path.is_file():
-        raise FileNotFoundError(index_path)
+    snapshot_manifest_path = root / "snapshot" / "manifest.json"
+    config_path, config = _validate_reveal_lineage(
+        root,
+        lock_path=lock_path,
+        locked=locked,
+    )
     stage_id, identity = _reveal_identity(
         lock_path=lock_path,
         features_path=features_path,
         config_path=config_path,
         index_path=index_path,
+        snapshot_manifest_path=snapshot_manifest_path,
         min_reveal_samples=args.min_reveal_samples,
     )
     matrix_path = matrix_dir / "reveal_matrix.parquet"
@@ -2232,7 +2576,11 @@ def run_reveal(args: argparse.Namespace) -> dict[str, Any]:
 
     events = load_feature_events(features_path)
     index = pd.read_parquet(index_path, columns=["date", "close"])
-    events, benchmark_audit = attach_index_benchmark(events, index)
+    events, benchmark_audit = attach_index_benchmark(
+        events,
+        index,
+        index_source=config["index_source"],
+    )
     time_splits = config["time_splits"]
     family_size = len(MODEL_CODES) * len(TRIGGER_SELECTORS) * FILTER_SUBSET_COUNT
     writer = AtomicParquetWriter(matrix_path)

--- a/script/clx_backtest/research/clx_30m_f1_f6_portfolio.py
+++ b/script/clx_backtest/research/clx_30m_f1_f6_portfolio.py
@@ -33,6 +33,16 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+import pyarrow.parquet as pq
+
+if __package__:
+    from . import clx_30m_f1_f6_matrix as _matrix_contract
+else:
+    import clx_30m_f1_f6_matrix as _matrix_contract  # type: ignore[no-redef]
+
+_matrix_load_lock_for_reveal = _matrix_contract._load_lock_for_reveal
+_matrix_reveal_identity = _matrix_contract._reveal_identity
+_matrix_validate_reveal_lineage = _matrix_contract._validate_reveal_lineage
 
 STUDY_ID = "clx-30m-full-trigger-f1-f6-v1"
 PORTFOLIO_CONTRACT_VERSION = 1
@@ -42,6 +52,11 @@ SLOT_CAPITAL = 125_000.0
 FEE_PER_SIDE = 0.0002
 DAILY_ENTRY_LIMITS: tuple[int | None, ...] = (1, 3, 5, 10, 20, None)
 HORIZONS = (5, 30, 60, 90)
+CHECKPOINT_SCOPE_TOKENS = {
+    "AVAILABLE": "available",
+    "AUDIT": "audit",
+    "MATCHED90": "matched90",
+}
 FILTER_NAMES = tuple(f"F{offset}" for offset in range(1, 7))
 FILTER_DESCRIPTIONS = {
     "F1": "未复权原始开盘价1～6元",
@@ -49,7 +64,7 @@ FILTER_DESCRIPTIONS = {
     "F3": "距近20个交易日高点回撤≥10%",
     "F4": "近20个交易日非年化日等效波动率≥3%",
     "F5": "收盘价≤MA60日等效均线",
-    "F6": "上证指数近20个完整交易日收益≤0",
+    "F6": "冻结市场基准近20个完整交易日收益≤0",
 }
 TRIGGER_BITS = {
     "MODEL_STRUCTURAL": 0x01,
@@ -73,6 +88,35 @@ BAR_CLOCKS = (
 SHANGHAI_TIMEZONE = "Asia/Shanghai"
 DEFAULT_ROOT = Path(
     "D:/fqpack/runtime/clx-backtest/studies/clx-30m-full-trigger-f1-f6-v1"
+)
+REPRODUCE_SCRIPT = (
+    r"<REPO_ROOT>\script\clx_backtest\research\clx_30m_f1_f6_portfolio.py"
+)
+PORTFOLIO_FRAME_NAMES = (
+    "portfolio_summary",
+    "random_order_runs",
+    "random_order_sensitivity",
+    "period_metrics",
+    "equity_30m",
+    "equity_daily",
+    "chart_curves",
+    "trades",
+    "decision_summary",
+    "locked_selections",
+    "daily_baseline_comparison",
+)
+REQUIRED_LOGICAL_OUTPUTS = frozenset(
+    {
+        *(
+            f"portfolio/{name}.{suffix}"
+            for name in PORTFOLIO_FRAME_NAMES
+            for suffix in ("parquet", "csv")
+        ),
+        "portfolio/clx_30m_portfolio_report.xlsx",
+        "portfolio/report.md",
+        "portfolio/portfolio_config.json",
+        "portfolio/reproduce_command.txt",
+    }
 )
 
 DAILY_BASELINES = {
@@ -285,11 +329,49 @@ def _normalise_model_codes(value: object) -> tuple[str, ...]:
     return tuple(items)
 
 
+def _validated_matrix_lineage(
+    root: Path,
+) -> tuple[Path, dict[str, Any], Path, dict[str, Any]]:
+    """Translate the Matrix fail-closed lineage contract for Portfolio callers."""
+
+    try:
+        lock_path, locked = _matrix_load_lock_for_reveal(root)
+        config_path, study_config = _matrix_validate_reveal_lineage(
+            root,
+            lock_path=lock_path,
+            locked=locked,
+        )
+    except (KeyError, OSError, TypeError, ValueError, RuntimeError) as exc:
+        raise PortfolioContractError(f"matrix lock lineage mismatch: {exc}") from exc
+    return lock_path, locked, config_path, study_config
+
+
 def load_locked_selections(path: Path) -> list[LockedSelection]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
         raise PortfolioContractError(f"locked config is missing: {path}") from exc
+    if not isinstance(payload, Mapping) or payload.get("study_id") != STUDY_ID:
+        raise PortfolioContractError("locked_config.json study_id mismatch")
+    if path.name != "locked_config.json" or path.parent.name != "matrix":
+        raise PortfolioContractError("locked_config.json path is outside matrix/")
+    root = path.resolve().parents[1]
+    validated_path, validated, _, _ = _validated_matrix_lineage(root)
+    if validated_path.resolve() != path.resolve() or dict(payload) != validated:
+        raise PortfolioContractError("locked_config.json lineage payload mismatch")
+    return _parse_locked_selections(payload)
+
+
+def _parse_locked_selections(payload: Mapping[str, Any]) -> list[LockedSelection]:
+    filter_contract = payload.get("filter_contract")
+    if isinstance(filter_contract, Mapping) and (
+        int(filter_contract.get("subset_count", -1)) != 64
+        or list(filter_contract.get("mask_range", [])) != [0, 63]
+        or list(filter_contract.get("filters", [])) != list(FILTER_NAMES)
+    ):
+        raise PortfolioContractError(
+            "locked_config.json F1-F6 filter contract mismatch"
+        )
     raw = payload.get("selections") if isinstance(payload, Mapping) else None
     if not isinstance(raw, list):
         raise PortfolioContractError("locked_config.json must contain selections[]")
@@ -367,6 +449,77 @@ def load_locked_selections(path: Path) -> list[LockedSelection]:
     return sorted(selections, key=lambda item: item.horizon)
 
 
+def validate_reveal_inputs(root: Path, lock_path: Path) -> dict[str, tuple[Path, str]]:
+    paths = {
+        "matrix": root / "matrix" / "reveal_matrix.parquet",
+        "summary": root / "matrix" / "reveal_summary.csv",
+        "locked_detailed": root / "matrix" / "reveal_locked_detailed.parquet",
+        "group_detail": root / "matrix" / "reveal_locked_group_detail.parquet",
+    }
+    manifest_path = root / "matrix" / "reveal_manifest.json"
+    if not manifest_path.is_file() or any(
+        not path.is_file() for path in paths.values()
+    ):
+        raise PortfolioContractError(
+            "portfolio requires the completed matrix reveal summary, locked "
+            "detail, group detail, and reveal manifest"
+        )
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise PortfolioContractError("matrix reveal contract is unreadable") from exc
+    validated_lock_path, lock, config_path, _ = _validated_matrix_lineage(root)
+    if (
+        validated_lock_path.resolve() != lock_path.resolve()
+        or manifest.get("study_id") != STUDY_ID
+        or manifest.get("stage") != "reveal"
+        or manifest.get("lock_id") != lock.get("lock_id")
+    ):
+        raise PortfolioContractError("matrix reveal identity mismatch")
+    identity = manifest.get("identity")
+    if not isinstance(identity, Mapping):
+        raise PortfolioContractError("matrix reveal identity payload is missing")
+    try:
+        minimum_reveal_samples = int(identity["minimum_reveal_samples"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise PortfolioContractError(
+            "matrix reveal minimum_reveal_samples is invalid"
+        ) from exc
+    current_stage_id, current_identity = _matrix_reveal_identity(
+        lock_path=lock_path,
+        features_path=root / "features" / "candidate_events.parquet",
+        config_path=config_path,
+        index_path=root / "snapshot" / "index_day.parquet",
+        snapshot_manifest_path=root / "snapshot" / "manifest.json",
+        min_reveal_samples=minimum_reveal_samples,
+    )
+    if (
+        dict(identity) != current_identity
+        or manifest.get("stage_id") != current_stage_id
+    ):
+        raise PortfolioContractError("matrix reveal stage/input identity mismatch")
+    outputs = manifest.get("outputs")
+    if not isinstance(outputs, Mapping) or set(outputs) != set(paths):
+        raise PortfolioContractError("matrix reveal frozen output set mismatch")
+    validated: dict[str, tuple[Path, str]] = {}
+    for key, path in paths.items():
+        expected = outputs.get(key)
+        if not isinstance(expected, Mapping):
+            raise PortfolioContractError(
+                f"matrix reveal {key} metadata must be an object"
+            )
+        digest = sha256_file(path)
+        if (
+            expected.get("file_sha256") != digest
+            or Path(str(expected.get("path", ""))).resolve() != path.resolve()
+            or expected.get("file_size") != path.stat().st_size
+        ):
+            raise PortfolioContractError(f"matrix reveal {key} identity mismatch")
+        validated[key] = (path, digest)
+    validated["manifest"] = (manifest_path, sha256_file(manifest_path))
+    return validated
+
+
 def _trigger_mask(frame: pd.DataFrame, selection: LockedSelection) -> pd.Series:
     masks = (
         pd.to_numeric(frame["concurrent_trigger_mask"], errors="coerce")
@@ -425,6 +578,7 @@ def select_locked_candidates(
     required = {
         "code",
         "model_code",
+        "split_id",
         "reveal_at",
         "entry_at",
         "qfq_entry_open",
@@ -433,19 +587,19 @@ def select_locked_candidates(
         f"h{selection.horizon}_status",
         f"h{selection.horizon}_exit_at",
         f"h{selection.horizon}_gross_return",
+        f"h{selection.horizon}_split_boundary_status",
     }
     missing = sorted(required - set(events.columns))
     if missing:
         raise PortfolioContractError(f"candidate events miss columns: {missing}")
-    frame = events.copy()
+    wildcard = bool(set(selection.model_codes) & {"ALL", "*", "UNION"})
+    frame = (
+        events.copy()
+        if wildcard
+        else events.loc[events["model_code"].isin(selection.model_codes)].copy()
+    )
     for column in ("reveal_at", "entry_at", f"h{selection.horizon}_exit_at"):
         frame[column] = _as_shanghai(frame[column])
-    wildcard = bool(set(selection.model_codes) & {"ALL", "*", "UNION"})
-    model_pass = (
-        pd.Series(True, index=frame.index)
-        if wildcard
-        else frame["model_code"].isin(selection.model_codes)
-    )
     pass_masks = (
         pd.to_numeric(frame["filter_pass_mask"], errors="coerce")
         .fillna(0)
@@ -456,15 +610,27 @@ def select_locked_candidates(
         frame.get("entry_executable", pd.Series(True, index=frame.index))
         .fillna(False)
         .astype(bool)
-        & frame.get("entry_status", pd.Series("OK", index=frame.index)).eq("OK")
-        & frame[f"h{selection.horizon}_status"].eq("OK")
+        & frame.get("entry_status", pd.Series("OK", index=frame.index))
+        .astype("string")
+        .eq("OK")
+        .fillna(False)
+        & frame[f"h{selection.horizon}_status"].astype("string").eq("OK").fillna(False)
+        & frame[f"h{selection.horizon}_split_boundary_status"]
+        .astype("string")
+        .eq("AVAILABLE")
+        .fillna(False)
     )
-    mask = model_pass & filters_pass & executable & _trigger_mask(frame, selection)
-    if scope.upper() == "AUDIT":
-        if "split_id" not in frame:
-            raise PortfolioContractError("AUDIT portfolio requires split_id")
-        mask &= frame["split_id"].eq("AUDIT")
-    elif scope.upper() != "AVAILABLE":
+    scope_name = scope.upper()
+    split_ids = frame["split_id"].astype("string")
+    mask = (
+        filters_pass
+        & executable
+        & _trigger_mask(frame, selection)
+        & split_ids.isin(("TRAIN", "VALIDATION", "AUDIT")).fillna(False)
+    )
+    if scope_name == "AUDIT":
+        mask &= split_ids.eq("AUDIT").fillna(False)
+    elif scope_name != "AVAILABLE":
         raise PortfolioContractError(f"unsupported portfolio scope: {scope}")
     frame = frame.loc[mask].copy()
     if frame.empty:
@@ -515,6 +681,7 @@ class MarkStore:
     def __init__(self, root: Path):
         self.root = root
         self._values: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        self._aligned: dict[tuple[str, int], np.ndarray] = {}
         self.source_rows = 0
 
     def load(self, codes: Iterable[str]) -> None:
@@ -549,6 +716,21 @@ class MarkStore:
         times, closes = self._values[code]
         offset = int(np.searchsorted(times, timestamp.value, side="right") - 1)
         return float(closes[offset]) if offset >= 0 else float(fallback)
+
+    def aligned_closes(self, code: str, clock: pd.DatetimeIndex) -> np.ndarray:
+        """Carry the last observed QFQ close across one immutable clock."""
+
+        key = (code, id(clock))
+        cached = self._aligned.get(key)
+        if cached is not None:
+            return cached
+        times, closes = self._values[code]
+        offsets = np.searchsorted(times, clock.asi8, side="right") - 1
+        output = np.full(len(clock), np.nan, dtype=float)
+        valid = offsets >= 0
+        output[valid] = closes[offsets[valid]]
+        self._aligned[key] = output
+        return output
 
     def all_timestamps(self, codes: Iterable[str]) -> pd.DatetimeIndex:
         arrays = [self._values[str(code)][0] for code in sorted(set(codes))]
@@ -641,7 +823,32 @@ def _stable_order(frame: pd.DataFrame, policy: str, seed: int | None) -> pd.Data
     )
 
 
-def _max_consecutive_losses(returns: Sequence[float]) -> int:
+def prepare_ordered_entries(
+    candidates: pd.DataFrame,
+    *,
+    ranking_policy: str,
+    random_seed: int | None = None,
+) -> dict[int, list[dict[str, Any]]]:
+    """Freeze one causal within-timestamp ordering for reuse across six caps."""
+
+    columns = (
+        "candidate_id",
+        "code",
+        "qfq_entry_open",
+        "qfq_exit_open",
+        "exit_at",
+        "market_regime",
+    )
+    output: dict[int, list[dict[str, Any]]] = {}
+    for timestamp, group in candidates.groupby("entry_at", sort=False):
+        ordered = _stable_order(group, ranking_policy, random_seed)
+        output[pd.Timestamp(timestamp).value] = ordered.loc[:, columns].to_dict(
+            orient="records"
+        )
+    return output
+
+
+def _max_consecutive_losses(returns: Iterable[float]) -> int:
     longest = current = 0
     for value in returns:
         if value < 0:
@@ -684,11 +891,18 @@ def simulate_portfolio(
     daily_entry_limit: int | None,
     ranking_policy: str,
     random_seed: int | None = None,
+    ordered_entries: Mapping[int, Sequence[Mapping[str, Any]]] | None = None,
+    record_decisions: bool = False,
 ) -> SimulationResult:
-    entries = {
-        int(pd.Timestamp(timestamp).value): group
-        for timestamp, group in candidates.groupby("entry_at", sort=False)
-    }
+    entries = (
+        ordered_entries
+        if ordered_entries is not None
+        else prepare_ordered_entries(
+            candidates,
+            ranking_policy=ranking_policy,
+            random_seed=random_seed,
+        )
+    )
     cash = INITIAL_CAPITAL
     positions: dict[str, dict[str, Any]] = {}
     opened_by_day: dict[object, int] = {}
@@ -698,7 +912,8 @@ def simulate_portfolio(
     peak_positions = 0
     decisions: list[dict[str, Any]] = []
     trades: list[dict[str, Any]] = []
-    curve: list[dict[str, Any]] = []
+    cash_values = np.empty(len(clock), dtype=float)
+    position_counts = np.empty(len(clock), dtype=np.int16)
     rejected = {
         "occupied": 0,
         "daily_limit": 0,
@@ -708,22 +923,23 @@ def simulate_portfolio(
 
     def reject(row: Mapping[str, Any], timestamp: pd.Timestamp, reason: str) -> None:
         rejected[reason] += 1
-        decisions.append(
-            {
-                "selection_id": selection.selection_id,
-                "horizon_trading_days": selection.horizon,
-                "scope": scope,
-                "daily_entry_limit": _limit_label(daily_entry_limit),
-                "ranking_policy": ranking_policy,
-                "random_seed": random_seed,
-                "candidate_id": row["candidate_id"],
-                "code": row["code"],
-                "entry_at": timestamp,
-                "decision": f"REJECT_{reason.upper()}",
-            }
-        )
+        if record_decisions:
+            decisions.append(
+                {
+                    "selection_id": selection.selection_id,
+                    "horizon_trading_days": selection.horizon,
+                    "scope": scope,
+                    "daily_entry_limit": _limit_label(daily_entry_limit),
+                    "ranking_policy": ranking_policy,
+                    "random_seed": random_seed,
+                    "candidate_id": row["candidate_id"],
+                    "code": row["code"],
+                    "entry_at": timestamp,
+                    "decision": f"REJECT_{reason.upper()}",
+                }
+            )
 
-    for timestamp in clock:
+    for clock_index, timestamp in enumerate(clock):
         timestamp = pd.Timestamp(timestamp)
         # Contract: every due exit is booked before any entry at the same bar.
         due = sorted(
@@ -765,15 +981,16 @@ def simulate_portfolio(
                     "net_pnl": net_pnl,
                     "net_return": net_return,
                     "entry_market_regime": position["market_regime"],
+                    "_entry_clock_index": position["entry_clock_index"],
+                    "_exit_clock_index": clock_index,
                 }
             )
             positions.pop(code)
 
         incoming = entries.get(timestamp.value)
         if incoming is not None:
-            ordered = _stable_order(incoming, ranking_policy, random_seed)
             day = timestamp.date()
-            for row in ordered.to_dict(orient="records"):
+            for row in incoming:
                 code = str(row["code"])
                 if code in positions:
                     reject(row, timestamp, "occupied")
@@ -808,61 +1025,91 @@ def simulate_portfolio(
                     "entry_fee": entry_fee,
                     "entry_cost": capital_budget,
                     "market_regime": str(row.get("market_regime", "UNKNOWN")),
+                    "entry_clock_index": clock_index,
                 }
                 opened_by_day[day] = opened_by_day.get(day, 0) + 1
-                decisions.append(
-                    {
-                        "selection_id": selection.selection_id,
-                        "horizon_trading_days": selection.horizon,
-                        "scope": scope,
-                        "daily_entry_limit": _limit_label(daily_entry_limit),
-                        "ranking_policy": ranking_policy,
-                        "random_seed": random_seed,
-                        "candidate_id": row["candidate_id"],
-                        "code": code,
-                        "entry_at": timestamp,
-                        "decision": "ACCEPT",
-                    }
-                )
-        invested = 0.0
-        for code, position in positions.items():
-            invested += position["units"] * marks.close(
-                code, timestamp, position["entry_price"]
-            )
-        equity = cash + invested
-        if cash < -0.01 or len(positions) > MAX_POSITIONS or equity <= 0:
+                if record_decisions:
+                    decisions.append(
+                        {
+                            "selection_id": selection.selection_id,
+                            "horizon_trading_days": selection.horizon,
+                            "scope": scope,
+                            "daily_entry_limit": _limit_label(daily_entry_limit),
+                            "ranking_policy": ranking_policy,
+                            "random_seed": random_seed,
+                            "candidate_id": row["candidate_id"],
+                            "code": code,
+                            "entry_at": timestamp,
+                            "decision": "ACCEPT",
+                        }
+                    )
+        if cash < -0.01 or len(positions) > MAX_POSITIONS:
             raise PortfolioContractError(
                 f"portfolio invariant failed at {timestamp}: "
-                f"cash={cash}, positions={len(positions)}, equity={equity}"
+                f"cash={cash}, positions={len(positions)}"
             )
         peak_positions = max(peak_positions, len(positions))
-        curve.append(
-            {
-                "selection_id": selection.selection_id,
-                "horizon_trading_days": selection.horizon,
-                "scope": scope,
-                "daily_entry_limit": _limit_label(daily_entry_limit),
-                "ranking_policy": ranking_policy,
-                "random_seed": random_seed,
-                "bar_at": timestamp,
-                "cash": cash,
-                "invested_value": invested,
-                "equity": equity,
-                "positions": len(positions),
-                "capital_utilization": invested / equity,
-            }
-        )
+        cash_values[clock_index] = cash
+        position_counts[clock_index] = len(positions)
     if positions:
         raise PortfolioContractError(
             f"{len(positions)} positions remain after the last mature exit"
         )
-    equity_frame = pd.DataFrame(curve)
+    invested_values = np.zeros(len(clock), dtype=float)
+    for trade in trades:
+        start = int(trade["_entry_clock_index"])
+        end = int(trade["_exit_clock_index"])
+        prices = marks.aligned_closes(str(trade["code"]), clock)[start:end]
+        if np.isnan(prices).any():
+            prices = np.where(np.isnan(prices), float(trade["entry_price"]), prices)
+        invested_values[start:end] += float(trade["units"]) * prices
+    equity_values = cash_values + invested_values
+    if (equity_values <= 0).any():
+        bad = int(np.flatnonzero(equity_values <= 0)[0])
+        raise PortfolioContractError(
+            f"portfolio equity invariant failed at {clock[bad]}: "
+            f"equity={equity_values[bad]}"
+        )
+    equity_frame = pd.DataFrame(
+        {
+            "selection_id": selection.selection_id,
+            "horizon_trading_days": selection.horizon,
+            "scope": scope,
+            "daily_entry_limit": _limit_label(daily_entry_limit),
+            "ranking_policy": ranking_policy,
+            "random_seed": random_seed,
+            "bar_at": clock,
+            "cash": cash_values,
+            "invested_value": invested_values,
+            "equity": equity_values,
+            "positions": position_counts,
+            "capital_utilization": invested_values / equity_values,
+        }
+    )
     equity_frame["normalized_equity"] = equity_frame["equity"] / INITIAL_CAPITAL
     equity_frame["drawdown"] = (
         equity_frame["equity"] / equity_frame["equity"].cummax() - 1
     )
     trade_frame = pd.DataFrame(trades)
-    decision_frame = pd.DataFrame(decisions)
+    if not trade_frame.empty:
+        trade_frame = trade_frame.drop(
+            columns=["_entry_clock_index", "_exit_clock_index"]
+        )
+    decision_frame = pd.DataFrame(
+        decisions,
+        columns=[
+            "selection_id",
+            "horizon_trading_days",
+            "scope",
+            "daily_entry_limit",
+            "ranking_policy",
+            "random_seed",
+            "candidate_id",
+            "code",
+            "entry_at",
+            "decision",
+        ],
+    )
     trade_returns = (
         trade_frame["net_return"].to_numpy(dtype=float)
         if not trade_frame.empty
@@ -1151,6 +1398,35 @@ def _daily_curves(equity: pd.DataFrame) -> pd.DataFrame:
     )
 
 
+def build_chart_data(daily_curves: pd.DataFrame) -> pd.DataFrame:
+    selected = daily_curves[
+        daily_curves["scope"].eq("AVAILABLE")
+        & daily_curves["daily_entry_limit"].eq("5")
+        & daily_curves["ranking_policy"].eq("quality")
+    ].copy()
+    if selected.empty:
+        return pd.DataFrame()
+    output: pd.DataFrame | None = None
+    for metric in ("normalized_equity", "drawdown"):
+        wide = selected.pivot_table(
+            index="trade_date",
+            columns="horizon_trading_days",
+            values=metric,
+            aggfunc="last",
+        )
+        wide = wide.rename(
+            columns={horizon: f"h{int(horizon)}_{metric}" for horizon in wide.columns}
+        ).reset_index()
+        output = (
+            wide
+            if output is None
+            else output.merge(wide, on="trade_date", how="outer", validate="one_to_one")
+        )
+    assert output is not None
+    output["trade_date"] = pd.to_datetime(output["trade_date"])
+    return output.sort_values("trade_date", kind="stable").reset_index(drop=True)
+
+
 def _write_excel(
     path: Path,
     *,
@@ -1158,10 +1434,135 @@ def _write_excel(
     random_summary: pd.DataFrame,
     period_metrics: pd.DataFrame,
     daily_curves: pd.DataFrame,
+    chart_data: pd.DataFrame,
     locked: pd.DataFrame,
     baseline: pd.DataFrame,
     reveal: pd.DataFrame,
+    reveal_detailed: pd.DataFrame,
+    reveal_groups: pd.DataFrame,
 ) -> None:
+    def column_kind(column: str) -> str:
+        name = column.lower()
+        if name == "trade_date" or name.endswith("_date"):
+            return "date"
+        if name.endswith("_at"):
+            return "datetime"
+        if (
+            "return" in name
+            or "win_rate" in name
+            or "cagr" in name
+            or "drawdown" in name
+            or "utilization" in name
+            or "utilisation" in name
+            or "acceptance_rate" in name
+            or "normalized_" in name
+            or name in {"average_win", "average_loss_abs"}
+        ):
+            return "percentage"
+        if any(
+            token in name
+            for token in ("capital", "equity", "cash", "notional", "total_fee")
+        ):
+            return "currency"
+        if (
+            name in {"n", "random_seed", "random_runs", "filter_mask", "trigger_value"}
+            or name.endswith(
+                ("_n", "_count", "_rows", "_signals", "_trades", "_positions")
+            )
+            or name.startswith(("rejected_", "unique_"))
+            or "horizon_trading_days" in name
+        ):
+            if name == "average_positions":
+                return "decimal"
+            return "integer"
+        if (
+            any(
+                token in name
+                for token in (
+                    "profit_factor",
+                    "payoff_ratio",
+                    "turnover",
+                    "average_loss",
+                )
+            )
+            or name == "longest_underwater_days"
+        ):
+            return "decimal"
+        if name.endswith("_id") or "sha256" in name:
+            return "identifier"
+        if any(
+            token in name
+            for token in (
+                "name",
+                "contract",
+                "description",
+                "warning",
+                "reason",
+                "comparability",
+                "model_code",
+                "filter_names",
+            )
+        ):
+            return "text"
+        return "general"
+
+    def style_worksheet(worksheet: Any) -> None:
+        from openpyxl.styles import Alignment, Font, PatternFill
+        from openpyxl.utils import get_column_letter
+
+        if worksheet.max_column < 1:
+            return
+        header_fill = PatternFill("solid", fgColor="1F4E78")
+        header_font = Font(color="FFFFFF", bold=True)
+        header_alignment = Alignment(
+            horizontal="center",
+            vertical="center",
+            wrap_text=True,
+        )
+        worksheet.row_dimensions[1].height = 34
+        for cell in worksheet[1]:
+            cell.fill = header_fill
+            cell.font = header_font
+            cell.alignment = header_alignment
+        for column_number, header in enumerate(worksheet[1], start=1):
+            name = str(header.value or "")
+            kind = column_kind(name)
+            if kind == "identifier":
+                width = 24
+            elif kind == "text":
+                sample_lengths = [
+                    len(str(worksheet.cell(row, column_number).value or ""))
+                    for row in range(2, min(worksheet.max_row, 101) + 1)
+                ]
+                width = min(
+                    42,
+                    max(16, len(name) + 2, max(sample_lengths, default=0) + 2),
+                )
+            elif kind == "datetime":
+                width = 20
+            elif kind == "date":
+                width = 13
+            elif kind == "currency":
+                width = 18
+            elif kind in {"percentage", "decimal"}:
+                width = 15
+            elif kind == "integer":
+                width = 14
+            else:
+                width = min(24, max(12, len(name) + 2))
+            worksheet.column_dimensions[get_column_letter(column_number)].width = width
+            number_format = {
+                "date": "yyyy-mm-dd",
+                "datetime": "yyyy-mm-dd hh:mm",
+                "percentage": "0.00%",
+                "currency": '"¥"#,##0.00',
+                "integer": "#,##0",
+                "decimal": "0.00",
+            }.get(kind)
+            if number_format is not None:
+                for row in range(2, worksheet.max_row + 1):
+                    worksheet.cell(row, column_number).number_format = number_format
+
     def excel_safe(frame: pd.DataFrame) -> pd.DataFrame:
         value = frame.copy()
         for column in value.columns:
@@ -1171,54 +1572,273 @@ def _write_excel(
 
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.stem}.tmp{path.suffix}")
-    with pd.ExcelWriter(temporary, engine="openpyxl") as writer:
-        excel_safe(summary).to_excel(writer, sheet_name="Portfolio", index=False)
-        excel_safe(random_summary).to_excel(
-            writer, sheet_name="RandomSensitivity", index=False
-        )
-        excel_safe(period_metrics).to_excel(
-            writer, sheet_name="AnnualQuarterRegime", index=False
-        )
-        excel_safe(daily_curves).to_excel(
-            writer, sheet_name="NormalizedCurves", index=False
-        )
-        excel_safe(locked).to_excel(writer, sheet_name="LockedConfigs", index=False)
-        excel_safe(baseline).to_excel(writer, sheet_name="DailyBaseline", index=False)
-        if not reveal.empty:
-            excel_safe(reveal.iloc[:1_048_575]).to_excel(
-                writer, sheet_name="AuditReveal", index=False
+    temporary.unlink(missing_ok=True)
+    excel_chart_data = excel_safe(chart_data)
+    if "trade_date" in excel_chart_data:
+        excel_chart_data["trade_date_label"] = pd.to_datetime(
+            excel_chart_data["trade_date"],
+            errors="coerce",
+        ).dt.strftime("%Y-%m-%d")
+    try:
+        with pd.ExcelWriter(temporary, engine="openpyxl") as writer:
+            excel_safe(summary).to_excel(writer, sheet_name="Portfolio", index=False)
+            excel_safe(random_summary).to_excel(
+                writer, sheet_name="RandomSensitivity", index=False
             )
-        disclosure = pd.DataFrame(
-            {
-                "item": [
-                    "signal",
-                    "entry",
-                    "exit",
-                    "fee",
-                    "mark",
-                    "not_modelled",
-                ],
-                "contract": [
-                    "30分钟K线收盘揭示；只用当时及以前数据",
-                    "下一根实际存在的30分钟K线开盘",
-                    "第5/30/60/90个股票交易日同槽位，缺K线按候选事实的下一可交易K线",
-                    "买入、卖出各0.02%",
-                    "30分钟前复权收盘，缺当前K线时沿用此前最近收盘",
-                    "滑点、印花税、最低佣金、100股取整",
-                ],
-            }
-        )
-        disclosure.to_excel(writer, sheet_name="Contract", index=False)
-        for worksheet in writer.book.worksheets:
-            worksheet.freeze_panes = "A2"
-            worksheet.auto_filter.ref = worksheet.dimensions
-    os.replace(temporary, path)
+            excel_safe(period_metrics).to_excel(
+                writer, sheet_name="AnnualQuarterRegime", index=False
+            )
+            excel_safe(daily_curves).to_excel(
+                writer, sheet_name="NormalizedCurves", index=False
+            )
+            excel_chart_data.to_excel(writer, sheet_name="ChartData", index=False)
+            excel_safe(locked).to_excel(writer, sheet_name="LockedConfigs", index=False)
+            excel_safe(baseline).to_excel(
+                writer, sheet_name="DailyBaseline", index=False
+            )
+            if not reveal.empty:
+                excel_safe(reveal.iloc[:1_048_575]).to_excel(
+                    writer, sheet_name="AuditReveal", index=False
+                )
+            excel_safe(reveal_detailed.iloc[:1_048_575]).to_excel(
+                writer, sheet_name="RevealDetailed", index=False
+            )
+            excel_safe(reveal_groups.iloc[:1_048_575]).to_excel(
+                writer, sheet_name="RevealByPeriod", index=False
+            )
+            disclosure = pd.DataFrame(
+                {
+                    "item": [
+                        "signal",
+                        "entry",
+                        "exit",
+                        "fee",
+                        "mark",
+                        "not_modelled",
+                    ],
+                    "contract": [
+                        "30分钟K线收盘揭示；只用当时及以前数据",
+                        "下一根实际存在的30分钟K线开盘",
+                        "第5/30/60/90个股票交易日同槽位，缺K线按候选事实的下一可交易K线",
+                        "买入、卖出各0.02%",
+                        "30分钟前复权收盘，缺当前K线时沿用此前最近收盘",
+                        "滑点、印花税、最低佣金、100股取整",
+                    ],
+                }
+            )
+            disclosure.to_excel(writer, sheet_name="Contract", index=False)
+            charts = writer.book.create_sheet("Charts")
+            if not chart_data.empty:
+                from openpyxl.chart import LineChart, Reference
+                from openpyxl.chart.data_source import AxDataSource, StrRef
+                from openpyxl.chart.series import SeriesLabel
+
+                data_sheet = writer.book["ChartData"]
+                date_label_column = (
+                    excel_chart_data.columns.get_loc("trade_date_label") + 1
+                )
+                equity_columns = [
+                    offset
+                    for offset, name in enumerate(chart_data.columns, start=1)
+                    if str(name).endswith("_normalized_equity")
+                ]
+                drawdown_columns = [
+                    offset
+                    for offset, name in enumerate(chart_data.columns, start=1)
+                    if str(name).endswith("_drawdown")
+                ]
+                for title, columns, anchor, y_title in (
+                    (
+                        "5/30/60/90日归一净值（每日上限5）",
+                        equity_columns,
+                        "A1",
+                        "归一净值",
+                    ),
+                    (
+                        "5/30/60/90日回撤（每日上限5）",
+                        drawdown_columns,
+                        "A20",
+                        "回撤",
+                    ),
+                ):
+                    chart = LineChart()
+                    chart.title = title
+                    chart.y_axis.title = y_title
+                    chart.y_axis.numFmt = "0.00%"
+                    chart.x_axis.title = "交易日"
+                    chart.height = 8
+                    chart.width = 18
+                    for column in columns:
+                        column_name = str(chart_data.columns[column - 1])
+                        horizon = column_name.split("_", 1)[0].removeprefix("h")
+                        chart.add_data(
+                            Reference(
+                                data_sheet,
+                                min_col=column,
+                                max_col=column,
+                                min_row=1,
+                                max_row=len(chart_data) + 1,
+                            ),
+                            titles_from_data=True,
+                        )
+                        chart.series[-1].tx = SeriesLabel(v=f"{horizon}日")
+                    categories = Reference(
+                        data_sheet,
+                        min_col=date_label_column,
+                        min_row=2,
+                        max_row=len(chart_data) + 1,
+                    )
+                    for series in chart.series:
+                        series.cat = AxDataSource(strRef=StrRef(f=str(categories)))
+                    charts.add_chart(chart, anchor)
+            for worksheet in writer.book.worksheets:
+                style_worksheet(worksheet)
+                if worksheet.max_row > 1:
+                    worksheet.freeze_panes = "A2"
+                    worksheet.auto_filter.ref = worksheet.dimensions
+            from openpyxl.styles import Alignment
+
+            contract_sheet = writer.book["Contract"]
+            for row in range(2, contract_sheet.max_row + 1):
+                contract_sheet.cell(row, 2).alignment = Alignment(
+                    vertical="top",
+                    wrap_text=True,
+                )
+                contract_sheet.row_dimensions[row].height = 36
+            charts.sheet_view.showGridLines = False
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _fmt_pct(value: Any) -> str:
     if value is None or pd.isna(value):
         return "NA"
     return f"{float(value):.2%}"
+
+
+def _fmt_ratio(value: Any) -> str:
+    if value is None or pd.isna(value):
+        return "NA"
+    number = float(value)
+    return "∞" if np.isposinf(number) else f"{number:.2f}"
+
+
+def _portfolio_quality_statement(row: pd.Series) -> str:
+    total_return = float(row["total_return"])
+    raw_profit_factor = row["profit_factor"]
+    profit_factor = (
+        None
+        if raw_profit_factor is None or pd.isna(raw_profit_factor)
+        else float(raw_profit_factor)
+    )
+    if profit_factor is None:
+        interpretation = "PF缺少可计算的已平仓盈亏样本"
+    elif total_return > 0 and profit_factor > 1:
+        interpretation = "总收益与PF均高于各自基准"
+    elif total_return <= 0 and profit_factor <= 1:
+        interpretation = "总收益与PF均未高于各自基准"
+    else:
+        interpretation = "总收益方向与PF基准不一致"
+    return (
+        f"总收益 `{_fmt_pct(total_return)}`、PF `{_fmt_ratio(profit_factor)}`、"
+        f"平仓胜率 `{_fmt_pct(row['closed_win_rate'])}`；{interpretation}。"
+    )
+
+
+def _stability_statement(
+    available: pd.Series,
+    audit: pd.Series | None,
+) -> str:
+    if audit is None:
+        return (
+            f"AVAILABLE总收益 `{_fmt_pct(available['total_return'])}`、"
+            f"PF `{_fmt_ratio(available['profit_factor'])}`；资金AUDIT未执行。"
+        )
+    available_return = float(available["total_return"])
+    audit_return = float(audit["total_return"])
+    raw_profit_factor = audit["profit_factor"]
+    audit_profit_factor = (
+        None
+        if raw_profit_factor is None or pd.isna(raw_profit_factor)
+        else float(raw_profit_factor)
+    )
+    if available_return > 0 and audit_return > 0:
+        return_interpretation = "两段总收益均为正，资金方向一致"
+    elif available_return < 0 and audit_return < 0:
+        return_interpretation = "两段总收益均为负，资金方向一致"
+    elif available_return * audit_return < 0:
+        return_interpretation = "AVAILABLE与AUDIT总收益异号，资金方向不一致"
+    elif available_return == 0 and audit_return == 0:
+        return_interpretation = "两段总收益均为零"
+    else:
+        return_interpretation = "至少一段总收益为零，资金方向未完全一致"
+    if audit_profit_factor is None:
+        pf_interpretation = "AUDIT PF缺少可计算的已平仓盈亏样本"
+    elif audit_profit_factor > 1:
+        pf_interpretation = "AUDIT PF高于1"
+    elif audit_profit_factor == 1:
+        pf_interpretation = "AUDIT PF等于1"
+    else:
+        pf_interpretation = "AUDIT PF未高于1"
+    return (
+        f"AVAILABLE总收益 `{_fmt_pct(available_return)}`、"
+        f"AUDIT总收益 `{_fmt_pct(audit_return)}`、"
+        f"AUDIT PF `{_fmt_ratio(audit_profit_factor)}`、"
+        f"AUDIT平仓胜率 `{_fmt_pct(audit['closed_win_rate'])}`；"
+        f"{return_interpretation}；{pf_interpretation}。"
+    )
+
+
+def _audit_period_extrema(period_metrics: pd.DataFrame) -> pd.DataFrame:
+    required = {
+        "scope",
+        "daily_entry_limit",
+        "ranking_policy",
+        "horizon_trading_days",
+        "period_type",
+        "period_id",
+        "portfolio_return",
+        "closed_trades",
+        "closed_win_rate",
+    }
+    if period_metrics.empty or not required.issubset(period_metrics.columns):
+        return pd.DataFrame()
+    audit = period_metrics[
+        period_metrics["scope"].eq("AUDIT")
+        & period_metrics["daily_entry_limit"].eq("5")
+        & period_metrics["ranking_policy"].eq("quality")
+    ].copy()
+    audit["portfolio_return"] = pd.to_numeric(
+        audit["portfolio_return"], errors="coerce"
+    )
+    audit = audit.dropna(subset=["portfolio_return"])
+    rows: list[dict[str, Any]] = []
+    for identity, group in audit.groupby(
+        ["horizon_trading_days", "period_type"],
+        sort=True,
+    ):
+        horizon, period_type = identity
+        ordered = group.sort_values(
+            ["portfolio_return", "period_id"],
+            ascending=[False, True],
+            kind="stable",
+        )
+        best = ordered.iloc[0]
+        worst = ordered.iloc[-1]
+        rows.append(
+            {
+                "horizon_trading_days": int(horizon),
+                "period_type": str(period_type),
+                "best_period_id": str(best["period_id"]),
+                "best_return": float(best["portfolio_return"]),
+                "best_closed_trades": int(best["closed_trades"]),
+                "best_closed_win_rate": best["closed_win_rate"],
+                "worst_period_id": str(worst["period_id"]),
+                "worst_return": float(worst["portfolio_return"]),
+            }
+        )
+    return pd.DataFrame(rows)
 
 
 def build_markdown_report(
@@ -1231,12 +1851,39 @@ def build_markdown_report(
     baseline: pd.DataFrame,
     feature_summary: Mapping[str, Any],
     reveal_summary: pd.DataFrame,
+    reveal_detailed: pd.DataFrame,
+    index_benchmark: Mapping[str, Any],
+    portfolio_logic_sha256: str,
 ) -> str:
     dates = summary[["start_at", "end_at"]].copy()
     minimum = pd.to_datetime(dates["start_at"]).min()
     maximum = pd.to_datetime(dates["end_at"]).max()
     short_sample = minimum.year >= 2024
     grade = "SHORT_SAMPLE（短样本）" if short_sample else "FULL_HISTORY"
+    random_run_counts = pd.to_numeric(
+        random_summary.get("random_runs", pd.Series(dtype=float)),
+        errors="coerce",
+    ).dropna()
+    unique_random_run_counts = sorted(
+        {int(value) for value in random_run_counts if value >= 0}
+    )
+    if not unique_random_run_counts:
+        random_contract_text = "本次未执行SHA确定性随机排序敏感性。"
+        random_output_text = "本次未生成SHA随机排序分位数"
+    else:
+        random_run_label = (
+            f"{unique_random_run_counts[0]}组"
+            if len(unique_random_run_counts) == 1
+            else (
+                f"{unique_random_run_counts[0]}至" f"{unique_random_run_counts[-1]}组"
+            )
+        )
+        random_contract_text = (
+            f"{random_run_label}敏感性用 " "`SHA256(seed|candidate_id)` 确定排序。"
+        )
+        random_output_text = f"{random_run_label}SHA随机排序分位数"
+    benchmark_label = str(index_benchmark["benchmark_label"])
+    benchmark_role = "ETF代理" if bool(index_benchmark["is_proxy"]) else "指数基准"
     lines = [
         "# CLX18 30分钟锁定组合真实资金回测",
         "",
@@ -1250,6 +1897,12 @@ def build_markdown_report(
         ),
         f"- AUDIT揭示摘要：`{'已读取' if not reveal_summary.empty else '本次报告未找到揭示产物'}`。",
         "- 30分钟数据由本地 MongoDB 冻结为不可变 snapshot；报告阶段不修改源数据。",
+        (
+            f"- 市场基准：**{benchmark_label}**（{benchmark_role}；"
+            f"`source_kind={index_benchmark['source_kind']}`，"
+            f"`source_name={index_benchmark['source_name']}`）；"
+            "报告内全部超额收益均相对此冻结基准计算。"
+        ),
         "",
         "## 二、冻结研究假设与资金合同",
         "",
@@ -1257,7 +1910,10 @@ def build_markdown_report(
         "- 过滤空间为 **F1-F6 共64个子集**，`filter_mask` 范围 `0..63`。",
         "- 初始资金500万元；40槽；每槽最多12.5万元（含买入费的资本预算）。",
         "- 同一时点先退出后入场；同股持有期间不加仓；每日新开上限分别为1/3/5/10/20/不限。",
-        "- 同一可交易时点内才做质量排序；不跨未来时点重排。100组敏感性用 `SHA256(seed|candidate_id)` 确定排序。",
+        (
+            "- 同一可交易时点内才做质量排序；不跨未来时点重排。"
+            f"{random_contract_text}"
+        ),
         "- 买卖各收0.02%；30分钟前复权收盘盯市，停牌时沿用此前最近可得前复权收盘。",
         "- 未计：**滑点、印花税、最低佣金、100股取整**。",
         "",
@@ -1278,7 +1934,10 @@ def build_markdown_report(
             "",
             "## 四、样本外 AUDIT 一次性揭示",
             "",
-            "|期限|n|净胜率|95% CI|平均净收益|中位净收益|PF|相对上证平均超额|提示|",
+            (
+                "|期限|n|净胜率|95% CI|平均净收益|中位净收益|PF|"
+                f"相对{benchmark_label}平均超额|提示|"
+            ),
             "|---:|---:|---:|---:|---:|---:|---:|---:|---|",
         ]
     )
@@ -1308,6 +1967,41 @@ def build_markdown_report(
                 f"{'NA' if pd.isna(row.profit_factor) else f'{row.profit_factor:.2f}'}|"
                 f"{_fmt_pct(row.mean_net_excess_return)}|{warning}|"
             )
+    exact_audit = (
+        reveal_detailed[reveal_detailed["scope"].eq("AUDIT")]
+        .sort_values(
+            ["horizon_trading_days", "model_population", "aggregation"],
+            kind="stable",
+        )
+        .copy()
+        if not reveal_detailed.empty
+        and {
+            "scope",
+            "model_population",
+            "aggregation",
+        }.issubset(reveal_detailed.columns)
+        else pd.DataFrame()
+    )
+    lines.extend(
+        [
+            "",
+            "### AUDIT多聚合口径",
+            "",
+            "|期限|模型总体|聚合|n|净胜率|平均净收益|平均超额|",
+            "|---:|---|---|---:|---:|---:|---:|",
+        ]
+    )
+    if exact_audit.empty:
+        lines.append("|—|—|—|—|—|—|揭示明细尚未产出|")
+    else:
+        for row in exact_audit.itertuples(index=False):
+            lines.append(
+                f"|{row.horizon_trading_days}|{row.model_population}|"
+                f"{row.aggregation}|{row.sample_count}|"
+                f"{_fmt_pct(row.net_win_rate)}|"
+                f"{_fmt_pct(row.mean_net_return)}|"
+                f"{_fmt_pct(row.mean_net_excess_return)}|"
+            )
     lines.extend(
         [
             "",
@@ -1333,10 +2027,77 @@ def build_markdown_report(
             f"{_fmt_pct(row.average_capital_utilization)}|"
             f"{_fmt_pct(row.candidate_acceptance_rate)}|"
         )
+    audit_main = summary[
+        summary["scope"].eq("AUDIT")
+        & summary["daily_entry_limit"].eq("5")
+        & summary["ranking_policy"].eq("quality")
+    ].sort_values("horizon_trading_days")
     lines.extend(
         [
             "",
-            "完整的每日容量限制、年度/季度/行情阶段、30分钟净值与回撤、100组SHA随机排序分位数见同目录 CSV/Parquet 和 Excel。",
+            "### 冻结配置的资金 AUDIT（质量排序、每日上限5）",
+            "",
+            "|期限|总收益|CAGR|最大回撤|交易数|胜率|PF|费用|资金占用|录取率|",
+            "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for row in audit_main.itertuples(index=False):
+        lines.append(
+            f"|{row.horizon_trading_days}|{_fmt_pct(row.total_return)}|"
+            f"{_fmt_pct(row.cagr)}|{_fmt_pct(row.max_drawdown)}|"
+            f"{row.closed_trades}|{_fmt_pct(row.closed_win_rate)}|"
+            f"{'NA' if pd.isna(row.profit_factor) else f'{row.profit_factor:.2f}'}|"
+            f"¥{row.total_fees:,.0f}|{_fmt_pct(row.average_capital_utilization)}|"
+            f"{_fmt_pct(row.candidate_acceptance_rate)}|"
+        )
+    lines.append("")
+    if audit_main.empty:
+        lines.append("- 本次运行未执行资金AUDIT。")
+    else:
+        for row in audit_main.itertuples(index=False):
+            lines.append(
+                f"- **{row.horizon_trading_days}日资金AUDIT**："
+                f"{_portfolio_quality_statement(pd.Series(row._asdict()))}"
+            )
+        audit_start = pd.to_datetime(audit_main["start_at"]).min()
+        audit_end = pd.to_datetime(audit_main["end_at"]).max()
+        lines.append(
+            f"- 资金AUDIT实际区间：`{audit_start.isoformat()}` 至 "
+            f"`{audit_end.isoformat()}`；季度收益包含跨季持仓盯市损益。"
+        )
+    extrema = _audit_period_extrema(period_metrics)
+    lines.extend(
+        [
+            "",
+            "### 资金AUDIT年度、季度与行情分期",
+            "",
+            "|期限|维度|收益最高分期|该期收益|交易数|平仓胜率|收益最低分期|该期收益|",
+            "|---:|---|---|---:|---:|---:|---|---:|",
+        ]
+    )
+    if extrema.empty:
+        lines.append("|—|—|—|—|—|—|—|资金AUDIT分期结果缺失|")
+    else:
+        period_labels = {"YEAR": "年度", "QUARTER": "季度", "REGIME": "行情"}
+        for row in extrema.sort_values(
+            ["horizon_trading_days", "period_type"],
+            kind="stable",
+        ).itertuples(index=False):
+            lines.append(
+                f"|{row.horizon_trading_days}|"
+                f"{period_labels.get(row.period_type, row.period_type)}|"
+                f"{row.best_period_id}|{_fmt_pct(row.best_return)}|"
+                f"{row.best_closed_trades}|{_fmt_pct(row.best_closed_win_rate)}|"
+                f"{row.worst_period_id}|{_fmt_pct(row.worst_return)}|"
+            )
+    lines.extend(
+        [
+            "",
+            (
+                "完整的每日容量限制、年度/季度/行情阶段、30分钟净值与回撤、"
+                f"{random_output_text}见同目录 CSV/Parquet；Excel 的 `Charts` "
+                "工作表内嵌5/30/60/90日归一净值与回撤图。"
+            ),
             "",
             "## 六、与日线基准直接对照（每日上限5）",
             "",
@@ -1369,40 +2130,51 @@ def build_markdown_report(
         row = main[main["horizon_trading_days"].eq(horizon)]
         if len(row):
             item = row.iloc[0]
-            audit_row = audit[audit["horizon_trading_days"].eq(horizon)]
-            audit_text = (
-                f"、AUDIT净胜率 `{_fmt_pct(audit_row.iloc[0].net_win_rate)}`"
-                f"、AUDIT平均净收益 `{_fmt_pct(audit_row.iloc[0].mean_net_return)}`"
-                if len(audit_row)
-                else ""
-            )
+            audit_row = audit_main[audit_main["horizon_trading_days"].eq(horizon)]
+            audit_item = audit_row.iloc[0] if len(audit_row) else None
             lines.append(
-                f"- **{horizon}日稳定性**：资金端净收益 `{_fmt_pct(item.total_return)}`、"
-                f"MDD `{_fmt_pct(item.max_drawdown)}`{audit_text}；"
-                "跨年/季度一致性须结合 `period_metrics.csv`，"
-                "不以单一胜率下结论。"
+                f"- **{horizon}日稳定性**：" f"{_stability_statement(item, audit_item)}"
             )
     five = main[main["horizon_trading_days"].eq(5)]
     if len(five):
         item = five.iloc[0]
-        audit_five = audit[audit["horizon_trading_days"].eq(5)]
+        audit_five = audit_main[audit_main["horizon_trading_days"].eq(5)]
         audit_five_text = (
-            f"30分钟AUDIT净胜率 `{_fmt_pct(audit_five.iloc[0].net_win_rate)}`、"
-            f"平均净收益 `{_fmt_pct(audit_five.iloc[0].mean_net_return)}`；"
+            _portfolio_quality_statement(audit_five.iloc[0])
             if len(audit_five)
-            else "30分钟AUDIT揭示摘要尚未产出；"
+            else "资金AUDIT未执行。"
         )
         lines.append(
-            f"- **5日样本外表现**：日线AUDIT胜率47.61%；{audit_five_text}"
-            "30分钟资金端总收益"
-            f"`{_fmt_pct(item.total_return)}`、CAGR `{_fmt_pct(item.cagr)}`。"
-            "失效判断同时看净收益、样本量和资金回撤。"
+            f"- **5日样本外表现**：日线AUDIT胜率47.61%；"
+            f"30分钟{audit_five_text} AVAILABLE总收益为 "
+            f"`{_fmt_pct(item.total_return)}`。"
         )
+    audit_ninety = audit_main[audit_main["horizon_trading_days"].eq(90)]
+    audit_ninety_text = (
+        _portfolio_quality_statement(audit_ninety.iloc[0])
+        if len(audit_ninety)
+        else "资金AUDIT未执行。"
+    )
+    ninety_periods = (
+        extrema[extrema["horizon_trading_days"].eq(90)]
+        if not extrema.empty
+        else extrema
+    )
+    ninety_best = (
+        "；".join(
+            f"{row.period_type}最高为{row.best_period_id}"
+            f"（{_fmt_pct(row.best_return)}）"
+            for row in ninety_periods.itertuples(index=False)
+        )
+        if not ninety_periods.empty
+        else "资金AUDIT分期结果缺失"
+    )
     lines.extend(
         [
             (
-                f"- **90日高胜率来源**：本轮证据等级为 `{grade}`；若数据始于2024，"
-                "则90日结论天然主要由2024年后行情贡献，不能外推到2015年以来。"
+                f"- **90日高胜率来源**：本轮证据等级为 `{grade}`，资金曲线实际始于"
+                f"`{minimum.year}`年；30分钟{audit_ninety_text}"
+                f" 分期中{ninety_best}。来源判断只适用于上述实际样本区间。"
             ),
             (
                 f"- **模型优先级**：锁定冠军中 S0006/S0016/S0000 命中为"
@@ -1425,6 +2197,10 @@ def build_markdown_report(
             "",
             f"- 结果目录：`{(root / 'portfolio').resolve()}`",
             "- 复现命令见 `portfolio/reproduce_command.txt`；输入与输出SHA256见 `portfolio/manifest.json`。",
+            (
+                "- 复现前须核对稳定仓库脚本的SHA256与 manifest 中"
+                f"`portfolio_logic_sha256={portfolio_logic_sha256}`一致。"
+            ),
             "- 数据事实、研究假设、样本内锁定、AUDIT揭示与资金模拟在本报告中分区呈现。",
             "",
         ]
@@ -1432,18 +2208,323 @@ def build_markdown_report(
     return "\n".join(lines)
 
 
-def _load_feature_summary(root: Path, events: pd.DataFrame) -> dict[str, Any]:
-    path = root / "features" / "summary.json"
-    if path.is_file():
-        return json.loads(path.read_text(encoding="utf-8"))
+def _read_json_object(path: Path, label: str) -> dict[str, Any]:
+    if not path.is_file():
+        raise PortfolioContractError(f"required {label} is missing: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise PortfolioContractError(f"{label} is unreadable: {path}") from exc
+    if not isinstance(payload, Mapping):
+        raise PortfolioContractError(f"{label} must be a JSON object")
+    return dict(payload)
+
+
+def _load_feature_summary(root: Path) -> dict[str, Any]:
+    payload = _read_json_object(
+        root / "features" / "summary.json",
+        "features/summary.json",
+    )
+    if payload.get("study_id") != STUDY_ID:
+        raise PortfolioContractError("features/summary.json study_id mismatch")
+    return payload
+
+
+def validate_feature_inputs(root: Path) -> dict[str, Any]:
+    """Cross-check the frozen feature manifest, replay, snapshot, and Parquet."""
+
+    feature_manifest = _read_json_object(
+        root / "features" / "manifest.json",
+        "features/manifest.json",
+    )
+    feature_summary = _load_feature_summary(root)
+    snapshot_manifest = _read_json_object(
+        root / "snapshot" / "manifest.json",
+        "snapshot/manifest.json",
+    )
+    replay_manifest = _read_json_object(
+        root / "replay" / "manifest.json",
+        "replay/manifest.json",
+    )
+    for label, payload in (
+        ("features/manifest.json", feature_manifest),
+        ("snapshot/manifest.json", snapshot_manifest),
+        ("replay/manifest.json", replay_manifest),
+    ):
+        if payload.get("study_id") != STUDY_ID:
+            raise PortfolioContractError(f"{label} study_id mismatch")
+    if feature_manifest.get("summary") != feature_summary:
+        raise PortfolioContractError(
+            "features/manifest.json summary disagrees with features/summary.json"
+        )
+    snapshot_id = feature_manifest.get("snapshot_id")
+    if (
+        not isinstance(snapshot_id, str)
+        or not snapshot_id.startswith("sha256:")
+        or snapshot_manifest.get("snapshot_id") != snapshot_id
+        or replay_manifest.get("snapshot_id") != snapshot_id
+    ):
+        raise PortfolioContractError("features snapshot_id lineage mismatch")
+    signal_set_id = feature_manifest.get("signal_set_id")
+    if (
+        not isinstance(signal_set_id, str)
+        or len(signal_set_id) != 71
+        or not signal_set_id.startswith("sha256:")
+        or any(
+            character not in "0123456789abcdef"
+            for character in signal_set_id.removeprefix("sha256:")
+        )
+        or replay_manifest.get("signal_set_id") != signal_set_id
+    ):
+        raise PortfolioContractError("features signal_set_id lineage mismatch")
+
+    output = feature_summary.get("output")
+    if not isinstance(output, Mapping):
+        raise PortfolioContractError("features summary.output must be an object")
+    candidate_path = root / "features" / "candidate_events.parquet"
+    if Path(str(output.get("path", ""))).resolve() != candidate_path.resolve():
+        raise PortfolioContractError("features candidate output path mismatch")
+    candidate_identity = _verify_declared_snapshot_file(
+        path=candidate_path,
+        logical_path="features/candidate_events.parquet",
+        metadata=output,
+        label="features candidate_events.parquet",
+    )
+    declared_rows = feature_summary.get("candidate_event_rows")
+    if (
+        not isinstance(declared_rows, int)
+        or isinstance(declared_rows, bool)
+        or declared_rows < 0
+    ):
+        raise PortfolioContractError("features candidate_event_rows is invalid")
+    actual_rows = pq.ParquetFile(candidate_path).metadata.num_rows
+    if actual_rows != declared_rows:
+        raise PortfolioContractError(
+            "features candidate_events Parquet row count mismatch"
+        )
     return {
-        "candidate_event_rows": len(events),
-        "unique_union_signals": (
-            int(events["union_signal_id"].nunique())
-            if "union_signal_id" in events
-            else None
+        "status": "VERIFIED",
+        "study_id": STUDY_ID,
+        "snapshot_id": snapshot_id,
+        "signal_set_id": signal_set_id,
+        "candidate_event_rows": actual_rows,
+        "candidate_events": candidate_identity,
+    }
+
+
+def _load_index_benchmark(root: Path) -> dict[str, Any]:
+    payload = _read_json_object(
+        root / "audit" / "study_config.json",
+        "audit/study_config.json",
+    )
+    if payload.get("study_id") != STUDY_ID:
+        raise PortfolioContractError("audit/study_config.json study_id mismatch")
+    source = payload.get("index_source")
+    if not isinstance(source, Mapping):
+        raise PortfolioContractError(
+            "audit/study_config.json index_source must be an object"
+        )
+    source_kind = str(source.get("source_kind", "")).strip()
+    source_code = str(source.get("source_code", "")).strip()
+    source_name = str(source.get("source_name", "")).strip()
+    if not source_name:
+        raise PortfolioContractError("index_source source_name is missing")
+    if source_kind == "SHANGHAI_COMPOSITE_ETF_PROXY":
+        if source_code != "510980":
+            raise PortfolioContractError(
+                "Shanghai Composite ETF proxy must use source_code=510980"
+            )
+        benchmark_label = "510980上证综合ETF代理"
+        is_proxy = True
+    elif source_kind == "SHANGHAI_COMPOSITE":
+        if source_code != "000001":
+            raise PortfolioContractError(
+                "Shanghai Composite source must use source_code=000001"
+            )
+        benchmark_label = "000001上证指数"
+        is_proxy = False
+    else:
+        raise PortfolioContractError(
+            f"unsupported index_source source_kind: {source_kind or '<missing>'}"
+        )
+    return {
+        "source_kind": source_kind,
+        "source_code": source_code,
+        "source_name": source_name,
+        "benchmark_label": benchmark_label,
+        "is_proxy": is_proxy,
+    }
+
+
+def _verify_declared_snapshot_file(
+    *,
+    path: Path,
+    logical_path: str,
+    metadata: Mapping[str, Any],
+    label: str,
+) -> dict[str, Any]:
+    if not path.is_file():
+        raise PortfolioContractError(f"{label} is missing: {path}")
+    expected_size = metadata.get("file_size")
+    if (
+        not isinstance(expected_size, int)
+        or isinstance(expected_size, bool)
+        or expected_size < 0
+    ):
+        raise PortfolioContractError(f"{label} has invalid declared file_size")
+    actual_size = path.stat().st_size
+    if actual_size != expected_size:
+        raise PortfolioContractError(
+            f"{label} size mismatch: expected {expected_size}, got {actual_size}"
+        )
+    expected_sha256 = metadata.get("file_sha256")
+    if not isinstance(expected_sha256, str) or len(expected_sha256) != 64:
+        raise PortfolioContractError(f"{label} has invalid declared file_sha256")
+    actual_sha256 = sha256_file(path)
+    if actual_sha256 != expected_sha256.lower():
+        raise PortfolioContractError(f"{label} SHA256 mismatch")
+    return {
+        "logical_path": logical_path,
+        "file_size": actual_size,
+        "sha256": actual_sha256,
+    }
+
+
+def validate_snapshot_inputs(
+    root: Path,
+    *,
+    index_benchmark: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Verify every immutable index/bar file declared by the snapshot manifest."""
+
+    manifest_path = root / "snapshot" / "manifest.json"
+    manifest = _read_json_object(manifest_path, "snapshot/manifest.json")
+    if manifest.get("study_id") != STUDY_ID:
+        raise PortfolioContractError("snapshot/manifest.json study_id mismatch")
+    snapshot_id = manifest.get("snapshot_id")
+    if not isinstance(snapshot_id, str) or not snapshot_id.startswith("sha256:"):
+        raise PortfolioContractError("snapshot/manifest.json snapshot_id is invalid")
+
+    index_meta = manifest.get("index")
+    if not isinstance(index_meta, Mapping):
+        raise PortfolioContractError("snapshot manifest index must be an object")
+    index_logical_path = "snapshot/index_day.parquet"
+    if index_meta.get("logical_path") != index_logical_path:
+        raise PortfolioContractError(
+            "snapshot index logical_path must be snapshot/index_day.parquet"
+        )
+    for field in ("source_kind", "source_code", "source_name"):
+        if index_meta.get(field) != index_benchmark.get(field):
+            raise PortfolioContractError(
+                f"snapshot index {field} disagrees with audit/study_config.json"
+            )
+    index_path = root / "snapshot" / "index_day.parquet"
+    if not index_path.resolve().is_relative_to(root.resolve()):
+        raise PortfolioContractError("snapshot index path escapes the study root")
+    index_identity = _verify_declared_snapshot_file(
+        path=index_path,
+        logical_path=index_logical_path,
+        metadata=index_meta,
+        label="snapshot index_day.parquet",
+    )
+
+    code_files = manifest.get("code_files")
+    if not isinstance(code_files, list) or not code_files:
+        raise PortfolioContractError(
+            "snapshot manifest code_files must be a non-empty list"
+        )
+    bars_dir = root / "snapshot" / "bars"
+    if not bars_dir.resolve().is_relative_to(root.resolve()):
+        raise PortfolioContractError("snapshot bars directory escapes the study root")
+    declared_codes: set[str] = set()
+    declared_logical_paths: set[str] = set()
+    bar_identities: list[dict[str, Any]] = []
+    bar_rows = 0
+    for offset, item in enumerate(code_files):
+        if not isinstance(item, Mapping):
+            raise PortfolioContractError(
+                f"snapshot code_files[{offset}] must be an object"
+            )
+        code = item.get("code")
+        if not isinstance(code, str) or len(code) != 6 or not code.isdigit():
+            raise PortfolioContractError(
+                f"snapshot code_files[{offset}] has invalid code"
+            )
+        if code in declared_codes:
+            raise PortfolioContractError(
+                f"snapshot manifest has duplicate code: {code}"
+            )
+        declared_codes.add(code)
+        logical_path = f"snapshot/bars/{code}.parquet"
+        for path_field in ("logical_path", "path"):
+            supplied_path = item.get(path_field)
+            if supplied_path is not None and supplied_path != logical_path:
+                raise PortfolioContractError(
+                    f"snapshot bars/{code}.parquet {path_field} mismatch"
+                )
+        path = root / "snapshot" / "bars" / f"{code}.parquet"
+        if (
+            not path.resolve().is_relative_to(root.resolve())
+            or path.resolve().parent != bars_dir.resolve()
+        ):
+            raise PortfolioContractError(
+                f"snapshot bars/{code}.parquet path escapes the bars directory"
+            )
+        declared_logical_paths.add(logical_path)
+        identity = _verify_declared_snapshot_file(
+            path=path,
+            logical_path=logical_path,
+            metadata=item,
+            label=f"snapshot bars/{code}.parquet",
+        )
+        identity["code"] = code
+        rows = item.get("rows")
+        if not isinstance(rows, int) or isinstance(rows, bool) or rows < 0:
+            raise PortfolioContractError(
+                f"snapshot bars/{code}.parquet has invalid declared rows"
+            )
+        actual_rows = pq.ParquetFile(path).metadata.num_rows
+        if actual_rows != rows:
+            raise PortfolioContractError(
+                f"snapshot bars/{code}.parquet Parquet row count mismatch"
+            )
+        identity["rows"] = actual_rows
+        bar_identities.append(identity)
+        bar_rows += rows
+
+    actual_logical_paths = {
+        path.relative_to(root).as_posix()
+        for path in bars_dir.rglob("*.parquet")
+        if path.is_file()
+    }
+    if actual_logical_paths != declared_logical_paths:
+        missing = len(declared_logical_paths - actual_logical_paths)
+        extra = len(actual_logical_paths - declared_logical_paths)
+        raise PortfolioContractError(
+            "snapshot bars file set disagrees with manifest "
+            f"(missing={missing}, extra={extra})"
+        )
+
+    verified_identities = [index_identity, *bar_identities]
+    identities_sha256 = hashlib.sha256(
+        _canonical_bytes(verified_identities)
+    ).hexdigest()
+    return {
+        "status": "VERIFIED",
+        "study_id": STUDY_ID,
+        "snapshot_id": snapshot_id,
+        "all_declared_files_verified": True,
+        "verified_file_count": len(verified_identities),
+        "verified_bar_file_count": len(bar_identities),
+        "verified_bar_rows": bar_rows,
+        "verified_total_bytes": sum(
+            int(identity["file_size"]) for identity in verified_identities
         ),
-        "unique_stocks": int(events["code"].nunique()),
+        "verified_identities_sha256": identities_sha256,
+        "index_source": {
+            field: index_benchmark[field]
+            for field in ("source_kind", "source_code", "source_name")
+        },
     }
 
 
@@ -1455,6 +2536,225 @@ def _manifest_entry(
         "rows": rows,
         "file_size": path.stat().st_size,
         "sha256": sha256_file(path),
+    }
+
+
+def _required_input_identity(path: Path, root: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise PortfolioContractError(f"required portfolio input is missing: {path}")
+    return {
+        "logical_path": path.relative_to(root).as_posix(),
+        "file_size": path.stat().st_size,
+        "sha256": sha256_file(path),
+    }
+
+
+def _run_input_paths(root: Path) -> dict[str, Path]:
+    return {
+        "candidate_events": root / "features" / "candidate_events.parquet",
+        "features_manifest": root / "features" / "manifest.json",
+        "feature_summary": root / "features" / "summary.json",
+        "replay_manifest": root / "replay" / "manifest.json",
+        "market_segments": root / "features" / "market_segments.csv",
+        "locked_config": root / "matrix" / "locked_config.json",
+        "lock_manifest": root / "matrix" / "lock_manifest.json",
+        "development_manifest": root / "matrix" / "development_manifest.json",
+        "development_lock_candidates": (
+            root / "matrix" / "development_lock_candidates.parquet"
+        ),
+        "reveal_manifest": root / "matrix" / "reveal_manifest.json",
+        "reveal_matrix": root / "matrix" / "reveal_matrix.parquet",
+        "reveal_summary": root / "matrix" / "reveal_summary.csv",
+        "reveal_locked_detailed": (root / "matrix" / "reveal_locked_detailed.parquet"),
+        "reveal_locked_group_detail": (
+            root / "matrix" / "reveal_locked_group_detail.parquet"
+        ),
+        "study_config": root / "audit" / "study_config.json",
+        "snapshot_manifest": root / "snapshot" / "manifest.json",
+        "index_day": root / "snapshot" / "index_day.parquet",
+    }
+
+
+def _current_run_input_identities(root: Path) -> dict[str, dict[str, Any]]:
+    return {
+        name: _required_input_identity(path, root)
+        for name, path in _run_input_paths(root).items()
+    }
+
+
+def _validate_frozen_run_inputs(
+    root: Path,
+    run_contract: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    frozen = run_contract.get("input_identities")
+    if not isinstance(frozen, Mapping):
+        raise PortfolioContractError("frozen run_contract input_identities is missing")
+    current = _current_run_input_identities(root)
+    if set(frozen) != set(current):
+        raise PortfolioContractError("frozen run_contract input set mismatch")
+    for name, identity in current.items():
+        if frozen.get(name) != identity:
+            raise PortfolioContractError(
+                f"frozen run_contract external input drift: {name}"
+            )
+    return current
+
+
+def _checkpoint_key(
+    *,
+    selection: LockedSelection,
+    scope: str,
+    daily_entry_limit: int | None,
+    ranking_policy: str,
+    random_seed: int | None,
+) -> str:
+    seed = "n" if random_seed is None else f"{random_seed:03d}"
+    cap = "u" if daily_entry_limit is None else str(daily_entry_limit)
+    try:
+        scope_token = CHECKPOINT_SCOPE_TOKENS[scope]
+    except KeyError as exc:
+        raise PortfolioContractError(f"unsupported checkpoint scope: {scope}") from exc
+    return f"h{selection.horizon}_{scope_token}_c{cap}_" f"{ranking_policy[0]}_s{seed}"
+
+
+def _load_quality_checkpoint(path: Path, *, run_id: str) -> SimulationResult | None:
+    complete = path / "complete.json"
+    if not complete.is_file():
+        return None
+    try:
+        metadata = json.loads(complete.read_text(encoding="utf-8"))
+        if metadata.get("run_id") != run_id:
+            return None
+        equity_path = path / "equity.parquet"
+        trades_path = path / "trades.parquet"
+        if metadata.get("equity_sha256") != sha256_file(equity_path) or metadata.get(
+            "trades_sha256"
+        ) != sha256_file(trades_path):
+            return None
+        summary = dict(metadata["summary"])
+        for column in ("start_at", "end_at"):
+            if summary.get(column):
+                summary[column] = pd.Timestamp(summary[column])
+        return SimulationResult(
+            summary=summary,
+            equity=pd.read_parquet(equity_path),
+            trades=pd.read_parquet(trades_path),
+            decisions=pd.DataFrame(),
+        )
+    except (FileNotFoundError, KeyError, OSError, ValueError):
+        return None
+
+
+def _save_quality_checkpoint(
+    path: Path, *, run_id: str, result: SimulationResult
+) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    equity_path = path / "equity.parquet"
+    trades_path = path / "trades.parquet"
+    _atomic_parquet(result.equity, equity_path)
+    _atomic_parquet(result.trades, trades_path)
+    _atomic_json(
+        path / "complete.json",
+        {
+            "run_id": run_id,
+            "summary": result.summary,
+            "equity_sha256": sha256_file(equity_path),
+            "trades_sha256": sha256_file(trades_path),
+        },
+    )
+
+
+def _load_random_checkpoint(path: Path, *, run_id: str) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if payload.get("run_id") != run_id:
+            return None
+        return dict(payload["summary"])
+    except (KeyError, OSError, ValueError):
+        return None
+
+
+def _save_random_checkpoint(
+    path: Path, *, run_id: str, summary: Mapping[str, Any]
+) -> None:
+    _atomic_json(path, {"run_id": run_id, "summary": dict(summary)})
+
+
+def _completed_result(root: Path, *, run_id: str) -> dict[str, Any] | None:
+    output = root / "portfolio"
+    manifest_path = output / "manifest.json"
+    if not manifest_path.is_file():
+        return None
+    manifest = _read_json_object(manifest_path, "portfolio/manifest.json")
+    if manifest.get("status") != "COMPLETE" or manifest.get("run_id") != run_id:
+        return None
+    if manifest.get("study_id") != STUDY_ID:
+        raise PortfolioContractError("completed portfolio study_id mismatch")
+    if manifest.get("portfolio_logic_sha256") != sha256_file(Path(__file__).resolve()):
+        raise PortfolioContractError("completed portfolio logic SHA256 mismatch")
+    outputs = manifest.get("outputs")
+    if not isinstance(outputs, list) or not outputs:
+        raise PortfolioContractError(
+            "completed portfolio outputs must be a non-empty list"
+        )
+    logical_paths: list[str] = []
+    for offset, item in enumerate(outputs):
+        if not isinstance(item, Mapping):
+            raise PortfolioContractError(
+                f"completed portfolio outputs[{offset}] must be an object"
+            )
+        logical_path = item.get("logical_path")
+        if not isinstance(logical_path, str) or not logical_path:
+            raise PortfolioContractError(
+                f"completed portfolio outputs[{offset}] logical_path is invalid"
+            )
+        logical_paths.append(logical_path)
+    if len(logical_paths) != len(set(logical_paths)):
+        raise PortfolioContractError(
+            "completed portfolio outputs contain duplicate logical_path values"
+        )
+    actual_outputs = set(logical_paths)
+    if actual_outputs != REQUIRED_LOGICAL_OUTPUTS:
+        raise PortfolioContractError(
+            "completed portfolio required logical outputs mismatch "
+            f"(missing={len(REQUIRED_LOGICAL_OUTPUTS - actual_outputs)}, "
+            f"extra={len(actual_outputs - REQUIRED_LOGICAL_OUTPUTS)})"
+        )
+    for item in outputs:
+        logical_path = str(item["logical_path"])
+        path = root / logical_path
+        expected_size = item.get("file_size")
+        expected_sha256 = item.get("sha256")
+        if (
+            not path.is_file()
+            or not isinstance(expected_size, int)
+            or isinstance(expected_size, bool)
+            or path.stat().st_size != expected_size
+            or not isinstance(expected_sha256, str)
+            or len(expected_sha256) != 64
+            or sha256_file(path) != expected_sha256.lower()
+        ):
+            raise PortfolioContractError(
+                f"completed portfolio output identity mismatch: {logical_path}"
+            )
+    try:
+        quality_portfolios = int(manifest["quality_portfolios"])
+        random_portfolios = int(manifest["random_portfolios"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise PortfolioContractError("completed portfolio counts are invalid") from exc
+    return {
+        "study_id": STUDY_ID,
+        "run_id": run_id,
+        "root": str(root),
+        "portfolio_dir": str(output),
+        "quality_portfolios": quality_portfolios,
+        "random_portfolios": random_portfolios,
+        "report": str(output / "report.md"),
+        "workbook": str(output / "clx_30m_portfolio_report.xlsx"),
+        "manifest": str(manifest_path),
+        "reused": True,
     }
 
 
@@ -1472,6 +2772,62 @@ def run_portfolios(
     if not event_path.is_file():
         raise PortfolioContractError(f"candidate events are missing: {event_path}")
     selections = load_locked_selections(lock_path)
+    reveal_artifacts = validate_reveal_inputs(root, lock_path)
+    reveal_path, reveal_matrix_sha256 = reveal_artifacts["matrix"]
+    reveal_summary_path, reveal_summary_sha256 = reveal_artifacts["summary"]
+    reveal_detailed_path, reveal_detailed_sha256 = reveal_artifacts["locked_detailed"]
+    reveal_group_path, reveal_group_sha256 = reveal_artifacts["group_detail"]
+    _reveal_manifest_path, reveal_manifest_sha256 = reveal_artifacts["manifest"]
+    event_sha256 = sha256_file(event_path)
+    lock_sha256 = sha256_file(lock_path)
+    snapshot_manifest_path = root / "snapshot" / "manifest.json"
+    segment_path = root / "features" / "market_segments.csv"
+    feature_summary_path = root / "features" / "summary.json"
+    study_config_path = root / "audit" / "study_config.json"
+    snapshot_manifest_identity = _required_input_identity(
+        snapshot_manifest_path,
+        root,
+    )
+    market_segments_identity = _required_input_identity(segment_path, root)
+    feature_summary_identity = _required_input_identity(feature_summary_path, root)
+    study_config_identity = _required_input_identity(study_config_path, root)
+    feature_verification = validate_feature_inputs(root)
+    feature_summary = _load_feature_summary(root)
+    index_benchmark = _load_index_benchmark(root)
+    snapshot_verification = validate_snapshot_inputs(
+        root,
+        index_benchmark=index_benchmark,
+    )
+    input_identities = _current_run_input_identities(root)
+    run_contract = {
+        "study_id": STUDY_ID,
+        "contract_version": PORTFOLIO_CONTRACT_VERSION,
+        "portfolio_logic_sha256": sha256_file(Path(__file__).resolve()),
+        "candidate_events_sha256": event_sha256,
+        "locked_config_sha256": lock_sha256,
+        "reveal_manifest_sha256": reveal_manifest_sha256,
+        "reveal_matrix_sha256": reveal_matrix_sha256,
+        "reveal_summary_sha256": reveal_summary_sha256,
+        "reveal_locked_detailed_sha256": reveal_detailed_sha256,
+        "reveal_locked_group_detail_sha256": reveal_group_sha256,
+        "snapshot_manifest": snapshot_manifest_identity,
+        "market_segments": market_segments_identity,
+        "feature_summary": feature_summary_identity,
+        "study_config": study_config_identity,
+        "input_identities": input_identities,
+        "feature_verification": feature_verification,
+        "snapshot_verification": snapshot_verification,
+        "random_seed_count": random_seeds,
+        "include_audit_scope": include_audit_scope,
+        "checkpoint_scope_tokens": CHECKPOINT_SCOPE_TOKENS,
+    }
+    run_id = "sha256:" + hashlib.sha256(_canonical_bytes(run_contract)).hexdigest()
+    reusable = _completed_result(root, run_id=run_id)
+    if reusable is not None:
+        print(json.dumps(reusable, ensure_ascii=False), flush=True)
+        return reusable
+    output = root / "portfolio"
+    checkpoint_root = output / "ckpt" / run_id.removeprefix("sha256:")[:16]
     event_columns = [
         "signal_fact_id",
         "union_signal_id",
@@ -1498,9 +2854,25 @@ def run_portfolios(
                 f"h{horizon}_status",
                 f"h{horizon}_exit_at",
                 f"h{horizon}_gross_return",
+                f"h{horizon}_split_boundary_status",
             )
         )
-    events = pd.read_parquet(event_path, columns=event_columns)
+    locked_models = sorted(
+        {
+            model
+            for selection in selections
+            for model in selection.model_codes
+            if model not in {"ALL", "*", "UNION"}
+        }
+    )
+    wildcard_model = any(
+        set(selection.model_codes) & {"ALL", "*", "UNION"} for selection in selections
+    )
+    events = pd.read_parquet(
+        event_path,
+        columns=event_columns,
+        filters=(None if wildcard_model else [("model_code", "in", locked_models)]),
+    )
     scopes = ["AVAILABLE"]
     if (
         include_audit_scope
@@ -1510,9 +2882,13 @@ def run_portfolios(
         scopes.append("AUDIT")
     selected: dict[tuple[str, str], pd.DataFrame] = {}
     for selection in selections:
-        for scope in scopes:
-            selected[(selection.selection_id, scope)] = select_locked_candidates(
-                events, selection, scope=scope
+        available = select_locked_candidates(events, selection, scope="AVAILABLE")
+        selected[(selection.selection_id, "AVAILABLE")] = available
+        if "AUDIT" in scopes:
+            selected[(selection.selection_id, "AUDIT")] = select_locked_candidates(
+                events,
+                selection,
+                scope="AUDIT",
             )
     available_frames = [
         selected[(selection.selection_id, "AVAILABLE")] for selection in selections
@@ -1533,54 +2909,111 @@ def run_portfolios(
             scope_clocks["AUDIT"] = build_simulation_clock(root, audit_frames, marks)
         else:
             scope_clocks["AUDIT"] = scope_clocks["AVAILABLE"]
-    segment_path = root / "features" / "market_segments.csv"
-    segments = (
-        pd.read_csv(segment_path, encoding="utf-8-sig")
-        if segment_path.is_file()
-        else pd.DataFrame()
-    )
+    segments = pd.read_csv(segment_path, encoding="utf-8-sig")
     summaries: list[dict[str, Any]] = []
     random_summaries: list[dict[str, Any]] = []
     quality_equity: list[pd.DataFrame] = []
     quality_trades: list[pd.DataFrame] = []
-    quality_decisions: list[pd.DataFrame] = []
     periods: list[pd.DataFrame] = []
     for selection in selections:
         for scope in scopes:
             frame = selected[(selection.selection_id, scope)]
+            quality_entries: dict[int, list[dict[str, Any]]] | None = None
             for daily_limit in DAILY_ENTRY_LIMITS:
-                quality = simulate_portfolio(
-                    frame,
-                    selection=selection,
-                    scope=scope,
-                    clock=scope_clocks[scope],
-                    marks=marks,
-                    daily_entry_limit=daily_limit,
-                    ranking_policy="quality",
+                checkpoint_path = (
+                    checkpoint_root
+                    / "quality"
+                    / _checkpoint_key(
+                        selection=selection,
+                        scope=scope,
+                        daily_entry_limit=daily_limit,
+                        ranking_policy="quality",
+                        random_seed=None,
+                    )
                 )
+                quality = _load_quality_checkpoint(checkpoint_path, run_id=run_id)
+                if quality is None:
+                    if quality_entries is None:
+                        quality_entries = prepare_ordered_entries(
+                            frame,
+                            ranking_policy="quality",
+                        )
+                    quality = simulate_portfolio(
+                        frame,
+                        selection=selection,
+                        scope=scope,
+                        clock=scope_clocks[scope],
+                        marks=marks,
+                        daily_entry_limit=daily_limit,
+                        ranking_policy="quality",
+                        ordered_entries=quality_entries,
+                    )
+                    _save_quality_checkpoint(
+                        checkpoint_path,
+                        run_id=run_id,
+                        result=quality,
+                    )
                 summaries.append(quality.summary)
                 quality_equity.append(quality.equity)
                 quality_trades.append(quality.trades)
-                quality_decisions.append(quality.decisions)
                 periods.append(
                     build_period_metrics(quality.equity, quality.trades, segments)
                 )
-                # Random ordering is a capacity sensitivity on the full AVAILABLE
-                # sequence. AUDIT receives the frozen quality run but no duplicate
-                # 100-seed expansion.
-                if scope == "AVAILABLE":
-                    for seed in range(random_seeds):
-                        random = simulate_portfolio(
+            # Random ordering is a capacity sensitivity on the full AVAILABLE
+            # sequence. The order is independent of the daily cap, so one
+            # SHA ordering is reused by all six accounts for that seed.
+            if scope == "AVAILABLE":
+                for seed in range(random_seeds):
+                    pending: list[tuple[int | None, Path]] = []
+                    seed_summaries: dict[str, dict[str, Any]] = {}
+                    for daily_limit in DAILY_ENTRY_LIMITS:
+                        checkpoint_path = (
+                            checkpoint_root
+                            / "random"
+                            / (
+                                _checkpoint_key(
+                                    selection=selection,
+                                    scope=scope,
+                                    daily_entry_limit=daily_limit,
+                                    ranking_policy="sha_random",
+                                    random_seed=seed,
+                                )
+                                + ".json"
+                            )
+                        )
+                        cached = _load_random_checkpoint(checkpoint_path, run_id=run_id)
+                        if cached is None:
+                            pending.append((daily_limit, checkpoint_path))
+                        else:
+                            seed_summaries[_limit_label(daily_limit)] = cached
+                    if pending:
+                        random_entries = prepare_ordered_entries(
                             frame,
-                            selection=selection,
-                            scope=scope,
-                            clock=scope_clocks[scope],
-                            marks=marks,
-                            daily_entry_limit=daily_limit,
                             ranking_policy="sha_random",
                             random_seed=seed,
                         )
-                        random_summaries.append(random.summary)
+                        for daily_limit, checkpoint_path in pending:
+                            random = simulate_portfolio(
+                                frame,
+                                selection=selection,
+                                scope=scope,
+                                clock=scope_clocks[scope],
+                                marks=marks,
+                                daily_entry_limit=daily_limit,
+                                ranking_policy="sha_random",
+                                random_seed=seed,
+                                ordered_entries=random_entries,
+                            )
+                            _save_random_checkpoint(
+                                checkpoint_path,
+                                run_id=run_id,
+                                summary=random.summary,
+                            )
+                            seed_summaries[_limit_label(daily_limit)] = random.summary
+                    random_summaries.extend(
+                        seed_summaries[_limit_label(daily_limit)]
+                        for daily_limit in DAILY_ENTRY_LIMITS
+                    )
     summary_frame = pd.DataFrame(summaries)
     random_frame = pd.DataFrame(random_summaries)
     random_summary = summarise_random_runs(random_frame)
@@ -1590,11 +3023,23 @@ def run_portfolios(
         if any(not frame.empty for frame in quality_trades)
         else pd.DataFrame()
     )
-    decision_frame = (
-        pd.concat(quality_decisions, ignore_index=True)
-        if any(not frame.empty for frame in quality_decisions)
-        else pd.DataFrame()
-    )
+    decision_frame = summary_frame.loc[
+        :,
+        [
+            "selection_id",
+            "horizon_trading_days",
+            "scope",
+            "daily_entry_limit",
+            "ranking_policy",
+            "candidate_signals",
+            "closed_trades",
+            "candidate_acceptance_rate",
+            "rejected_occupied",
+            "rejected_daily_limit",
+            "rejected_slots",
+            "rejected_cash",
+        ],
+    ].copy()
     period_frame = (
         pd.concat(periods, ignore_index=True)
         if any(not frame.empty for frame in periods)
@@ -1603,6 +3048,7 @@ def run_portfolios(
     locked_frame = pd.DataFrame([selection.as_row() for selection in selections])
     baseline_frame = build_daily_baseline_comparison(summary_frame)
     daily_curve_frame = _daily_curves(equity_frame)
+    chart_frame = build_chart_data(daily_curve_frame)
     reveal_path = root / "matrix" / "reveal_matrix.parquet"
     reveal_summary_path = root / "matrix" / "reveal_summary.csv"
     reveal_frame = (
@@ -1610,8 +3056,8 @@ def run_portfolios(
         if reveal_summary_path.is_file()
         else pd.DataFrame()
     )
-    feature_summary = _load_feature_summary(root, events)
-
+    reveal_detailed_frame = pd.read_parquet(reveal_detailed_path)
+    reveal_group_frame = pd.read_parquet(reveal_group_path)
     output = root / "portfolio"
     output.mkdir(parents=True, exist_ok=True)
     frames = {
@@ -1621,11 +3067,14 @@ def run_portfolios(
         "period_metrics": period_frame,
         "equity_30m": equity_frame,
         "equity_daily": daily_curve_frame,
+        "chart_curves": chart_frame,
         "trades": trade_frame,
-        "decisions": decision_frame,
+        "decision_summary": decision_frame,
         "locked_selections": locked_frame,
         "daily_baseline_comparison": baseline_frame,
     }
+    if set(frames) != set(PORTFOLIO_FRAME_NAMES):
+        raise PortfolioContractError("portfolio logical output frame set drifted")
     written: list[Path] = []
     output_rows: dict[Path, int] = {}
     for name, frame in frames.items():
@@ -1643,9 +3092,12 @@ def run_portfolios(
         random_summary=random_summary,
         period_metrics=period_frame,
         daily_curves=daily_curve_frame,
+        chart_data=chart_frame,
         locked=locked_frame,
         baseline=baseline_frame,
         reveal=reveal_frame,
+        reveal_detailed=reveal_detailed_frame,
+        reveal_groups=reveal_group_frame,
     )
     written.append(workbook)
     report = build_markdown_report(
@@ -1657,12 +3109,17 @@ def run_portfolios(
         baseline=baseline_frame,
         feature_summary=feature_summary,
         reveal_summary=reveal_frame,
+        reveal_detailed=reveal_detailed_frame,
+        index_benchmark=index_benchmark,
+        portfolio_logic_sha256=str(run_contract["portfolio_logic_sha256"]),
     )
     report_path = output / "report.md"
     report_path.write_text(report, encoding="utf-8")
     written.append(report_path)
     config = {
         "study_id": STUDY_ID,
+        "run_id": run_id,
+        "run_contract": run_contract,
         "contract_version": PORTFOLIO_CONTRACT_VERSION,
         "filter_contract": "F1_F6_64_SUBSETS_ONLY",
         "initial_capital": INITIAL_CAPITAL,
@@ -1679,6 +3136,13 @@ def run_portfolios(
             "sensitivity": "SHA256(seed|candidate_id)",
             "random_seed_count": random_seeds,
         },
+        "execution": {
+            "candidate_read": "Parquet projection plus locked-model predicate",
+            "ordering_reuse": "one ordering per selection/scope/seed shared by six caps",
+            "mark_to_market": "vectorised trade slices over cached clock-aligned QFQ closes",
+            "checkpoint": "immutable run-id quality Parquet and random-summary JSON",
+            "completed_rerun": "verify output SHA256 and return REUSED",
+        },
         "clock": "30-minute QFQ close; carry prior close through missing bars",
         "metric_formulas": {
             "one_way_turnover": "(buy_notional+sell_notional)/(2*mean_equity)",
@@ -1686,7 +3150,13 @@ def run_portfolios(
             "profit_factor": "sum(positive_net_pnl)/abs(sum(negative_net_pnl))",
             "capital_utilization": "marked_position_value/equity",
         },
-        "filter_descriptions": FILTER_DESCRIPTIONS,
+        "filter_descriptions": {
+            **FILTER_DESCRIPTIONS,
+            "F6": (f"{index_benchmark['benchmark_label']}" "近20个完整交易日收益≤0"),
+        },
+        "index_benchmark": index_benchmark,
+        "feature_verification": feature_verification,
+        "snapshot_verification": snapshot_verification,
         "omitted_costs": [
             "slippage",
             "stamp_duty",
@@ -1694,32 +3164,43 @@ def run_portfolios(
             "100_share_rounding",
         ],
         "scopes": scopes,
-        "candidate_events_sha256": sha256_file(event_path),
-        "locked_config_sha256": sha256_file(lock_path),
+        "input": {
+            "snapshot_manifest": snapshot_manifest_identity,
+            "market_segments": market_segments_identity,
+            "feature_summary": feature_summary_identity,
+            "study_config": study_config_identity,
+            "all_frozen_inputs": input_identities,
+        },
+        "candidate_events_sha256": event_sha256,
+        "locked_config_sha256": lock_sha256,
     }
     config_path = output / "portfolio_config.json"
     _atomic_json(config_path, config)
     written.append(config_path)
     command = (
-        f'& "<PYTHON>" "{Path(__file__).resolve()}" --root "{root}" '
+        f'& "<PYTHON>" "{REPRODUCE_SCRIPT}" --root "{root}" '
         f"run --random-seeds {random_seeds}"
     )
+    if not include_audit_scope:
+        command += " --no-audit-scope"
     reproduce = output / "reproduce_command.txt"
     reproduce.write_text(command + "\n", encoding="utf-8")
     written.append(reproduce)
     manifest = {
         "study_id": STUDY_ID,
+        "run_id": run_id,
         "status": "COMPLETE",
+        "portfolio_logic_sha256": run_contract["portfolio_logic_sha256"],
         "input": {
             "candidate_events": {
                 "logical_path": "features/candidate_events.parquet",
                 "file_size": event_path.stat().st_size,
-                "sha256": sha256_file(event_path),
+                "sha256": event_sha256,
             },
             "locked_config": {
                 "logical_path": "matrix/locked_config.json",
                 "file_size": lock_path.stat().st_size,
-                "sha256": sha256_file(lock_path),
+                "sha256": lock_sha256,
             },
             "reveal_matrix": (
                 {
@@ -1739,10 +3220,41 @@ def run_portfolios(
                 if reveal_summary_path.is_file()
                 else None
             ),
+            "reveal_locked_detailed": {
+                "logical_path": "matrix/reveal_locked_detailed.parquet",
+                "file_size": reveal_detailed_path.stat().st_size,
+                "sha256": reveal_detailed_sha256,
+            },
+            "reveal_locked_group_detail": {
+                "logical_path": "matrix/reveal_locked_group_detail.parquet",
+                "file_size": reveal_group_path.stat().st_size,
+                "sha256": reveal_group_sha256,
+            },
+            "snapshot_manifest": snapshot_manifest_identity,
+            "market_segments": market_segments_identity,
+            "feature_summary": feature_summary_identity,
+            "study_config": study_config_identity,
         },
+        "index_benchmark": index_benchmark,
+        "feature_verification": feature_verification,
+        "snapshot_verification": snapshot_verification,
         "selection_count": len(selections),
+        "loaded_locked_model_event_rows": len(events),
+        "selected_candidate_rows": {
+            f"h{selection.horizon}_{scope}": len(
+                selected[(selection.selection_id, scope)]
+            )
+            for selection in selections
+            for scope in scopes
+        },
         "quality_portfolios": len(summary_frame),
         "random_portfolios": len(random_frame),
+        "ordering_builds": {
+            "quality": len(selections) * len(scopes),
+            "sha_random": len(selections) * random_seeds,
+            "six_daily_caps_share_each_ordering": True,
+        },
+        "checkpoint_root": checkpoint_root.relative_to(root).as_posix(),
         "mark_source_codes": len(codes),
         "mark_source_rows": marks.source_rows,
         "clock_rows": {
@@ -1756,6 +3268,7 @@ def run_portfolios(
     _atomic_json(manifest_path, manifest)
     result = {
         "study_id": STUDY_ID,
+        "run_id": run_id,
         "root": str(root),
         "portfolio_dir": str(output),
         "quality_portfolios": len(summary_frame),
@@ -1763,6 +3276,7 @@ def run_portfolios(
         "report": str(report_path),
         "workbook": str(workbook),
         "manifest": str(manifest_path),
+        "reused": False,
     }
     print(json.dumps(result, ensure_ascii=False), flush=True)
     return result
@@ -1771,20 +3285,68 @@ def run_portfolios(
 def rebuild_report(root: Path) -> dict[str, Any]:
     resolved = root.resolve()
     output = resolved / "portfolio"
+    config = _read_json_object(
+        output / "portfolio_config.json",
+        "portfolio/portfolio_config.json",
+    )
+    if config.get("study_id") != STUDY_ID:
+        raise PortfolioContractError("portfolio config study_id mismatch")
+    run_contract = config.get("run_contract")
+    if not isinstance(run_contract, Mapping):
+        raise PortfolioContractError("portfolio config run_contract is missing")
+    frozen_logic_sha256 = run_contract.get("portfolio_logic_sha256")
+    current_logic_sha256 = sha256_file(Path(__file__).resolve())
+    if frozen_logic_sha256 != current_logic_sha256:
+        raise PortfolioContractError("rebuild-report portfolio logic SHA256 mismatch")
+    manifest = _read_json_object(
+        output / "manifest.json",
+        "portfolio/manifest.json",
+    )
+    run_id = config.get("run_id")
+    if (
+        not isinstance(run_id, str)
+        or manifest.get("run_id") != run_id
+        or run_contract.get("study_id") != STUDY_ID
+        or "sha256:" + hashlib.sha256(_canonical_bytes(run_contract)).hexdigest()
+        != run_id
+    ):
+        raise PortfolioContractError("rebuild-report run identity mismatch")
+    if _completed_result(resolved, run_id=run_id) is None:
+        raise PortfolioContractError("rebuild-report requires a COMPLETE portfolio")
+
+    _validate_frozen_run_inputs(resolved, run_contract)
+    lock_path = resolved / "matrix" / "locked_config.json"
+    load_locked_selections(lock_path)
+    validate_reveal_inputs(resolved, lock_path)
+    feature_verification = validate_feature_inputs(resolved)
+    if run_contract.get("feature_verification") != feature_verification:
+        raise PortfolioContractError("rebuild-report feature verification drift")
+    feature_summary = _load_feature_summary(resolved)
+    index_benchmark = _load_index_benchmark(resolved)
+    if config.get("index_benchmark") != index_benchmark:
+        raise PortfolioContractError("rebuild-report index benchmark mismatch")
+    snapshot_verification = validate_snapshot_inputs(
+        resolved,
+        index_benchmark=index_benchmark,
+    )
+    if run_contract.get("snapshot_verification") != snapshot_verification:
+        raise PortfolioContractError("rebuild-report snapshot verification drift")
+
     summary = pd.read_parquet(output / "portfolio_summary.parquet")
     random_summary = pd.read_parquet(output / "random_order_sensitivity.parquet")
     period_metrics = pd.read_parquet(output / "period_metrics.parquet")
     locked = pd.read_parquet(output / "locked_selections.parquet")
     baseline = pd.read_parquet(output / "daily_baseline_comparison.parquet")
-    event_path = resolved / "features" / "candidate_events.parquet"
-    try:
-        events = pd.read_parquet(event_path, columns=["code", "union_signal_id"])
-    except (KeyError, ValueError):
-        events = pd.read_parquet(event_path, columns=["code"])
     reveal_summary_path = resolved / "matrix" / "reveal_summary.csv"
     reveal_summary = (
         pd.read_csv(reveal_summary_path, encoding="utf-8-sig")
         if reveal_summary_path.is_file()
+        else pd.DataFrame()
+    )
+    reveal_detailed_path = resolved / "matrix" / "reveal_locked_detailed.parquet"
+    reveal_detailed = (
+        pd.read_parquet(reveal_detailed_path)
+        if reveal_detailed_path.is_file()
         else pd.DataFrame()
     )
     text = build_markdown_report(
@@ -1794,11 +3356,21 @@ def rebuild_report(root: Path) -> dict[str, Any]:
         period_metrics=period_metrics,
         locked=locked,
         baseline=baseline,
-        feature_summary=_load_feature_summary(resolved, events),
+        feature_summary=feature_summary,
         reveal_summary=reveal_summary,
+        reveal_detailed=reveal_detailed,
+        index_benchmark=index_benchmark,
+        portfolio_logic_sha256=str(frozen_logic_sha256),
     )
     path = output / "report.md"
     path.write_text(text, encoding="utf-8")
+    manifest_path = output / "manifest.json"
+    for item in manifest["outputs"]:
+        if item["logical_path"] == "portfolio/report.md":
+            item["file_size"] = path.stat().st_size
+            item["sha256"] = sha256_file(path)
+            break
+    _atomic_json(manifest_path, manifest)
     result = {"report": str(path), "sha256": sha256_file(path)}
     print(json.dumps(result, ensure_ascii=False), flush=True)
     return result
@@ -1813,6 +3385,12 @@ def status(root: Path) -> dict[str, Any]:
         "locked_config": (root / "matrix" / "locked_config.json").is_file(),
         "reveal_matrix": (root / "matrix" / "reveal_matrix.parquet").is_file(),
         "reveal_summary": (root / "matrix" / "reveal_summary.csv").is_file(),
+        "reveal_locked_detailed": (
+            root / "matrix" / "reveal_locked_detailed.parquet"
+        ).is_file(),
+        "reveal_locked_group_detail": (
+            root / "matrix" / "reveal_locked_group_detail.parquet"
+        ).is_file(),
         "portfolio_complete": (root / "portfolio" / "manifest.json").is_file(),
     }
     print(json.dumps(result, ensure_ascii=False), flush=True)

--- a/script/clx_backtest/research/clx_30m_f1_f6_portfolio.py
+++ b/script/clx_backtest/research/clx_30m_f1_f6_portfolio.py
@@ -1,0 +1,1850 @@
+"""Build the locked CLX18 30-minute F1-F6 capital simulation and report.
+
+The executable filter contract contains the 64 F1-F6 subsets, represented by
+``filter_mask`` values in ``0..63``.
+
+Inputs (all below ``--root``):
+
+* ``features/candidate_events.parquet`` - immutable signal facts;
+* ``matrix/locked_config.json`` - four TRAIN+VALIDATION locked selections;
+* ``matrix/reveal_matrix.parquet`` - optional, already-once-revealed AUDIT facts;
+* ``snapshot/bars/<code>.parquet`` - 30-minute QFQ closes used for marking;
+* ``snapshot/index_day.parquet`` and ``features/market_segments.csv`` -
+  market calendar/regime facts.
+
+The simulator uses CNY 5,000,000, 40 slots with up to CNY 125,000 capital per
+slot, exits before entries at an identical bar timestamp, never adds to an
+already-held stock, and applies 0.02% on each side.  It intentionally does not
+model slippage, stamp duty, minimum commission, or 100-share board-lot
+rounding; those omissions are repeated in every generated report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+STUDY_ID = "clx-30m-full-trigger-f1-f6-v1"
+PORTFOLIO_CONTRACT_VERSION = 1
+INITIAL_CAPITAL = 5_000_000.0
+MAX_POSITIONS = 40
+SLOT_CAPITAL = 125_000.0
+FEE_PER_SIDE = 0.0002
+DAILY_ENTRY_LIMITS: tuple[int | None, ...] = (1, 3, 5, 10, 20, None)
+HORIZONS = (5, 30, 60, 90)
+FILTER_NAMES = tuple(f"F{offset}" for offset in range(1, 7))
+FILTER_DESCRIPTIONS = {
+    "F1": "未复权原始开盘价1～6元",
+    "F2": "个股近20个交易日收益≤0",
+    "F3": "距近20个交易日高点回撤≥10%",
+    "F4": "近20个交易日非年化日等效波动率≥3%",
+    "F5": "收盘价≤MA60日等效均线",
+    "F6": "上证指数近20个完整交易日收益≤0",
+}
+TRIGGER_BITS = {
+    "MODEL_STRUCTURAL": 0x01,
+    "PIN_BAR": 0x02,
+    "ENGULFING": 0x04,
+    "STRONG_FRACTAL": 0x08,
+    "MA5_TURN": 0x10,
+    "PRICE_VOLUME_CONFIRMATION": 0x20,
+    "MACD_CROSS": 0x40,
+}
+BAR_CLOCKS = (
+    "10:00",
+    "10:30",
+    "11:00",
+    "11:30",
+    "13:30",
+    "14:00",
+    "14:30",
+    "15:00",
+)
+SHANGHAI_TIMEZONE = "Asia/Shanghai"
+DEFAULT_ROOT = Path(
+    "D:/fqpack/runtime/clx-backtest/studies/clx-30m-full-trigger-f1-f6-v1"
+)
+
+DAILY_BASELINES = {
+    5: {
+        "locked_combo": "MACD金叉+F4+F6",
+        "train_net_win_rate": 0.5277,
+        "validation_net_win_rate": 0.5719,
+        "audit_net_win_rate": 0.4761,
+        "total_return": -0.2324,
+        "cagr": -0.0127,
+        "max_drawdown": -0.4002,
+    },
+    30: {
+        "locked_combo": "吞没+F3+F5",
+        "train_net_win_rate": 0.5769,
+        "validation_net_win_rate": 0.6135,
+        "audit_net_win_rate": 0.5717,
+        "total_return": 1.5508,
+        "cagr": 0.0462,
+        "max_drawdown": -0.4703,
+    },
+    60: {
+        "locked_combo": "同时2个触发+F1+F2+F3",
+        "train_net_win_rate": 0.6100,
+        "validation_net_win_rate": 0.5995,
+        "audit_net_win_rate": 0.6113,
+        "total_return": 2.0773,
+        "cagr": 0.0557,
+        "max_drawdown": -0.6074,
+    },
+    90: {
+        "locked_combo": "Pin Bar+F1+F4+F6",
+        "train_net_win_rate": 0.6501,
+        "validation_net_win_rate": 0.6141,
+        "audit_net_win_rate": 0.7907,
+        "total_return": 2.1358,
+        "cagr": 0.0566,
+        "max_drawdown": -0.5179,
+    },
+}
+
+
+class PortfolioContractError(RuntimeError):
+    """Raised when an immutable input or portfolio contract is invalid."""
+
+
+@dataclass(frozen=True)
+class LockedSelection:
+    selection_id: str
+    horizon: int
+    model_codes: tuple[str, ...]
+    trigger_kind: str
+    trigger_value: int | None
+    trigger_name: str
+    trigger_id: str
+    filter_mask: int
+    filter_names: tuple[str, ...]
+    development_score: float | None
+    train_metrics: Mapping[str, Any]
+    validation_metrics: Mapping[str, Any]
+
+    def as_row(self) -> dict[str, Any]:
+        return {
+            "selection_id": self.selection_id,
+            "horizon_trading_days": self.horizon,
+            "model_code": ",".join(self.model_codes),
+            "trigger_id": self.trigger_id,
+            "trigger_kind": self.trigger_kind,
+            "trigger_value": self.trigger_value,
+            "trigger_name": self.trigger_name,
+            "filter_mask": self.filter_mask,
+            "filter_names": ",".join(self.filter_names),
+            "development_score": self.development_score,
+            "train_n": _metric(self.train_metrics, "sample_count", "n"),
+            "train_net_win_rate": _metric(
+                self.train_metrics, "net_win_rate", "win_rate"
+            ),
+            "train_mean_net_return": _metric(
+                self.train_metrics, "mean_net_return", "net_mean_return"
+            ),
+            "validation_n": _metric(self.validation_metrics, "sample_count", "n"),
+            "validation_net_win_rate": _metric(
+                self.validation_metrics, "net_win_rate", "win_rate"
+            ),
+            "validation_mean_net_return": _metric(
+                self.validation_metrics, "mean_net_return", "net_mean_return"
+            ),
+        }
+
+
+@dataclass
+class SimulationResult:
+    summary: dict[str, Any]
+    equity: pd.DataFrame
+    trades: pd.DataFrame
+    decisions: pd.DataFrame
+
+
+def _metric(value: Mapping[str, Any], *names: str) -> Any:
+    for name in names:
+        if name in value:
+            return value[name]
+    return None
+
+
+def _canonical_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+    ).encode("utf-8")
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, (pd.Timestamp, np.datetime64)):
+        return pd.Timestamp(value).isoformat()
+    if isinstance(value, np.generic):
+        return value.item()
+    if value is pd.NA:
+        return None
+    raise TypeError(f"{type(value).__name__} is not JSON serializable")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _atomic_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+        default=_json_default,
+    )
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as stream:
+        stream.write(payload)
+        temporary = Path(stream.name)
+    os.replace(temporary, path)
+
+
+def _atomic_parquet(frame: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as stream:
+        temporary = Path(stream.name)
+    try:
+        frame.to_parquet(temporary, index=False)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_csv(frame: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8-sig",
+        newline="",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as stream:
+        temporary = Path(stream.name)
+    try:
+        frame.to_csv(temporary, index=False, encoding="utf-8-sig")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _as_shanghai(values: Iterable[object]) -> pd.DatetimeIndex:
+    result = pd.DatetimeIndex(pd.to_datetime(values, errors="coerce", utc=True))
+    return result.tz_convert(SHANGHAI_TIMEZONE)
+
+
+def _normalise_model_codes(value: object) -> tuple[str, ...]:
+    if isinstance(value, str):
+        items = [item.strip() for item in value.split(",") if item.strip()]
+    elif isinstance(value, Sequence):
+        items = [str(item).strip() for item in value if str(item).strip()]
+    else:
+        items = []
+    if not items:
+        raise PortfolioContractError("locked selection has no model_code")
+    for item in items:
+        if item not in {"ALL", "*", "UNION"} and not (
+            len(item) == 5 and item.startswith("S") and item[1:].isdigit()
+        ):
+            raise PortfolioContractError(f"invalid locked model_code: {item}")
+    return tuple(items)
+
+
+def load_locked_selections(path: Path) -> list[LockedSelection]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise PortfolioContractError(f"locked config is missing: {path}") from exc
+    raw = payload.get("selections") if isinstance(payload, Mapping) else None
+    if not isinstance(raw, list):
+        raise PortfolioContractError("locked_config.json must contain selections[]")
+    selections: list[LockedSelection] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            raise PortfolioContractError("locked selection must be an object")
+        selector = item.get("trigger_selector")
+        if not isinstance(selector, Mapping):
+            raise PortfolioContractError("locked trigger_selector is missing")
+        kind = str(selector.get("kind", "")).upper()
+        if kind not in {"SINGLE_BIT", "EXACT_MASK", "COUNT_EQ", "COUNT_GTE", "ALL"}:
+            raise PortfolioContractError(f"unsupported trigger kind: {kind}")
+        value = selector.get("value")
+        parsed_value = None if value is None else int(value)
+        if kind == "SINGLE_BIT" and parsed_value not in TRIGGER_BITS.values():
+            raise PortfolioContractError(
+                "SINGLE_BIT value must be a native trigger bit"
+            )
+        if kind == "EXACT_MASK" and not (1 <= int(parsed_value or 0) <= 127):
+            raise PortfolioContractError("EXACT_MASK value must be 1..127")
+        if kind == "COUNT_EQ" and parsed_value != 2:
+            raise PortfolioContractError("COUNT_EQ is frozen to value=2")
+        if kind == "COUNT_GTE" and parsed_value != 3:
+            raise PortfolioContractError("COUNT_GTE is frozen to value=3")
+        if kind == "ALL" and parsed_value is not None:
+            raise PortfolioContractError("ALL trigger value must be null")
+        horizon = int(item.get("horizon_trading_days", item.get("horizon", 0)))
+        if horizon not in HORIZONS:
+            raise PortfolioContractError(f"invalid horizon: {horizon}")
+        filter_mask = int(item.get("filter_mask", -1))
+        if not 0 <= filter_mask <= 63:
+            raise PortfolioContractError(
+                f"F1-F6 filter_mask must be in 0..63, got {filter_mask}"
+            )
+        expected_names = tuple(
+            name for bit, name in enumerate(FILTER_NAMES) if filter_mask & (1 << bit)
+        )
+        supplied_names = tuple(str(value) for value in item.get("filter_names", []))
+        if supplied_names and supplied_names != expected_names:
+            raise PortfolioContractError(
+                f"selection {item.get('selection_id')} filter_names disagree with mask"
+            )
+        selection_id = str(item.get("selection_id", "")).strip()
+        if not selection_id:
+            raise PortfolioContractError("locked selection_id is missing")
+        score = item.get("development_score")
+        selections.append(
+            LockedSelection(
+                selection_id=selection_id,
+                horizon=horizon,
+                model_codes=_normalise_model_codes(
+                    item.get("model_code", item.get("model_codes"))
+                ),
+                trigger_kind=kind,
+                trigger_value=parsed_value,
+                trigger_name=str(selector.get("name", kind)),
+                trigger_id=str(item.get("trigger_id", kind)),
+                filter_mask=filter_mask,
+                filter_names=expected_names,
+                development_score=(
+                    float(score) if score is not None and pd.notna(score) else None
+                ),
+                train_metrics=dict(item.get("train_metrics") or {}),
+                validation_metrics=dict(item.get("validation_metrics") or {}),
+            )
+        )
+    horizons = [selection.horizon for selection in selections]
+    if len(selections) != 4 or sorted(horizons) != list(HORIZONS):
+        raise PortfolioContractError(
+            "F1-F6 lock must contain exactly one selection for each 5/30/60/90 horizon"
+        )
+    if len({item.selection_id for item in selections}) != len(selections):
+        raise PortfolioContractError("locked selection_id values are not unique")
+    return sorted(selections, key=lambda item: item.horizon)
+
+
+def _trigger_mask(frame: pd.DataFrame, selection: LockedSelection) -> pd.Series:
+    masks = (
+        pd.to_numeric(frame["concurrent_trigger_mask"], errors="coerce")
+        .fillna(0)
+        .astype("int64")
+    )
+    counts = (
+        pd.to_numeric(frame["concurrent_trigger_count"], errors="coerce")
+        .fillna(masks.map(int.bit_count))
+        .astype("int64")
+    )
+    if selection.trigger_kind == "SINGLE_BIT":
+        return masks.map(
+            lambda value: bool(int(value) & int(selection.trigger_value or 0))
+        )
+    if selection.trigger_kind == "EXACT_MASK":
+        return masks.eq(int(selection.trigger_value or 0))
+    if selection.trigger_kind == "COUNT_EQ":
+        return counts.eq(int(selection.trigger_value or 0))
+    if selection.trigger_kind == "COUNT_GTE":
+        return counts.ge(int(selection.trigger_value or 0))
+    return pd.Series(True, index=frame.index)
+
+
+def _event_ids(frame: pd.DataFrame) -> pd.Series:
+    if "union_signal_id" in frame:
+        supplied = frame["union_signal_id"].astype("string")
+    elif "signal_fact_id" in frame:
+        supplied = frame["signal_fact_id"].astype("string")
+    else:
+        supplied = pd.Series(pd.NA, index=frame.index, dtype="string")
+    generated = [
+        "sha256:"
+        + hashlib.sha256(
+            _canonical_bytes(
+                {
+                    "code": str(code),
+                    "model_code": str(model),
+                    "reveal_at": pd.Timestamp(reveal).isoformat(),
+                }
+            )
+        ).hexdigest()
+        for code, model, reveal in zip(
+            frame["code"], frame["model_code"], frame["reveal_at"], strict=True
+        )
+    ]
+    return supplied.fillna(pd.Series(generated, index=frame.index)).astype(str)
+
+
+def select_locked_candidates(
+    events: pd.DataFrame,
+    selection: LockedSelection,
+    *,
+    scope: str = "AVAILABLE",
+) -> pd.DataFrame:
+    required = {
+        "code",
+        "model_code",
+        "reveal_at",
+        "entry_at",
+        "qfq_entry_open",
+        "concurrent_trigger_mask",
+        "filter_pass_mask",
+        f"h{selection.horizon}_status",
+        f"h{selection.horizon}_exit_at",
+        f"h{selection.horizon}_gross_return",
+    }
+    missing = sorted(required - set(events.columns))
+    if missing:
+        raise PortfolioContractError(f"candidate events miss columns: {missing}")
+    frame = events.copy()
+    for column in ("reveal_at", "entry_at", f"h{selection.horizon}_exit_at"):
+        frame[column] = _as_shanghai(frame[column])
+    wildcard = bool(set(selection.model_codes) & {"ALL", "*", "UNION"})
+    model_pass = (
+        pd.Series(True, index=frame.index)
+        if wildcard
+        else frame["model_code"].isin(selection.model_codes)
+    )
+    pass_masks = (
+        pd.to_numeric(frame["filter_pass_mask"], errors="coerce")
+        .fillna(0)
+        .astype("int64")
+    )
+    filters_pass = (pass_masks & selection.filter_mask).eq(selection.filter_mask)
+    executable = (
+        frame.get("entry_executable", pd.Series(True, index=frame.index))
+        .fillna(False)
+        .astype(bool)
+        & frame.get("entry_status", pd.Series("OK", index=frame.index)).eq("OK")
+        & frame[f"h{selection.horizon}_status"].eq("OK")
+    )
+    mask = model_pass & filters_pass & executable & _trigger_mask(frame, selection)
+    if scope.upper() == "AUDIT":
+        if "split_id" not in frame:
+            raise PortfolioContractError("AUDIT portfolio requires split_id")
+        mask &= frame["split_id"].eq("AUDIT")
+    elif scope.upper() != "AVAILABLE":
+        raise PortfolioContractError(f"unsupported portfolio scope: {scope}")
+    frame = frame.loc[mask].copy()
+    if frame.empty:
+        return frame
+    frame["candidate_id"] = _event_ids(frame)
+    frame["exit_at"] = frame[f"h{selection.horizon}_exit_at"]
+    frame["qfq_entry_open"] = pd.to_numeric(frame["qfq_entry_open"], errors="coerce")
+    frame["gross_return"] = pd.to_numeric(
+        frame[f"h{selection.horizon}_gross_return"], errors="coerce"
+    )
+    frame["qfq_exit_open"] = frame["qfq_entry_open"] * (1 + frame["gross_return"])
+    frame = frame[
+        frame["qfq_entry_open"].gt(0)
+        & frame["qfq_exit_open"].gt(0)
+        & frame["exit_at"].gt(frame["entry_at"])
+    ].copy()
+    quality_columns = {
+        "concurrent_trigger_count": 0,
+        "same_code_reveal_model_count": 1,
+        "same_reveal_event_count": 1,
+        "amount_median_20d": 0.0,
+        "raw_entry_gap": 0.0,
+    }
+    for column, default in quality_columns.items():
+        if column not in frame:
+            frame[column] = default
+        frame[column] = pd.to_numeric(frame[column], errors="coerce").fillna(default)
+    frame = frame.sort_values(
+        [
+            "entry_at",
+            "concurrent_trigger_count",
+            "same_code_reveal_model_count",
+            "same_reveal_event_count",
+            "amount_median_20d",
+            "raw_entry_gap",
+            "candidate_id",
+        ],
+        ascending=[True, False, False, True, False, True, True],
+        kind="stable",
+    )
+    # Union duplicate facts represent the same stock/reveal decision.
+    return frame.drop_duplicates("candidate_id", keep="first").reset_index(drop=True)
+
+
+class MarkStore:
+    """Lazy, audited QFQ 30-minute close lookup."""
+
+    def __init__(self, root: Path):
+        self.root = root
+        self._values: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        self.source_rows = 0
+
+    def load(self, codes: Iterable[str]) -> None:
+        for code in sorted({str(value) for value in codes}):
+            if code in self._values:
+                continue
+            path = self.root / "snapshot" / "bars" / f"{code}.parquet"
+            if not path.is_file():
+                raise PortfolioContractError(
+                    f"mark bars are missing for {code}: {path}"
+                )
+            frame = pd.read_parquet(path, columns=["bar_at", "qfq_close"])
+            frame["bar_at"] = _as_shanghai(frame["bar_at"])
+            frame["qfq_close"] = pd.to_numeric(frame["qfq_close"], errors="coerce")
+            frame = (
+                frame.dropna(subset=["bar_at", "qfq_close"])
+                .loc[lambda value: value["qfq_close"].gt(0)]
+                .sort_values("bar_at", kind="stable")
+                .drop_duplicates("bar_at", keep="last")
+            )
+            if frame.empty:
+                raise PortfolioContractError(
+                    f"mark bars have no usable rows for {code}"
+                )
+            self._values[code] = (
+                pd.DatetimeIndex(frame["bar_at"]).asi8,
+                frame["qfq_close"].to_numpy(dtype=float),
+            )
+            self.source_rows += len(frame)
+
+    def close(self, code: str, timestamp: pd.Timestamp, fallback: float) -> float:
+        times, closes = self._values[code]
+        offset = int(np.searchsorted(times, timestamp.value, side="right") - 1)
+        return float(closes[offset]) if offset >= 0 else float(fallback)
+
+    def all_timestamps(self, codes: Iterable[str]) -> pd.DatetimeIndex:
+        arrays = [self._values[str(code)][0] for code in sorted(set(codes))]
+        if not arrays:
+            return pd.DatetimeIndex([], tz=SHANGHAI_TIMEZONE)
+        values = np.unique(np.concatenate(arrays))
+        return pd.DatetimeIndex(values, tz="UTC").tz_convert(SHANGHAI_TIMEZONE)
+
+
+def build_simulation_clock(
+    root: Path,
+    selected_frames: Sequence[pd.DataFrame],
+    marks: MarkStore,
+) -> pd.DatetimeIndex:
+    nonempty = [frame for frame in selected_frames if not frame.empty]
+    if not nonempty:
+        raise PortfolioContractError(
+            "all locked selections have zero portfolio candidates"
+        )
+    first = min(frame["entry_at"].min() for frame in nonempty)
+    last = max(frame["exit_at"].max() for frame in nonempty)
+    index_path = root / "snapshot" / "index_day.parquet"
+    if index_path.is_file():
+        sessions = pd.to_datetime(
+            pd.read_parquet(index_path, columns=["date"])["date"],
+            errors="coerce",
+        ).dropna()
+        dates = sorted(
+            {
+                value.date()
+                for value in sessions
+                if first.date() <= value.date() <= last.date()
+            }
+        )
+        regular = pd.DatetimeIndex(
+            [
+                pd.Timestamp(f"{session.isoformat()} {clock}", tz=SHANGHAI_TIMEZONE)
+                for session in dates
+                for clock in BAR_CLOCKS
+            ]
+        )
+    else:
+        codes = {
+            str(code)
+            for frame in nonempty
+            for code in frame["code"].astype(str).unique()
+        }
+        regular = marks.all_timestamps(codes)
+        regular = regular[(regular >= first) & (regular <= last)]
+    actions = pd.DatetimeIndex(
+        [
+            value
+            for frame in nonempty
+            for column in ("entry_at", "exit_at")
+            for value in frame[column]
+        ]
+    )
+    clock = regular.union(actions).sort_values().unique()
+    clock = clock[(clock >= first) & (clock <= last)]
+    if clock.empty:
+        raise PortfolioContractError("simulation clock is empty")
+    return clock
+
+
+def _stable_order(frame: pd.DataFrame, policy: str, seed: int | None) -> pd.DataFrame:
+    if len(frame) <= 1:
+        return frame
+    if policy == "quality":
+        return frame.sort_values(
+            [
+                "concurrent_trigger_count",
+                "same_code_reveal_model_count",
+                "same_reveal_event_count",
+                "amount_median_20d",
+                "raw_entry_gap",
+                "candidate_id",
+            ],
+            ascending=[False, False, True, False, True, True],
+            kind="stable",
+        )
+    if policy != "sha_random" or seed is None:
+        raise PortfolioContractError(f"invalid ranking policy: {policy}")
+    ordered = frame.copy()
+    ordered["_order_hash"] = [
+        hashlib.sha256(f"{seed:03d}|{value}".encode()).hexdigest()
+        for value in ordered["candidate_id"]
+    ]
+    return ordered.sort_values(["_order_hash", "candidate_id"], kind="stable").drop(
+        columns="_order_hash"
+    )
+
+
+def _max_consecutive_losses(returns: Sequence[float]) -> int:
+    longest = current = 0
+    for value in returns:
+        if value < 0:
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def _underwater_stats(timestamps: pd.Series, drawdowns: pd.Series) -> tuple[int, float]:
+    start: pd.Timestamp | None = None
+    longest_bars = 0
+    current_bars = 0
+    longest_days = 0.0
+    for timestamp, value in zip(timestamps, drawdowns, strict=True):
+        if float(value) < -1e-14:
+            if start is None:
+                start = pd.Timestamp(timestamp)
+                current_bars = 0
+            current_bars += 1
+            longest_bars = max(longest_bars, current_bars)
+            longest_days = max(
+                longest_days,
+                (pd.Timestamp(timestamp) - start).total_seconds() / 86_400,
+            )
+        else:
+            start = None
+            current_bars = 0
+    return longest_bars, longest_days
+
+
+def simulate_portfolio(
+    candidates: pd.DataFrame,
+    *,
+    selection: LockedSelection,
+    scope: str,
+    clock: pd.DatetimeIndex,
+    marks: MarkStore,
+    daily_entry_limit: int | None,
+    ranking_policy: str,
+    random_seed: int | None = None,
+) -> SimulationResult:
+    entries = {
+        int(pd.Timestamp(timestamp).value): group
+        for timestamp, group in candidates.groupby("entry_at", sort=False)
+    }
+    cash = INITIAL_CAPITAL
+    positions: dict[str, dict[str, Any]] = {}
+    opened_by_day: dict[object, int] = {}
+    total_fees = 0.0
+    buy_notional = 0.0
+    sell_notional = 0.0
+    peak_positions = 0
+    decisions: list[dict[str, Any]] = []
+    trades: list[dict[str, Any]] = []
+    curve: list[dict[str, Any]] = []
+    rejected = {
+        "occupied": 0,
+        "daily_limit": 0,
+        "slots": 0,
+        "cash": 0,
+    }
+
+    def reject(row: Mapping[str, Any], timestamp: pd.Timestamp, reason: str) -> None:
+        rejected[reason] += 1
+        decisions.append(
+            {
+                "selection_id": selection.selection_id,
+                "horizon_trading_days": selection.horizon,
+                "scope": scope,
+                "daily_entry_limit": _limit_label(daily_entry_limit),
+                "ranking_policy": ranking_policy,
+                "random_seed": random_seed,
+                "candidate_id": row["candidate_id"],
+                "code": row["code"],
+                "entry_at": timestamp,
+                "decision": f"REJECT_{reason.upper()}",
+            }
+        )
+
+    for timestamp in clock:
+        timestamp = pd.Timestamp(timestamp)
+        # Contract: every due exit is booked before any entry at the same bar.
+        due = sorted(
+            [
+                (code, position)
+                for code, position in positions.items()
+                if position["exit_at"] <= timestamp
+            ],
+            key=lambda value: (value[1]["exit_at"], value[0]),
+        )
+        for code, position in due:
+            exit_notional = position["units"] * position["exit_price"]
+            exit_fee = exit_notional * FEE_PER_SIDE
+            cash += exit_notional - exit_fee
+            total_fees += exit_fee
+            sell_notional += exit_notional
+            net_pnl = exit_notional - exit_fee - position["entry_cost"]
+            net_return = (exit_notional - exit_fee) / position["entry_cost"] - 1
+            trades.append(
+                {
+                    "selection_id": selection.selection_id,
+                    "horizon_trading_days": selection.horizon,
+                    "scope": scope,
+                    "daily_entry_limit": _limit_label(daily_entry_limit),
+                    "ranking_policy": ranking_policy,
+                    "random_seed": random_seed,
+                    "candidate_id": position["candidate_id"],
+                    "code": code,
+                    "entry_at": position["entry_at"],
+                    "exit_at": timestamp,
+                    "entry_price": position["entry_price"],
+                    "exit_price": position["exit_price"],
+                    "units": position["units"],
+                    "entry_notional": position["entry_notional"],
+                    "exit_notional": exit_notional,
+                    "entry_fee": position["entry_fee"],
+                    "exit_fee": exit_fee,
+                    "total_fee": position["entry_fee"] + exit_fee,
+                    "net_pnl": net_pnl,
+                    "net_return": net_return,
+                    "entry_market_regime": position["market_regime"],
+                }
+            )
+            positions.pop(code)
+
+        incoming = entries.get(timestamp.value)
+        if incoming is not None:
+            ordered = _stable_order(incoming, ranking_policy, random_seed)
+            day = timestamp.date()
+            for row in ordered.to_dict(orient="records"):
+                code = str(row["code"])
+                if code in positions:
+                    reject(row, timestamp, "occupied")
+                    continue
+                if (
+                    daily_entry_limit is not None
+                    and opened_by_day.get(day, 0) >= daily_entry_limit
+                ):
+                    reject(row, timestamp, "daily_limit")
+                    continue
+                if len(positions) >= MAX_POSITIONS:
+                    reject(row, timestamp, "slots")
+                    continue
+                capital_budget = min(SLOT_CAPITAL, cash)
+                if capital_budget <= 0:
+                    reject(row, timestamp, "cash")
+                    continue
+                entry_notional = capital_budget / (1 + FEE_PER_SIDE)
+                entry_fee = capital_budget - entry_notional
+                units = entry_notional / float(row["qfq_entry_open"])
+                cash -= capital_budget
+                total_fees += entry_fee
+                buy_notional += entry_notional
+                positions[code] = {
+                    "candidate_id": row["candidate_id"],
+                    "entry_at": timestamp,
+                    "exit_at": pd.Timestamp(row["exit_at"]),
+                    "entry_price": float(row["qfq_entry_open"]),
+                    "exit_price": float(row["qfq_exit_open"]),
+                    "units": units,
+                    "entry_notional": entry_notional,
+                    "entry_fee": entry_fee,
+                    "entry_cost": capital_budget,
+                    "market_regime": str(row.get("market_regime", "UNKNOWN")),
+                }
+                opened_by_day[day] = opened_by_day.get(day, 0) + 1
+                decisions.append(
+                    {
+                        "selection_id": selection.selection_id,
+                        "horizon_trading_days": selection.horizon,
+                        "scope": scope,
+                        "daily_entry_limit": _limit_label(daily_entry_limit),
+                        "ranking_policy": ranking_policy,
+                        "random_seed": random_seed,
+                        "candidate_id": row["candidate_id"],
+                        "code": code,
+                        "entry_at": timestamp,
+                        "decision": "ACCEPT",
+                    }
+                )
+        invested = 0.0
+        for code, position in positions.items():
+            invested += position["units"] * marks.close(
+                code, timestamp, position["entry_price"]
+            )
+        equity = cash + invested
+        if cash < -0.01 or len(positions) > MAX_POSITIONS or equity <= 0:
+            raise PortfolioContractError(
+                f"portfolio invariant failed at {timestamp}: "
+                f"cash={cash}, positions={len(positions)}, equity={equity}"
+            )
+        peak_positions = max(peak_positions, len(positions))
+        curve.append(
+            {
+                "selection_id": selection.selection_id,
+                "horizon_trading_days": selection.horizon,
+                "scope": scope,
+                "daily_entry_limit": _limit_label(daily_entry_limit),
+                "ranking_policy": ranking_policy,
+                "random_seed": random_seed,
+                "bar_at": timestamp,
+                "cash": cash,
+                "invested_value": invested,
+                "equity": equity,
+                "positions": len(positions),
+                "capital_utilization": invested / equity,
+            }
+        )
+    if positions:
+        raise PortfolioContractError(
+            f"{len(positions)} positions remain after the last mature exit"
+        )
+    equity_frame = pd.DataFrame(curve)
+    equity_frame["normalized_equity"] = equity_frame["equity"] / INITIAL_CAPITAL
+    equity_frame["drawdown"] = (
+        equity_frame["equity"] / equity_frame["equity"].cummax() - 1
+    )
+    trade_frame = pd.DataFrame(trades)
+    decision_frame = pd.DataFrame(decisions)
+    trade_returns = (
+        trade_frame["net_return"].to_numpy(dtype=float)
+        if not trade_frame.empty
+        else np.asarray([], dtype=float)
+    )
+    pnl = (
+        trade_frame["net_pnl"].to_numpy(dtype=float)
+        if not trade_frame.empty
+        else np.asarray([], dtype=float)
+    )
+    winners = trade_returns[trade_returns > 0]
+    losers = trade_returns[trade_returns < 0]
+    longest_bars, longest_days = _underwater_stats(
+        equity_frame["bar_at"], equity_frame["drawdown"]
+    )
+    elapsed_years = max(
+        (
+            equity_frame["bar_at"].iloc[-1] - equity_frame["bar_at"].iloc[0]
+        ).total_seconds()
+        / (365.25 * 86_400),
+        1 / 365.25,
+    )
+    final_equity = float(equity_frame["equity"].iloc[-1])
+    accepted = len(trade_frame)
+    average_equity = float(equity_frame["equity"].mean())
+    summary = {
+        "selection_id": selection.selection_id,
+        "horizon_trading_days": selection.horizon,
+        "scope": scope,
+        "daily_entry_limit": _limit_label(daily_entry_limit),
+        "ranking_policy": ranking_policy,
+        "random_seed": random_seed,
+        "order_sha256": (
+            "sha256:"
+            + hashlib.sha256(
+                f"{selection.selection_id}|{ranking_policy}|{random_seed}".encode()
+            ).hexdigest()
+        ),
+        "initial_capital": INITIAL_CAPITAL,
+        "final_equity": final_equity,
+        "total_return": final_equity / INITIAL_CAPITAL - 1,
+        "cagr": (final_equity / INITIAL_CAPITAL) ** (1 / elapsed_years) - 1,
+        "max_drawdown": float(equity_frame["drawdown"].min()),
+        "longest_underwater_bars": longest_bars,
+        "longest_underwater_days": longest_days,
+        "candidate_signals": len(candidates),
+        "closed_trades": accepted,
+        "candidate_acceptance_rate": (
+            accepted / len(candidates) if len(candidates) else None
+        ),
+        "closed_win_rate": (
+            float(np.mean(trade_returns > 0)) if len(trade_returns) else None
+        ),
+        "mean_trade_return": (
+            float(trade_returns.mean()) if len(trade_returns) else None
+        ),
+        "median_trade_return": (
+            float(np.median(trade_returns)) if len(trade_returns) else None
+        ),
+        "average_win": float(winners.mean()) if len(winners) else None,
+        "average_loss_abs": float(abs(losers.mean())) if len(losers) else None,
+        "payoff_ratio": (
+            float(winners.mean() / abs(losers.mean()))
+            if len(winners) and len(losers)
+            else None
+        ),
+        "profit_factor": (
+            float(pnl[pnl > 0].sum() / abs(pnl[pnl < 0].sum()))
+            if np.any(pnl > 0) and np.any(pnl < 0)
+            else None
+        ),
+        "max_consecutive_losses": _max_consecutive_losses(trade_returns),
+        "total_fees": total_fees,
+        "buy_notional": buy_notional,
+        "sell_notional": sell_notional,
+        "one_way_turnover": (
+            (buy_notional + sell_notional) / (2 * average_equity)
+            if average_equity > 0
+            else None
+        ),
+        "two_way_turnover": (
+            (buy_notional + sell_notional) / average_equity
+            if average_equity > 0
+            else None
+        ),
+        "average_positions": float(equity_frame["positions"].mean()),
+        "peak_positions": peak_positions,
+        "average_capital_utilization": float(
+            equity_frame["capital_utilization"].mean()
+        ),
+        "peak_capital_utilization": float(equity_frame["capital_utilization"].max()),
+        "rejected_occupied": rejected["occupied"],
+        "rejected_daily_limit": rejected["daily_limit"],
+        "rejected_slots": rejected["slots"],
+        "rejected_cash": rejected["cash"],
+        "start_at": equity_frame["bar_at"].iloc[0],
+        "end_at": equity_frame["bar_at"].iloc[-1],
+    }
+    return SimulationResult(summary, equity_frame, trade_frame, decision_frame)
+
+
+def _limit_label(value: int | None) -> str:
+    return "UNLIMITED" if value is None else str(value)
+
+
+def _regime_for_dates(dates: pd.Series, segments: pd.DataFrame) -> pd.Series:
+    output = pd.Series("UNKNOWN", index=dates.index, dtype="string")
+    if segments.empty:
+        return output
+    parsed = segments.copy()
+    parsed["start_date"] = pd.to_datetime(parsed["start_date"]).dt.date
+    parsed["end_date"] = pd.to_datetime(parsed["end_date"]).dt.date
+    day_values = pd.to_datetime(dates).dt.date
+    for row in parsed.itertuples(index=False):
+        in_segment = day_values.ge(row.start_date) & day_values.le(row.end_date)
+        output.loc[in_segment] = str(row.regime)
+    return output
+
+
+def build_period_metrics(
+    equity: pd.DataFrame,
+    trades: pd.DataFrame,
+    segments: pd.DataFrame,
+) -> pd.DataFrame:
+    if equity.empty:
+        return pd.DataFrame()
+    frame = equity.sort_values("bar_at", kind="stable").copy()
+    frame["year"] = frame["bar_at"].dt.year.astype(str)
+    frame["quarter"] = (
+        frame["bar_at"].dt.tz_localize(None).dt.to_period("Q").astype(str)
+    )
+    frame["regime"] = _regime_for_dates(frame["bar_at"], segments)
+    frame["bar_return"] = (
+        frame["equity"]
+        .pct_change(fill_method=None)
+        .fillna(frame["equity"].iloc[0] / INITIAL_CAPITAL - 1)
+    )
+    trade_frame = trades.copy()
+    if not trade_frame.empty:
+        trade_frame["year"] = trade_frame["entry_at"].dt.year.astype(str)
+        trade_frame["quarter"] = (
+            trade_frame["entry_at"].dt.tz_localize(None).dt.to_period("Q").astype(str)
+        )
+        trade_frame["regime"] = trade_frame["entry_market_regime"].fillna("UNKNOWN")
+    keys = [
+        "selection_id",
+        "horizon_trading_days",
+        "scope",
+        "daily_entry_limit",
+        "ranking_policy",
+    ]
+    identity = {key: frame[key].iloc[0] for key in keys}
+    rows: list[dict[str, Any]] = []
+    for period_type, column in (
+        ("YEAR", "year"),
+        ("QUARTER", "quarter"),
+        ("REGIME", "regime"),
+    ):
+        for period_id, group in frame.groupby(column, sort=True):
+            period_trades = (
+                trade_frame[trade_frame[column].eq(period_id)]
+                if not trade_frame.empty
+                else trade_frame
+            )
+            returns = (
+                period_trades["net_return"].to_numpy(dtype=float)
+                if not period_trades.empty
+                else np.asarray([], dtype=float)
+            )
+            rows.append(
+                {
+                    **identity,
+                    "period_type": period_type,
+                    "period_id": str(period_id),
+                    "start_at": group["bar_at"].min(),
+                    "end_at": group["bar_at"].max(),
+                    "start_equity": float(group["equity"].iloc[0]),
+                    "end_equity": float(group["equity"].iloc[-1]),
+                    "normalized_end_equity": float(
+                        group["equity"].iloc[-1] / INITIAL_CAPITAL
+                    ),
+                    "portfolio_return": float(
+                        np.prod(1 + group["bar_return"].to_numpy(dtype=float)) - 1
+                    ),
+                    "max_drawdown_within_period": float(
+                        (group["equity"] / group["equity"].cummax() - 1).min()
+                    ),
+                    "closed_trades": len(period_trades),
+                    "closed_win_rate": (
+                        float(np.mean(returns > 0)) if len(returns) else None
+                    ),
+                    "mean_trade_return": (
+                        float(np.mean(returns)) if len(returns) else None
+                    ),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def summarise_random_runs(frame: pd.DataFrame) -> pd.DataFrame:
+    if frame.empty:
+        return frame
+    metrics = (
+        "total_return",
+        "cagr",
+        "max_drawdown",
+        "closed_win_rate",
+        "profit_factor",
+        "total_fees",
+        "average_capital_utilization",
+        "candidate_acceptance_rate",
+    )
+    keys = [
+        "selection_id",
+        "horizon_trading_days",
+        "scope",
+        "daily_entry_limit",
+    ]
+    rows: list[dict[str, Any]] = []
+    for identity, group in frame.groupby(keys, dropna=False, sort=True):
+        row = dict(zip(keys, identity, strict=True))
+        row["random_runs"] = len(group)
+        for metric in metrics:
+            values = pd.to_numeric(group[metric], errors="coerce").dropna()
+            for label, quantile in (("p05", 0.05), ("p50", 0.50), ("p95", 0.95)):
+                row[f"{metric}_{label}"] = (
+                    float(values.quantile(quantile)) if len(values) else None
+                )
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def build_daily_baseline_comparison(summary: pd.DataFrame) -> pd.DataFrame:
+    selected = summary[
+        summary["scope"].eq("AVAILABLE")
+        & summary["daily_entry_limit"].eq("5")
+        & summary["ranking_policy"].eq("quality")
+    ].copy()
+    rows: list[dict[str, Any]] = []
+    for row in selected.itertuples(index=False):
+        baseline = DAILY_BASELINES[int(row.horizon_trading_days)]
+        rows.append(
+            {
+                "horizon_trading_days": row.horizon_trading_days,
+                "selection_id_30m": row.selection_id,
+                "daily_locked_combo": baseline["locked_combo"],
+                "portfolio_total_return_30m": row.total_return,
+                "portfolio_total_return_daily": baseline["total_return"],
+                "total_return_delta_30m_minus_daily": (
+                    row.total_return - baseline["total_return"]
+                ),
+                "portfolio_cagr_30m": row.cagr,
+                "portfolio_cagr_daily": baseline["cagr"],
+                "cagr_delta_30m_minus_daily": row.cagr - baseline["cagr"],
+                "portfolio_mdd_30m": row.max_drawdown,
+                "portfolio_mdd_daily": baseline["max_drawdown"],
+                "mdd_delta_30m_minus_daily": row.max_drawdown
+                - baseline["max_drawdown"],
+                "daily_train_net_win_rate": baseline["train_net_win_rate"],
+                "daily_validation_net_win_rate": baseline["validation_net_win_rate"],
+                "daily_audit_net_win_rate": baseline["audit_net_win_rate"],
+                "period_comparability": "DIFFERENT_SAMPLE_WINDOWS_REVIEW_REQUIRED",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _daily_curves(equity: pd.DataFrame) -> pd.DataFrame:
+    if equity.empty:
+        return equity
+    frame = equity.copy()
+    frame["trade_date"] = frame["bar_at"].dt.date
+    keys = [
+        "selection_id",
+        "horizon_trading_days",
+        "scope",
+        "daily_entry_limit",
+        "ranking_policy",
+        "trade_date",
+    ]
+    return (
+        frame.sort_values("bar_at", kind="stable")
+        .groupby(keys, as_index=False, dropna=False)
+        .tail(1)
+        .reset_index(drop=True)
+    )
+
+
+def _write_excel(
+    path: Path,
+    *,
+    summary: pd.DataFrame,
+    random_summary: pd.DataFrame,
+    period_metrics: pd.DataFrame,
+    daily_curves: pd.DataFrame,
+    locked: pd.DataFrame,
+    baseline: pd.DataFrame,
+    reveal: pd.DataFrame,
+) -> None:
+    def excel_safe(frame: pd.DataFrame) -> pd.DataFrame:
+        value = frame.copy()
+        for column in value.columns:
+            if isinstance(value[column].dtype, pd.DatetimeTZDtype):
+                value[column] = value[column].dt.tz_localize(None)
+        return value
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.stem}.tmp{path.suffix}")
+    with pd.ExcelWriter(temporary, engine="openpyxl") as writer:
+        excel_safe(summary).to_excel(writer, sheet_name="Portfolio", index=False)
+        excel_safe(random_summary).to_excel(
+            writer, sheet_name="RandomSensitivity", index=False
+        )
+        excel_safe(period_metrics).to_excel(
+            writer, sheet_name="AnnualQuarterRegime", index=False
+        )
+        excel_safe(daily_curves).to_excel(
+            writer, sheet_name="NormalizedCurves", index=False
+        )
+        excel_safe(locked).to_excel(writer, sheet_name="LockedConfigs", index=False)
+        excel_safe(baseline).to_excel(writer, sheet_name="DailyBaseline", index=False)
+        if not reveal.empty:
+            excel_safe(reveal.iloc[:1_048_575]).to_excel(
+                writer, sheet_name="AuditReveal", index=False
+            )
+        disclosure = pd.DataFrame(
+            {
+                "item": [
+                    "signal",
+                    "entry",
+                    "exit",
+                    "fee",
+                    "mark",
+                    "not_modelled",
+                ],
+                "contract": [
+                    "30分钟K线收盘揭示；只用当时及以前数据",
+                    "下一根实际存在的30分钟K线开盘",
+                    "第5/30/60/90个股票交易日同槽位，缺K线按候选事实的下一可交易K线",
+                    "买入、卖出各0.02%",
+                    "30分钟前复权收盘，缺当前K线时沿用此前最近收盘",
+                    "滑点、印花税、最低佣金、100股取整",
+                ],
+            }
+        )
+        disclosure.to_excel(writer, sheet_name="Contract", index=False)
+        for worksheet in writer.book.worksheets:
+            worksheet.freeze_panes = "A2"
+            worksheet.auto_filter.ref = worksheet.dimensions
+    os.replace(temporary, path)
+
+
+def _fmt_pct(value: Any) -> str:
+    if value is None or pd.isna(value):
+        return "NA"
+    return f"{float(value):.2%}"
+
+
+def build_markdown_report(
+    *,
+    root: Path,
+    summary: pd.DataFrame,
+    random_summary: pd.DataFrame,
+    period_metrics: pd.DataFrame,
+    locked: pd.DataFrame,
+    baseline: pd.DataFrame,
+    feature_summary: Mapping[str, Any],
+    reveal_summary: pd.DataFrame,
+) -> str:
+    dates = summary[["start_at", "end_at"]].copy()
+    minimum = pd.to_datetime(dates["start_at"]).min()
+    maximum = pd.to_datetime(dates["end_at"]).max()
+    short_sample = minimum.year >= 2024
+    grade = "SHORT_SAMPLE（短样本）" if short_sample else "FULL_HISTORY"
+    lines = [
+        "# CLX18 30分钟锁定组合真实资金回测",
+        "",
+        "## 一、数据事实",
+        "",
+        f"- 证据等级：**{grade}**。",
+        f"- 资金曲线区间：`{minimum.isoformat()}` 至 `{maximum.isoformat()}`。",
+        (
+            f"- 候选事件数：`{feature_summary.get('candidate_event_rows', 'NA')}`；"
+            f"Union去重信号数：`{feature_summary.get('unique_union_signals', 'NA')}`。"
+        ),
+        f"- AUDIT揭示摘要：`{'已读取' if not reveal_summary.empty else '本次报告未找到揭示产物'}`。",
+        "- 30分钟数据由本地 MongoDB 冻结为不可变 snapshot；报告阶段不修改源数据。",
+        "",
+        "## 二、冻结研究假设与资金合同",
+        "",
+        "- 模型冠军只由 TRAIN+VALIDATION 锁定；资金模拟直接使用 `matrix/locked_config.json`，不按 AUDIT 或资金结果重选。",
+        "- 过滤空间为 **F1-F6 共64个子集**，`filter_mask` 范围 `0..63`。",
+        "- 初始资金500万元；40槽；每槽最多12.5万元（含买入费的资本预算）。",
+        "- 同一时点先退出后入场；同股持有期间不加仓；每日新开上限分别为1/3/5/10/20/不限。",
+        "- 同一可交易时点内才做质量排序；不跨未来时点重排。100组敏感性用 `SHA256(seed|candidate_id)` 确定排序。",
+        "- 买卖各收0.02%；30分钟前复权收盘盯市，停牌时沿用此前最近可得前复权收盘。",
+        "- 未计：**滑点、印花税、最低佣金、100股取整**。",
+        "",
+        "## 三、样本内锁定配置",
+        "",
+        "|期限|模型|触发|过滤|TRAIN n/胜率|VALIDATION n/胜率|",
+        "|---:|---|---|---|---:|---:|",
+    ]
+    for row in locked.itertuples(index=False):
+        lines.append(
+            f"|{row.horizon_trading_days}|{row.model_code}|{row.trigger_name}|"
+            f"{row.filter_names or '零过滤'}|"
+            f"{row.train_n}/{_fmt_pct(row.train_net_win_rate)}|"
+            f"{row.validation_n}/{_fmt_pct(row.validation_net_win_rate)}|"
+        )
+    lines.extend(
+        [
+            "",
+            "## 四、样本外 AUDIT 一次性揭示",
+            "",
+            "|期限|n|净胜率|95% CI|平均净收益|中位净收益|PF|相对上证平均超额|提示|",
+            "|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    audit = (
+        reveal_summary[reveal_summary["scope"].eq("AUDIT")]
+        .sort_values("horizon_trading_days")
+        .copy()
+        if not reveal_summary.empty and "scope" in reveal_summary
+        else pd.DataFrame()
+    )
+    if audit.empty:
+        lines.append("|—|—|—|—|—|—|—|—|揭示摘要尚未产出|")
+    else:
+        for row in audit.itertuples(index=False):
+            warning = (
+                "小样本；多重比较"
+                if bool(getattr(row, "small_sample_warning", False))
+                else "多重比较"
+            )
+            lines.append(
+                f"|{row.horizon_trading_days}|{row.sample_count}|"
+                f"{_fmt_pct(row.net_win_rate)}|"
+                f"[{_fmt_pct(row.net_win_rate_ci_low)},"
+                f"{_fmt_pct(row.net_win_rate_ci_high)}]|"
+                f"{_fmt_pct(row.mean_net_return)}|"
+                f"{_fmt_pct(row.median_net_return)}|"
+                f"{'NA' if pd.isna(row.profit_factor) else f'{row.profit_factor:.2f}'}|"
+                f"{_fmt_pct(row.mean_net_excess_return)}|{warning}|"
+            )
+    lines.extend(
+        [
+            "",
+            "## 五、真实资金模拟（AVAILABLE、质量排序、每日上限5）",
+            "",
+            "|期限|总收益|CAGR|最大回撤|最长水下天数|交易数|胜率|PF|费用|平均持仓|资金占用|录取率|",
+            "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    main = summary[
+        summary["scope"].eq("AVAILABLE")
+        & summary["daily_entry_limit"].eq("5")
+        & summary["ranking_policy"].eq("quality")
+    ].sort_values("horizon_trading_days")
+    for row in main.itertuples(index=False):
+        lines.append(
+            f"|{row.horizon_trading_days}|{_fmt_pct(row.total_return)}|"
+            f"{_fmt_pct(row.cagr)}|{_fmt_pct(row.max_drawdown)}|"
+            f"{row.longest_underwater_days:.1f}|{row.closed_trades}|"
+            f"{_fmt_pct(row.closed_win_rate)}|"
+            f"{'NA' if pd.isna(row.profit_factor) else f'{row.profit_factor:.2f}'}|"
+            f"¥{row.total_fees:,.0f}|{row.average_positions:.2f}|"
+            f"{_fmt_pct(row.average_capital_utilization)}|"
+            f"{_fmt_pct(row.candidate_acceptance_rate)}|"
+        )
+    lines.extend(
+        [
+            "",
+            "完整的每日容量限制、年度/季度/行情阶段、30分钟净值与回撤、100组SHA随机排序分位数见同目录 CSV/Parquet 和 Excel。",
+            "",
+            "## 六、与日线基准直接对照（每日上限5）",
+            "",
+            "|期限|30分钟总收益|日线总收益|30分钟CAGR|日线CAGR|30分钟MDD|日线MDD|",
+            "|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for row in baseline.sort_values("horizon_trading_days").itertuples(index=False):
+        lines.append(
+            f"|{row.horizon_trading_days}|{_fmt_pct(row.portfolio_total_return_30m)}|"
+            f"{_fmt_pct(row.portfolio_total_return_daily)}|"
+            f"{_fmt_pct(row.portfolio_cagr_30m)}|{_fmt_pct(row.portfolio_cagr_daily)}|"
+            f"{_fmt_pct(row.portfolio_mdd_30m)}|{_fmt_pct(row.portfolio_mdd_daily)}|"
+        )
+    selected_models = set(locked["model_code"].astype(str).str.split(",").explode())
+    preferred = [
+        code for code in ("S0006", "S0016", "S0000") if code in selected_models
+    ]
+    reentered = [code for code in ("S0008", "S0013") if code in selected_models]
+    lines.extend(
+        [
+            "",
+            "> 日线和30分钟样本区间不相同；上表是合同基准对照，不把差值解释成纯周期因果效应。",
+            "",
+            "## 七、逐项回答",
+            "",
+        ]
+    )
+    for horizon in (30, 60):
+        row = main[main["horizon_trading_days"].eq(horizon)]
+        if len(row):
+            item = row.iloc[0]
+            audit_row = audit[audit["horizon_trading_days"].eq(horizon)]
+            audit_text = (
+                f"、AUDIT净胜率 `{_fmt_pct(audit_row.iloc[0].net_win_rate)}`"
+                f"、AUDIT平均净收益 `{_fmt_pct(audit_row.iloc[0].mean_net_return)}`"
+                if len(audit_row)
+                else ""
+            )
+            lines.append(
+                f"- **{horizon}日稳定性**：资金端净收益 `{_fmt_pct(item.total_return)}`、"
+                f"MDD `{_fmt_pct(item.max_drawdown)}`{audit_text}；"
+                "跨年/季度一致性须结合 `period_metrics.csv`，"
+                "不以单一胜率下结论。"
+            )
+    five = main[main["horizon_trading_days"].eq(5)]
+    if len(five):
+        item = five.iloc[0]
+        audit_five = audit[audit["horizon_trading_days"].eq(5)]
+        audit_five_text = (
+            f"30分钟AUDIT净胜率 `{_fmt_pct(audit_five.iloc[0].net_win_rate)}`、"
+            f"平均净收益 `{_fmt_pct(audit_five.iloc[0].mean_net_return)}`；"
+            if len(audit_five)
+            else "30分钟AUDIT揭示摘要尚未产出；"
+        )
+        lines.append(
+            f"- **5日样本外表现**：日线AUDIT胜率47.61%；{audit_five_text}"
+            "30分钟资金端总收益"
+            f"`{_fmt_pct(item.total_return)}`、CAGR `{_fmt_pct(item.cagr)}`。"
+            "失效判断同时看净收益、样本量和资金回撤。"
+        )
+    lines.extend(
+        [
+            (
+                f"- **90日高胜率来源**：本轮证据等级为 `{grade}`；若数据始于2024，"
+                "则90日结论天然主要由2024年后行情贡献，不能外推到2015年以来。"
+            ),
+            (
+                f"- **模型优先级**：锁定冠军中 S0006/S0016/S0000 命中为"
+                f"`{preferred or '无'}`。"
+            ),
+            (
+                f"- **S0008/S0013重新进入**：锁定冠军中命中为 `{reentered or '无'}`；"
+                "这只表示TRAIN+VALIDATION选择结果。"
+            ),
+            (
+                "- **费用覆盖**：表内净值已逐笔扣买卖各0.02%，累计费用和换手已输出；"
+                "更高信号频率是否值得，以净CAGR、MDD和录取率共同判断。"
+            ),
+            (
+                "- **新增信息还是拆密**：用候选事件数/Union去重信号数、同股同揭示模型数、"
+                "录取率及随机排序区间共同审计；高重复且收益无改善更接近“拆得更密”。"
+            ),
+            "",
+            "## 八、产物与复现",
+            "",
+            f"- 结果目录：`{(root / 'portfolio').resolve()}`",
+            "- 复现命令见 `portfolio/reproduce_command.txt`；输入与输出SHA256见 `portfolio/manifest.json`。",
+            "- 数据事实、研究假设、样本内锁定、AUDIT揭示与资金模拟在本报告中分区呈现。",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _load_feature_summary(root: Path, events: pd.DataFrame) -> dict[str, Any]:
+    path = root / "features" / "summary.json"
+    if path.is_file():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "candidate_event_rows": len(events),
+        "unique_union_signals": (
+            int(events["union_signal_id"].nunique())
+            if "union_signal_id" in events
+            else None
+        ),
+        "unique_stocks": int(events["code"].nunique()),
+    }
+
+
+def _manifest_entry(
+    path: Path, root: Path, *, rows: int | None = None
+) -> dict[str, Any]:
+    return {
+        "logical_path": path.relative_to(root).as_posix(),
+        "rows": rows,
+        "file_size": path.stat().st_size,
+        "sha256": sha256_file(path),
+    }
+
+
+def run_portfolios(
+    *,
+    root: Path,
+    random_seeds: int = 100,
+    include_audit_scope: bool = True,
+) -> dict[str, Any]:
+    root = root.resolve()
+    if random_seeds < 0:
+        raise PortfolioContractError("random_seeds must be non-negative")
+    event_path = root / "features" / "candidate_events.parquet"
+    lock_path = root / "matrix" / "locked_config.json"
+    if not event_path.is_file():
+        raise PortfolioContractError(f"candidate events are missing: {event_path}")
+    selections = load_locked_selections(lock_path)
+    event_columns = [
+        "signal_fact_id",
+        "union_signal_id",
+        "code",
+        "model_code",
+        "reveal_at",
+        "entry_at",
+        "qfq_entry_open",
+        "entry_executable",
+        "entry_status",
+        "concurrent_trigger_mask",
+        "concurrent_trigger_count",
+        "filter_pass_mask",
+        "same_code_reveal_model_count",
+        "same_reveal_event_count",
+        "amount_median_20d",
+        "raw_entry_gap",
+        "market_regime",
+        "split_id",
+    ]
+    for horizon in HORIZONS:
+        event_columns.extend(
+            (
+                f"h{horizon}_status",
+                f"h{horizon}_exit_at",
+                f"h{horizon}_gross_return",
+            )
+        )
+    events = pd.read_parquet(event_path, columns=event_columns)
+    scopes = ["AVAILABLE"]
+    if (
+        include_audit_scope
+        and "split_id" in events
+        and events["split_id"].eq("AUDIT").any()
+    ):
+        scopes.append("AUDIT")
+    selected: dict[tuple[str, str], pd.DataFrame] = {}
+    for selection in selections:
+        for scope in scopes:
+            selected[(selection.selection_id, scope)] = select_locked_candidates(
+                events, selection, scope=scope
+            )
+    available_frames = [
+        selected[(selection.selection_id, "AVAILABLE")] for selection in selections
+    ]
+    codes = {
+        str(code)
+        for frame in available_frames
+        for code in frame.get("code", pd.Series(dtype=str)).astype(str).unique()
+    }
+    marks = MarkStore(root)
+    marks.load(codes)
+    scope_clocks = {"AVAILABLE": build_simulation_clock(root, available_frames, marks)}
+    if "AUDIT" in scopes:
+        audit_frames = [
+            selected[(selection.selection_id, "AUDIT")] for selection in selections
+        ]
+        if any(not frame.empty for frame in audit_frames):
+            scope_clocks["AUDIT"] = build_simulation_clock(root, audit_frames, marks)
+        else:
+            scope_clocks["AUDIT"] = scope_clocks["AVAILABLE"]
+    segment_path = root / "features" / "market_segments.csv"
+    segments = (
+        pd.read_csv(segment_path, encoding="utf-8-sig")
+        if segment_path.is_file()
+        else pd.DataFrame()
+    )
+    summaries: list[dict[str, Any]] = []
+    random_summaries: list[dict[str, Any]] = []
+    quality_equity: list[pd.DataFrame] = []
+    quality_trades: list[pd.DataFrame] = []
+    quality_decisions: list[pd.DataFrame] = []
+    periods: list[pd.DataFrame] = []
+    for selection in selections:
+        for scope in scopes:
+            frame = selected[(selection.selection_id, scope)]
+            for daily_limit in DAILY_ENTRY_LIMITS:
+                quality = simulate_portfolio(
+                    frame,
+                    selection=selection,
+                    scope=scope,
+                    clock=scope_clocks[scope],
+                    marks=marks,
+                    daily_entry_limit=daily_limit,
+                    ranking_policy="quality",
+                )
+                summaries.append(quality.summary)
+                quality_equity.append(quality.equity)
+                quality_trades.append(quality.trades)
+                quality_decisions.append(quality.decisions)
+                periods.append(
+                    build_period_metrics(quality.equity, quality.trades, segments)
+                )
+                # Random ordering is a capacity sensitivity on the full AVAILABLE
+                # sequence. AUDIT receives the frozen quality run but no duplicate
+                # 100-seed expansion.
+                if scope == "AVAILABLE":
+                    for seed in range(random_seeds):
+                        random = simulate_portfolio(
+                            frame,
+                            selection=selection,
+                            scope=scope,
+                            clock=scope_clocks[scope],
+                            marks=marks,
+                            daily_entry_limit=daily_limit,
+                            ranking_policy="sha_random",
+                            random_seed=seed,
+                        )
+                        random_summaries.append(random.summary)
+    summary_frame = pd.DataFrame(summaries)
+    random_frame = pd.DataFrame(random_summaries)
+    random_summary = summarise_random_runs(random_frame)
+    equity_frame = pd.concat(quality_equity, ignore_index=True)
+    trade_frame = (
+        pd.concat(quality_trades, ignore_index=True)
+        if any(not frame.empty for frame in quality_trades)
+        else pd.DataFrame()
+    )
+    decision_frame = (
+        pd.concat(quality_decisions, ignore_index=True)
+        if any(not frame.empty for frame in quality_decisions)
+        else pd.DataFrame()
+    )
+    period_frame = (
+        pd.concat(periods, ignore_index=True)
+        if any(not frame.empty for frame in periods)
+        else pd.DataFrame()
+    )
+    locked_frame = pd.DataFrame([selection.as_row() for selection in selections])
+    baseline_frame = build_daily_baseline_comparison(summary_frame)
+    daily_curve_frame = _daily_curves(equity_frame)
+    reveal_path = root / "matrix" / "reveal_matrix.parquet"
+    reveal_summary_path = root / "matrix" / "reveal_summary.csv"
+    reveal_frame = (
+        pd.read_csv(reveal_summary_path, encoding="utf-8-sig")
+        if reveal_summary_path.is_file()
+        else pd.DataFrame()
+    )
+    feature_summary = _load_feature_summary(root, events)
+
+    output = root / "portfolio"
+    output.mkdir(parents=True, exist_ok=True)
+    frames = {
+        "portfolio_summary": summary_frame,
+        "random_order_runs": random_frame,
+        "random_order_sensitivity": random_summary,
+        "period_metrics": period_frame,
+        "equity_30m": equity_frame,
+        "equity_daily": daily_curve_frame,
+        "trades": trade_frame,
+        "decisions": decision_frame,
+        "locked_selections": locked_frame,
+        "daily_baseline_comparison": baseline_frame,
+    }
+    written: list[Path] = []
+    output_rows: dict[Path, int] = {}
+    for name, frame in frames.items():
+        parquet = output / f"{name}.parquet"
+        csv = output / f"{name}.csv"
+        _atomic_parquet(frame, parquet)
+        _atomic_csv(frame, csv)
+        written.extend((parquet, csv))
+        output_rows[parquet] = len(frame)
+        output_rows[csv] = len(frame)
+    workbook = output / "clx_30m_portfolio_report.xlsx"
+    _write_excel(
+        workbook,
+        summary=summary_frame,
+        random_summary=random_summary,
+        period_metrics=period_frame,
+        daily_curves=daily_curve_frame,
+        locked=locked_frame,
+        baseline=baseline_frame,
+        reveal=reveal_frame,
+    )
+    written.append(workbook)
+    report = build_markdown_report(
+        root=root,
+        summary=summary_frame,
+        random_summary=random_summary,
+        period_metrics=period_frame,
+        locked=locked_frame,
+        baseline=baseline_frame,
+        feature_summary=feature_summary,
+        reveal_summary=reveal_frame,
+    )
+    report_path = output / "report.md"
+    report_path.write_text(report, encoding="utf-8")
+    written.append(report_path)
+    config = {
+        "study_id": STUDY_ID,
+        "contract_version": PORTFOLIO_CONTRACT_VERSION,
+        "filter_contract": "F1_F6_64_SUBSETS_ONLY",
+        "initial_capital": INITIAL_CAPITAL,
+        "max_positions": MAX_POSITIONS,
+        "slot_capital_budget": SLOT_CAPITAL,
+        "fee_per_side": FEE_PER_SIDE,
+        "daily_entry_limits": [_limit_label(value) for value in DAILY_ENTRY_LIMITS],
+        "ordering": {
+            "quality": (
+                "within identical entry_at: concurrent trigger count desc, "
+                "same-code model count desc, crowding asc, liquidity desc, "
+                "entry gap asc, candidate_id"
+            ),
+            "sensitivity": "SHA256(seed|candidate_id)",
+            "random_seed_count": random_seeds,
+        },
+        "clock": "30-minute QFQ close; carry prior close through missing bars",
+        "metric_formulas": {
+            "one_way_turnover": "(buy_notional+sell_notional)/(2*mean_equity)",
+            "two_way_turnover": "(buy_notional+sell_notional)/mean_equity",
+            "profit_factor": "sum(positive_net_pnl)/abs(sum(negative_net_pnl))",
+            "capital_utilization": "marked_position_value/equity",
+        },
+        "filter_descriptions": FILTER_DESCRIPTIONS,
+        "omitted_costs": [
+            "slippage",
+            "stamp_duty",
+            "minimum_commission",
+            "100_share_rounding",
+        ],
+        "scopes": scopes,
+        "candidate_events_sha256": sha256_file(event_path),
+        "locked_config_sha256": sha256_file(lock_path),
+    }
+    config_path = output / "portfolio_config.json"
+    _atomic_json(config_path, config)
+    written.append(config_path)
+    command = (
+        f'& "<PYTHON>" "{Path(__file__).resolve()}" --root "{root}" '
+        f"run --random-seeds {random_seeds}"
+    )
+    reproduce = output / "reproduce_command.txt"
+    reproduce.write_text(command + "\n", encoding="utf-8")
+    written.append(reproduce)
+    manifest = {
+        "study_id": STUDY_ID,
+        "status": "COMPLETE",
+        "input": {
+            "candidate_events": {
+                "logical_path": "features/candidate_events.parquet",
+                "file_size": event_path.stat().st_size,
+                "sha256": sha256_file(event_path),
+            },
+            "locked_config": {
+                "logical_path": "matrix/locked_config.json",
+                "file_size": lock_path.stat().st_size,
+                "sha256": sha256_file(lock_path),
+            },
+            "reveal_matrix": (
+                {
+                    "logical_path": "matrix/reveal_matrix.parquet",
+                    "file_size": reveal_path.stat().st_size,
+                    "sha256": sha256_file(reveal_path),
+                }
+                if reveal_path.is_file()
+                else None
+            ),
+            "reveal_summary": (
+                {
+                    "logical_path": "matrix/reveal_summary.csv",
+                    "file_size": reveal_summary_path.stat().st_size,
+                    "sha256": sha256_file(reveal_summary_path),
+                }
+                if reveal_summary_path.is_file()
+                else None
+            ),
+        },
+        "selection_count": len(selections),
+        "quality_portfolios": len(summary_frame),
+        "random_portfolios": len(random_frame),
+        "mark_source_codes": len(codes),
+        "mark_source_rows": marks.source_rows,
+        "clock_rows": {
+            scope: len(scope_clock) for scope, scope_clock in scope_clocks.items()
+        },
+        "outputs": [
+            _manifest_entry(path, root, rows=output_rows.get(path)) for path in written
+        ],
+    }
+    manifest_path = output / "manifest.json"
+    _atomic_json(manifest_path, manifest)
+    result = {
+        "study_id": STUDY_ID,
+        "root": str(root),
+        "portfolio_dir": str(output),
+        "quality_portfolios": len(summary_frame),
+        "random_portfolios": len(random_frame),
+        "report": str(report_path),
+        "workbook": str(workbook),
+        "manifest": str(manifest_path),
+    }
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return result
+
+
+def rebuild_report(root: Path) -> dict[str, Any]:
+    resolved = root.resolve()
+    output = resolved / "portfolio"
+    summary = pd.read_parquet(output / "portfolio_summary.parquet")
+    random_summary = pd.read_parquet(output / "random_order_sensitivity.parquet")
+    period_metrics = pd.read_parquet(output / "period_metrics.parquet")
+    locked = pd.read_parquet(output / "locked_selections.parquet")
+    baseline = pd.read_parquet(output / "daily_baseline_comparison.parquet")
+    event_path = resolved / "features" / "candidate_events.parquet"
+    try:
+        events = pd.read_parquet(event_path, columns=["code", "union_signal_id"])
+    except (KeyError, ValueError):
+        events = pd.read_parquet(event_path, columns=["code"])
+    reveal_summary_path = resolved / "matrix" / "reveal_summary.csv"
+    reveal_summary = (
+        pd.read_csv(reveal_summary_path, encoding="utf-8-sig")
+        if reveal_summary_path.is_file()
+        else pd.DataFrame()
+    )
+    text = build_markdown_report(
+        root=resolved,
+        summary=summary,
+        random_summary=random_summary,
+        period_metrics=period_metrics,
+        locked=locked,
+        baseline=baseline,
+        feature_summary=_load_feature_summary(resolved, events),
+        reveal_summary=reveal_summary,
+    )
+    path = output / "report.md"
+    path.write_text(text, encoding="utf-8")
+    result = {"report": str(path), "sha256": sha256_file(path)}
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return result
+
+
+def status(root: Path) -> dict[str, Any]:
+    root = root.resolve()
+    result = {
+        "study_id": STUDY_ID,
+        "root": str(root),
+        "candidate_events": (root / "features" / "candidate_events.parquet").is_file(),
+        "locked_config": (root / "matrix" / "locked_config.json").is_file(),
+        "reveal_matrix": (root / "matrix" / "reveal_matrix.parquet").is_file(),
+        "reveal_summary": (root / "matrix" / "reveal_summary.csv").is_file(),
+        "portfolio_complete": (root / "portfolio" / "manifest.json").is_file(),
+    }
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    commands = parser.add_subparsers(dest="command", required=True)
+    run = commands.add_parser("run")
+    run.add_argument("--random-seeds", type=int, default=100)
+    run.add_argument("--no-audit-scope", action="store_true")
+    commands.add_parser("report")
+    commands.add_parser("status")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "run":
+        run_portfolios(
+            root=args.root,
+            random_seeds=args.random_seeds,
+            include_audit_scope=not args.no_audit_scope,
+        )
+    elif args.command == "report":
+        rebuild_report(args.root)
+    else:
+        status(args.root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/clx_backtest/research/clx_30m_full_trigger_f1_f6_study.py
+++ b/script/clx_backtest/research/clx_30m_full_trigger_f1_f6_study.py
@@ -1,0 +1,2301 @@
+"""Execute the independent CLX18 30-minute full-trigger/F1-F6 study.
+
+This entry point deliberately does not reuse or overwrite the artifacts from
+``clx-30m-regime-trigger-v1``.  It reads the local QuantAxis MongoDB source,
+freezes a per-code immutable snapshot, performs exact from-zero prefix replay,
+and stores one executable row per model/reveal with all seven native trigger
+bits plus the count of same-model facts collapsed by that execution key.
+
+The later matrix/lock/portfolio stages consume these immutable facts.  This
+module owns the source audit and candidate-event milestones because those two
+steps are the expensive, resumable part of the research.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import importlib
+import inspect
+import json
+import math
+import os
+import time
+from collections.abc import Iterable, Mapping, Sequence
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pymongo
+
+from freshquant.backtest.clx.engine import ClxEngineOptions, FqCopilotClxEngine
+from freshquant.backtest.clx.intraday import (
+    BAR_SLOT_CLOCKS,
+    LIMIT_MOVE,
+    MONGO_MINUTE_TYPE,
+    SHANGHAI_TIMEZONE,
+    attach_previous_session_regimes,
+    build_intraday_bars,
+    replay_prefix_events,
+)
+from script.clx_backtest.research.clx_regime_trigger_study import (
+    build_market_segments,
+    classify_market_regimes,
+)
+
+STUDY_ID = "clx-30m-full-trigger-f1-f6-v1"
+SNAPSHOT_CONTRACT_VERSION = 4
+SIGNAL_REPLAY_CONTRACT_VERSION = 2
+STUDY_CONTRACT_VERSION = 1
+MODEL_CODES = tuple(f"S{model_id:04d}" for model_id in range(18))
+TRIGGER_BITS = {
+    "MODEL_STRUCTURAL": 0x01,
+    "PIN_BAR": 0x02,
+    "ENGULFING": 0x04,
+    "STRONG_FRACTAL": 0x08,
+    "MA5_TURN": 0x10,
+    "PRICE_VOLUME_CONFIRMATION": 0x20,
+    "MACD_CROSS": 0x40,
+}
+TRIGGER_MASK = sum(TRIGGER_BITS.values())
+HORIZONS = (5, 30, 60, 90)
+FEE_PER_SIDE = 0.0002
+DEFAULT_START_DATE = "2014-01-01"
+DEFAULT_OUTPUT_ROOT = Path("D:/fqpack/runtime/clx-backtest/studies/" + STUDY_ID)
+DEFAULT_MONGO_URI = "mongodb://127.0.0.1:27027"
+INDEX_CODE = "000001"
+INDEX_PROXY_CODE = "510980"
+INDEX_PROXY_NAME = "上证综合"
+BAR_WINDOWS = {
+    "20d": 160,
+    "60d": 480,
+}
+EXPECTED_SESSION_LABELS = frozenset(BAR_SLOT_CLOCKS)
+
+MINUTE_PROJECTION = {
+    "_id": 0,
+    "code": 1,
+    "type": 1,
+    "date": 1,
+    "datetime": 1,
+    "time_stamp": 1,
+    "date_stamp": 1,
+    "open": 1,
+    "high": 1,
+    "low": 1,
+    "close": 1,
+    "vol": 1,
+    "amount": 1,
+}
+ADJ_PROJECTION = {"_id": 0, "code": 1, "date": 1, "adj": 1}
+DAY_PROJECTION = {
+    "_id": 0,
+    "code": 1,
+    "date": 1,
+    "date_stamp": 1,
+    "open": 1,
+    "high": 1,
+    "low": 1,
+    "close": 1,
+    "vol": 1,
+    "amount": 1,
+}
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+    ).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, (date, pd.Timestamp)):
+        return value.isoformat()
+    if isinstance(value, np.generic):
+        return value.item()
+    if value is pd.NA:
+        return None
+    raise TypeError(f"{type(value).__name__} is not JSON serializable")
+
+
+def write_json_atomic(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_bytes(
+        (
+            json.dumps(
+                value,
+                ensure_ascii=False,
+                sort_keys=True,
+                indent=2,
+                default=_json_default,
+            )
+            + "\n"
+        ).encode("utf-8")
+    )
+    os.replace(temporary, path)
+
+
+def write_frame_atomic(frame: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    frame.to_parquet(temporary, index=False, compression="zstd")
+    os.replace(temporary, path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError(f"{path} must contain a JSON object")
+    return value
+
+
+def _valid_checkpoint(
+    *,
+    data_path: Path,
+    meta_path: Path,
+    identity_key: str,
+    identity_value: str,
+) -> dict[str, Any] | None:
+    if not data_path.is_file() or not meta_path.is_file():
+        return None
+    try:
+        meta = read_json(meta_path)
+        if meta.get(identity_key) != identity_value:
+            return None
+        if meta.get("file_sha256") != sha256_file(data_path):
+            return None
+        return meta
+    except (OSError, TypeError, ValueError, RuntimeError):
+        return None
+
+
+def _snapshot_code_paths(root: Path, code: str) -> tuple[Path, Path]:
+    return (
+        root / "snapshot" / "bars" / f"{code}.parquet",
+        root / "snapshot" / "checkpoints" / f"{code}.json",
+    )
+
+
+def _replay_code_paths(root: Path, code: str) -> tuple[Path, Path]:
+    return (
+        root / "replay" / "candidates" / f"{code}.parquet",
+        root / "replay" / "checkpoints" / f"{code}.json",
+    )
+
+
+def _mongo_client(mongo_uri: str) -> pymongo.MongoClient:
+    return pymongo.MongoClient(
+        mongo_uri,
+        serverSelectionTimeoutMS=10_000,
+        connectTimeoutMS=10_000,
+        socketTimeoutMS=120_000,
+    )
+
+
+def discover_source(mongo_uri: str) -> dict[str, Any]:
+    """Discover the local source without a type-only collection scan."""
+
+    client = _mongo_client(mongo_uri)
+    client.admin.command("ping")
+    database = client["quantaxis"]
+    collections = {
+        name: int(database[name].estimated_document_count())
+        for name in ("stock_min", "stock_day", "stock_adj", "index_day", "stock_list")
+    }
+    codes = sorted(
+        str(value)
+        for value in database["stock_min"].distinct("code")
+        if str(value).isdigit() and len(str(value)) == 6
+    )
+    latest_daily = database["stock_day"].find_one(
+        {},
+        {"_id": 0, "date": 1},
+        sort=[("date", pymongo.DESCENDING)],
+    )
+    if not latest_daily:
+        raise RuntimeError("quantaxis.stock_day has no latest date")
+    stock_list_codes = {
+        str(value)
+        for value in database["stock_list"].distinct("code")
+        if str(value).isdigit() and len(str(value)) == 6
+    }
+    minute_indexes = database["stock_min"].index_information()
+    client.close()
+    return {
+        "mongo_uri_redacted": mongo_uri.split("@")[-1],
+        "collections": collections,
+        "stock_min_code_count": len(codes),
+        "codes": codes,
+        "stock_list_code_count": len(stock_list_codes),
+        "codes_absent_from_current_stock_list": sorted(set(codes) - stock_list_codes),
+        "stock_list_codes_without_minute_history": sorted(
+            stock_list_codes - set(codes)
+        ),
+        "latest_stock_day": str(latest_daily["date"]),
+        "stock_min_indexes": minute_indexes,
+    }
+
+
+def _load_code_source_documents(
+    *,
+    mongo_uri: str,
+    code: str,
+    start_date: str,
+    end_date: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    client = _mongo_client(mongo_uri)
+    try:
+        database = client["quantaxis"]
+        minute_docs = list(
+            database["stock_min"]
+            .find(
+                {
+                    "code": code,
+                    "type": MONGO_MINUTE_TYPE,
+                    "date": {"$gte": start_date, "$lte": end_date},
+                },
+                MINUTE_PROJECTION,
+            )
+            .sort([("time_stamp", pymongo.ASCENDING)])
+        )
+        daily_docs = list(
+            database["stock_day"]
+            .find(
+                {"code": code, "date": {"$gte": start_date, "$lte": end_date}},
+                DAY_PROJECTION,
+            )
+            .sort([("date", pymongo.ASCENDING)])
+        )
+        previous_daily = database["stock_day"].find_one(
+            {"code": code, "date": {"$lt": start_date}},
+            DAY_PROJECTION,
+            sort=[("date", pymongo.DESCENDING)],
+        )
+        if previous_daily is not None:
+            daily_docs.insert(0, previous_daily)
+        adj_docs = list(
+            database["stock_adj"]
+            .find(
+                {
+                    "code": code,
+                    "date": {"$gte": start_date, "$lte": end_date},
+                },
+                ADJ_PROJECTION,
+            )
+            .sort([("date", pymongo.ASCENDING)])
+        )
+    finally:
+        client.close()
+    return minute_docs, adj_docs, daily_docs
+
+
+def _stock_trading_calendar(
+    *,
+    daily_docs: Sequence[Mapping[str, Any]],
+    start_date: str,
+    end_date: str,
+) -> tuple[list[str], dict[str, int]]:
+    """Freeze the per-stock daily calendar used to count exit horizons."""
+
+    parsed = pd.to_datetime(
+        [document.get("date") for document in daily_docs],
+        errors="coerce",
+    )
+    valid_dates = [
+        value.date().isoformat()
+        for value in parsed
+        if pd.notna(value) and start_date <= value.date().isoformat() <= end_date
+    ]
+    unique_dates = sorted(set(valid_dates))
+    return (
+        unique_dates,
+        {
+            "source_rows": len(daily_docs),
+            "invalid_date_rows": int(pd.isna(parsed).sum()),
+            "in_period_rows": len(valid_dates),
+            "duplicate_date_rows": len(valid_dates) - len(unique_dates),
+            "trading_dates": len(unique_dates),
+        },
+    )
+
+
+def _daily_source_quality(
+    *,
+    daily_docs: Sequence[Mapping[str, Any]],
+    adj_docs: Sequence[Mapping[str, Any]],
+    start_date: str,
+    end_date: str,
+) -> dict[str, Any]:
+    daily_dates = pd.to_datetime(
+        [document.get("date") for document in daily_docs],
+        errors="coerce",
+    )
+    adj_dates = {
+        pd.Timestamp(value).date()
+        for value in pd.to_datetime(
+            [document.get("date") for document in adj_docs],
+            errors="coerce",
+        )
+        if pd.notna(value)
+    }
+    valid_daily_dates = [
+        value.date()
+        for value in daily_dates
+        if pd.notna(value) and start_date <= value.date().isoformat() <= end_date
+    ]
+    return {
+        "daily_rows": len(valid_daily_dates),
+        "daily_adj_rows": len(adj_docs),
+        "daily_min_date": (
+            min(valid_daily_dates).isoformat() if valid_daily_dates else None
+        ),
+        "daily_max_date": (
+            max(valid_daily_dates).isoformat() if valid_daily_dates else None
+        ),
+        "daily_invalid_date_rows": int(pd.isna(daily_dates).sum()),
+        "daily_duplicate_date_rows": len(valid_daily_dates)
+        - len(set(valid_daily_dates)),
+        "daily_adj_missing_rows": sum(
+            value not in adj_dates for value in set(valid_daily_dates)
+        ),
+    }
+
+
+def _document_clock(document: Mapping[str, Any]) -> str:
+    value = str(document.get("datetime", ""))
+    return value[11:16] if len(value) >= 16 else ""
+
+
+def _select_usable_session_documents(
+    documents: Iterable[Mapping[str, Any]],
+) -> tuple[list[Mapping[str, Any]], dict[str, Any]]:
+    """Keep complete and partial sessions made only of real standard bars."""
+
+    source_rows = list(documents)
+    rows = [
+        document
+        for document in source_rows
+        if document.get("type") == MONGO_MINUTE_TYPE
+    ]
+    grouped: dict[tuple[str, str], list[Mapping[str, Any]]] = {}
+    for document in rows:
+        key = (str(document.get("code", "")), str(document.get("date", "")))
+        grouped.setdefault(key, []).append(document)
+
+    selected: list[Mapping[str, Any]] = []
+    excluded_sessions: list[dict[str, Any]] = []
+    partial_sessions: list[dict[str, Any]] = []
+    unique_bars = 0
+    duplicate_extra_docs = 0
+    complete_sessions = 0
+    partial_missing_slot_count = 0
+    for (code, trade_date), session_rows in sorted(grouped.items()):
+        stamp_groups: dict[object, list[Mapping[str, Any]]] = {}
+        for document in session_rows:
+            stamp_groups.setdefault(document.get("time_stamp"), []).append(document)
+        unique_count = len(stamp_groups)
+        unique_bars += unique_count
+        duplicate_extra_docs += len(session_rows) - unique_count
+        labels = {_document_clock(group[0]) for group in stamp_groups.values()}
+        total_volume = sum(float(row.get("vol", 0.0) or 0.0) for row in session_rows)
+        total_amount = sum(float(row.get("amount", 0.0) or 0.0) for row in session_rows)
+        reasons: list[str] = []
+        if (
+            not labels
+            or not labels.issubset(EXPECTED_SESSION_LABELS)
+            or len(labels) != unique_count
+        ):
+            reasons.append("NONSTANDARD_OR_DUPLICATE_BAR_SLOT")
+        if total_volume <= 1e-12 or total_amount <= 1e-12:
+            reasons.append("NON_TRADING_PLACEHOLDER")
+        if reasons:
+            excluded_sessions.append(
+                {
+                    "code": code,
+                    "date": trade_date,
+                    "raw_docs": len(session_rows),
+                    "unique_bars": unique_count,
+                    "labels": sorted(labels),
+                    "reasons": reasons,
+                }
+            )
+            continue
+
+        selected.extend(session_rows)
+        if labels == EXPECTED_SESSION_LABELS:
+            complete_sessions += 1
+            continue
+        missing_slots = sorted(EXPECTED_SESSION_LABELS - labels)
+        partial_missing_slot_count += len(missing_slots)
+        partial_sessions.append(
+            {
+                "code": code,
+                "date": trade_date,
+                "raw_docs": len(session_rows),
+                "unique_bars": unique_count,
+                "labels": sorted(labels),
+                "missing_slots": missing_slots,
+            }
+        )
+
+    return selected, {
+        "raw_docs": len(rows),
+        "unique_bars": unique_bars,
+        "duplicate_extra_docs": duplicate_extra_docs,
+        "source_sessions": len(grouped),
+        "standard_sessions": complete_sessions + len(partial_sessions),
+        "usable_sessions": complete_sessions + len(partial_sessions),
+        "complete_sessions": complete_sessions,
+        "partial_session_count": len(partial_sessions),
+        "partial_missing_slot_count": partial_missing_slot_count,
+        "partial_sessions": partial_sessions,
+        "excluded_session_count": len(excluded_sessions),
+        "excluded_sessions": excluded_sessions,
+        "ignored_non_30min_docs": sum(
+            document.get("type") != MONGO_MINUTE_TYPE for document in source_rows
+        ),
+    }
+
+
+def _select_joinable_session_documents(
+    documents: Iterable[Mapping[str, Any]],
+    *,
+    adj_docs: Iterable[Mapping[str, Any]],
+    daily_docs: Iterable[Mapping[str, Any]],
+    quality: Mapping[str, Any],
+) -> tuple[list[Mapping[str, Any]], dict[str, Any]]:
+    """Keep usable sessions with exact daily and adjustment joins."""
+
+    rows = list(documents)
+    adj_keys = {
+        (str(document.get("code", "")), str(document.get("date", "")))
+        for document in adj_docs
+    }
+    daily_keys = {
+        (str(document.get("code", "")), str(document.get("date", "")))
+        for document in daily_docs
+    }
+    grouped: dict[tuple[str, str], list[Mapping[str, Any]]] = {}
+    for document in rows:
+        key = (str(document.get("code", "")), str(document.get("date", "")))
+        grouped.setdefault(key, []).append(document)
+
+    selected: list[Mapping[str, Any]] = []
+    excluded: list[dict[str, Any]] = []
+    joinable_complete_sessions = 0
+    joinable_partial_sessions = 0
+    for (code, trade_date), session_rows in sorted(grouped.items()):
+        reasons: list[str] = []
+        if (code, trade_date) not in adj_keys:
+            reasons.append("MISSING_ADJ_FACTOR")
+        if (code, trade_date) not in daily_keys:
+            reasons.append("MISSING_STOCK_DAY")
+        stamp_groups: dict[object, list[Mapping[str, Any]]] = {}
+        for document in session_rows:
+            stamp_groups.setdefault(document.get("time_stamp"), []).append(document)
+        labels = {_document_clock(group[0]) for group in stamp_groups.values()}
+        if reasons:
+            excluded.append(
+                {
+                    "code": code,
+                    "date": trade_date,
+                    "raw_docs": len(session_rows),
+                    "unique_bars": len(stamp_groups),
+                    "labels": sorted(labels),
+                    "reasons": reasons,
+                }
+            )
+            continue
+        selected.extend(session_rows)
+        if labels == EXPECTED_SESSION_LABELS:
+            joinable_complete_sessions += 1
+        else:
+            joinable_partial_sessions += 1
+
+    existing_excluded = [dict(item) for item in quality.get("excluded_sessions", [])]
+    updated = dict(quality)
+    updated.update(
+        {
+            "complete_sessions": joinable_complete_sessions,
+            "joinable_partial_session_count": joinable_partial_sessions,
+            "joinable_sessions": (
+                joinable_complete_sessions + joinable_partial_sessions
+            ),
+            "cross_source_excluded_session_count": len(excluded),
+            "excluded_session_count": len(existing_excluded) + len(excluded),
+            "excluded_sessions": existing_excluded + excluded,
+        }
+    )
+    return selected, updated
+
+
+def _snapshot_logic_sha256() -> str:
+    functions = (
+        _load_code_source_documents,
+        _stock_trading_calendar,
+        _daily_source_quality,
+        _document_clock,
+        _select_usable_session_documents,
+        _select_joinable_session_documents,
+        build_intraday_bars,
+        _write_index_snapshot,
+        snapshot_one_code,
+    )
+    return sha256_bytes(
+        "\n".join(
+            ast.dump(
+                ast.parse(inspect.getsource(function)),
+                annotate_fields=True,
+                include_attributes=False,
+            )
+            for function in functions
+        ).encode("utf-8")
+    )
+
+
+def _snapshot_config(
+    *,
+    start_date: str,
+    end_date: str,
+    index_source: Mapping[str, Any],
+    mongo_uri_redacted: str,
+) -> dict[str, Any]:
+    return {
+        "study_id": STUDY_ID,
+        "study_contract_version": STUDY_CONTRACT_VERSION,
+        "snapshot_contract_version": SNAPSHOT_CONTRACT_VERSION,
+        "snapshot_logic_sha256": _snapshot_logic_sha256(),
+        "source": {
+            "mongo_uri": mongo_uri_redacted,
+            "database": "quantaxis",
+            "minute_collection": "stock_min",
+            "daily_collection": "stock_day",
+            "adjustment_collection": "stock_adj",
+            "index_collection": "index_day",
+            "download_permitted": False,
+        },
+        "period": {
+            "requested_research_start": "2015-01-01",
+            "indicator_warmup_start": start_date,
+            "source_end": end_date,
+        },
+        "minute_type": MONGO_MINUTE_TYPE,
+        "required_bar_slots": list(BAR_SLOT_CLOCKS),
+        "session_quality": (
+            "retain every actually present standard 30-minute slot from "
+            "positive-volume/amount complete or partial sessions; do not "
+            "fabricate missing slots; exclude full code-days containing a "
+            "nonstandard/duplicate slot, zero-trading placeholders, or missing "
+            "exact stock_day/stock_adj joins"
+        ),
+        "qfq_formula": "raw_price * stock_adj.adj",
+        "stock_trading_day_calendar": (
+            "sorted unique quantaxis.stock_day dates for the code; target "
+            "horizon dates count this frozen calendar even when the target "
+            "30-minute slot or the whole intraday session is absent"
+        ),
+        "enhanced_filters": {
+            "F1": "1 <= raw 30-minute signal-bar open <= 6",
+            "F2": "160-actual-bar QFQ close return <= 0",
+            "F3": "QFQ close drawdown from 160-actual-bar high >= 10%",
+            "F4": (
+                "non-annualised daily-equivalent volatility = sample std of "
+                "160 actual 30-minute QFQ close returns * sqrt(8), >= 3%"
+            ),
+            "F5": "QFQ close <= rolling mean of 480 actual 30-minute closes",
+            "F6": (
+                "Shanghai-index 20-completed-session return <= 0, mapped "
+                "strictly from the prior completed index session"
+            ),
+        },
+        "entry": "next actually existing 30-minute bar open after reveal",
+        "horizons_stock_trading_days": list(HORIZONS),
+        "fee_per_side": FEE_PER_SIDE,
+        "net_return_formula": ("net=(1+gross)*(1-0.0002)/(1+0.0002)-1"),
+        "unmodelled_costs": [
+            "slippage",
+            "stamp_duty",
+            "minimum_commission",
+            "100-share lot rounding",
+        ],
+        "native_trigger_bits": TRIGGER_BITS,
+        "index_source": dict(index_source),
+    }
+
+
+def _write_index_snapshot(
+    *,
+    mongo_uri: str,
+    root: Path,
+    start_date: str,
+    end_date: str,
+) -> tuple[dict[str, Any], list[str]]:
+    client = _mongo_client(mongo_uri)
+    database = client["quantaxis"]
+    findings: list[str] = []
+    actual_count = database["index_day"].count_documents({"code": INDEX_CODE})
+    if actual_count:
+        source_code = INDEX_CODE
+        source_kind = "SHANGHAI_COMPOSITE"
+        source_name = "上证指数"
+    else:
+        proxy = database["etf_list"].find_one(
+            {"code": INDEX_PROXY_CODE},
+            {"_id": 0, "code": 1, "name": 1},
+        )
+        if proxy is None:
+            raise RuntimeError("Mongo lacks both index 000001 and proxy 510980")
+        source_code = INDEX_PROXY_CODE
+        source_kind = "SHANGHAI_COMPOSITE_ETF_PROXY"
+        source_name = str(proxy.get("name") or INDEX_PROXY_NAME)
+        findings.append(
+            "quantaxis.index_day has zero code=000001 rows; code=510980 "
+            f"({source_name}) is frozen as the market-regime proxy"
+        )
+    records = list(
+        database["index_day"]
+        .find(
+            {
+                "code": source_code,
+                "date": {"$gte": start_date, "$lte": end_date},
+            },
+            {
+                "_id": 0,
+                "code": 1,
+                "date": 1,
+                "open": 1,
+                "high": 1,
+                "low": 1,
+                "close": 1,
+                "vol": 1,
+                "amount": 1,
+            },
+        )
+        .sort([("date_stamp", pymongo.ASCENDING)])
+    )
+    client.close()
+    if not records:
+        raise RuntimeError(f"index source {source_code} has no rows")
+    frame = pd.DataFrame(records)
+    frame["date"] = pd.to_datetime(frame["date"], errors="coerce")
+    for field in ("open", "high", "low", "close", "vol", "amount"):
+        frame[field] = pd.to_numeric(frame[field], errors="coerce")
+    duplicate_rows = int(frame["date"].duplicated(keep=False).sum())
+    frame = (
+        frame.dropna(subset=["date", "close"])
+        .sort_values("date", kind="stable")
+        .drop_duplicates("date", keep="last")
+        .reset_index(drop=True)
+    )
+    invalid_ohlc = int(
+        (
+            frame["high"].lt(frame[["open", "close"]].max(axis=1))
+            | frame["low"].gt(frame[["open", "close"]].min(axis=1))
+            | frame["high"].lt(frame["low"])
+            | frame["close"].le(0)
+        ).sum()
+    )
+    frame["return_20"] = frame["close"].pct_change(20, fill_method=None)
+    path = root / "snapshot" / "index_day.parquet"
+    write_frame_atomic(frame, path)
+    meta = {
+        "source_code": source_code,
+        "source_kind": source_kind,
+        "source_name": source_name,
+        "actual_shanghai_composite_rows": actual_count,
+        "rows": len(frame),
+        "min_date": frame["date"].min().date().isoformat(),
+        "max_date": frame["date"].max().date().isoformat(),
+        "duplicate_date_rows": duplicate_rows,
+        "invalid_ohlc_rows": invalid_ohlc,
+        "file_size": path.stat().st_size,
+        "file_sha256": sha256_file(path),
+        "logical_path": "snapshot/index_day.parquet",
+    }
+    return meta, findings
+
+
+def snapshot_one_code(
+    *,
+    mongo_uri: str,
+    root: str,
+    code: str,
+    start_date: str,
+    end_date: str,
+    config_sha256: str,
+    market_dates: Sequence[str],
+) -> dict[str, Any]:
+    output_root = Path(root)
+    data_path, meta_path = _snapshot_code_paths(output_root, code)
+    existing = _valid_checkpoint(
+        data_path=data_path,
+        meta_path=meta_path,
+        identity_key="snapshot_config_sha256",
+        identity_value=config_sha256,
+    )
+    if existing is not None:
+        stock_trading_dates = existing.get("stock_trading_dates")
+        expected_calendar_sha256 = existing.get("stock_trading_calendar_sha256")
+        if isinstance(
+            stock_trading_dates, list
+        ) and expected_calendar_sha256 == sha256_bytes(
+            canonical_json_bytes(stock_trading_dates)
+        ):
+            return {**existing, "checkpoint_status": "REUSED"}
+
+    started = time.perf_counter()
+    minute_docs, adj_docs, daily_docs = _load_code_source_documents(
+        mongo_uri=mongo_uri,
+        code=code,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    selected_docs, quality = _select_usable_session_documents(minute_docs)
+    selected_docs, quality = _select_joinable_session_documents(
+        selected_docs,
+        adj_docs=adj_docs,
+        daily_docs=daily_docs,
+        quality=quality,
+    )
+    bars = build_intraday_bars(
+        minute_docs=selected_docs,
+        adj_docs=adj_docs,
+        daily_docs=daily_docs,
+    )
+    daily_quality = _daily_source_quality(
+        daily_docs=daily_docs,
+        adj_docs=adj_docs,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    stock_trading_dates, calendar_quality = _stock_trading_calendar(
+        daily_docs=daily_docs,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    stock_trading_calendar_sha256 = sha256_bytes(
+        canonical_json_bytes(stock_trading_dates)
+    )
+    if not bars.empty and set(bars["code"]) != {code}:
+        raise RuntimeError(f"{code} snapshot contains another code")
+    bar_trade_dates = {
+        pd.Timestamp(value).date().isoformat() for value in bars["trade_date"]
+    }
+    missing_calendar_dates = sorted(bar_trade_dates - set(stock_trading_dates))
+    if missing_calendar_dates:
+        raise RuntimeError(
+            f"{code} intraday dates are absent from stock_day calendar: "
+            f"{missing_calendar_dates[:3]}"
+        )
+
+    session_dates = sorted(
+        {pd.Timestamp(value).date().isoformat() for value in bars["trade_date"]}
+    )
+    market = [
+        value
+        for value in market_dates
+        if session_dates and session_dates[0] <= value <= session_dates[-1]
+    ]
+    missing_trade_dates = sorted(set(market) - set(session_dates))
+    yearly_rows: list[dict[str, Any]] = []
+    if not bars.empty:
+        grouped = bars.groupby("trade_year", sort=True)
+        for year, frame in grouped:
+            yearly_rows.append(
+                {
+                    "year": int(year),
+                    "bar_rows": len(frame),
+                    "trading_sessions": int(frame["trade_date"].nunique()),
+                    "zero_volume_bars": int(frame["raw_volume"].le(0).sum()),
+                    "duplicate_extra_docs": int(
+                        (frame["source_duplicate_count"] - 1).clip(lower=0).sum()
+                    ),
+                }
+            )
+
+    write_frame_atomic(bars, data_path)
+    meta = {
+        "code": code,
+        "snapshot_config_sha256": config_sha256,
+        "logical_path": f"snapshot/bars/{code}.parquet",
+        "rows": len(bars),
+        "min_bar_at": bars["bar_at"].min().isoformat() if len(bars) else None,
+        "max_bar_at": bars["bar_at"].max().isoformat() if len(bars) else None,
+        "session_count": len(session_dates),
+        "missing_market_session_count_active_span": len(missing_trade_dates),
+        "missing_market_sessions_sample": missing_trade_dates[:100],
+        "yearly_coverage": yearly_rows,
+        "source_quality": quality,
+        "daily_quality": daily_quality,
+        "stock_trading_dates": stock_trading_dates,
+        "stock_trading_calendar_sha256": stock_trading_calendar_sha256,
+        "stock_trading_calendar_quality": calendar_quality,
+        "stock_trading_calendar_min_date": (
+            stock_trading_dates[0] if stock_trading_dates else None
+        ),
+        "stock_trading_calendar_max_date": (
+            stock_trading_dates[-1] if stock_trading_dates else None
+        ),
+        "file_size": data_path.stat().st_size,
+        "file_sha256": sha256_file(data_path),
+        "elapsed_seconds": round(time.perf_counter() - started, 3),
+    }
+    write_json_atomic(meta_path, meta)
+    return {**meta, "checkpoint_status": "BUILT"}
+
+
+def _aggregate_year_coverage(metas: Sequence[Mapping[str, Any]]) -> pd.DataFrame:
+    rows = [
+        {**year, "code": str(meta["code"])}
+        for meta in metas
+        for year in meta.get("yearly_coverage", [])
+    ]
+    if not rows:
+        return pd.DataFrame()
+    frame = pd.DataFrame(rows)
+    return (
+        frame.groupby("year", as_index=False)
+        .agg(
+            code_count=("code", "nunique"),
+            bar_rows=("bar_rows", "sum"),
+            trading_sessions=("trading_sessions", "sum"),
+            zero_volume_bars=("zero_volume_bars", "sum"),
+            duplicate_extra_docs=("duplicate_extra_docs", "sum"),
+        )
+        .sort_values("year")
+        .reset_index(drop=True)
+    )
+
+
+def _freeze_splits(
+    market_dates: Sequence[str],
+    signal_start: str,
+    end_date: str,
+) -> dict[str, list[str]]:
+    dates = sorted(
+        {value for value in market_dates if signal_start <= value <= end_date}
+    )
+    if len(dates) < 30:
+        raise RuntimeError("too few market dates to freeze time splits")
+    preferred = {
+        "TRAIN": [max(signal_start, "2015-01-01"), "2019-12-31"],
+        "VALIDATION": ["2020-01-01", "2023-12-31"],
+        "AUDIT": ["2024-01-01", end_date],
+    }
+    preferred_dates = {
+        split_id: [value for value in dates if bounds[0] <= value <= bounds[1]]
+        for split_id, bounds in preferred.items()
+    }
+    if (
+        signal_start <= "2015-01-31"
+        and end_date >= "2024-01-01"
+        and all(preferred_dates.values())
+    ):
+        return {
+            split_id: [values[0], values[-1]]
+            for split_id, values in preferred_dates.items()
+        }
+    train_end_index = max(0, math.floor(len(dates) * 0.50) - 1)
+    validation_end_index = max(train_end_index + 1, math.floor(len(dates) * 0.80) - 1)
+    return {
+        "TRAIN": [dates[0], dates[train_end_index]],
+        "VALIDATION": [
+            dates[train_end_index + 1],
+            dates[validation_end_index],
+        ],
+        "AUDIT": [dates[validation_end_index + 1], dates[-1]],
+    }
+
+
+def run_audit(args: argparse.Namespace) -> dict[str, Any]:
+    root = args.root.resolve()
+    source = discover_source(args.mongo_uri)
+    end_date = args.end_date or str(source["latest_stock_day"])
+    index_meta, findings = _write_index_snapshot(
+        mongo_uri=args.mongo_uri,
+        root=root,
+        start_date=args.start_date,
+        end_date=end_date,
+    )
+    config = _snapshot_config(
+        start_date=args.start_date,
+        end_date=end_date,
+        index_source=index_meta,
+        mongo_uri_redacted=str(source["mongo_uri_redacted"]),
+    )
+    config_sha256 = sha256_bytes(canonical_json_bytes(config))
+    codes = list(source["codes"])
+    if args.code:
+        requested = {str(value) for value in args.code}
+        codes = [code for code in codes if code in requested]
+    if args.code_limit is not None:
+        codes = codes[: args.code_limit]
+    if not codes:
+        raise RuntimeError("no 30-minute source codes selected")
+
+    index_frame = pd.read_parquet(root / "snapshot" / "index_day.parquet")
+    market_dates = [
+        pd.Timestamp(value).date().isoformat() for value in index_frame["date"]
+    ]
+    progress_path = root / "audit" / "progress.json"
+    outputs: dict[str, dict[str, Any]] = {}
+    failures: dict[str, str] = {}
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {
+            executor.submit(
+                snapshot_one_code,
+                mongo_uri=args.mongo_uri,
+                root=str(root),
+                code=code,
+                start_date=args.start_date,
+                end_date=end_date,
+                config_sha256=config_sha256,
+                market_dates=market_dates,
+            ): code
+            for code in codes
+        }
+        for completed, future in enumerate(as_completed(futures), start=1):
+            code = futures[future]
+            try:
+                outputs[code] = future.result()
+            except Exception as exc:  # noqa: BLE001 - persisted worker boundary
+                failures[code] = f"{type(exc).__name__}: {exc}"
+            if (
+                completed == len(codes)
+                or completed % args.progress_every == 0
+                or failures
+            ):
+                progress = {
+                    "phase": "audit_snapshot",
+                    "total_codes": len(codes),
+                    "completed_codes": completed,
+                    "successful_codes": len(outputs),
+                    "failed_codes": len(failures),
+                    "elapsed_seconds": round(time.perf_counter() - started, 3),
+                    "failures": failures,
+                }
+                write_json_atomic(progress_path, progress)
+                print(json.dumps(progress, ensure_ascii=False), flush=True)
+    if failures:
+        raise RuntimeError(
+            f"audit snapshot failed for {len(failures)} codes; inspect {progress_path}"
+        )
+
+    metas = [outputs[code] for code in codes]
+    nonempty = [meta for meta in metas if int(meta["rows"]) > 0]
+    if not nonempty:
+        raise RuntimeError("all 30-minute snapshots are empty")
+    min_bar_at = min(str(meta["min_bar_at"]) for meta in nonempty)
+    max_bar_at = max(str(meta["max_bar_at"]) for meta in nonempty)
+    actual_end_date = pd.Timestamp(max_bar_at).date().isoformat()
+    source_quality_keys = (
+        "raw_docs",
+        "unique_bars",
+        "duplicate_extra_docs",
+        "source_sessions",
+        "standard_sessions",
+        "usable_sessions",
+        "complete_sessions",
+        "partial_session_count",
+        "partial_missing_slot_count",
+        "joinable_partial_session_count",
+        "joinable_sessions",
+        "cross_source_excluded_session_count",
+        "excluded_session_count",
+    )
+    source_quality = {
+        key: sum(int(meta["source_quality"].get(key, 0)) for meta in metas)
+        for key in source_quality_keys
+    }
+    excluded = [
+        row
+        for meta in metas
+        for row in meta["source_quality"].get("excluded_sessions", [])
+    ]
+    partial_sessions = [
+        row
+        for meta in metas
+        for row in meta["source_quality"].get("partial_sessions", [])
+    ]
+    year_coverage = _aggregate_year_coverage(metas)
+    signal_start = max(
+        "2015-01-01",
+        pd.Timestamp(min_bar_at).date().isoformat(),
+    )
+    splits = _freeze_splits(market_dates, signal_start, actual_end_date)
+    config["time_splits"] = splits
+    config["time_split_policy"] = (
+        "PREFERRED_2015_2019_2020_2023_2024_LATEST"
+        if splits["VALIDATION"][0][:4] == "2020" and splits["AUDIT"][0][:4] == "2024"
+        else "COVERAGE_PROPORTIONAL_50_30_20"
+    )
+    config["evidence_grade"] = (
+        "FULL_HISTORY"
+        if pd.Timestamp(min_bar_at).date() <= date(2015, 1, 31)
+        else "SHORT_SAMPLE"
+    )
+    config["actual_minute_period"] = [
+        pd.Timestamp(min_bar_at).date().isoformat(),
+        pd.Timestamp(max_bar_at).date().isoformat(),
+    ]
+    config["snapshot_config_sha256"] = config_sha256
+
+    audit_dir = root / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    year_coverage.to_csv(
+        audit_dir / "data_coverage_by_year.csv",
+        index=False,
+        encoding="utf-8-sig",
+    )
+    pd.DataFrame(
+        excluded,
+        columns=[
+            "code",
+            "date",
+            "raw_docs",
+            "unique_bars",
+            "labels",
+            "reasons",
+        ],
+    ).to_csv(
+        audit_dir / "data_exclusions.csv",
+        index=False,
+        encoding="utf-8-sig",
+    )
+    pd.DataFrame(
+        partial_sessions,
+        columns=[
+            "code",
+            "date",
+            "raw_docs",
+            "unique_bars",
+            "labels",
+            "missing_slots",
+        ],
+    ).to_csv(
+        audit_dir / "data_partial_sessions.csv",
+        index=False,
+        encoding="utf-8-sig",
+    )
+    by_code_rows = []
+    for meta in metas:
+        by_code_rows.append(
+            {
+                "code": meta["code"],
+                "bar_rows": meta["rows"],
+                "session_count": meta["session_count"],
+                "min_bar_at": meta["min_bar_at"],
+                "max_bar_at": meta["max_bar_at"],
+                "missing_market_session_count_active_span": meta[
+                    "missing_market_session_count_active_span"
+                ],
+                "excluded_session_count": meta["source_quality"].get(
+                    "excluded_session_count", 0
+                ),
+                "partial_session_count": meta["source_quality"].get(
+                    "partial_session_count", 0
+                ),
+                "partial_missing_slot_count": meta["source_quality"].get(
+                    "partial_missing_slot_count", 0
+                ),
+                "joinable_partial_session_count": meta["source_quality"].get(
+                    "joinable_partial_session_count", 0
+                ),
+                "daily_rows": meta["daily_quality"]["daily_rows"],
+                "daily_adj_rows": meta["daily_quality"]["daily_adj_rows"],
+                "daily_adj_missing_rows": meta["daily_quality"][
+                    "daily_adj_missing_rows"
+                ],
+                "stock_trading_dates": meta["stock_trading_calendar_quality"][
+                    "trading_dates"
+                ],
+                "stock_trading_calendar_min_date": meta[
+                    "stock_trading_calendar_min_date"
+                ],
+                "stock_trading_calendar_max_date": meta[
+                    "stock_trading_calendar_max_date"
+                ],
+                "stock_trading_calendar_duplicate_date_rows": meta[
+                    "stock_trading_calendar_quality"
+                ]["duplicate_date_rows"],
+                "file_sha256": meta["file_sha256"],
+            }
+        )
+    pd.DataFrame(by_code_rows).to_csv(
+        audit_dir / "data_coverage_by_code.csv",
+        index=False,
+        encoding="utf-8-sig",
+    )
+    identity_payload = {
+        "config": config,
+        "index_file_sha256": index_meta["file_sha256"],
+        "code_files": [
+            {
+                "code": meta["code"],
+                "rows": meta["rows"],
+                "file_sha256": meta["file_sha256"],
+                "stock_trading_calendar_sha256": meta["stock_trading_calendar_sha256"],
+            }
+            for meta in metas
+        ],
+    }
+    snapshot_id = "sha256:" + sha256_bytes(canonical_json_bytes(identity_payload))
+    total_bars = sum(int(meta["rows"]) for meta in metas)
+    runtime_estimate = {
+        "prefix_calls": total_bars,
+        "native_models_per_prefix_call": len(MODEL_CODES),
+        "native_model_prefix_evaluations": total_bars * len(MODEL_CODES),
+        "candidate_event_rows_estimate": {
+            "low": int(total_bars * 0.05),
+            "high": int(total_bars * 1.00),
+            "basis": "before the immutable full-trigger replay is observed",
+        },
+        "snapshot_disk_bytes": sum(int(meta["file_size"]) for meta in metas),
+        "matrix_filter_subsets": 64,
+        "horizons": list(HORIZONS),
+        "models": len(MODEL_CODES),
+    }
+    audit = {
+        "study_id": STUDY_ID,
+        "snapshot_id": snapshot_id,
+        "generated_at": pd.Timestamp.now(tz=SHANGHAI_TIMEZONE).isoformat(),
+        "source": {key: value for key, value in source.items() if key != "codes"},
+        "config": config,
+        "coverage": {
+            "snapshot_codes": len(metas),
+            "nonempty_codes": len(nonempty),
+            "bar_rows": total_bars,
+            "stock_sessions": sum(int(meta["session_count"]) for meta in metas),
+            "min_bar_at": min_bar_at,
+            "max_bar_at": max_bar_at,
+        },
+        "source_quality": source_quality,
+        "index_quality": index_meta,
+        "data_findings": findings,
+        "runtime_estimate": runtime_estimate,
+    }
+    write_json_atomic(audit_dir / "study_config.json", config)
+    write_json_atomic(audit_dir / "run_volume_estimate.json", runtime_estimate)
+    write_json_atomic(audit_dir / "data_audit.json", audit)
+    manifest = {
+        "study_id": STUDY_ID,
+        "snapshot_id": snapshot_id,
+        "snapshot_contract_version": SNAPSHOT_CONTRACT_VERSION,
+        "snapshot_config_sha256": config_sha256,
+        "audit_sha256": sha256_file(audit_dir / "data_audit.json"),
+        "index": index_meta,
+        "code_files": [
+            {
+                key: meta[key]
+                for key in (
+                    "code",
+                    "rows",
+                    "min_bar_at",
+                    "max_bar_at",
+                    "file_size",
+                    "file_sha256",
+                    "stock_trading_calendar_sha256",
+                    "stock_trading_calendar_min_date",
+                    "stock_trading_calendar_max_date",
+                )
+            }
+            for meta in metas
+        ],
+    }
+    write_json_atomic(root / "snapshot" / "manifest.json", manifest)
+    result = {
+        "study_id": STUDY_ID,
+        "evidence_grade": config["evidence_grade"],
+        "snapshot_id": snapshot_id,
+        "code_count": len(metas),
+        "nonempty_code_count": len(nonempty),
+        "bar_rows": total_bars,
+        "minute_period": config["actual_minute_period"],
+        "splits": splits,
+        "index_source_kind": index_meta["source_kind"],
+        "audit_path": str(audit_dir / "data_audit.json"),
+    }
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return result
+
+
+def _sum_nested_counts(values: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for mapping in values:
+        for key, value in mapping.items():
+            result[str(key)] = result.get(str(key), 0) + int(value)
+    return dict(sorted(result.items()))
+
+
+def _split_id(value: object, splits: Mapping[str, Sequence[str]]) -> str:
+    trade_date = pd.Timestamp(value).date().isoformat()
+    for split_id, bounds in splits.items():
+        if str(bounds[0]) <= trade_date <= str(bounds[1]):
+            return split_id
+    return "WARMUP"
+
+
+def _feature_arrays(bars: pd.DataFrame) -> dict[str, np.ndarray]:
+    close = pd.Series(
+        pd.to_numeric(bars["qfq_close"], errors="coerce").to_numpy(dtype=float)
+    )
+    amount = pd.Series(
+        pd.to_numeric(bars["raw_amount"], errors="coerce").to_numpy(dtype=float)
+    )
+    returns = close.pct_change(fill_method=None)
+    window20 = BAR_WINDOWS["20d"]
+    window60 = BAR_WINDOWS["60d"]
+    return {
+        "stock_return_20d": close.pct_change(window20, fill_method=None).to_numpy(),
+        "stock_drawdown_20d": (
+            close / close.rolling(window20, min_periods=window20).max() - 1
+        ).to_numpy(),
+        # Non-annualised daily-equivalent volatility: 30m std * sqrt(8).
+        "stock_volatility_20d": (
+            returns.rolling(window20, min_periods=window20).std() * math.sqrt(8)
+        ).to_numpy(),
+        "stock_above_ma60d_equivalent": (
+            close / close.rolling(window60, min_periods=window60).mean() - 1
+        ).to_numpy(),
+        "amount_median_20d": amount.rolling(window20, min_periods=window20)
+        .median()
+        .to_numpy(),
+    }
+
+
+def _normalise_stock_trading_dates(
+    values: Iterable[object],
+) -> list[date]:
+    parsed: set[date] = set()
+    for value in values:
+        timestamp = pd.Timestamp(value)
+        if pd.isna(timestamp):
+            raise RuntimeError("stock trading calendar contains an invalid date")
+        if timestamp.tzinfo is not None:
+            timestamp = timestamp.tz_convert(SHANGHAI_TIMEZONE)
+        parsed.add(timestamp.date())
+    return sorted(parsed)
+
+
+def compute_code_outcome_map(
+    bars: pd.DataFrame,
+    reveal_times: Iterable[object],
+    *,
+    horizons: Sequence[int] = HORIZONS,
+    fee_per_side: float = FEE_PER_SIDE,
+    stock_trading_dates: Sequence[object] | None = None,
+) -> dict[int, dict[str, Any]]:
+    """Match next-bar entries and stock-calendar/same-slot exits for one code."""
+
+    frame = bars.sort_values("bar_at", kind="stable").reset_index(drop=True).copy()
+    bar_at = pd.DatetimeIndex(frame["bar_at"])
+    if bar_at.tz is None:
+        bar_at = bar_at.tz_localize(SHANGHAI_TIMEZONE)
+    else:
+        bar_at = bar_at.tz_convert(SHANGHAI_TIMEZONE)
+    if bar_at.has_duplicates:
+        raise RuntimeError("snapshot contains duplicate bar_at")
+    times = bar_at.asi8
+    trade_dates = [pd.Timestamp(value).date() for value in frame["trade_date"]]
+    calendar_dates = _normalise_stock_trading_dates(
+        stock_trading_dates if stock_trading_dates is not None else trade_dates
+    )
+    calendar_index = {value: index for index, value in enumerate(calendar_dates)}
+    missing_calendar_dates = sorted(set(trade_dates) - set(calendar_dates))
+    if missing_calendar_dates:
+        raise RuntimeError(
+            "execution bars contain dates absent from the frozen stock trading "
+            f"calendar: {missing_calendar_dates[:3]}"
+        )
+    horizon_values: list[int] = []
+    for horizon in horizons:
+        if isinstance(horizon, bool) or not isinstance(horizon, (int, np.integer)):
+            raise TypeError("horizons must contain positive integers")
+        parsed_horizon = int(horizon)
+        if parsed_horizon <= 0:
+            raise RuntimeError("horizons must contain positive integers")
+        horizon_values.append(parsed_horizon)
+    if not (0 <= fee_per_side < 1):
+        raise RuntimeError("fee_per_side must be in [0, 1)")
+    slots = pd.to_numeric(frame["bar_slot"], errors="raise").to_numpy(dtype=int)
+    raw_opens = pd.to_numeric(frame["raw_open"], errors="coerce").to_numpy(dtype=float)
+    qfq_opens = pd.to_numeric(frame["qfq_open"], errors="coerce").to_numpy(dtype=float)
+    prior_closes = pd.to_numeric(
+        frame["prior_raw_daily_close"], errors="coerce"
+    ).to_numpy(dtype=float)
+
+    outcomes: dict[int, dict[str, Any]] = {}
+    unique_reveals = {
+        (
+            pd.Timestamp(value).tz_localize(SHANGHAI_TIMEZONE)
+            if pd.Timestamp(value).tzinfo is None
+            else pd.Timestamp(value).tz_convert(SHANGHAI_TIMEZONE)
+        )
+        for value in reveal_times
+    }
+    for reveal_at in sorted(unique_reveals):
+        outcome: dict[str, Any] = {
+            "reveal_at": reveal_at,
+            "entry_executable": False,
+            "entry_status": "NO_NEXT_BAR",
+        }
+        entry_index = int(np.searchsorted(times, reveal_at.value, side="right"))
+        if entry_index >= len(frame):
+            for horizon in horizon_values:
+                outcome[f"h{horizon}_status"] = "NO_NEXT_BAR"
+            outcomes[reveal_at.value] = outcome
+            continue
+        entry_raw = float(raw_opens[entry_index])
+        entry_qfq = float(qfq_opens[entry_index])
+        prior_close = float(prior_closes[entry_index])
+        entry_date = trade_dates[entry_index]
+        entry_slot = int(slots[entry_index])
+        outcome.update(
+            {
+                "_entry_index": entry_index,
+                "entry_at": bar_at[entry_index],
+                "entry_trade_date": entry_date,
+                "entry_bar_slot": entry_slot,
+                "raw_entry_open": entry_raw,
+                "qfq_entry_open": entry_qfq,
+                "prior_raw_daily_close": prior_close,
+            }
+        )
+        if not (
+            math.isfinite(entry_raw)
+            and entry_raw > 0
+            and math.isfinite(entry_qfq)
+            and entry_qfq > 0
+            and math.isfinite(prior_close)
+            and prior_close > 0
+        ):
+            outcome["entry_status"] = "INVALID_ENTRY_PRICE"
+            for horizon in horizon_values:
+                outcome[f"h{horizon}_status"] = "INVALID_ENTRY_PRICE"
+            outcomes[reveal_at.value] = outcome
+            continue
+        entry_gap = entry_raw / prior_close - 1
+        outcome["raw_entry_gap"] = entry_gap
+        if entry_gap > LIMIT_MOVE:
+            outcome["entry_status"] = "ENTRY_LIMIT_UP"
+            for horizon in horizon_values:
+                outcome[f"h{horizon}_status"] = "ENTRY_LIMIT_UP"
+            outcomes[reveal_at.value] = outcome
+            continue
+        outcome["entry_status"] = "OK"
+        outcome["entry_executable"] = True
+        entry_session_index = calendar_index[entry_date]
+        for horizon in horizon_values:
+            prefix = f"h{horizon}"
+            target_session_index = entry_session_index + int(horizon)
+            if target_session_index >= len(calendar_dates):
+                outcome[f"{prefix}_status"] = "CENSORED"
+                outcome[f"{prefix}_censor_reason"] = "NO_TARGET_STOCK_TRADING_DAY"
+                continue
+            target_date = calendar_dates[target_session_index]
+            target_at = pd.Timestamp(
+                f"{target_date.isoformat()} {BAR_SLOT_CLOCKS[entry_slot]}",
+                tz=SHANGHAI_TIMEZONE,
+            )
+            outcome[f"{prefix}_target_trade_date"] = target_date
+            outcome[f"{prefix}_target_at"] = target_at
+            candidate_index = int(np.searchsorted(times, target_at.value, side="left"))
+            target_slot_exists = bool(
+                candidate_index < len(frame)
+                and times[candidate_index] == target_at.value
+            )
+            limit_down_skips = 0
+            invalid_exit = False
+            while candidate_index < len(frame):
+                raw_open = float(raw_opens[candidate_index])
+                candidate_prior_close = float(prior_closes[candidate_index])
+                if not (
+                    math.isfinite(raw_open)
+                    and raw_open > 0
+                    and math.isfinite(candidate_prior_close)
+                    and candidate_prior_close > 0
+                ):
+                    invalid_exit = True
+                    break
+                if raw_open / candidate_prior_close - 1 <= -LIMIT_MOVE:
+                    limit_down_skips += 1
+                    candidate_index += 1
+                    continue
+                break
+            if candidate_index >= len(frame):
+                outcome[f"{prefix}_status"] = (
+                    "CENSORED_LIMIT_DOWN" if limit_down_skips else "CENSORED"
+                )
+                outcome[f"{prefix}_censor_reason"] = (
+                    "NO_TRADABLE_BAR_AFTER_LIMIT_DOWN"
+                    if limit_down_skips
+                    else "NO_EXIT_BAR_AT_OR_AFTER_TARGET"
+                )
+                outcome[f"{prefix}_target_slot_exists"] = target_slot_exists
+                outcome[f"{prefix}_limit_down_skip_count"] = limit_down_skips
+                continue
+            if invalid_exit:
+                outcome[f"{prefix}_status"] = "INVALID_EXIT_PRICE"
+                continue
+            exit_qfq = float(qfq_opens[candidate_index])
+            if not math.isfinite(exit_qfq) or exit_qfq <= 0:
+                outcome[f"{prefix}_status"] = "INVALID_EXIT_PRICE"
+                continue
+            exit_date = trade_dates[candidate_index]
+            exit_slot = int(slots[candidate_index])
+            if exit_date not in calendar_index:
+                raise RuntimeError(
+                    f"exit date {exit_date} is absent from stock calendar"
+                )
+            delay = (
+                (calendar_index[exit_date] - target_session_index)
+                * len(BAR_SLOT_CLOCKS)
+                + exit_slot
+                - entry_slot
+            )
+            fallback_reasons = []
+            if not target_slot_exists:
+                fallback_reasons.append("TARGET_SLOT_OR_SESSION_MISSING")
+            if limit_down_skips:
+                fallback_reasons.append("LIMIT_DOWN")
+            gross_return = exit_qfq / entry_qfq - 1
+            net_return = (1 + gross_return) * (1 - fee_per_side) / (
+                1 + fee_per_side
+            ) - 1
+            outcome.update(
+                {
+                    f"{prefix}_status": "OK",
+                    f"{prefix}_exit_at": bar_at[candidate_index],
+                    f"{prefix}_exit_trade_date": exit_date,
+                    f"{prefix}_exit_bar_slot": exit_slot,
+                    f"{prefix}_exit_delay": delay,
+                    f"{prefix}_target_slot_exists": target_slot_exists,
+                    f"{prefix}_limit_down_skip_count": limit_down_skips,
+                    f"{prefix}_exit_fallback_used": bool(fallback_reasons),
+                    f"{prefix}_exit_fallback_reason": "+".join(fallback_reasons),
+                    f"{prefix}_gross_return": gross_return,
+                    f"{prefix}_net_return": net_return,
+                }
+            )
+        outcomes[reveal_at.value] = outcome
+    return outcomes
+
+
+def build_full_candidate_frame(
+    *,
+    events: Sequence[Mapping[str, Any]],
+    bars: pd.DataFrame,
+    splits: Mapping[str, Sequence[str]],
+    stock_trading_dates: Sequence[object] | None = None,
+) -> pd.DataFrame:
+    """Keep one executable row per model/reveal and audit collapsed facts."""
+
+    if not events:
+        return pd.DataFrame()
+    frame = pd.DataFrame(events)
+    frame = frame[frame["actionable"].eq(True) & frame["direction"].eq(1)].copy()
+    if frame.empty:
+        return frame
+    frame["signal_at"] = pd.to_datetime(frame["signal_at"], utc=True).dt.tz_convert(
+        SHANGHAI_TIMEZONE
+    )
+    frame["reveal_at"] = pd.to_datetime(frame["reveal_at"], utc=True).dt.tz_convert(
+        SHANGHAI_TIMEZONE
+    )
+    duplicate_keys = ["code", "model_code", "reveal_at"]
+    frame["same_model_reveal_fact_count"] = (
+        frame.groupby(duplicate_keys)["signal_fact_id"]
+        .transform("size")
+        .astype("int16")
+    )
+    frame["same_model_reveal_unique_signal_count"] = (
+        frame.groupby(duplicate_keys)["signal_at"].transform("nunique").astype("int16")
+    )
+    frame["same_model_reveal_collapsed_fact_count"] = (
+        frame["same_model_reveal_fact_count"] - 1
+    ).astype("int16")
+    frame["same_model_reveal_selection_policy"] = (
+        "LATEST_SIGNAL_AT_THEN_REVISION_THEN_FACT_ID"
+    )
+    frame = (
+        frame.sort_values(
+            [
+                "code",
+                "model_code",
+                "reveal_at",
+                "signal_at",
+                "revision_no",
+                "signal_fact_id",
+            ],
+            kind="stable",
+        )
+        .drop_duplicates(duplicate_keys, keep="last")
+        .reset_index(drop=True)
+    )
+    trigger_masks = pd.to_numeric(
+        frame["concurrent_trigger_mask"], errors="raise"
+    ).astype("int64")
+    invalid_masks = trigger_masks.lt(0) | trigger_masks.map(
+        lambda value: bool(int(value) & ~TRIGGER_MASK)
+    )
+    if invalid_masks.any():
+        invalid_values = sorted({int(value) for value in trigger_masks[invalid_masks]})
+        raise RuntimeError(
+            f"native output contains unknown trigger bits: {invalid_values[:5]}"
+        )
+    frame["concurrent_trigger_mask"] = trigger_masks
+    frame = frame[frame["concurrent_trigger_mask"].ne(0)].copy()
+    if frame.empty:
+        return frame
+
+    sorted_bars = bars.sort_values("bar_at", kind="stable").reset_index(drop=True)
+    bar_at = pd.DatetimeIndex(sorted_bars["bar_at"])
+    if bar_at.tz is None:
+        bar_at = bar_at.tz_localize(SHANGHAI_TIMEZONE)
+    else:
+        bar_at = bar_at.tz_convert(SHANGHAI_TIMEZONE)
+    bar_index = {int(value): index for index, value in enumerate(bar_at.asi8)}
+    features = _feature_arrays(sorted_bars)
+    outcomes = compute_code_outcome_map(
+        sorted_bars,
+        frame["reveal_at"],
+        stock_trading_dates=stock_trading_dates,
+    )
+    enriched: list[dict[str, Any]] = []
+    for row in frame.to_dict(orient="records"):
+        reveal = pd.Timestamp(row["reveal_at"])
+        signal = pd.Timestamp(row["signal_at"])
+        split_id = _split_id(reveal, splits)
+        split_bounds = splits.get(split_id)
+        reveal_index = bar_index[reveal.value]
+        signal_index = bar_index[signal.value]
+        outcome = dict(outcomes[reveal.value])
+        entry_index = outcome.pop("_entry_index", None)
+        values: dict[str, Any] = {
+            name: float(array[reveal_index]) for name, array in features.items()
+        }
+        raw_open = float(sorted_bars.at[reveal_index, "raw_open"])
+        values.update(
+            {
+                "raw_signal_open": raw_open,
+                "qfq_signal_close": float(sorted_bars.at[reveal_index, "qfq_close"]),
+                "reveal_bar_slot": int(sorted_bars.at[reveal_index, "bar_slot"]),
+                "signal_bar_slot": int(sorted_bars.at[signal_index, "bar_slot"]),
+                "signal_age_bars": reveal_index - signal_index,
+                "source_duplicate_count_at_reveal": int(
+                    sorted_bars.at[reveal_index, "source_duplicate_count"]
+                ),
+                "concurrent_trigger_count": int(
+                    int(row["concurrent_trigger_mask"]).bit_count()
+                ),
+                "reveal_trade_date": reveal.date(),
+                "split_id": split_id,
+                "split_start_trade_date": (
+                    pd.Timestamp(split_bounds[0]).date()
+                    if split_bounds is not None
+                    else None
+                ),
+                "split_end_trade_date": (
+                    pd.Timestamp(split_bounds[1]).date()
+                    if split_bounds is not None
+                    else None
+                ),
+                "entry_overnight": (
+                    bool(
+                        entry_index is not None
+                        and sorted_bars.at[entry_index, "trade_date"] > reveal.date()
+                    )
+                    if entry_index is not None
+                    else None
+                ),
+                "entry_delay_bars": (
+                    int(entry_index - reveal_index) if entry_index is not None else None
+                ),
+            }
+        )
+        for horizon in HORIZONS:
+            prefix = f"h{horizon}"
+            maturity_at = outcome.get(f"{prefix}_exit_at")
+            outcome[f"{prefix}_result_maturity_at"] = maturity_at
+            if split_bounds is None:
+                boundary_status = "OUT_OF_SCOPE"
+            elif outcome.get(f"{prefix}_status") != "OK":
+                boundary_status = "UNAVAILABLE"
+            elif (
+                pd.Timestamp(maturity_at).date() <= pd.Timestamp(split_bounds[1]).date()
+            ):
+                boundary_status = "AVAILABLE"
+            else:
+                boundary_status = "PURGED"
+            outcome[f"{prefix}_split_boundary_status"] = boundary_status
+        for trigger_name, bit in TRIGGER_BITS.items():
+            values[f"trigger_{trigger_name.lower()}"] = bool(
+                int(row["concurrent_trigger_mask"]) & bit
+            )
+        values.update(
+            {
+                "f1_raw_open_1_to_6": 1.0 <= raw_open <= 6.0,
+                "f2_return_20d_le_0": (
+                    math.isfinite(values["stock_return_20d"])
+                    and values["stock_return_20d"] <= 0
+                ),
+                "f3_drawdown_20d_ge_10pct": (
+                    math.isfinite(values["stock_drawdown_20d"])
+                    and values["stock_drawdown_20d"] <= -0.10
+                ),
+                "f4_volatility_20d_ge_3pct": (
+                    math.isfinite(values["stock_volatility_20d"])
+                    and values["stock_volatility_20d"] >= 0.03
+                ),
+                "f5_close_le_ma60d_equivalent": (
+                    math.isfinite(values["stock_above_ma60d_equivalent"])
+                    and values["stock_above_ma60d_equivalent"] <= 0
+                ),
+            }
+        )
+        enriched.append({**row, **values, **outcome})
+    return (
+        pd.DataFrame(enriched)
+        .sort_values(["code", "reveal_at", "model_code"], kind="stable")
+        .reset_index(drop=True)
+    )
+
+
+def _engine_identity() -> dict[str, Any]:
+    backend = importlib.import_module("fqcopilot")
+    path = Path(str(backend.__file__)).resolve()
+    detailed = callable(getattr(backend, "fq_clxs_all_detailed", None))
+    if not detailed:
+        raise RuntimeError("native fqcopilot lacks fq_clxs_all_detailed")
+    return {
+        "module": "fqcopilot",
+        "path": str(path),
+        "file_size": path.stat().st_size,
+        "file_sha256": sha256_file(path),
+        "detailed_output": True,
+    }
+
+
+def _module_identity(module_name: str) -> dict[str, Any]:
+    module = importlib.import_module(module_name)
+    path = Path(str(module.__file__)).resolve()
+    return {
+        "module": module_name,
+        "path": str(path),
+        "file_size": path.stat().st_size,
+        "file_sha256": sha256_file(path),
+    }
+
+
+def _replay_logic_sha256() -> str:
+    functions = (
+        _feature_arrays,
+        _normalise_stock_trading_dates,
+        compute_code_outcome_map,
+        build_full_candidate_frame,
+        replay_one_code,
+    )
+    return sha256_bytes(
+        "\n".join(
+            ast.dump(
+                ast.parse(inspect.getsource(function)),
+                annotate_fields=True,
+                include_attributes=False,
+            )
+            for function in functions
+        ).encode("utf-8")
+    )
+
+
+def replay_one_code(
+    *,
+    root: str,
+    code: str,
+    snapshot_file_sha256: str,
+    stock_trading_calendar_sha256: str,
+    signal_set_id: str,
+    options: Mapping[str, int],
+    splits: Mapping[str, Sequence[str]],
+) -> dict[str, Any]:
+    output_root = Path(root)
+    data_path, meta_path = _replay_code_paths(output_root, code)
+    existing = _valid_checkpoint(
+        data_path=data_path,
+        meta_path=meta_path,
+        identity_key="signal_set_id",
+        identity_value=signal_set_id,
+    )
+    if (
+        existing is not None
+        and existing.get("snapshot_file_sha256") == snapshot_file_sha256
+        and existing.get("stock_trading_calendar_sha256")
+        == stock_trading_calendar_sha256
+    ):
+        return {**existing, "checkpoint_status": "REUSED"}
+    snapshot_path, snapshot_meta_path = _snapshot_code_paths(output_root, code)
+    if sha256_file(snapshot_path) != snapshot_file_sha256:
+        raise RuntimeError(f"{code} snapshot file hash changed")
+    snapshot_meta = read_json(snapshot_meta_path)
+    stock_trading_dates = snapshot_meta.get("stock_trading_dates")
+    if not isinstance(stock_trading_dates, list):
+        raise TypeError(f"{code} snapshot has no frozen stock calendar")
+    actual_calendar_sha256 = sha256_bytes(canonical_json_bytes(stock_trading_dates))
+    if actual_calendar_sha256 != stock_trading_calendar_sha256:
+        raise RuntimeError(f"{code} stock trading calendar hash changed")
+    bars = pd.read_parquet(snapshot_path)
+    started = time.perf_counter()
+    engine = FqCopilotClxEngine()
+    if not engine.supports_detailed_output:
+        raise RuntimeError("native fqcopilot lacks fq_clxs_all_detailed")
+    events = replay_prefix_events(
+        bars=bars,
+        engine=engine,
+        signal_set_id=signal_set_id,
+        options=ClxEngineOptions(**dict(options)),
+        code=code,
+    )
+    candidates = build_full_candidate_frame(
+        events=events,
+        bars=bars,
+        splits=splits,
+        stock_trading_dates=stock_trading_dates,
+    )
+    write_frame_atomic(candidates, data_path)
+    mask_counts = (
+        candidates["concurrent_trigger_mask"].value_counts().sort_index().to_dict()
+        if len(candidates)
+        else {}
+    )
+    meta = {
+        "code": code,
+        "signal_set_id": signal_set_id,
+        "snapshot_file_sha256": snapshot_file_sha256,
+        "stock_trading_calendar_sha256": stock_trading_calendar_sha256,
+        "logical_path": f"replay/candidates/{code}.parquet",
+        "source_bar_rows": len(bars),
+        "prefix_calls": len(bars),
+        "revision_event_rows": len(events),
+        "candidate_rows": len(candidates),
+        "unique_reveal_times": (
+            int(candidates["reveal_at"].nunique()) if len(candidates) else 0
+        ),
+        "exact_trigger_mask_counts": {
+            str(key): int(value) for key, value in mask_counts.items()
+        },
+        "file_size": data_path.stat().st_size,
+        "file_sha256": sha256_file(data_path),
+        "elapsed_seconds": round(time.perf_counter() - started, 3),
+    }
+    write_json_atomic(meta_path, meta)
+    return {**meta, "checkpoint_status": "BUILT"}
+
+
+def run_replay(args: argparse.Namespace) -> dict[str, Any]:
+    root = args.root.resolve()
+    snapshot_manifest_path = root / "snapshot" / "manifest.json"
+    audit_path = root / "audit" / "data_audit.json"
+    snapshot_manifest = read_json(snapshot_manifest_path)
+    audit = read_json(audit_path)
+    engine_identity = _engine_identity()
+    options = {
+        "wave_opt": args.wave_opt,
+        "stretch_opt": args.stretch_opt,
+        "trend_opt": args.trend_opt,
+    }
+    signal_contract = {
+        "study_id": STUDY_ID,
+        "signal_replay_contract_version": SIGNAL_REPLAY_CONTRACT_VERSION,
+        "snapshot_id": snapshot_manifest["snapshot_id"],
+        "engine_identity": engine_identity,
+        "python_adapter_identities": [
+            _module_identity("freshquant.backtest.clx.engine"),
+            _module_identity("freshquant.backtest.clx.intraday"),
+        ],
+        "replay_logic_sha256": _replay_logic_sha256(),
+        "engine_options": options,
+        "causal_route": "EXACT_FROM_ZERO_PREFIX_PER_ACTUAL_30MIN_BAR",
+        "direction": "BUY_ONLY",
+        "trigger_mask": TRIGGER_MASK,
+        "native_trigger_bits": TRIGGER_BITS,
+        "horizons": list(HORIZONS),
+        "horizon_calendar": "PER_CODE_FROZEN_STOCK_DAY_DATES",
+        "target_exit": (
+            "entry slot on the Nth later frozen stock_day date, then the first "
+            "actual tradable 30-minute open at or after that timestamp"
+        ),
+        "fee_per_side": FEE_PER_SIDE,
+        "splits": audit["config"]["time_splits"],
+    }
+    signal_set_id = "sha256:" + sha256_bytes(canonical_json_bytes(signal_contract))
+    metas = [
+        dict(meta) for meta in snapshot_manifest["code_files"] if int(meta["rows"]) > 0
+    ]
+    if args.code:
+        requested = {str(value) for value in args.code}
+        metas = [meta for meta in metas if str(meta["code"]) in requested]
+    if args.code_limit is not None:
+        metas = metas[: args.code_limit]
+    if not metas:
+        raise RuntimeError("no non-empty snapshot codes selected")
+
+    progress_path = root / "replay" / "progress.json"
+    outputs: dict[str, dict[str, Any]] = {}
+    failures: dict[str, str] = {}
+    started = time.perf_counter()
+    with ProcessPoolExecutor(max_workers=args.workers) as executor:
+        futures = {
+            executor.submit(
+                replay_one_code,
+                root=str(root),
+                code=str(meta["code"]),
+                snapshot_file_sha256=str(meta["file_sha256"]),
+                stock_trading_calendar_sha256=str(
+                    meta["stock_trading_calendar_sha256"]
+                ),
+                signal_set_id=signal_set_id,
+                options=options,
+                splits=audit["config"]["time_splits"],
+            ): str(meta["code"])
+            for meta in metas
+        }
+        for completed, future in enumerate(as_completed(futures), start=1):
+            code = futures[future]
+            try:
+                outputs[code] = future.result()
+            except Exception as exc:  # noqa: BLE001 - persisted worker boundary
+                failures[code] = f"{type(exc).__name__}: {exc}"
+            if (
+                completed == len(metas)
+                or completed % args.progress_every == 0
+                or failures
+            ):
+                elapsed = time.perf_counter() - started
+                progress = {
+                    "phase": "full_trigger_replay",
+                    "total_codes": len(metas),
+                    "completed_codes": completed,
+                    "successful_codes": len(outputs),
+                    "failed_codes": len(failures),
+                    "prefix_calls_completed": sum(
+                        int(meta["prefix_calls"]) for meta in outputs.values()
+                    ),
+                    "revision_event_rows": sum(
+                        int(meta["revision_event_rows"]) for meta in outputs.values()
+                    ),
+                    "candidate_rows": sum(
+                        int(meta["candidate_rows"]) for meta in outputs.values()
+                    ),
+                    "elapsed_seconds": round(elapsed, 3),
+                    "estimated_remaining_seconds": (
+                        round(elapsed / completed * (len(metas) - completed), 1)
+                        if completed
+                        else None
+                    ),
+                    "failures": failures,
+                }
+                write_json_atomic(progress_path, progress)
+                print(json.dumps(progress, ensure_ascii=False), flush=True)
+    if failures:
+        raise RuntimeError(
+            f"replay failed for {len(failures)} codes; inspect {progress_path}"
+        )
+    ordered = [outputs[str(meta["code"])] for meta in metas]
+    replay_manifest = {
+        "study_id": STUDY_ID,
+        "signal_set_id": signal_set_id,
+        "signal_contract": signal_contract,
+        "snapshot_id": snapshot_manifest["snapshot_id"],
+        "snapshot_manifest_file_sha256": sha256_file(snapshot_manifest_path),
+        "code_files": [
+            {
+                key: meta[key]
+                for key in (
+                    "code",
+                    "source_bar_rows",
+                    "prefix_calls",
+                    "revision_event_rows",
+                    "candidate_rows",
+                    "file_size",
+                    "file_sha256",
+                    "stock_trading_calendar_sha256",
+                )
+            }
+            for meta in ordered
+        ],
+        "totals": {
+            "codes": len(ordered),
+            "prefix_calls": sum(int(meta["prefix_calls"]) for meta in ordered),
+            "revision_event_rows": sum(
+                int(meta["revision_event_rows"]) for meta in ordered
+            ),
+            "candidate_rows": sum(int(meta["candidate_rows"]) for meta in ordered),
+            "exact_trigger_mask_counts": _sum_nested_counts(
+                meta["exact_trigger_mask_counts"] for meta in ordered
+            ),
+        },
+    }
+    manifest_path = root / "replay" / "manifest.json"
+    write_json_atomic(manifest_path, replay_manifest)
+    result = {
+        "study_id": STUDY_ID,
+        "signal_set_id": signal_set_id,
+        "codes": len(ordered),
+        **replay_manifest["totals"],
+        "manifest_path": str(manifest_path),
+    }
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return result
+
+
+def _load_replay_candidates(
+    *,
+    root: Path,
+    allow_partial: bool,
+) -> tuple[pd.DataFrame, list[dict[str, Any]], list[str]]:
+    snapshot_manifest = read_json(root / "snapshot" / "manifest.json")
+    expected_by_code = {
+        str(meta["code"]): dict(meta)
+        for meta in snapshot_manifest["code_files"]
+        if int(meta["rows"]) > 0
+    }
+    expected = list(expected_by_code)
+    frames: list[pd.DataFrame] = []
+    metas: list[dict[str, Any]] = []
+    missing: list[str] = []
+    for code in expected:
+        path, meta_path = _replay_code_paths(root, code)
+        if not path.is_file() or not meta_path.is_file():
+            missing.append(code)
+            continue
+        meta = read_json(meta_path)
+        if meta["file_sha256"] != sha256_file(path):
+            raise RuntimeError(f"{code} replay candidate hash mismatch")
+        snapshot_meta = expected_by_code[code]
+        if meta.get("snapshot_file_sha256") != snapshot_meta["file_sha256"]:
+            raise RuntimeError(f"{code} replay uses a stale snapshot file")
+        if (
+            meta.get("stock_trading_calendar_sha256")
+            != snapshot_meta["stock_trading_calendar_sha256"]
+        ):
+            raise RuntimeError(f"{code} replay uses a stale stock calendar")
+        metas.append(meta)
+        if int(meta["candidate_rows"]) > 0:
+            frames.append(pd.read_parquet(path))
+    if missing and not allow_partial:
+        raise RuntimeError(f"replay incomplete: {len(missing)} codes are absent")
+    if not frames:
+        raise RuntimeError("no full-trigger candidate facts")
+    signal_set_ids = {str(meta.get("signal_set_id")) for meta in metas}
+    if len(signal_set_ids) != 1:
+        raise RuntimeError("replay checkpoints mix multiple signal_set_id values")
+    replay_manifest_path = root / "replay" / "manifest.json"
+    if replay_manifest_path.is_file():
+        replay_manifest = read_json(replay_manifest_path)
+        if signal_set_ids != {str(replay_manifest["signal_set_id"])}:
+            raise RuntimeError("replay checkpoints disagree with replay manifest")
+    return pd.concat(frames, ignore_index=True), metas, missing
+
+
+def _attach_index_features(events: pd.DataFrame, index: pd.DataFrame) -> pd.DataFrame:
+    classified = classify_market_regimes(index)
+    classified["index_return_20"] = classified["close"].pct_change(20, fill_method=None)
+    keep = [
+        column
+        for column in classified.columns
+        if column == "date"
+        or column.startswith("index_")
+        or column
+        in {
+            "market_regime",
+            "raw_market_regime",
+            "regime_segment_no",
+        }
+    ]
+    frame = attach_previous_session_regimes(events, classified.loc[:, keep])
+    if (
+        (
+            pd.to_datetime(frame["index_feature_date"]).dt.date
+            >= pd.to_datetime(frame["reveal_at"]).dt.date
+        )
+        .fillna(False)
+        .any()
+    ):
+        raise RuntimeError("future-or-same-session index feature join detected")
+    frame["f6_index_return_20d_le_0"] = (
+        pd.to_numeric(frame["index_return_20"], errors="coerce").le(0)
+        & frame["index_return_20"].notna()
+    )
+    return frame
+
+
+def _filter_pass_mask(frame: pd.DataFrame) -> np.ndarray:
+    columns = (
+        "f1_raw_open_1_to_6",
+        "f2_return_20d_le_0",
+        "f3_drawdown_20d_ge_10pct",
+        "f4_volatility_20d_ge_3pct",
+        "f5_close_le_ma60d_equivalent",
+        "f6_index_return_20d_le_0",
+    )
+    output = np.zeros(len(frame), dtype=np.uint8)
+    for offset, column in enumerate(columns):
+        output |= (
+            frame[column].fillna(False).to_numpy(dtype=bool).astype(np.uint8) << offset
+        )
+    return output
+
+
+def run_features(args: argparse.Namespace) -> dict[str, Any]:
+    root = args.root.resolve()
+    events, metas, missing = _load_replay_candidates(
+        root=root,
+        allow_partial=args.allow_partial,
+    )
+    for column in ("signal_at", "reveal_at", "entry_at"):
+        if column in events:
+            events[column] = pd.to_datetime(events[column], utc=True).dt.tz_convert(
+                SHANGHAI_TIMEZONE
+            )
+    index = pd.read_parquet(root / "snapshot" / "index_day.parquet")
+    events = _attach_index_features(events, index)
+    events["filter_pass_mask"] = _filter_pass_mask(events)
+    events["union_signal_id"] = [
+        "sha256:"
+        + sha256_bytes(
+            canonical_json_bytes(
+                {
+                    "code": str(code),
+                    "reveal_at": pd.Timestamp(reveal).isoformat(),
+                }
+            )
+        )
+        for code, reveal in zip(events["code"], events["reveal_at"], strict=True)
+    ]
+    events["same_code_reveal_model_count"] = (
+        events.groupby(["code", "reveal_at"])["model_code"]
+        .transform("nunique")
+        .astype("int16")
+    )
+    events["same_reveal_stock_count"] = (
+        events.groupby("reveal_at")["code"].transform("nunique").astype("int32")
+    )
+    events["same_reveal_event_count"] = (
+        events.groupby("reveal_at")["signal_fact_id"]
+        .transform("nunique")
+        .astype("int32")
+    )
+    output_path = root / "features" / "candidate_events.parquet"
+    write_frame_atomic(events, output_path)
+    segments = build_market_segments(classify_market_regimes(index))
+    segments.to_csv(
+        root / "features" / "market_segments.csv",
+        index=False,
+        encoding="utf-8-sig",
+    )
+    summary = {
+        "study_id": STUDY_ID,
+        "partial": bool(missing),
+        "missing_codes": missing,
+        "replayed_codes": len(metas),
+        "candidate_event_rows": len(events),
+        "unique_union_signals": int(events["union_signal_id"].nunique()),
+        "unique_stocks": int(events["code"].nunique()),
+        "unique_reveal_times": int(events["reveal_at"].nunique()),
+        "models": sorted(events["model_code"].unique()),
+        "exact_trigger_mask_counts": {
+            str(key): int(value)
+            for key, value in events["concurrent_trigger_mask"]
+            .value_counts()
+            .sort_index()
+            .items()
+        },
+        "trigger_concurrency_counts": {
+            str(key): int(value)
+            for key, value in events["concurrent_trigger_count"]
+            .value_counts()
+            .sort_index()
+            .items()
+        },
+        "execution_audit": {
+            "entry_status_counts": {
+                str(key): int(value)
+                for key, value in events["entry_status"]
+                .value_counts(dropna=False)
+                .items()
+            },
+            "entry_overnight_rows": int(events["entry_overnight"].fillna(False).sum()),
+            "horizons": {
+                str(horizon): {
+                    "status_counts": {
+                        str(key): int(value)
+                        for key, value in events[f"h{horizon}_status"]
+                        .value_counts(dropna=False)
+                        .items()
+                    },
+                    "fallback_rows": int(
+                        events.get(
+                            f"h{horizon}_exit_fallback_used",
+                            pd.Series(False, index=events.index),
+                        )
+                        .fillna(False)
+                        .sum()
+                    ),
+                    "purged_rows": int(
+                        events[f"h{horizon}_split_boundary_status"].eq("PURGED").sum()
+                    ),
+                }
+                for horizon in HORIZONS
+            },
+        },
+        "within_cross_model_duplicates": {
+            "rows_with_same_model_reveal_collapsed_facts": int(
+                events["same_model_reveal_fact_count"].gt(1).sum()
+            ),
+            "same_model_reveal_facts_collapsed": int(
+                events["same_model_reveal_collapsed_fact_count"].sum()
+            ),
+            "max_facts_same_model_reveal": int(
+                events["same_model_reveal_fact_count"].max()
+            ),
+            "same_model_reveal_selection_policy": (
+                "LATEST_SIGNAL_AT_THEN_REVISION_THEN_FACT_ID"
+            ),
+            "rows_with_cross_model_same_code_reveal": int(
+                events["same_code_reveal_model_count"].gt(1).sum()
+            ),
+            "max_models_same_code_reveal": int(
+                events["same_code_reveal_model_count"].max()
+            ),
+        },
+        "future_or_same_day_index_joins": int(
+            (
+                pd.to_datetime(events["index_feature_date"]).dt.date
+                >= events["reveal_at"].dt.date
+            )
+            .fillna(False)
+            .sum()
+        ),
+        "output": {
+            "path": str(output_path),
+            "file_size": output_path.stat().st_size,
+            "file_sha256": sha256_file(output_path),
+        },
+    }
+    write_json_atomic(root / "features" / "summary.json", summary)
+    write_json_atomic(
+        root / "features" / "manifest.json",
+        {
+            "study_id": STUDY_ID,
+            "snapshot_id": read_json(root / "snapshot" / "manifest.json")[
+                "snapshot_id"
+            ],
+            "signal_set_id": metas[0]["signal_set_id"],
+            "summary": summary,
+        },
+    )
+    print(json.dumps(summary, ensure_ascii=False), flush=True)
+    return summary
+
+
+def run_status(args: argparse.Namespace) -> dict[str, Any]:
+    root = args.root.resolve()
+    snapshot_manifest = root / "snapshot" / "manifest.json"
+    replay_manifest = root / "replay" / "manifest.json"
+    feature_manifest = root / "features" / "manifest.json"
+    result = {
+        "study_id": STUDY_ID,
+        "root": str(root),
+        "audit_complete": (root / "audit" / "data_audit.json").is_file(),
+        "snapshot_complete": snapshot_manifest.is_file(),
+        "replay_complete": replay_manifest.is_file(),
+        "features_complete": feature_manifest.is_file(),
+        "audit_progress": (
+            read_json(root / "audit" / "progress.json")
+            if (root / "audit" / "progress.json").is_file()
+            else None
+        ),
+        "replay_progress": (
+            read_json(root / "replay" / "progress.json")
+            if (root / "replay" / "progress.json").is_file()
+            else None
+        ),
+    }
+    print(json.dumps(result, ensure_ascii=False), flush=True)
+    return result
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    audit = subparsers.add_parser("audit")
+    audit.add_argument("--mongo-uri", default=DEFAULT_MONGO_URI)
+    audit.add_argument("--start-date", default=DEFAULT_START_DATE)
+    audit.add_argument("--end-date")
+    audit.add_argument("--workers", type=_positive_int, default=8)
+    audit.add_argument("--progress-every", type=_positive_int, default=25)
+    audit.add_argument("--code", action="append", default=[])
+    audit.add_argument("--code-limit", type=int)
+    audit.set_defaults(handler=run_audit)
+
+    replay = subparsers.add_parser("replay")
+    replay.add_argument(
+        "--workers",
+        type=_positive_int,
+        default=max(1, min(24, (os.cpu_count() or 2) - 4)),
+    )
+    replay.add_argument("--progress-every", type=_positive_int, default=10)
+    replay.add_argument("--code", action="append", default=[])
+    replay.add_argument("--code-limit", type=int)
+    replay.add_argument("--wave-opt", type=int, default=1560)
+    replay.add_argument("--stretch-opt", type=int, default=0)
+    replay.add_argument("--trend-opt", type=int, default=0)
+    replay.set_defaults(handler=run_replay)
+
+    features = subparsers.add_parser("features")
+    features.add_argument("--allow-partial", action="store_true")
+    features.set_defaults(handler=run_features)
+
+    status = subparsers.add_parser("status")
+    status.set_defaults(handler=run_status)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    args.handler(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py
+++ b/sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py
@@ -112,6 +112,48 @@ def _insert_stock_day_rows(collection, data):
     collection.insert_many(documents)
     return len(documents)
 
+
+def _select_strictly_new_minute_rows(data, latest_datetime):
+    """Keep fetched minute bars strictly newer than the Mongo high-water mark.
+
+    TDX does not always return the requested starting bar (for example when
+    Mongo contains a pre-listing placeholder).  Dropping ``data.iloc[0]``
+    therefore loses the first real bar.  Compare timestamps instead.
+    """
+    if data is None or getattr(data, 'empty', False):
+        return data
+    fetched_at = pd.to_datetime(data['datetime'], errors='coerce')
+    if latest_datetime is None:
+        selected = data.loc[fetched_at.notna()]
+    else:
+        cutoff = pd.Timestamp(latest_datetime)
+        selected = data.loc[fetched_at > cutoff]
+    time_key = (
+        'time_stamp'
+        if 'time_stamp' in selected.columns
+        else 'datetime' if 'datetime' in selected.columns else None
+    )
+    dedupe_keys = [
+        key
+        for key in ('code', 'type', time_key)
+        if key is not None and key in selected.columns
+    ]
+    if dedupe_keys:
+        selected = selected.drop_duplicates(dedupe_keys, keep='last')
+    return selected
+
+
+def _insert_new_minute_rows(collection, data, latest_datetime):
+    selected = _select_strictly_new_minute_rows(data, latest_datetime)
+    if selected is None or getattr(selected, 'empty', False):
+        return 0
+    documents = QA_util_to_json_from_pandas(selected)
+    if not documents:
+        return 0
+    collection.insert_many(documents)
+    return len(documents)
+
+
 def QA_SU_save_single_stock_day(code : str, client= DATABASE, ui_log=None):
     '''
      save single stock_day
@@ -766,10 +808,7 @@ def QA_SU_save_stock_min(client=DATABASE, ui_log=None, ui_progress=None):
                             end_time,
                             type
                         )
-                        if len(__data) > 1:
-                            coll.insert_many(
-                                QA_util_to_json_from_pandas(__data)[1::]
-                            )
+                        _insert_new_minute_rows(coll, __data, start_time)
                 else:
                     start_time = '2015-01-01'
                     QA_util_log_info(
@@ -793,10 +832,7 @@ def QA_SU_save_stock_min(client=DATABASE, ui_log=None, ui_progress=None):
                             end_time,
                             type
                         )
-                        if len(__data) > 1:
-                            coll.insert_many(
-                                QA_util_to_json_from_pandas(__data)
-                            )
+                        _insert_new_minute_rows(coll, __data, None)
         except Exception as e:
             QA_util_log_info(e, ui_log=ui_log)
             err.append(code)
@@ -890,10 +926,7 @@ def QA_SU_save_single_stock_min(code : str, client=DATABASE, ui_log=None, ui_pro
                             end_time,
                             type
                         )
-                        if len(__data) > 1:
-                            coll.insert_many(
-                                QA_util_to_json_from_pandas(__data)[1::]
-                            )
+                        _insert_new_minute_rows(coll, __data, start_time)
                 else:
                     start_time = '2015-01-01'
                     QA_util_log_info(
@@ -917,10 +950,7 @@ def QA_SU_save_single_stock_min(code : str, client=DATABASE, ui_log=None, ui_pro
                             end_time,
                             type
                         )
-                        if len(__data) > 1:
-                            coll.insert_many(
-                                QA_util_to_json_from_pandas(__data)
-                            )
+                        _insert_new_minute_rows(coll, __data, None)
         except Exception as e:
             QA_util_log_info(e, ui_log=ui_log)
             err.append(code)

--- a/sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py
+++ b/sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py
@@ -122,25 +122,25 @@ def _select_strictly_new_minute_rows(data, latest_datetime):
     """
     if data is None or getattr(data, 'empty', False):
         return data
-    fetched_at = pd.to_datetime(data['datetime'], errors='coerce')
+    working = data.copy()
+    working['_qa_bar_datetime'] = pd.to_datetime(
+        working['datetime'],
+        errors='coerce'
+    ).to_numpy()
     if latest_datetime is None:
-        selected = data.loc[fetched_at.notna()]
+        keep = working['_qa_bar_datetime'].notna().to_numpy()
     else:
         cutoff = pd.Timestamp(latest_datetime)
-        selected = data.loc[fetched_at > cutoff]
-    time_key = (
-        'time_stamp'
-        if 'time_stamp' in selected.columns
-        else 'datetime' if 'datetime' in selected.columns else None
-    )
+        keep = (working['_qa_bar_datetime'] > cutoff).to_numpy()
+    selected = working.iloc[keep].copy()
     dedupe_keys = [
         key
-        for key in ('code', 'type', time_key)
-        if key is not None and key in selected.columns
+        for key in ('code', 'type')
+        if key in selected.columns
     ]
-    if dedupe_keys:
-        selected = selected.drop_duplicates(dedupe_keys, keep='last')
-    return selected
+    dedupe_keys.append('_qa_bar_datetime')
+    selected = selected.drop_duplicates(dedupe_keys, keep='last')
+    return selected.drop(columns=['_qa_bar_datetime'])
 
 
 def _insert_new_minute_rows(collection, data, latest_datetime):


### PR DESCRIPTION
## 背景

现有30分钟研究轮只覆盖吞没/强分型，缺少18模型全部原生触发、F1-F6全部64个组合、时间外锁定揭示和真实资金合同的可审计实现。本PR补齐本轮研究管线，并修复审计期间暴露的分钟增量落库与Windows预检问题。

## 目标

- 在30分钟级别实现 S0000-S0017、全部7个原生触发位及组合、F1-F6 64子集的候选生成、矩阵统计、TRAIN/VALIDATION锁定与AUDIT一次性揭示。
- 实现500万元、40槽、六档每日开仓上限及100组SHA确定性随机排序的资金回测。
- 保证snapshot、候选事件、lock/reveal和portfolio之间具备完整SHA血缘、幂等复跑及输入漂移阻断。
- 修复TDX股票分钟增量落库在缺失/空 `time_stamp` 或重复索引时的去重问题。

## 范围

- 新增三套CLX 30分钟研究脚本及对应测试。
- 加强Matrix/Portfolio输入身份、成熟期、lock/reveal、输出manifest与直接脚本执行校验。
- 分钟增量落库改为按规范化 `datetime` + `code` + `type` 去重。
- 同步更新 `docs/current/troubleshooting.md`。
- 修复main既有Windows全仓预检阻断：golden JSON固定LF；Git UTF-8输出显式按UTF-8解码。

## 非目标

- 不引入F7；本轮过滤空间固定为F1-F6、64子集。
- 不把本机研究产物提交到Git。
- 不修改线上交易策略选择或生产信号口径。
- 不下载或覆盖MongoDB正式行情数据。

## 验收结果

- 正式研究快照：2024-04-15至2026-07-21，19,923,376根30分钟K线，3,238,364个候选事件。
- Development matrix 1,262,592行；Reveal matrix 2,525,184行；资金质量组合48条、随机排序2,400条。
- Matrix与Portfolio正式复跑业务结果逐项一致，manifest状态均为COMPLETE。
- CLX 30m/intraday定向测试：69 passed。
- 分钟增量测试：8 passed。
- Windows预检修复定向测试：33 passed。
- 完整本地预检：docs-current-guard、pre-commit、mypy、isort通过；pytest 1744 passed、51 skipped。

## 部署影响

研究脚本、测试及文档本身不改变生产运行面。`sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py` 会影响分钟行情增量落库；合并后按部署计划重部署/重启 Dagster、QAWebServer、API Server 与 Guardian相关宿主机运行面，并执行分钟新鲜度、去重和运行健康检查。