### PR TITLE
feat: add XTData QFQ shadow pipeline and fix Index BFQ routing (#467, PR1/2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
 
       - name: Install uv
-        run: python -m pip install --upgrade pip uv
+        run: python -m pip install --upgrade pip "uv==0.11.29"
 
       - name: Sync locked environment
         run: uv sync --frozen

--- a/deployment/examples/supervisord.fqnext.example.conf
+++ b/deployment/examples/supervisord.fqnext.example.conf
@@ -94,8 +94,17 @@ autostart=true
 autorestart=true
 startsecs=5
 
+[program:fqnext_xtdata_qfq_worker]
+command=D:/fqpack/freshquant-2026.2.23/.venv/Scripts/python.exe -m freshquant.market_data.xtdata.qfq_worker worker
+directory=D:/fqpack/freshquant-2026.2.23
+stdout_logfile=D:/fqdata/log/fqnext_xtdata_qfq_worker.log
+stderr_logfile=D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log
+autostart=true
+autorestart=true
+startsecs=5
+
 [group:fqnext_reference_data]
-programs=fqnext_xtdata_adj_refresh_worker
+programs=fqnext_xtdata_adj_refresh_worker,fqnext_xtdata_qfq_worker
 
 [group:fqnext_trading_chain]
 programs=fqnext_realtime_xtdata_producer,fqnext_realtime_xtdata_consumer,fqnext_guardian_event,fqnext_xt_account_sync_worker,fqnext_xt_auto_repay_worker,fqnext_tpsl_worker,fqnext_xtquant_broker

--- a/docs/current/architecture.md
+++ b/docs/current/architecture.md
@@ -31,6 +31,17 @@
   - 涉及运行交付时，以最新远程 `main` 的正式 deploy 与 health check 为准
   - 所有代码更新的 PR + CI + merge gate 仍是交付收敛面的正式真值
 
+## 当前行情复权边界
+
+- Stock / ETF 线上读取链仍使用 `quantaxis.stock_adj` / `quantaxis.etf_adj`；现有 `stock_xdxr`、`etf_xdxr -> etf_adj` 写入链继续运行。
+- `freshquant.market_data.xtdata.qfq` 以 XTData 日线 `preClose` 生成独立的 Stock / ETF QFQ shadow 快照：
+  - Stock：`stock_adj_qfq_a` / `stock_adj_qfq_b`
+  - ETF：`etf_adj_qfq_a` / `etf_adj_qfq_b`
+  - `quantaxis.qfq_ready` 以每个 `scope` 的单文档保存 `active_slot` 与两个槽位的快照元数据。
+- shadow writer 只构建 inactive slot，审计通过后再原子切换 `active_slot`；`worker`、人工 `build` 与 `rollback` 共用 `qfq_writer_locks` 的 scope 唯一 lease，回滚也只切换 marker，不改写 active 集合。
+- 当前 Stock / ETF reader 尚未读取 `*_adj_qfq_a/b`，因此 shadow 快照发布不会改变 API、策略或实时 Kline 的复权结果。
+- 真实 Index 的日线、分钟线和实时合并固定使用 BFQ；Index 路径不读取 Stock / ETF 因子，实时数据读取 `freshquant.index_realtime`。
+
 ## 订单相关核心调用链
 
 ### 实时交易链
@@ -162,6 +173,13 @@
 
 ## 当前部署边界
 
+- `freshquant/market_data/**`
+  - 重启 XTData producer / consumer
+  - 重启 `xtdata_adj_refresh_worker` 与 `fqnext_xtdata_qfq_worker`
+- `morningglory/fqdagster/**` / `morningglory/fqdagsterconfig/**`
+  - 重部署 Dagster webserver / daemon
+- `freshquant/data/index.py` / `freshquant/quote/index.py` / `freshquant/chanlun_service.py` / `freshquant/chanlun_structure_service.py`
+  - 重建 API Server
 - `freshquant/order_management/**`
   - 重建 API Server
   - 重启 `xt_account_sync.worker`

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -197,7 +197,8 @@ powershell -ExecutionPolicy Bypass -File script/install_fqnext_supervisord_resta
 | `freshquant/xt_account_sync/**` | XT 主动查询统一 worker（仓位管理 + 订单管理） | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface position_management -DeploymentSurface order_management -BridgeIfServiceUnavailable` |
 | `freshquant/xt_auto_repay/**` | XT 自动还款 worker | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface order_management -BridgeIfServiceUnavailable` |
 | `freshquant/tpsl/**` | TPSL | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface tpsl -BridgeIfServiceUnavailable` |
-| `freshquant/market_data/**` | XTData producer / consumer | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface market_data -BridgeIfServiceUnavailable`；必要时重新 prewarm |
+| `freshquant/market_data/**` | XTData producer / consumer、adj refresh worker、QFQ shadow worker | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface market_data -BridgeIfServiceUnavailable`；必要时重新 prewarm |
+| `freshquant/data/index.py` / `freshquant/quote/index.py` / `freshquant/chanlun_service.py` / `freshquant/chanlun_structure_service.py` | Index BFQ API / Chanlun 读取链 | 重建 `fq_apiserver` |
 | `freshquant/strategy/**` 或 `freshquant/signal/**` | Guardian | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface guardian -BridgeIfServiceUnavailable` |
 | `sunflower/QUANTAXIS/**` | QAWebServer 与依赖 QUANTAXIS 的宿主机策略链路 | 重建 `fq_qawebserver`；同步重启受影响宿主机 Guardian / strategy 进程 |
 | `freshquant/data/gantt*` / `freshquant/shouban30_pool_service.py` | Gantt/Shouban30 读模型与 API | 重建 API；必要时重跑 Dagster 任务 |
@@ -206,6 +207,35 @@ powershell -ExecutionPolicy Bypass -File script/install_fqnext_supervisord_resta
 | `morningglory/fqwebui/**` | Web UI | 重建 `fq_webui` |
 | `morningglory/fqdagster/**` / `morningglory/fqdagsterconfig/**` | Dagster | 重启 `fq_dagster_webserver` 与 `fq_dagster_daemon` |
 | `third_party/tradingagents-cn/**` | TradingAgents-CN | 重建 `ta_backend` 与 `ta_frontend` |
+
+### XTData QFQ shadow worker
+
+`fqnext_xtdata_qfq_worker` 属于 `market_data` 宿主机 surface。部署后先确认 Supervisor 状态，再检查两个 scope 的 marker 与 active slot：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode Status
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker status
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope stock
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope etf
+```
+
+需要显式补建到某个交易日时使用 `build`；需要核对非 active 槽时显式传 `--slot a` 或 `--slot b`：
+
+```powershell
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker build --scope stock --target-date YYYY-MM-DD
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker build --scope stock --target-date YYYY-MM-DD --full
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope stock --slot b
+```
+
+`--full` 会在 inactive slot 对整个 scope 做全历史确定性重算，允许在 active `factor_asof` 不变时修复 60 个交易日窗口之前的 XTData 历史修订，但拒绝更早的目标日期。该操作进入自动周期前必须先通过 PR1 全市场容量与耗时 gate。
+
+只有目标 inactive slot 的状态为 `ready` 时才执行 marker 回切：
+
+```powershell
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker rollback --scope stock
+```
+
+该 worker 当前只发布 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b` shadow 快照；部署它不会切换仍在读取 `stock_adj` / `etf_adj` 的线上 Stock / ETF 消费者，也不替代现有 XDXR / ETF adj writer。Dagster ready asset 或 `dagster.yaml` 同时变更时，还必须按 `dagster` surface 重部署 webserver / daemon。
 
 - `script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces` 当前会先做 surface reconcile；若首次重启失败且启用了 `-BridgeIfServiceUnavailable`，即使 `fqnext-supervisord` service 仍是 `Running`，也允许触发一次管理员桥接
 - 管理员桥接恢复后，脚本会先确认目标 programs 是否已经 settled 到 `RUNNING`；只有仍未恢复时，才继续补做第二次 `restart-surfaces`
@@ -286,7 +316,7 @@ powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mod
 
 - API 蓝图能返回，不是只监听端口。
 - Web UI 页面不是空白页。
-- XTData 相关修改后，producer/consumer 日志持续产出，Redis 队列不持续堆积。
+- XTData 相关修改后，producer/consumer 日志持续产出，Redis 队列不持续堆积；涉及 QFQ shadow writer 时，`fqnext_xtdata_qfq_worker` 为 `RUNNING`，且 `status` / active-slot `audit` 返回有效结果。
 - 宿主机 deployment surface 修改后，`fqnext-supervisord` 保持 `Running`，且 `script/fqnext_host_runtime_ctl.ps1 -Mode Status` 能返回目标 program 为 `RUNNING`。
 - 如果本轮有实际 deploy，`check_freshquant_runtime_post_deploy.ps1` 的 verify 结果必须 `passed=true`，且 `failures` 为空。
 

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -198,7 +198,7 @@ powershell -ExecutionPolicy Bypass -File script/install_fqnext_supervisord_resta
 | `freshquant/xt_auto_repay/**` | XT 自动还款 worker | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface order_management -BridgeIfServiceUnavailable` |
 | `freshquant/tpsl/**` | TPSL | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface tpsl -BridgeIfServiceUnavailable` |
 | `freshquant/market_data/**` | XTData producer / consumer、adj refresh worker、QFQ shadow worker | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface market_data -BridgeIfServiceUnavailable`；必要时重新 prewarm |
-| `freshquant/data/index.py` / `freshquant/quote/index.py` / `freshquant/chanlun_service.py` / `freshquant/chanlun_structure_service.py` | Index BFQ API / Chanlun 读取链 | 重建 `fq_apiserver` |
+| `freshquant/data/index.py` / `freshquant/quote/index.py` / `freshquant/instrument/general.py` / `freshquant/chanlun_service.py` / `freshquant/chanlun_structure_service.py` | Index BFQ API / 分类 / Chanlun 读取链 | 重建 `fq_apiserver` |
 | `freshquant/strategy/**` 或 `freshquant/signal/**` | Guardian | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface guardian -BridgeIfServiceUnavailable` |
 | `sunflower/QUANTAXIS/**` | QAWebServer 与依赖 QUANTAXIS 的宿主机策略链路 | 重建 `fq_qawebserver`；同步重启受影响宿主机 Guardian / strategy 进程 |
 | `freshquant/data/gantt*` / `freshquant/shouban30_pool_service.py` | Gantt/Shouban30 读模型与 API | 重建 API；必要时重跑 Dagster 任务 |
@@ -214,9 +214,9 @@ powershell -ExecutionPolicy Bypass -File script/install_fqnext_supervisord_resta
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode Status
-& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker status
-& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope stock
-& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope etf
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker status --strict
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope stock --mode full
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope etf --mode full
 ```
 
 需要显式补建到某个交易日时使用 `build`；需要核对非 active 槽时显式传 `--slot a` 或 `--slot b`：
@@ -224,10 +224,13 @@ powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mod
 ```powershell
 & D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker build --scope stock --target-date YYYY-MM-DD
 & D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker build --scope stock --target-date YYYY-MM-DD --full
-& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope stock --slot b
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope stock --slot b --mode structure
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope stock --code 000001 --mode tail --tail-days 60
 ```
 
-`--full` 会在 inactive slot 对整个 scope 做全历史确定性重算，允许在 active `factor_asof` 不变时修复 60 个交易日窗口之前的 XTData 历史修订，但拒绝更早的目标日期。该操作进入自动周期前必须先通过 PR1 全市场容量与耗时 gate。
+`--full` 会在 inactive slot 对整个 scope 做全历史确定性重算，删除已退出当前 BFQ universe 的残留 code，允许在 active `factor_asof` 不变时修复 60 个交易日窗口之前的 XTData 历史修订，但拒绝更早的目标日期。该操作进入自动周期前必须先通过 PR1 全市场容量与耗时 gate。
+
+`audit --mode structure` 只检查日期覆盖、唯一键、正因子和末日因子，适合快速检查；正式发布 gate 使用 `--mode full` 从 XTData 重新加载 source bars 并验证完整递推恒等式。`--mode tail` 可配合 `--code` 做低成本定位。
 
 只有目标 inactive slot 的状态为 `ready` 时才执行 marker 回切：
 
@@ -235,7 +238,7 @@ powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mod
 & D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker rollback --scope stock
 ```
 
-该 worker 当前只发布 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b` shadow 快照；部署它不会切换仍在读取 `stock_adj` / `etf_adj` 的线上 Stock / ETF 消费者，也不替代现有 XDXR / ETF adj writer。Dagster ready asset 或 `dagster.yaml` 同时变更时，还必须按 `dagster` surface 重部署 webserver / daemon。
+该 worker 当前只发布 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b` shadow 快照；部署它不会切换仍在读取 `stock_adj` / `etf_adj` 的线上 Stock / ETF 消费者，也不替代现有 XDXR / ETF adj writer。Dagster ready asset 或 `dagster.yaml` 同时变更时，还必须按 `dagster` surface 重部署 webserver / daemon。`check_freshquant_runtime_post_deploy.ps1 -Mode Verify` 对 `market_data` surface 会自动执行 `status --strict`，marker 缺失或落后时 health gate 失败。
 
 - `script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces` 当前会先做 surface reconcile；若首次重启失败且启用了 `-BridgeIfServiceUnavailable`，即使 `fqnext-supervisord` service 仍是 `Running`，也允许触发一次管理员桥接
 - 管理员桥接恢复后，脚本会先确认目标 programs 是否已经 settled 到 `RUNNING`；只有仍未恢复时，才继续补做第二次 `restart-surfaces`
@@ -316,7 +319,7 @@ powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mod
 
 - API 蓝图能返回，不是只监听端口。
 - Web UI 页面不是空白页。
-- XTData 相关修改后，producer/consumer 日志持续产出，Redis 队列不持续堆积；涉及 QFQ shadow writer 时，`fqnext_xtdata_qfq_worker` 为 `RUNNING`，且 `status` / active-slot `audit` 返回有效结果。
+- XTData 相关修改后，producer/consumer 日志持续产出，Redis 队列不持续堆积；涉及 QFQ shadow writer 时，`fqnext_xtdata_qfq_worker` 为 `RUNNING`，且 `status --strict` / active-slot `audit --mode full` 通过。
 - 宿主机 deployment surface 修改后，`fqnext-supervisord` 保持 `Running`，且 `script/fqnext_host_runtime_ctl.ps1 -Mode Status` 能返回目标 program 为 `RUNNING`。
 - 如果本轮有实际 deploy，`check_freshquant_runtime_post_deploy.ps1` 的 verify 结果必须 `passed=true`，且 `failures` 为空。
 

--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -19,8 +19,8 @@ XTData 链路负责把宿主机 XTData 行情转换成 FreshQuant 可消费的�
 - QFQ shadow worker
   - `python -m freshquant.market_data.xtdata.qfq_worker worker`
 - QFQ 运维 CLI
-  - `python -m freshquant.market_data.xtdata.qfq_worker status`
-  - `python -m freshquant.market_data.xtdata.qfq_worker audit --scope <stock|etf>`
+  - `python -m freshquant.market_data.xtdata.qfq_worker status --strict`
+  - `python -m freshquant.market_data.xtdata.qfq_worker audit --scope <stock|etf> --mode <structure|tail|full> [--code CODE]`
   - `python -m freshquant.market_data.xtdata.qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD`
   - `python -m freshquant.market_data.xtdata.qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD --full`
   - `python -m freshquant.market_data.xtdata.qfq_worker rollback --scope <stock|etf>`
@@ -67,7 +67,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 
 - Stock 数据集合为 `stock_adj_qfq_a` / `stock_adj_qfq_b`，ETF 数据集合为 `etf_adj_qfq_a` / `etf_adj_qfq_b`。
 - `quantaxis.qfq_ready` 对每个 scope 使用一个原子双槽 marker；构建 inactive slot 期间 active slot 保持只读，inactive slot 审计成功后才切换。
-- `quantaxis.qfq_writer_locks` 对每个 scope 只允许一个带过期时间并持续续期的 writer lease；中断的 `building` 仅由下一位 lease owner 恢复，人工 build / rollback 不与 Supervisor worker 并发写。
+- `quantaxis.qfq_writer_locks` 对每个 scope 只允许一个带过期时间并由后台线程持续续期的 writer lease；单次 XTData 请求或 Mongo `$out` 阻塞时仍续租，发布前重新核对 owner。中断的 `building` 仅由下一位 lease owner 恢复，人工 build / rollback 不与 Supervisor worker 并发写。
 - 首次 bootstrap 先构建并审计 A，再复制和审计 B，之后发布双槽 marker；日更只对 inactive slot 写入。
 - 当前 Stock / ETF 在线 reader 和旧 `stock_xdxr`、`etf_xdxr -> etf_adj` writer 均未切换；A/B 发布不会改变现有 Kline 或策略读取结果。
 - 真实 Index 走 BFQ 日线/分钟线和 `index_realtime`，不读取 ETF/Stock 因子，也不进入 QFQ shadow scope。
@@ -124,8 +124,9 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
   - `tick_quote_pending_batches`
   - `tick_quote_dropped_batches`
 - `xtdata_adj_refresh_worker` 若在启动或日内计划刷新时遇到可重试的 XTData 连接失败，当前会退避后重建新的 refresh service / XTData client 再继续同步。
-- `fqnext_xtdata_qfq_worker` 默认每 60 秒轮询盘后 ready marker；可用 `worker --once` 单轮执行，用 `status`、`audit`、`build`、`rollback` 做运维检查。
-- 默认日更回看 60 个实际交易日；更早的 XTData 历史修订通过 `build --full` 在 inactive slot 做同截止日全 scope 重算，自动执行频率需在全市场容量 gate 后确定。
+- `fqnext_xtdata_qfq_worker` 默认每 60 秒轮询盘后 ready marker；可用 `worker --once` 单轮执行，用 `status --strict`、`audit`、`build`、`rollback` 做运维检查。正式 post-deploy verify 会执行严格 status，不能只以进程存在代替数据 ready。
+- 默认日更回看 60 个实际交易日；更早的 XTData 历史修订通过 `build --full` 在 inactive slot 做同截止日全 scope 重算并清除 universe 外残留 code，自动执行频率需在全市场容量 gate 后确定。
+- `audit --mode structure` 是 Mongo 快速结构审计；`--mode tail` / `--mode full` 会重新读取 XTData source bars 并验证递推恒等式，正式全市场 gate 使用 `--mode full`。
 
 ## 排障点
 
@@ -159,5 +160,5 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 
 - 检查 `fqnext_xtdata_qfq_worker` Supervisor 状态与 `D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log`。
 - 执行 `python -m freshquant.market_data.xtdata.qfq_worker worker --once`，区分 `waiting_for_bfq`、`current`、`published` 与错误结果。
-- 执行 `status` 查看 `qfq_ready` 双槽元数据，执行 `audit --scope stock|etf` 审计 active slot。
+- 执行 `status --strict` 核对 active 截止日与盘后 marker，执行 `audit --scope stock|etf --mode full` 对 active slot 做 XTData source-aware 审计；快速排查可先用 `--mode structure`。
 - 页面仍读取旧 Stock / ETF 因子；shadow 集合已更新但页面未变化，不代表 QFQ worker 失败。

--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -2,12 +2,13 @@
 
 ## 职责
 
-XTData 链路负责把宿主机 XTData 行情转换成 FreshQuant 可消费的实时事件流。它承担四件事：
+XTData 链路负责把宿主机 XTData 行情转换成 FreshQuant 可消费的实时事件流，并维护独立的盘后 QFQ shadow 快照。它承担五件事：
 
 - 从 XTQuant 订阅当前监控池的全量行情。
 - 把 tick 推入 Redis 分片队列。
 - 合成 1 分钟 bar，并继续向下游发布 bar close 事件。
 - 在 consumer 侧做 prewarm、结构计算、实时缓存与运行观测。
+- 在盘后 BFQ ready 后，以 XTData 日线 `preClose` 构建和审计 Stock / ETF A/B QFQ shadow 快照。
 
 ## 入口
 
@@ -15,8 +16,16 @@ XTData 链路负责把宿主机 XTData 行情转换成 FreshQuant 可消费的�
   - `python -m freshquant.market_data.xtdata.market_producer`
 - consumer
   - `python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
+- QFQ shadow worker
+  - `python -m freshquant.market_data.xtdata.qfq_worker worker`
+- QFQ 运维 CLI
+  - `python -m freshquant.market_data.xtdata.qfq_worker status`
+  - `python -m freshquant.market_data.xtdata.qfq_worker audit --scope <stock|etf>`
+  - `python -m freshquant.market_data.xtdata.qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD`
+  - `python -m freshquant.market_data.xtdata.qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD --full`
+  - `python -m freshquant.market_data.xtdata.qfq_worker rollback --scope <stock|etf>`
 
-producer 是唯一 XTData 入口；consumer 是唯一 bar 队列消费入口。
+producer 是唯一 XTData 实时订阅入口；consumer 是唯一 bar 队列消费入口。QFQ worker 是独立的盘后 XTData 日线读取入口，不参与实时队列。
 
 ## 依赖
 
@@ -24,6 +33,7 @@ producer 是唯一 XTData 入口；consumer 是唯一 bar 队列消费入口。
 - `XTQUANT_PORT`，默认 `58610`
 - Redis
 - QuantAxis 历史库
+- `freshquant.dagster_pipeline_markers` 的 `stock_postclose_ready` / `etf_postclose_ready` 成功文档
 - 监控池来源
   - `guardian_1m = xt_positions + must_pool`
   - `guardian_and_clx_15_30 = (xt_positions + must_pool) + stock_pools`
@@ -51,6 +61,17 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - `OneMinuteBarGenerator` 和 `StrategyConsumer` 都会通过 FreshQuant A 股交易日历拦截非交易日 bar；周末/节假日 tick 不生成 bar，非交易日 `BAR_CLOSE` 不写入 `stock_realtime/index_realtime`。
 - consumer prewarm、股票分钟线 API 拼接与 ETF/index K 线查询都会过滤非交易日 realtime 行，避免历史脏数据继续进入 Redis Kline cache 或 `/api/stock_data` 返回值。
 
+### QFQ shadow 链
+
+`Dagster Stock/ETF BFQ + 旧复权 writer -> postclose ready marker -> fqnext_xtdata_qfq_worker -> XTData preClose -> inactive A/B slot -> audit -> qfq_ready active_slot`
+
+- Stock 数据集合为 `stock_adj_qfq_a` / `stock_adj_qfq_b`，ETF 数据集合为 `etf_adj_qfq_a` / `etf_adj_qfq_b`。
+- `quantaxis.qfq_ready` 对每个 scope 使用一个原子双槽 marker；构建 inactive slot 期间 active slot 保持只读，inactive slot 审计成功后才切换。
+- `quantaxis.qfq_writer_locks` 对每个 scope 只允许一个带过期时间并持续续期的 writer lease；中断的 `building` 仅由下一位 lease owner 恢复，人工 build / rollback 不与 Supervisor worker 并发写。
+- 首次 bootstrap 先构建并审计 A，再复制和审计 B，之后发布双槽 marker；日更只对 inactive slot 写入。
+- 当前 Stock / ETF 在线 reader 和旧 `stock_xdxr`、`etf_xdxr -> etf_adj` writer 均未切换；A/B 发布不会改变现有 Kline 或策略读取结果。
+- 真实 Index 走 BFQ 日线/分钟线和 `index_realtime`，不读取 ETF/Stock 因子，也不进入 QFQ shadow scope。
+
 ## 存储
 
 - Redis
@@ -61,6 +82,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
   - 历史分钟线读取
   - 实时结构或补权结果所需的基础数据
   - `realtime_screen_multi_period`
+  - `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b` 与 `qfq_ready`
 
 当前模块会在启用 CLX 能力时把命中的多周期 CLX 信号写入 `realtime_screen_multi_period`。
 
@@ -81,6 +103,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
   - 决定 consumer 何时进入 catchup 模式。
 - `XTQUANT_PORT`
   - XTData 连接端口。
+  - QFQ worker 通过 `bootstrap_config.xtdata.port` 读取同一端口，默认 `58610`。
 
 对 Guardian 主链最重要的是：
 
@@ -89,8 +112,8 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 
 ## 部署/运行
 
-- 这两个进程通常运行在宿主机，不放进 Docker。
-- 修改 `freshquant/market_data/**` 后，至少重启 producer 与 consumer。
+- producer、consumer 与 QFQ worker 通常运行在宿主机，不放进 Docker。
+- 修改 `freshquant/market_data/**` 后，按 `market_data` surface 重启 producer、consumer、adj refresh worker 与 QFQ worker。
 - consumer 改动涉及结构缓存或 prewarm 逻辑时，建议带 `--prewarm` 重新拉起。
 - producer 启动阶段若遇到可重试的 XTData 连接失败，当前会在进程内按退避重试继续等待 XTQuant / QMT 就绪，不再只依赖 supervisor 外层重启。
 - producer 当前会在交易时段内监控 `rx_age_s`：
@@ -101,6 +124,8 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
   - `tick_quote_pending_batches`
   - `tick_quote_dropped_batches`
 - `xtdata_adj_refresh_worker` 若在启动或日内计划刷新时遇到可重试的 XTData 连接失败，当前会退避后重建新的 refresh service / XTData client 再继续同步。
+- `fqnext_xtdata_qfq_worker` 默认每 60 秒轮询盘后 ready marker；可用 `worker --once` 单轮执行，用 `status`、`audit`、`build`、`rollback` 做运维检查。
+- 默认日更回看 60 个实际交易日；更早的 XTData 历史修订通过 `build --full` 在 inactive slot 做同截止日全 scope 重算，自动执行频率需在全市场容量 gate 后确定。
 
 ## 排障点
 
@@ -129,3 +154,10 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 
 - 检查 tick 分片队列是否有目标 code。
 - 检查 producer 是否在向 `REDIS_TICK_QUEUE_PREFIX:<shard>` 推送。
+
+### QFQ shadow 不更新
+
+- 检查 `fqnext_xtdata_qfq_worker` Supervisor 状态与 `D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log`。
+- 执行 `python -m freshquant.market_data.xtdata.qfq_worker worker --once`，区分 `waiting_for_bfq`、`current`、`published` 与错误结果。
+- 执行 `status` 查看 `qfq_ready` 双槽元数据，执行 `audit --scope stock|etf` 审计 active slot。
+- 页面仍读取旧 Stock / ETF 因子；shadow 集合已更新但页面未变化，不代表 QFQ worker 失败。

--- a/docs/current/reference/market-data.md
+++ b/docs/current/reference/market-data.md
@@ -6,6 +6,7 @@ FreshQuant 当前同时使用三类行情来源：
 
 - XTData / XTQuant
   - 实时 tick 和分钟 bar 的唯一正式入口
+  - Stock / ETF QFQ shadow 快照的 `preClose` 权威来源
 - QuantAxis / Mongo 历史库
   - Kline、结构计算、历史回看使用的主要历史数据来源
 - Redis realtime cache
@@ -17,6 +18,13 @@ FreshQuant 当前同时使用三类行情来源：
   - `python -m freshquant.market_data.xtdata.market_producer`
 - 实时 consumer
   - `python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
+- QFQ shadow worker / 运维 CLI
+  - `python -m freshquant.market_data.xtdata.qfq_worker worker`
+  - `python -m freshquant.market_data.xtdata.qfq_worker status`
+  - `python -m freshquant.market_data.xtdata.qfq_worker audit --scope <stock|etf>`
+  - `python -m freshquant.market_data.xtdata.qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD`
+  - `python -m freshquant.market_data.xtdata.qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD --full`
+  - `python -m freshquant.market_data.xtdata.qfq_worker rollback --scope <stock|etf>`
 - HTTP 查询
   - `/api/stock_data`
   - `/api/stock_data_v2`
@@ -38,15 +46,19 @@ FreshQuant 当前同时使用三类行情来源：
 - 指定 `endDate` 时，以历史查询为准
 - TDX 股票日线对未上市/暂无源数据代码返回空结果时按 no-op 处理，不执行空批量写入；连接、抓取或真实写库异常仍由 Dagster 标记为失败
 - 股票除权除息复权计算使用显式列赋值与 `DataFrame.ffill()`，避免 Pandas 3.0 链式 `inplace`/`fillna(method=...)` 兼容性问题，计算口径不变
+- Stock / ETF 在线读取仍使用 `quantaxis.stock_adj` / `quantaxis.etf_adj`，现有 `stock_xdxr`、`etf_xdxr -> etf_adj` writer 继续运行
+- XTData `preClose` QFQ writer 维护独立 shadow 集合：`stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`；`quantaxis.qfq_ready` 保存每个 scope 的 active slot 与双槽快照元数据
+- shadow writer 只在 inactive slot 构建并审计，审计成功后原子切换 marker；当前 Stock / ETF reader 尚未读取这些 A/B 集合
+- 真实 Index 日线、分钟线与 realtime merge 固定为 BFQ，实时表使用 `freshquant.index_realtime`，不读取 ETF 或 Stock 复权因子
 
 Dagster 盘后桥接口径当前新增两条 ready asset：
 
 - `stock_postclose_ready_asset`
-  - 依赖股票日线与 `quality_stock_universe` 快照刷新
-  - 成功后写入 `dagster_pipeline_markers.stock_postclose_ready`
+  - 依赖股票日线、分钟线、`quality_stock_universe` 快照刷新与旧 `stock_xdxr` writer
+  - 成功后写入 `freshquant.dagster_pipeline_markers` 中 `pipeline_key=stock_postclose_ready` 的文档
 - `etf_postclose_ready_asset`
-  - 依赖 `etf_adj` 和通过日线/五周期完整性门禁的 `etf_min`
-  - 成功后写入 `dagster_pipeline_markers.etf_postclose_ready`
+  - 依赖旧 `etf_xdxr -> etf_adj` writer 和通过日线/五周期完整性门禁的 `etf_min`
+  - 成功后写入 `freshquant.dagster_pipeline_markers` 中 `pipeline_key=etf_postclose_ready` 的文档
 
 其中：
 
@@ -54,6 +66,7 @@ Dagster 盘后桥接口径当前新增两条 ready asset：
 - `etf_data_job` 仍由工作日 `16:00` schedule 驱动
 - `stock_postclose_ready` 是 Gantt / Daily Screening 盘后链路的正式股票侧就绪信号
 - `etf_postclose_ready` 当前仅保留给 ETF 扩展链路，不是每日选股硬门禁
+- Windows `fqnext_xtdata_qfq_worker` 消费上述两个 success marker，更新对应 scope 的 QFQ shadow 快照
 
 ## 当前常见字段语义
 

--- a/docs/current/reference/market-data.md
+++ b/docs/current/reference/market-data.md
@@ -20,8 +20,8 @@ FreshQuant 当前同时使用三类行情来源：
   - `python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
 - QFQ shadow worker / 运维 CLI
   - `python -m freshquant.market_data.xtdata.qfq_worker worker`
-  - `python -m freshquant.market_data.xtdata.qfq_worker status`
-  - `python -m freshquant.market_data.xtdata.qfq_worker audit --scope <stock|etf>`
+  - `python -m freshquant.market_data.xtdata.qfq_worker status --strict`
+  - `python -m freshquant.market_data.xtdata.qfq_worker audit --scope <stock|etf> --mode <structure|tail|full> [--code CODE]`
   - `python -m freshquant.market_data.xtdata.qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD`
   - `python -m freshquant.market_data.xtdata.qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD --full`
   - `python -m freshquant.market_data.xtdata.qfq_worker rollback --scope <stock|etf>`
@@ -48,7 +48,8 @@ FreshQuant 当前同时使用三类行情来源：
 - 股票除权除息复权计算使用显式列赋值与 `DataFrame.ffill()`，避免 Pandas 3.0 链式 `inplace`/`fillna(method=...)` 兼容性问题，计算口径不变
 - Stock / ETF 在线读取仍使用 `quantaxis.stock_adj` / `quantaxis.etf_adj`，现有 `stock_xdxr`、`etf_xdxr -> etf_adj` writer 继续运行
 - XTData `preClose` QFQ writer 维护独立 shadow 集合：`stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`；`quantaxis.qfq_ready` 保存每个 scope 的 active slot 与双槽快照元数据
-- shadow writer 只在 inactive slot 构建并审计，审计成功后原子切换 marker；当前 Stock / ETF reader 尚未读取这些 A/B 集合
+- shadow writer 只在 inactive slot 构建并审计，审计成功且 writer lease owner 仍匹配后原子切换 marker；当前 Stock / ETF reader 尚未读取这些 A/B 集合
+- `audit --mode structure` 只检查 Mongo 结构合同；`tail/full` 会加载 XTData source bars 并验证 `preClose` 递推，正式发布门禁使用 `full`
 - 真实 Index 日线、分钟线与 realtime merge 固定为 BFQ，实时表使用 `freshquant.index_realtime`，不读取 ETF 或 Stock 复权因子
 
 Dagster 盘后桥接口径当前新增两条 ready asset：

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -61,10 +61,10 @@
 - Supervisor program 为 `fqnext_xtdata_qfq_worker`，并与 `fqnext_xtdata_adj_refresh_worker` 同属 `fqnext_reference_data` group；它运行在 Windows 宿主机，默认每 60 秒检查一次盘后就绪状态。
 - worker 从 `freshquant.dagster_pipeline_markers` 读取 `pipeline_key=stock_postclose_ready` / `etf_postclose_ready` 的最新成功文档，再把目标交易日传给 XTData QFQ writer。
 - `stock_postclose_ready` 在股票日线、分钟线、质量股票池快照和旧 `stock_xdxr` writer 完成后发布；`etf_postclose_ready` 在 ETF 日线/分钟线及旧 `etf_xdxr -> etf_adj` writer 完成后发布。
-- shadow 快照与发布 marker 写在 QuantAxis Mongo：数据集合为 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`，marker 集合为 `qfq_ready`；`qfq_writer_locks` 以 scope 唯一 heartbeat lease 强制 worker、人工 build 与 rollback 串行。
+- shadow 快照与发布 marker 写在 QuantAxis Mongo：数据集合为 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`，marker 集合为 `qfq_ready`；`qfq_writer_locks` 以 scope 唯一后台 heartbeat lease 强制 worker、人工 build 与 rollback 串行，单次 XTData 下载或 Mongo `$out` 阻塞期间也会持续续租，发布前再次核对 owner。
 - 当前 Stock / ETF 在线 reader 继续读取 `stock_adj` / `etf_adj`，旧 writer 继续运行；QFQ worker 的发布只更新 shadow 链。
 - 真实 Index 当前固定读取 BFQ 日线/分钟线与 `index_realtime`，不读取 `stock_adj`、`etf_adj` 或 QFQ shadow 集合。
-- 运维 CLI 入口为 `python -m freshquant.market_data.xtdata.qfq_worker`，子命令为 `worker`、`build`、`audit`、`status`、`rollback`。
+- 运维 CLI 入口为 `python -m freshquant.market_data.xtdata.qfq_worker`，子命令为 `worker`、`build`、`audit`、`status`、`rollback`；`status --strict` 检查 active 截止日是否追平盘后 ready marker，`audit --mode structure|tail|full` 分别执行结构、近期 XTData 递推和全历史 XTData 递推审计。
 
 ## 会话与记忆口径
 

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -8,7 +8,7 @@
 - Mongo 通过 `127.0.0.1:27027` 接入 Docker `fq_mongodb`；宿主机链路不要再使用 `127.0.0.1:27017`。
 - `fqnext-supervisord` 宿主机底座与其托管的交易/运行链 Python 进程。
 - Guardian monitor。
-- XTData producer / consumer / adj refresh worker（XTData producer 启动阶段遇到可重试的 XTData 连接失败时会在进程内退避重试；交易时段若订阅链 stale，则先 `resubscribe`，持续 stale 再升级为 `xtdata.connect() + resubscribe`。`xtdata_adj_refresh_worker` 在启动或计划刷新遇到可重试的 XTData 连接失败时，会退避后重建新的 refresh service / XTData client 再继续同步。）
+- XTData producer / consumer / adj refresh worker / QFQ shadow worker（XTData producer 启动阶段遇到可重试的 XTData 连接失败时会在进程内退避重试；交易时段若订阅链 stale，则先 `resubscribe`，持续 stale 再升级为 `xtdata.connect() + resubscribe`。`xtdata_adj_refresh_worker` 在启动或计划刷新遇到可重试的 XTData 连接失败时，会退避后重建新的 refresh service / XTData client 再继续同步。`fqnext_xtdata_qfq_worker` 读取 Dagster 盘后 ready marker，再以 XTData `preClose` 更新 Stock / ETF A/B shadow 快照。）
 - XT account sync worker（作为 XT 账户数据的增量补偿同步入口，默认每 15 秒轮询 `assets / credit_detail / positions / orders / trades`；其中 `credit_detail` 保持高频刷新以驱动仓位管理状态，只把新增 `orders / trades` 送入 ingest；`credit_subjects` 只在启动和每日计划时间做低频同步，并在启动时做一次单标的实时仓位 fallback 种子刷新；若 `positions` 快照为空或严重缩水、但同轮 `credit_detail.market_value` 仍显著为正，则该轮快照会进入 quarantine，不覆盖 `xt_positions`，也不触发自动平账；这个 quarantine 现在也覆盖小账户单票/双票严重缩水的场景，同时 worker 会记录 warning 说明 quarantine 原因；对 `xtquant connect/subscribe` 可重试失败，worker 会在退避后重建新的 XT sync service/client 再继续同步）。
 - XT auto repay worker（默认每 30 分钟低频巡检一次已同步的 `credit_detail` 快照，只处理普通融资负债；盘中命中候选后才即时执行一次 `query_credit_detail()` 二次确认，再走 `CREDIT_DIRECT_CASH_REPAY`；固定在 `14:55` 做日终硬结算、`15:05` 做一次补偿重试；`broker_submit_mode=observe_only` 时只记录事件，不真实提交还款）。
 - TPSL tick listener。
@@ -55,6 +55,16 @@
 - memory context pack 产物根目录：`D:/fqpack/runtime/artifacts/memory/context-packs`
 - 冷记忆目录：`.codex/memory`
 - 热记忆 Mongo database：`fq_memory`
+
+## XTData QFQ shadow 运行口径
+
+- Supervisor program 为 `fqnext_xtdata_qfq_worker`，并与 `fqnext_xtdata_adj_refresh_worker` 同属 `fqnext_reference_data` group；它运行在 Windows 宿主机，默认每 60 秒检查一次盘后就绪状态。
+- worker 从 `freshquant.dagster_pipeline_markers` 读取 `pipeline_key=stock_postclose_ready` / `etf_postclose_ready` 的最新成功文档，再把目标交易日传给 XTData QFQ writer。
+- `stock_postclose_ready` 在股票日线、分钟线、质量股票池快照和旧 `stock_xdxr` writer 完成后发布；`etf_postclose_ready` 在 ETF 日线/分钟线及旧 `etf_xdxr -> etf_adj` writer 完成后发布。
+- shadow 快照与发布 marker 写在 QuantAxis Mongo：数据集合为 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`，marker 集合为 `qfq_ready`；`qfq_writer_locks` 以 scope 唯一 heartbeat lease 强制 worker、人工 build 与 rollback 串行。
+- 当前 Stock / ETF 在线 reader 继续读取 `stock_adj` / `etf_adj`，旧 writer 继续运行；QFQ worker 的发布只更新 shadow 链。
+- 真实 Index 当前固定读取 BFQ 日线/分钟线与 `index_realtime`，不读取 `stock_adj`、`etf_adj` 或 QFQ shadow 集合。
+- 运维 CLI 入口为 `python -m freshquant.market_data.xtdata.qfq_worker`，子命令为 `worker`、`build`、`audit`、`status`、`rollback`。
 
 ## 会话与记忆口径
 

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -685,10 +685,10 @@ print(audit_recent_etf_xdxr_coverage(recent_days=365))
 powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode Status
 Get-Content D:/fqdata/log/fqnext_xtdata_qfq_worker.log -Tail 200
 Get-Content D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log -Tail 200
-& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker status
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker status --strict
 & D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker worker --once
-& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope stock
-& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope etf
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope stock --mode full
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope etf --mode full
 ```
 
 处理：
@@ -696,7 +696,7 @@ Get-Content D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log -Tail 200
 - `worker --once` 返回 `waiting_for_bfq` 时，先在 Dagster 核对最新 `stock_data_job` / `etf_data_job`，以及 `freshquant.dagster_pipeline_markers` 中相应 `pipeline_key` 的成功文档；QFQ worker 不绕过 BFQ ready gate。
 - XTData 连接或历史下载失败时，先恢复 MiniQMT / XTData 端口，再重新执行 `worker --once`；worker 会把中断的 inactive `building` 状态恢复为可重试的 `failed`。
 - 返回 `writer lease is held` 时，先确认 Supervisor worker 或人工 build / rollback 是否仍在运行；正常 lease 会持续续期并在命令结束时释放，崩溃遗留 lease 到期后由下一轮原子接管，不要并发启动第二个 writer。
-- `audit` 失败时保留 active slot，修复源数据或日期轴后用 `build --scope <stock|etf> --target-date YYYY-MM-DD` 重建 inactive slot；不要手工修改 `active_slot` 或在 active 集合上原地修补。
+- `audit --mode structure` 只确认 Mongo 结构；递推或 XTData source 对账必须用 `--mode tail|full`。审计失败时保留 active slot，修复源数据或日期轴后用 `build --scope <stock|etf> --target-date YYYY-MM-DD` 重建 inactive slot；不要手工修改 `active_slot` 或在 active 集合上原地修补。
 - 怀疑 XTData 修订发生在默认 60 个交易日回看窗口之前时，使用同一 active 截止日执行 `build --scope <stock|etf> --target-date YYYY-MM-DD --full`；该命令重算整个 inactive scope，且不接受早于 active `factor_asof` 的日期。
 - 回切前先确认另一槽为 `ready` 并单独执行 `audit --slot <a|b>`，然后使用 `rollback --scope <stock|etf>`；回切只更新原子 marker。
 - 页面或策略结果未变化是当前边界：Stock / ETF 在线 reader 仍读取 `stock_adj` / `etf_adj`，A/B 集合是 shadow 数据。真实 Index 则固定使用 BFQ，不读取 ETF 因子。

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -617,6 +617,8 @@ docker exec fqnext_20260223-fq_mongodb-1 mongosh --quiet --eval 'const c=db.getS
 
 ## ETF 前复权未生效但 Dagster run 显示成功
 
+本节排查当前线上 `etf_xdxr -> etf_adj` 旧写入链；Stock / ETF 在线 reader 仍消费这条链。
+
 现象：
 
 - KlineSlim / ETF 日线在拆分、扩缩股之后仍显示 bfq 价格
@@ -667,6 +669,37 @@ from freshquant.data.etf_adj_sync import audit_recent_etf_xdxr_coverage
 print(audit_recent_etf_xdxr_coverage(recent_days=365))
 '@ | py -3.12 -m uv run -`
 - 正式修复后，重新部署 Dagster，并再跑一次 formal deploy health check / runtime verify
+
+## XTData QFQ shadow 快照不更新或审计失败
+
+现象：
+
+- `fqnext_xtdata_qfq_worker` 为 `FATAL` / `BACKOFF`，或 stderr 持续出现 `QFQ_DATA_NOT_READY`
+- `quantaxis.qfq_ready` 缺少 `scope=stock` / `scope=etf` 文档，active slot 的 `factor_asof` 落后于对应盘后 ready marker
+- inactive slot 长时间停在 `building` / `failed`，或 `audit` 返回日期轴、唯一性、非正因子、末日因子或递推恒等式错误
+- `stock_adj_qfq_a/b` / `etf_adj_qfq_a/b` 已更新，但页面或策略结果没有变化
+
+先检查：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode Status
+Get-Content D:/fqdata/log/fqnext_xtdata_qfq_worker.log -Tail 200
+Get-Content D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log -Tail 200
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker status
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker worker --once
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope stock
+& D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker audit --scope etf
+```
+
+处理：
+
+- `worker --once` 返回 `waiting_for_bfq` 时，先在 Dagster 核对最新 `stock_data_job` / `etf_data_job`，以及 `freshquant.dagster_pipeline_markers` 中相应 `pipeline_key` 的成功文档；QFQ worker 不绕过 BFQ ready gate。
+- XTData 连接或历史下载失败时，先恢复 MiniQMT / XTData 端口，再重新执行 `worker --once`；worker 会把中断的 inactive `building` 状态恢复为可重试的 `failed`。
+- 返回 `writer lease is held` 时，先确认 Supervisor worker 或人工 build / rollback 是否仍在运行；正常 lease 会持续续期并在命令结束时释放，崩溃遗留 lease 到期后由下一轮原子接管，不要并发启动第二个 writer。
+- `audit` 失败时保留 active slot，修复源数据或日期轴后用 `build --scope <stock|etf> --target-date YYYY-MM-DD` 重建 inactive slot；不要手工修改 `active_slot` 或在 active 集合上原地修补。
+- 怀疑 XTData 修订发生在默认 60 个交易日回看窗口之前时，使用同一 active 截止日执行 `build --scope <stock|etf> --target-date YYYY-MM-DD --full`；该命令重算整个 inactive scope，且不接受早于 active `factor_asof` 的日期。
+- 回切前先确认另一槽为 `ready` 并单独执行 `audit --slot <a|b>`，然后使用 `rollback --scope <stock|etf>`；回切只更新原子 marker。
+- 页面或策略结果未变化是当前边界：Stock / ETF 在线 reader 仍读取 `stock_adj` / `etf_adj`，A/B 集合是 shadow 数据。真实 Index 则固定使用 BFQ，不读取 ETF 因子。
 
 ## xt_account_sync worker 启动即 Fatal
 
@@ -770,6 +803,8 @@ print(inspect.signature(resolve_stock_account))
 - 或优先使用 `powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -ChangedPath freshquant/rear/api_server.py -RunHealthChecks`
 
 ## ETF 前复权错误
+
+本节排查当前线上 `etf_adj` 消费链；`etf_adj_qfq_a/b` 是独立 shadow 集合。
 
 现象：
 - ETF 在页面上跨扩缩股日出现价格断层

--- a/freshquant/chanlun_service.py
+++ b/freshquant/chanlun_service.py
@@ -17,7 +17,10 @@ from freshquant.config import cfg, config
 from freshquant.data.astock.holding import get_stock_fills
 from freshquant.data.future.basic import fq_fetch_future_basic
 from freshquant.instrument.etf import query_etf_map
-from freshquant.instrument.general import query_instrument_type
+from freshquant.instrument.general import (
+    infer_cn_instrument_type,
+    query_instrument_type,
+)
 from freshquant.instrument.stock import query_stock_map
 from freshquant.KlineDataTool import (
     get_future_data_v2,
@@ -37,8 +40,6 @@ from freshquant.signal.break_pivot import (
 )
 from freshquant.util.code import infer_cn_security_prefixed_code
 
-ETF_CODE_PREFIXES = ("15", "16", "18", "50", "51", "56", "58")
-
 
 def _resolve_security_symbol_and_type(symbol):
     normalized_symbol = infer_cn_security_prefixed_code(symbol)
@@ -47,11 +48,7 @@ def _resolve_security_symbol_and_type(symbol):
 
     instrument_type = query_instrument_type(normalized_symbol.lower())
     if instrument_type is None:
-        base_code = normalized_symbol[2:]
-        if base_code.startswith(ETF_CODE_PREFIXES):
-            instrument_type = InstrumentType.ETF_CN
-        else:
-            instrument_type = InstrumentType.STOCK_CN
+        instrument_type = infer_cn_instrument_type(normalized_symbol)
 
     return normalized_symbol, instrument_type
 
@@ -117,6 +114,25 @@ def get_data_v2(symbol, period, end_date=None, bar_count=0):
             stock_fills = stock_fills[existing_columns].to_dict(orient="records")
         else:
             stock_fills = None
+    elif instrumentType == InstrumentType.INDEX_CN:
+        try:
+            from freshquant.instrument.index import query_index_map
+
+            name = pydash.get(query_index_map(), f"{query_symbol.lower()}.name")
+        except Exception:
+            name = None
+
+        from freshquant.quote.index import queryIndexCandleSticks
+
+        get_instrument_data = (
+            lambda code, current_period, current_end_date: queryIndexCandleSticks(
+                code,
+                current_period,
+                current_end_date,
+                bar_count=bar_count,
+            )
+        )
+        stock_fills = None
     else:
         future_obj = fq_fetch_future_basic(symbol)
         if future_obj is not None:

--- a/freshquant/chanlun_structure_service.py
+++ b/freshquant/chanlun_structure_service.py
@@ -331,19 +331,29 @@ def _get_realtime_cache_payload(
 
 def _fetch_kline_df(symbol: str, period: str, end_date: str | None) -> pd.DataFrame:
     from freshquant.carnation.enum_instrument import InstrumentType
-    from freshquant.instrument.general import query_instrument_type
+    from freshquant.instrument.general import (
+        infer_cn_instrument_type,
+        query_instrument_type,
+    )
     from freshquant.KlineDataTool import get_future_data_v2, get_stock_data
     from freshquant.quote.etf import queryEtfCandleSticks
+    from freshquant.quote.index import queryIndexCandleSticks
+    from freshquant.util.code import infer_cn_security_prefixed_code
 
-    instrument_type = query_instrument_type((symbol or "").lower())
+    normalized_symbol = infer_cn_security_prefixed_code(symbol) or symbol
+    instrument_type = query_instrument_type((normalized_symbol or "").lower())
+    if instrument_type is None:
+        instrument_type = infer_cn_instrument_type(normalized_symbol)
     if instrument_type == InstrumentType.STOCK_CN:
         fetcher = get_stock_data
     elif instrument_type == InstrumentType.ETF_CN:
         fetcher = queryEtfCandleSticks
+    elif instrument_type == InstrumentType.INDEX_CN:
+        fetcher = queryIndexCandleSticks
     else:
         fetcher = get_future_data_v2
 
-    df = fetcher(symbol, period, end_date)
+    df = fetcher(normalized_symbol, period, end_date)
     return _sanitize_kline_df(df)
 
 

--- a/freshquant/data/adj_intraday.py
+++ b/freshquant/data/adj_intraday.py
@@ -124,7 +124,11 @@ def apply_qfq_with_intraday_override(
             )
 
     trade_date = _normalize_date_str((override or {}).get("trade_date"))
-    anchor_scale = float((override or {}).get("anchor_scale") or 1.0)
+    anchor_scale = float(
+        (override or {}).get("legacy_anchor_scale")
+        or (override or {}).get("anchor_scale")
+        or 1.0
+    )
     if trade_date:
         history_mask = date_key < trade_date
         trade_mask = date_key == trade_date

--- a/freshquant/data/index.py
+++ b/freshquant/data/index.py
@@ -18,12 +18,16 @@ from freshquant.util.code import fq_util_code_append_market_code
 
 @redis_cache.memoize(expiration=900)
 def fq_data_QA_fetch_index_min_adv(code, start, end, frequence):
-    return QA_fetch_index_min_adv(code, start, end, frequence).to_qfq().data
+    # Real indexes are intentionally BFQ.  ETF QFQ factors are never read on
+    # this path, even though both products use QUANTAXIS index collections.
+    data = QA_fetch_index_min_adv(code, start, end, frequence)
+    return data.data if data is not None else None
 
 
 @redis_cache.memoize(expiration=900)
 def fqDataQAFetchIndexDayAdv(code, start, end):
-    return QA_fetch_index_day_adv(code, start, end).data
+    data = QA_fetch_index_day_adv(code, start, end)
+    return data.data if data is not None else None
 
 
 @redis_cache.memoize(expiration=864000)
@@ -38,14 +42,14 @@ def fq_data_index_fetch_min(code, frequence, start=None, end=None):
         QA_util_datetime_to_strdatetime(end),
         frequence=frequence,
     )
+    if data is None or len(data) == 0:
+        return None
     data.reset_index(inplace=True)
     data["time_stamp"] = data["datetime"].apply(lambda dt: QA_util_time_stamp(dt))
     data.set_index("datetime", inplace=True, drop=False)
-    if data is None or len(data) == 0:
-        return None
-    last_datetime = data["datetime"][-1]
+    last_datetime = data["datetime"].iloc[-1]
     realtime_data_list = (
-        DBfreshquant["stock_realtime"]
+        DBfreshquant["index_realtime"]
         .find(
             {
                 "code": fq_util_code_append_market_code(code, upper_case=False),
@@ -88,7 +92,7 @@ def fq_data_index_fetch_min(code, frequence, start=None, end=None):
             lambda value: value.replace(tzinfo=None)
         )
         realtime_data_list.set_index("datetime", drop=False, inplace=True)
-        data = data.append(realtime_data_list)
+        data = pd.concat([data, realtime_data_list])
         data.drop_duplicates(subset="datetime", keep="first", inplace=True)
     data = data.round(
         {"open": 2, "high": 2, "low": 2, "close": 2, "volume": 2, "amount": 2}
@@ -102,6 +106,8 @@ def fqDataIndexFetchDay(code, start=None, end=None):
         QA_util_datetime_to_strdatetime(start),
         QA_util_datetime_to_strdatetime(end),
     )
+    if data is None or len(data) == 0:
+        return None
     data.reset_index(inplace=True)
     data["datetime"] = data["date"].apply(lambda x: datetime.combine(x, time()))
     data["date_stamp"] = data["datetime"].apply(lambda x: QA_util_time_stamp(x))
@@ -111,6 +117,10 @@ def fqDataIndexFetchDay(code, start=None, end=None):
     )
     data.set_index("datetime", drop=False, inplace=True)
     return data
+
+
+# Explicit BFQ aliases used by the type-routing layer.
+fq_data_index_fetch_day = fqDataIndexFetchDay
 
 
 def fq_data_stock_resample_60min(data):

--- a/freshquant/data/index.py
+++ b/freshquant/data/index.py
@@ -13,7 +13,23 @@ from QUANTAXIS.QAUtil.QADate import QA_util_datetime_to_strdatetime, QA_util_tim
 
 from freshquant.database.cache import redis_cache
 from freshquant.db import DBfreshquant
-from freshquant.util.code import fq_util_code_append_market_code
+from freshquant.instrument.index import query_index_map
+from freshquant.util.code import normalize_to_base_code
+
+
+def _index_realtime_code(code: str) -> str:
+    raw = str(code or "").strip()
+    upper = raw.upper()
+    base_code = normalize_to_base_code(raw)
+    if len(upper) == 8 and upper[:2] in {"SH", "SZ"}:
+        return upper.lower()
+    if len(upper) == 9 and upper[:6].isdigit() and upper[6:] in {".SH", ".SZ"}:
+        return f"{upper[7:].lower()}{upper[:6]}"
+    index_map = query_index_map()
+    instrument = index_map.get(raw) or index_map.get(base_code)
+    if instrument and instrument.get("sse"):
+        return f"{str(instrument['sse']).lower()}{base_code}"
+    return base_code
 
 
 @redis_cache.memoize(expiration=900)
@@ -36,8 +52,9 @@ def fqDataQAFetchIndexListAdv():
 
 
 def fq_data_index_fetch_min(code, frequence, start=None, end=None):
+    base_code = normalize_to_base_code(code)
     data = fq_data_QA_fetch_index_min_adv(
-        code,
+        base_code,
         QA_util_datetime_to_strdatetime(start),
         QA_util_datetime_to_strdatetime(end),
         frequence=frequence,
@@ -52,7 +69,7 @@ def fq_data_index_fetch_min(code, frequence, start=None, end=None):
         DBfreshquant["index_realtime"]
         .find(
             {
-                "code": fq_util_code_append_market_code(code, upper_case=False),
+                "code": _index_realtime_code(code),
                 "frequence": frequence,
                 "datetime": {"$gt": last_datetime, "$lte": end},
                 "open": {"$gt": 0},

--- a/freshquant/instrument/general.py
+++ b/freshquant/instrument/general.py
@@ -12,10 +12,64 @@ from freshquant.instrument.future import query_future_map
 from freshquant.instrument.index import query_index_map
 from freshquant.instrument.stock import query_stock_map
 
+CN_TRADING_ETF_CODE_PREFIXES = (
+    "15",
+    "16",
+    "18",
+    "50",
+    "51",
+    "52",
+    "53",
+    "56",
+    "58",
+)
+CN_INDEX_SYMBOL_PREFIXES = ("sh000", "sz399")
+
+
+def _normalized_cn_symbol(code: str) -> tuple[str, str] | None:
+    raw = str(code or "").strip().lower()
+    if not raw:
+        return None
+    if len(raw) == 9 and raw[:6].isdigit() and raw[6:] in {".sh", ".sz", ".bj"}:
+        raw = raw[7:] + raw[:6]
+    if len(raw) == 8 and raw[:2] in {"sh", "sz", "bj"} and raw[2:].isdigit():
+        return raw, raw[2:]
+    if len(raw) == 6 and raw.isdigit():
+        return raw, raw
+    return None
+
+
+def is_trading_etf_code(code: str) -> bool:
+    """Classify an exchange-traded ETF code without consulting runtime maps."""
+
+    normalized = _normalized_cn_symbol(code)
+    return bool(normalized and normalized[1].startswith(CN_TRADING_ETF_CODE_PREFIXES))
+
+
+def infer_cn_instrument_type(code: str) -> InstrumentType | None:
+    """Infer Stock/ETF/Index for a normalized Chinese security code.
+
+    Explicit market-qualified index symbols take precedence over numeric
+    prefixes. Bare codes remain Stock unless they are unambiguous ETF or
+    Shenzhen index codes; runtime instrument maps resolve other ambiguities.
+    """
+
+    normalized = _normalized_cn_symbol(code)
+    if normalized is None:
+        return None
+    symbol, base_code = normalized
+    if symbol.startswith(CN_INDEX_SYMBOL_PREFIXES) or (
+        len(symbol) == 6 and base_code.startswith("399")
+    ):
+        return InstrumentType.INDEX_CN
+    if is_trading_etf_code(symbol):
+        return InstrumentType.ETF_CN
+    return InstrumentType.STOCK_CN
+
 
 @in_memory_cache.memoize(expiration=900)
 def query_instrument_type(code: str) -> InstrumentType | None:
-    code = code.lower()
+    code = str(code or "").lower()
     if query_stock_map().get(code):
         return InstrumentType.STOCK_CN
     elif query_etf_map().get(code):
@@ -25,7 +79,7 @@ def query_instrument_type(code: str) -> InstrumentType | None:
     elif query_index_map().get(code):
         return InstrumentType.INDEX_CN
     else:
-        return None
+        return infer_cn_instrument_type(code)
 
 
 @in_memory_cache.memoize(expiration=900)
@@ -48,7 +102,7 @@ def query_decimal_point(code: str) -> int:
     decimal_point = 2
     inst_info = query_instrument_info(code)
     if inst_info is not None:
-        decimal_point = inst_info.get('decimal_point', 2)
+        decimal_point = inst_info.get("decimal_point", 2)
     return decimal_point
 
 

--- a/freshquant/market_data/xtdata/adj_refresh_service.py
+++ b/freshquant/market_data/xtdata/adj_refresh_service.py
@@ -82,6 +82,25 @@ class AdjRefreshRepository:
             projection={"_id": 0, "date": 1, "adj": 1},
         )
 
+    def get_snapshot_anchor(
+        self,
+        kind: str,
+        code: str,
+        base_anchor_date: str,
+        snapshot: dict[str, Any],
+    ) -> dict | None:
+        collection = str(snapshot.get("collection") or "")
+        if not collection:
+            return None
+        return DBQuantAxis[collection].find_one(
+            {
+                "code": normalize_to_base_code(code),
+                "date": {"$lte": base_anchor_date},
+            },
+            sort=[("date", -1)],
+            projection={"_id": 0, "date": 1, "adj": 1},
+        )
+
     def upsert_intraday_override(
         self, kind: str, document: dict[str, Any]
     ) -> dict[str, Any]:
@@ -260,17 +279,33 @@ class AdjRefreshService:
                 continue
 
             target_adj = front_close / raw_close
-            anchor_scale = target_adj / base_adj
+            legacy_anchor_scale = target_adj / base_adj
             document = {
                 "code": normalize_to_base_code(code),
                 "trade_date": trade_date,
                 "base_anchor_date": effective_anchor_date,
-                "anchor_scale": float(anchor_scale),
+                "anchor_scale": float(legacy_anchor_scale),
+                "legacy_anchor_scale": float(legacy_anchor_scale),
                 "source": "xtdata_front_raw",
                 "updated_at": updated_at,
             }
             snapshot = snapshots.get(kind) or {}
-            if snapshot.get("snapshot_id"):
+            snapshot_anchor_loader = getattr(
+                self.repository, "get_snapshot_anchor", None
+            )
+            snapshot_anchor = (
+                snapshot_anchor_loader(kind, code, base_anchor_date, snapshot)
+                if snapshot.get("snapshot_id") and snapshot_anchor_loader
+                else None
+            )
+            snapshot_anchor_date = str((snapshot_anchor or {}).get("date") or "")
+            snapshot_adj = float((snapshot_anchor or {}).get("adj") or 0.0)
+            if (
+                snapshot.get("snapshot_id")
+                and snapshot_anchor_date == effective_anchor_date
+                and snapshot_adj > 0
+            ):
+                document["anchor_scale"] = float(target_adj / snapshot_adj)
                 document["base_snapshot_id"] = str(snapshot["snapshot_id"])
                 document["base_factor_asof"] = str(snapshot.get("factor_asof") or "")
             self.repository.upsert_intraday_override(kind, document)

--- a/freshquant/market_data/xtdata/adj_refresh_service.py
+++ b/freshquant/market_data/xtdata/adj_refresh_service.py
@@ -47,6 +47,15 @@ def _default_code_loader() -> list[str]:
     return list(load_monitor_codes(mode=mode, max_symbols=max_symbols) or [])
 
 
+def _default_snapshot_provider(kind: str) -> dict[str, Any] | None:
+    try:
+        from freshquant.market_data.xtdata.qfq import resolve_active_slot
+
+        return resolve_active_slot(scope=kind, db=DBQuantAxis)
+    except Exception:
+        return None
+
+
 def _is_retryable_xtdata_error(error: Exception) -> bool:
     message = str(error or "")
     normalized = message.lower()
@@ -195,6 +204,7 @@ class AdjRefreshService:
         trade_date_provider=None,
         prev_trade_date_provider=None,
         now_provider=None,
+        snapshot_provider=None,
     ):
         self.repository = repository or AdjRefreshRepository()
         self.market_client = market_client or XtDataAdjRefreshClient()
@@ -204,6 +214,7 @@ class AdjRefreshService:
             prev_trade_date_provider or query_prev_trade_date
         )
         self.now_provider = now_provider or (lambda: datetime.now(timezone.utc))
+        self.snapshot_provider = snapshot_provider or _default_snapshot_provider
 
     def sync_once(self) -> dict[str, Any]:
         trade_date = _normalize_date_str(self.trade_date_provider())
@@ -227,6 +238,7 @@ class AdjRefreshService:
             "base_anchor_date": base_anchor_date,
             "updated_at": updated_at,
         }
+        snapshots = {kind: self.snapshot_provider(kind) for kind in ("stock", "etf")}
 
         for code in list(self.code_loader() or []):
             kind = "etf" if _is_index_like_code(code) else "stock"
@@ -257,6 +269,10 @@ class AdjRefreshService:
                 "source": "xtdata_front_raw",
                 "updated_at": updated_at,
             }
+            snapshot = snapshots.get(kind) or {}
+            if snapshot.get("snapshot_id"):
+                document["base_snapshot_id"] = str(snapshot["snapshot_id"])
+                document["base_factor_asof"] = str(snapshot.get("factor_asof") or "")
             self.repository.upsert_intraday_override(kind, document)
             result["count"] += 1
             result[f"{kind}_count"] += 1
@@ -272,6 +288,7 @@ def refresh_adj_overrides_once(
     trade_date_provider=None,
     prev_trade_date_provider=None,
     now_provider=None,
+    snapshot_provider=None,
 ) -> dict[str, Any]:
     service = AdjRefreshService(
         repository=repository,
@@ -280,5 +297,6 @@ def refresh_adj_overrides_once(
         trade_date_provider=trade_date_provider,
         prev_trade_date_provider=prev_trade_date_provider,
         now_provider=now_provider,
+        snapshot_provider=snapshot_provider,
     )
     return service.sync_once()

--- a/freshquant/market_data/xtdata/qfq.py
+++ b/freshquant/market_data/xtdata/qfq.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import math
 import re
+import threading
 import uuid
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import date, datetime, timedelta, timezone
@@ -719,6 +720,87 @@ def _release_writer_lease(*, db, scope: str, owner_id: str) -> None:
     db[WRITER_LOCK_COLLECTION].delete_one({"scope": scope, "owner_id": owner_id})
 
 
+class _WriterLeaseHeartbeat:
+    def __init__(
+        self,
+        *,
+        db,
+        scope: str,
+        owner_id: str,
+        lease_seconds: int,
+        now_provider=None,
+        heartbeat_seconds: float | None = None,
+    ):
+        self.db = db
+        self.scope = scope
+        self.owner_id = owner_id
+        self.lease_seconds = lease_seconds
+        self.now_provider = now_provider
+        self.interval = (
+            max(0.01, float(heartbeat_seconds))
+            if heartbeat_seconds is not None
+            else min(60.0, max(1.0, float(lease_seconds) / 3.0))
+        )
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._failure: Exception | None = None
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"qfq-lease-{scope}",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.interval):
+            with self._lock:
+                if self._stop.is_set():
+                    return
+                try:
+                    self._refresh()
+                except Exception as exc:  # noqa: BLE001
+                    self._failure = exc
+                    return
+
+    def _refresh(self) -> None:
+        _refresh_writer_lease(
+            db=self.db,
+            scope=self.scope,
+            owner_id=self.owner_id,
+            now_provider=self.now_provider,
+            lease_seconds=self.lease_seconds,
+        )
+
+    def pulse(self) -> None:
+        with self._lock:
+            self._raise_if_failed_locked()
+            self._refresh()
+
+    def raise_if_failed(self) -> None:
+        with self._lock:
+            self._raise_if_failed_locked()
+
+    def _raise_if_failed_locked(self) -> None:
+        if self._failure is not None:
+            raise QFQSyncError(
+                f"{self.scope} QFQ writer lease heartbeat failed"
+            ) from self._failure
+
+    def run_fenced_publish(self, callback: Callable[[], Any]) -> Any:
+        with self._lock:
+            self._raise_if_failed_locked()
+            self._refresh()
+            result = callback()
+            self._stop.set()
+            return result
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5.0)
+
+
 def _ensure_marker_indexes(collection) -> None:
     collection.create_index([("scope", 1)], unique=True, name="scope_unique")
 
@@ -1255,6 +1337,8 @@ def audit_qfq_slot(
     db=DBQuantAxis,
     codes: Iterable[str] | None = None,
     factor_asof: str | None = None,
+    bars_loader: Callable[..., Any] | None = None,
+    source_tail_days: int | None = None,
     progress_callback: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     if scope not in FACTOR_COLLECTIONS or slot not in {"a", "b"}:
@@ -1280,8 +1364,25 @@ def audit_qfq_slot(
         code_rows = _load_existing_factor_rows(
             db=db, collection_name=collection.name, code=code
         )
-        audit = _audit_code_rows(code=code, rows=code_rows, expected_dates=expected)
-        rows += len(code_rows)
+        audit_dates = expected
+        bars = None
+        audit_rows = code_rows
+        if bars_loader is not None:
+            if source_tail_days is not None:
+                audit_dates = expected[-max(2, int(source_tail_days)) :]
+            load_start, load_end, audit_dates = _bfq_download_bounds(audit_dates)
+            bars = _call_loader(bars_loader, code, load_start, load_end)
+            audit_date_set = set(audit_dates)
+            audit_rows = [
+                row for row in code_rows if _date_key(row.get("date")) in audit_date_set
+            ]
+        audit = _audit_code_rows(
+            code=code,
+            rows=audit_rows,
+            expected_dates=audit_dates,
+            bars=bars,
+        )
+        rows += len(audit_rows)
         checked_codes += 1
         if not audit["ok"]:
             failures.append({"code": code, "audit": audit})
@@ -1292,6 +1393,11 @@ def audit_qfq_slot(
         "slot": slot,
         "collection": collection.name,
         "factor_asof": factor_asof,
+        "audit_mode": (
+            "structure"
+            if bars_loader is None
+            else "tail_source" if source_tail_days is not None else "full_source"
+        ),
         "codes": checked_codes,
         "rows": rows,
         "failed": len(failures),
@@ -1309,6 +1415,7 @@ def _bootstrap_scope(
     loader: Callable[..., Any],
     now_provider=None,
     progress_callback: Callable[[], None] | None = None,
+    publish_callback: Callable[[Callable[[], Any]], Any] | None = None,
 ) -> dict[str, Any]:
     if get_qfq_marker(scope=scope, db=db):
         raise QFQSyncError(f"{scope} QFQ bootstrap requires no marker")
@@ -1366,9 +1473,18 @@ def _bootstrap_scope(
     )
     if not audit_b["ok"] or audit_a["rows"] != audit_b["rows"]:
         raise QFQSyncError(f"{scope} bootstrap slot B audit failed", stats=audit_b)
-    marker = _insert_bootstrap_marker(
-        db=db, scope=scope, factor_asof=target_date, now_provider=now_provider
-    )
+
+    def publish_marker() -> dict[str, Any]:
+        return _insert_bootstrap_marker(
+            db=db, scope=scope, factor_asof=target_date, now_provider=now_provider
+        )
+
+    if publish_callback:
+        marker = publish_callback(publish_marker)
+    else:
+        if progress_callback:
+            progress_callback()
+        marker = publish_marker()
     return {
         "scope": scope,
         "mode": "bootstrap",
@@ -1415,6 +1531,7 @@ def _update_scope(
     force_full_rebuild: bool,
     now_provider=None,
     progress_callback: Callable[[], None] | None = None,
+    publish_callback: Callable[[Callable[[], Any]], Any] | None = None,
 ) -> dict[str, Any]:
     marker = validate_qfq_marker(get_qfq_marker(scope=scope, db=db), scope=scope)
     active_slot = str(marker["active_slot"])
@@ -1439,7 +1556,13 @@ def _update_scope(
     )
     inactive_slot = _claim_inactive_slot(db=db, scope=scope, marker=marker)
     collection = db[FACTOR_COLLECTIONS[scope][inactive_slot]]
-    stats = {"full": 0, "incremental": 0, "unchanged": 0, "rows_written": 0}
+    stats = {
+        "full": 0,
+        "incremental": 0,
+        "unchanged": 0,
+        "rows_written": 0,
+        "stale_codes_removed": 0,
+    }
     try:
         _ensure_factor_indexes(collection)
         universe = load_factor_universe(kind=scope, db=db, codes=codes)
@@ -1474,6 +1597,10 @@ def _update_scope(
             stats["rows_written"] += int(result["rows_written"])
             included.append(code)
         stale_codes = _distinct_codes(collection) - set(included)
+        if stale_codes and force_full_rebuild:
+            collection.delete_many({"code": {"$in": sorted(stale_codes)}})
+            stats["stale_codes_removed"] = len(stale_codes)
+            stale_codes = _distinct_codes(collection) - set(included)
         if stale_codes:
             raise QFQSyncError(
                 f"{scope} inactive slot contains codes outside BFQ universe",
@@ -1489,14 +1616,23 @@ def _update_scope(
         )
         if not audit["ok"]:
             raise QFQSyncError(f"{scope} inactive slot audit failed", stats=audit)
-        published = _publish_inactive_slot(
-            db=db,
-            scope=scope,
-            marker=marker,
-            inactive_slot=inactive_slot,
-            factor_asof=target_date,
-            now_provider=now_provider,
-        )
+
+        def publish_marker() -> dict[str, Any]:
+            return _publish_inactive_slot(
+                db=db,
+                scope=scope,
+                marker=marker,
+                inactive_slot=inactive_slot,
+                factor_asof=target_date,
+                now_provider=now_provider,
+            )
+
+        if publish_callback:
+            published = publish_callback(publish_marker)
+        else:
+            if progress_callback:
+                progress_callback()
+            published = publish_marker()
         return {
             "scope": scope,
             "mode": "update",
@@ -1529,6 +1665,7 @@ def sync_qfq_factors(
     min_grace_seconds: int = DEFAULT_READER_GRACE_SECONDS,
     force_full_rebuild: bool = False,
     writer_lease_seconds: int = DEFAULT_WRITER_LEASE_SECONDS,
+    writer_heartbeat_seconds: float | None = None,
     now_provider=None,
 ) -> dict[str, Any]:
     scopes = [item.strip().lower() for item in str(scope).split(",") if item.strip()]
@@ -1537,6 +1674,10 @@ def sync_qfq_factors(
     target = _date_key(target_date)
     if not target:
         raise ValueError(f"invalid QFQ target date: {target_date}")
+    if force_full_rebuild and codes is not None:
+        raise ValueError(
+            "force_full_rebuild requires the full scope; codes must be omitted"
+        )
     client = xtdata_client or XtDataQfqClient()
     loader = bars_loader or client.load_daily_bars
     result: dict[str, Any] = {
@@ -1553,14 +1694,15 @@ def sync_qfq_factors(
             lease_seconds=writer_lease_seconds,
         )
 
-        def heartbeat() -> None:
-            _refresh_writer_lease(
-                db=db,
-                scope=kind,
-                owner_id=owner_id,
-                now_provider=now_provider,
-                lease_seconds=writer_lease_seconds,
-            )
+        lease_heartbeat = _WriterLeaseHeartbeat(
+            db=db,
+            scope=kind,
+            owner_id=owner_id,
+            lease_seconds=writer_lease_seconds,
+            now_provider=now_provider,
+            heartbeat_seconds=writer_heartbeat_seconds,
+        )
+        lease_heartbeat.start()
 
         try:
             marker = get_qfq_marker(scope=kind, db=db)
@@ -1577,7 +1719,8 @@ def sync_qfq_factors(
                     codes=codes,
                     loader=loader,
                     now_provider=now_provider,
-                    progress_callback=heartbeat,
+                    progress_callback=lease_heartbeat.pulse,
+                    publish_callback=lease_heartbeat.run_fenced_publish,
                 )
             else:
                 scope_result = _update_scope(
@@ -1590,10 +1733,13 @@ def sync_qfq_factors(
                     min_grace_seconds=min_grace_seconds,
                     force_full_rebuild=force_full_rebuild,
                     now_provider=now_provider,
-                    progress_callback=heartbeat,
+                    progress_callback=lease_heartbeat.pulse,
+                    publish_callback=lease_heartbeat.run_fenced_publish,
                 )
+            lease_heartbeat.raise_if_failed()
             result["by_scope"][kind] = scope_result
         finally:
+            lease_heartbeat.stop()
             _release_writer_lease(db=db, scope=kind, owner_id=owner_id)
     result["ready"] = True
     return result

--- a/freshquant/market_data/xtdata/qfq.py
+++ b/freshquant/market_data/xtdata/qfq.py
@@ -1,0 +1,1638 @@
+"""Canonical XTData ``preClose`` based QFQ factor pipeline.
+
+The public entry points are intentionally dependency-injectable.  Production
+uses ``xtquant.xtdata`` and Mongo; unit tests can provide a bar loader and an
+in-memory database without changing the factor contract.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import uuid
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from freshquant.bootstrap_config import bootstrap_config
+from freshquant.db import DBQuantAxis
+from freshquant.instrument.general import is_trading_etf_code
+
+QFQ_DATA_NOT_READY = "QFQ_DATA_NOT_READY"
+QFQ_SOURCE = "xtdata_preclose"
+QFQ_WRITER = "freshquant.market_data.xtdata.qfq"
+QFQ_SCHEMA_VERSION = 1
+FACTOR_COLLECTIONS = {
+    "stock": {
+        "a": "stock_adj_qfq_a",
+        "b": "stock_adj_qfq_b",
+    },
+    "etf": {
+        "a": "etf_adj_qfq_a",
+        "b": "etf_adj_qfq_b",
+    },
+}
+LEGACY_FACTOR_COLLECTIONS = {"stock": "stock_adj", "etf": "etf_adj"}
+# BFQ is the coverage authority for each factor universe.  ``index_day`` is
+# intentionally used for ETF history because QUANTAXIS stores exchange-traded
+# funds in that collection alongside real indexes.
+BFQ_COLLECTIONS = {"stock": "stock_day", "etf": "index_day"}
+READY_COLLECTION = "qfq_ready"
+WRITER_LOCK_COLLECTION = "qfq_writer_locks"
+DEFAULT_TAIL_AUDIT_DAYS = 60
+DEFAULT_READER_GRACE_SECONDS = 300
+DEFAULT_WRITER_LEASE_SECONDS = 3600
+ETF_OPEN_FUND_HINTS = (
+    "开放式",
+    "联接",
+    "场外",
+)
+
+
+class QFQSyncError(RuntimeError):
+    """A synchronization run failed before its snapshot became visible."""
+
+    error_code = QFQ_DATA_NOT_READY
+
+    def __init__(self, message: str, *, stats: Mapping[str, Any] | None = None):
+        self.stats = dict(stats or {})
+        super().__init__(f"{QFQ_DATA_NOT_READY}: {message}")
+
+
+def _date_key(value: Any) -> str | None:
+    if value is None or value is pd.NaT:
+        return None
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, str):
+        text = value.strip()
+        try:
+            if (
+                len(text) == 10
+                and text[4] == "-"
+                and text[7] == "-"
+                and text.replace("-", "").isdigit()
+            ):
+                return date.fromisoformat(text).isoformat()
+            if len(text) == 8 and text.isdigit():
+                return date(int(text[:4]), int(text[4:6]), int(text[6:8])).isoformat()
+        except ValueError:
+            return None
+    if isinstance(value, (int, float, np.integer, np.floating)) and not isinstance(
+        value, (bool, np.bool_)
+    ):
+        number = float(value)
+        if not math.isfinite(number):
+            return None
+        try:
+            if 10_000_000 <= number < 100_000_000:
+                text = str(int(number))
+                return date(int(text[:4]), int(text[4:6]), int(text[6:8])).isoformat()
+            if number > 10_000_000_000:
+                return (
+                    datetime.fromtimestamp(number / 1000, tz=timezone.utc)
+                    .date()
+                    .isoformat()
+                )
+            if number > 1_000_000_000:
+                return (
+                    datetime.fromtimestamp(number, tz=timezone.utc).date().isoformat()
+                )
+        except (OSError, OverflowError, ValueError):
+            return None
+    parsed = _parse_timestamp(value)
+    if pd.isna(parsed):
+        return None
+    return parsed.strftime("%Y-%m-%d")
+
+
+def _xt_date_arg(value: Any) -> str:
+    """Format a BFQ boundary in the date form accepted by XTData."""
+
+    key = _date_key(value)
+    return key.replace("-", "") if key else ""
+
+
+def normalize_code(code: Any) -> str:
+    """Normalize a security code to the six-character factor contract."""
+
+    text = str(code or "").strip().lower()
+    match = re.search(r"(\d{6})", text)
+    if match:
+        return match.group(1)
+    digits = "".join(char for char in text if char.isdigit())
+    return digits[-6:].zfill(6) if digits else ""
+
+
+def to_xt_code(code: Any, *, market: str | None = None) -> str:
+    """Convert a prefixed/base code to XTData's ``000001.SZ`` form."""
+
+    text = str(code or "").strip().upper()
+    if "." in text and len(text.rsplit(".", 1)[-1]) == 2:
+        return text
+    base = normalize_code(text)
+    suffix = str(market or "").strip().upper()
+    if suffix not in {"SH", "SZ", "BJ"}:
+        if base.startswith("920") or base.startswith(("4", "8")):
+            suffix = "BJ"
+        elif base.startswith(("5", "6")):
+            suffix = "SH"
+        else:
+            suffix = "SZ"
+    return f"{base}.{suffix}"
+
+
+def _parse_timestamp(value: Any) -> pd.Timestamp:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        number = float(value)
+        if not math.isfinite(number):
+            return pd.NaT
+        if 10_000_000 <= number < 100_000_000:
+            return pd.to_datetime(str(int(number)), format="%Y%m%d", errors="coerce")
+        if number > 10_000_000_000:
+            return pd.to_datetime(number, unit="ms", errors="coerce")
+        if number > 1_000_000_000:
+            return pd.to_datetime(number, unit="s", errors="coerce")
+    return pd.to_datetime(value, errors="coerce")
+
+
+def _row_key(frame: pd.DataFrame, code: str | None) -> Any:
+    if frame.empty:
+        return None
+    candidates = [str(code or ""), str(code or "").upper(), str(code or "").lower()]
+    for candidate in candidates:
+        if candidate and candidate in frame.index:
+            return candidate
+    return frame.index[0] if len(frame.index) == 1 else None
+
+
+def _field_table_to_rows(
+    payload: Mapping[str, Any], code: str | None
+) -> pd.DataFrame | None:
+    fields = {str(key).lower(): value for key, value in payload.items()}
+    known = {
+        "time",
+        "date",
+        "datetime",
+        "close",
+        "preclose",
+        "pre_close",
+        "open",
+        "high",
+        "low",
+    }
+    if not (known & set(fields)):
+        return None
+
+    # ``get_market_data`` returns field -> DataFrame(index=code, columns=time).
+    sample = next(
+        (value for value in fields.values() if isinstance(value, pd.DataFrame)), None
+    )
+    if sample is not None and not sample.empty:
+        key = _row_key(sample, code)
+        if key is not None:
+            columns = list(sample.columns)
+            rows: list[dict[str, Any]] = []
+            for column in columns:
+                row: dict[str, Any] = {"time": column}
+                for field_name, value in fields.items():
+                    if isinstance(value, pd.DataFrame) and key in value.index:
+                        row[field_name] = value.loc[key].get(column)
+                    elif isinstance(value, pd.Series):
+                        row[field_name] = value.get(column)
+                    elif isinstance(value, Sequence) and not isinstance(
+                        value, (str, bytes)
+                    ):
+                        index = columns.index(column)
+                        if index < len(value):
+                            row[field_name] = value[index]
+                rows.append(row)
+            return pd.DataFrame(rows)
+
+    # Some test doubles return field -> list/Series directly.
+    lengths = [
+        len(value)
+        for value in fields.values()
+        if isinstance(value, (list, tuple, pd.Series))
+    ]
+    if lengths:
+        size = max(lengths)
+        rows = []
+        for index in range(size):
+            row = {}
+            for field_name, value in fields.items():
+                if isinstance(value, (list, tuple, pd.Series)) and index < len(value):
+                    row[field_name] = value[index]
+                elif not isinstance(value, (list, tuple, pd.Series)):
+                    row[field_name] = value
+            rows.append(row)
+        return pd.DataFrame(rows)
+    return None
+
+
+def normalize_xtdata_bars(payload: Any, *, code: str | None = None) -> pd.DataFrame:
+    """Normalize common XTData daily payload shapes.
+
+    The result has ``date``, ``close`` and ``preClose`` columns and is sorted
+    by the actual dates returned by XTData.  No calendar interpolation occurs.
+    """
+
+    frame: pd.DataFrame | None = None
+    if isinstance(payload, pd.DataFrame):
+        frame = payload.copy()
+    elif isinstance(payload, Mapping):
+        frame = _field_table_to_rows(payload, code)
+        if frame is None:
+            # ``get_market_data_ex`` returns code -> DataFrame.
+            selected = None
+            for key in (
+                str(code or ""),
+                str(code or "").upper(),
+                str(code or "").lower(),
+            ):
+                if key and key in payload:
+                    selected = payload[key]
+                    break
+            if selected is None and len(payload) == 1:
+                selected = next(iter(payload.values()))
+            if isinstance(selected, pd.DataFrame):
+                frame = selected.copy()
+            elif isinstance(selected, Sequence) and not isinstance(
+                selected, (str, bytes)
+            ):
+                frame = pd.DataFrame(selected)
+    elif isinstance(payload, Sequence) and not isinstance(payload, (str, bytes)):
+        frame = pd.DataFrame(payload)
+    if frame is None:
+        raise QFQSyncError(f"unsupported XTData payload for code={code}")
+    if frame.empty:
+        raise QFQSyncError(f"XTData returned no daily bars for code={code}")
+
+    aliases = {
+        "pre_close": "preClose",
+        "preclose": "preClose",
+        "pre-close": "preClose",
+        "timestamp": "time",
+        "datetime": "time",
+    }
+    frame = frame.rename(
+        columns={
+            column: aliases.get(str(column).lower(), column) for column in frame.columns
+        }
+    )
+    if "time" not in frame.columns and "date" not in frame.columns:
+        frame = frame.copy()
+        frame["time"] = frame.index
+    if "close" not in frame.columns or "preClose" not in frame.columns:
+        raise QFQSyncError(f"XTData daily bars missing close/preClose for code={code}")
+    source_dates = frame["date"] if "date" in frame.columns else frame["time"]
+    frame["date"] = [_date_key(value) or "" for value in source_dates]
+    frame["close"] = pd.to_numeric(frame["close"], errors="coerce")
+    frame["preClose"] = pd.to_numeric(frame["preClose"], errors="coerce")
+    frame = frame.loc[frame["date"].astype(bool)].copy()
+    frame = frame.sort_values("date").reset_index(drop=True)
+    if frame["date"].duplicated().any():
+        duplicates = sorted(
+            frame.loc[frame["date"].duplicated(), "date"].unique().tolist()
+        )
+        raise QFQSyncError(
+            f"duplicate XTData trading dates for code={code}: {duplicates[:10]}"
+        )
+    valid_close = frame["close"].map(
+        lambda value: math.isfinite(float(value)) and float(value) > 0
+    )
+    if not valid_close.all():
+        raise QFQSyncError(f"invalid close values for code={code}")
+    used_preclose = frame["preClose"].iloc[1:]
+    valid_used_preclose = used_preclose.map(
+        lambda value: math.isfinite(float(value)) and float(value) > 0
+    )
+    if not valid_used_preclose.all():
+        raise QFQSyncError(f"invalid used preClose values for code={code}")
+    return frame
+
+
+def compute_preclose_adj(bars: Any, *, code: str | None = None) -> pd.DataFrame:
+    """Compute canonical QFQ factors from an ascending actual-date bar axis."""
+
+    day = normalize_xtdata_bars(bars, code=code)
+    close = day["close"].to_numpy(dtype=float)
+    preclose = day["preClose"].to_numpy(dtype=float)
+    factors = np.ones(len(day), dtype=float)
+    if len(day) > 1:
+        ratios = preclose[1:] / close[:-1]
+        if not np.isfinite(ratios).all() or (ratios <= 0).any():
+            raise QFQSyncError(f"invalid preClose/close ratio for code={code}")
+        factors[:-1] = np.cumprod(ratios[::-1])[::-1]
+    result = pd.DataFrame({"date": day["date"].tolist(), "adj": factors})
+    result["adj"] = pd.to_numeric(result["adj"], errors="coerce")
+    if (
+        not result["adj"]
+        .map(lambda value: math.isfinite(float(value)) and float(value) > 0)
+        .all()
+    ):
+        raise QFQSyncError(f"invalid computed factors for code={code}")
+    if code:
+        result.insert(0, "code", normalize_code(code))
+    return result
+
+
+# Names used by callers and older migration notes.
+compute_qfq_factors = compute_preclose_adj
+compute_xtdata_preclose_adj = compute_preclose_adj
+normalize_xtdata_daily_payload = normalize_xtdata_bars
+
+
+def _doc_text(document: Mapping[str, Any]) -> str:
+    return " ".join(
+        str(document.get(key) or "")
+        for key in ("name", "type", "category", "sec", "fund_type")
+    ).lower()
+
+
+def is_trading_etf(document_or_code: Any) -> bool:
+    """Return true only for exchange-traded ETF candidates.
+
+    Prefixes provide the fallback for sparse ``etf_list`` records; explicit
+    open-ended/fund metadata always wins and excludes the record.
+    """
+
+    document = document_or_code if isinstance(document_or_code, Mapping) else {}
+    code = normalize_code(document.get("code") if document else document_or_code)
+    if not code or not is_trading_etf_code(code):
+        return False
+    if document.get("is_etf") is False or document.get("etf") is False:
+        return False
+    text = _doc_text(document)
+    if any(hint in text for hint in ETF_OPEN_FUND_HINTS):
+        return False
+    type_value = str(
+        document.get("instrument_type") or document.get("asset_type") or ""
+    ).lower()
+    if type_value and "etf" not in type_value and "exchange" not in type_value:
+        return False
+    return True
+
+
+def _distinct_codes(collection) -> set[str]:
+    try:
+        values = collection.distinct("code")
+    except (AttributeError, TypeError):
+        try:
+            values = [row.get("code") for row in collection.find({}, {"code": 1})]
+        except TypeError:
+            values = [row.get("code") for row in collection.find({})]
+    return {normalize_code(value) for value in values if normalize_code(value)}
+
+
+def load_factor_universe(
+    *,
+    kind: str,
+    db=DBQuantAxis,
+    codes: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Load the full factor universe without monitor-pool/max-symbol limits."""
+
+    if kind not in FACTOR_COLLECTIONS:
+        raise ValueError(f"unsupported factor kind: {kind}")
+    list_collection_name = "stock_list" if kind == "stock" else "etf_list"
+    requested = {
+        normalize_code(value) for value in (codes or ()) if normalize_code(value)
+    }
+    documents = list(db[list_collection_name].find({}, {"_id": 0}))
+    metadata = {
+        normalize_code(document.get("code")): document
+        for document in documents
+        if normalize_code(document.get("code"))
+    }
+    candidates = (
+        _distinct_codes(db[BFQ_COLLECTIONS[kind]])
+        | set(metadata)
+        | _distinct_codes(db[LEGACY_FACTOR_COLLECTIONS[kind]])
+    )
+    if codes is not None:
+        candidates &= requested
+    included: set[str] = set()
+    excluded: list[dict[str, Any]] = []
+    for code in sorted(candidates):
+        document = metadata.get(code, {"code": code})
+        if kind == "etf" and not is_trading_etf(document):
+            excluded.append({"code": code, "reason": "not_trading_etf"})
+            continue
+        if kind == "stock" and is_trading_etf_code(code):
+            excluded.append({"code": code, "reason": "etf_like_code"})
+            continue
+        included.add(code)
+    missing_requested = requested - candidates if codes is not None else set()
+    excluded.extend(
+        {"code": code, "reason": "not_in_factor_universe"}
+        for code in sorted(missing_requested)
+    )
+    return {
+        "kind": kind,
+        "codes": sorted(included),
+        "excluded": excluded,
+        "monitor_pool_independent": True,
+    }
+
+
+def load_bfq_dates(*, kind: str, code: str, db=DBQuantAxis) -> list[str]:
+    """Return the actual BFQ trading-date axis for one included instrument."""
+
+    if kind not in BFQ_COLLECTIONS:
+        raise ValueError(f"unsupported BFQ kind: {kind}")
+    code6 = normalize_code(code)
+    collection = db[BFQ_COLLECTIONS[kind]]
+    query = {"code": code6}
+    projection = {"_id": 0, "date": 1}
+    try:
+        cursor = collection.find(query, projection)
+    except TypeError:
+        cursor = collection.find(query)
+    dates: list[str] = []
+    invalid: list[Any] = []
+    for row in cursor:
+        value = row.get("date") if isinstance(row, Mapping) else None
+        key = _date_key(value)
+        if key is None:
+            invalid.append(value)
+        else:
+            dates.append(key)
+    if invalid:
+        raise QFQSyncError(
+            f"{kind} BFQ history contains invalid dates for code={code6}",
+            stats={"kind": kind, "code": code6, "invalid_dates": invalid[:20]},
+        )
+    return sorted(set(dates))
+
+
+def _bfq_download_bounds(
+    bfq_dates: Iterable[str], *, start_time: str = "", end_time: str = ""
+) -> tuple[str, str, list[str]]:
+    """Resolve XTData bounds and the expected BFQ subset for a ticket."""
+
+    dates = sorted(set(str(value)[:10] for value in bfq_dates if str(value).strip()))
+    if not dates:
+        return _xt_date_arg(start_time), _xt_date_arg(end_time), []
+    requested_start = _date_key(start_time) if start_time else dates[0]
+    requested_end = _date_key(end_time) if end_time else dates[-1]
+    if requested_start is None:
+        requested_start = dates[0]
+    if requested_end is None:
+        requested_end = dates[-1]
+    if requested_start > requested_end:
+        raise QFQSyncError(
+            "invalid XTData date bounds",
+            stats={"start_time": start_time, "end_time": end_time},
+        )
+    expected = [value for value in dates if requested_start <= value <= requested_end]
+    return _xt_date_arg(requested_start), _xt_date_arg(requested_end), expected
+
+
+def audit_factor_snapshot(
+    documents: Iterable[Mapping[str, Any]],
+    *,
+    expected_dates_by_code: Mapping[str, Iterable[Any]] | None = None,
+    included_codes: Iterable[str] | None = None,
+    require_exact_dates: bool = False,
+    bars_by_code: Mapping[str, Any] | None = None,
+    rel_tol: float = 1e-10,
+) -> dict[str, Any]:
+    rows = [dict(item) for item in (documents or ())]
+    by_code: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        by_code.setdefault(normalize_code(row.get("code")), []).append(row)
+    expected_map = {
+        normalize_code(code): list(dates)
+        for code, dates in (expected_dates_by_code or {}).items()
+    }
+    missing_codes: list[str] = []
+    invalid = 0
+    duplicates = 0
+    terminal_not_one: list[str] = []
+    recurrence_errors: list[tuple[str, str]] = []
+    missing_dates: list[tuple[str, str]] = []
+    extra_dates: list[tuple[str, str]] = []
+    for code in sorted({normalize_code(c) for c in (included_codes or by_code)}):
+        code_rows = by_code.get(code, [])
+        normalized: list[tuple[str, float]] = []
+        seen: set[str] = set()
+        for row in code_rows:
+            date_key = _date_key(row.get("date"))
+            factor_value = row.get("adj")
+            try:
+                factor = float(factor_value) if factor_value is not None else math.nan
+            except (TypeError, ValueError):
+                factor = math.nan
+            if not date_key or not math.isfinite(factor) or factor <= 0:
+                invalid += 1
+                continue
+            if date_key in seen:
+                duplicates += 1
+            seen.add(date_key)
+            normalized.append((date_key, factor))
+        normalized.sort(key=lambda item: item[0])
+        expected_dates = {
+            key
+            for key in (_date_key(value) for value in expected_map.get(code, ()))
+            if key
+        }
+        actual_dates = {date for date, _factor in normalized}
+        missing_dates.extend(
+            (code, date) for date in sorted(expected_dates - actual_dates)
+        )
+        if require_exact_dates:
+            extra_dates.extend(
+                (code, date) for date in sorted(actual_dates - expected_dates)
+            )
+        if not code_rows:
+            missing_codes.append(code)
+            continue
+        if normalized and not math.isclose(
+            normalized[-1][1], 1.0, rel_tol=0.0, abs_tol=1e-12
+        ):
+            terminal_not_one.append(code)
+        bars_payload = (bars_by_code or {}).get(code)
+        if bars_payload is not None and normalized:
+            bars = normalize_xtdata_bars(bars_payload, code=code)
+            factors = {date: factor for date, factor in normalized}
+            bar_dates = set(bars["date"])
+            if require_exact_dates:
+                missing_dates.extend(
+                    (code, date) for date in sorted(bar_dates - set(factors))
+                )
+                extra_dates.extend(
+                    (code, date) for date in sorted(set(factors) - bar_dates)
+                )
+            for index in range(len(bars) - 1):
+                date = str(bars.iloc[index]["date"])
+                next_date = str(bars.iloc[index + 1]["date"])
+                if date not in factors or next_date not in factors:
+                    continue
+                expected = factors[next_date] * (
+                    float(bars.iloc[index + 1]["preClose"])
+                    / float(bars.iloc[index]["close"])
+                )
+                if not math.isclose(
+                    factors[date], expected, rel_tol=rel_tol, abs_tol=1e-12
+                ):
+                    recurrence_errors.append((code, date))
+    return {
+        "codes": len(set(by_code) | set(expected_map)),
+        "rows": len(rows),
+        "missing": len(missing_codes) + len(missing_dates),
+        "missing_codes": missing_codes,
+        "missing_dates": missing_dates,
+        "extra": len(extra_dates),
+        "extra_dates": extra_dates,
+        "invalid": invalid,
+        "duplicates": duplicates,
+        "terminal_not_one": terminal_not_one,
+        "recurrence_errors": recurrence_errors,
+        "ok": (
+            not missing_codes
+            and not missing_dates
+            and not extra_dates
+            and invalid == 0
+            and duplicates == 0
+            and not terminal_not_one
+            and not recurrence_errors
+        ),
+    }
+
+
+def _ensure_factor_indexes(collection) -> None:
+    collection.create_index(
+        [("code", 1), ("date", 1)], unique=True, name="code_date_unique"
+    )
+    collection.create_index([("date", 1)], name="date_idx")
+
+
+def _utc_now(now_provider=None) -> datetime:
+    now = now_provider() if callable(now_provider) else datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return now.astimezone(timezone.utc)
+
+
+def _datetime_iso(value: datetime) -> str:
+    return (
+        value.astimezone(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _utc_iso(now_provider=None) -> str:
+    return _datetime_iso(_utc_now(now_provider))
+
+
+def _ensure_writer_lock_indexes(collection) -> None:
+    collection.create_index([("scope", 1)], unique=True, name="scope_unique")
+
+
+def _acquire_writer_lease(
+    *,
+    db,
+    scope: str,
+    now_provider=None,
+    lease_seconds: int = DEFAULT_WRITER_LEASE_SECONDS,
+) -> str:
+    collection = db[WRITER_LOCK_COLLECTION]
+    _ensure_writer_lock_indexes(collection)
+    now = _utc_now(now_provider)
+    existing = collection.find_one({"scope": scope}, {"_id": 0})
+    if existing:
+        expires_at = pd.Timestamp(existing.get("expires_at"))
+        if pd.isna(expires_at):
+            raise QFQSyncError(
+                f"{scope} QFQ writer lease is invalid", stats={"lease": existing}
+            )
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.tz_localize("UTC")
+        if expires_at.tz_convert("UTC") > pd.Timestamp(now):
+            raise QFQSyncError(
+                f"{scope} QFQ writer lease is held",
+                stats={
+                    "owner_id": existing.get("owner_id"),
+                    "expires_at": existing.get("expires_at"),
+                },
+            )
+        stale_result = collection.delete_one(
+            {
+                "scope": scope,
+                "owner_id": existing.get("owner_id"),
+                "expires_at": existing.get("expires_at"),
+            }
+        )
+        if int(getattr(stale_result, "deleted_count", 0)) != 1:
+            raise QFQSyncError(f"{scope} QFQ stale writer lease takeover lost")
+
+    owner_id = uuid.uuid4().hex
+    acquired_at = _datetime_iso(now)
+    expires_at = _datetime_iso(now + timedelta(seconds=max(60, int(lease_seconds))))
+    try:
+        collection.insert_one(
+            {
+                "scope": scope,
+                "owner_id": owner_id,
+                "acquired_at": acquired_at,
+                "updated_at": acquired_at,
+                "expires_at": expires_at,
+            }
+        )
+    except Exception as exc:
+        raise QFQSyncError(f"{scope} QFQ writer lease acquisition lost") from exc
+    return owner_id
+
+
+def _refresh_writer_lease(
+    *,
+    db,
+    scope: str,
+    owner_id: str,
+    now_provider=None,
+    lease_seconds: int = DEFAULT_WRITER_LEASE_SECONDS,
+) -> None:
+    now = _utc_now(now_provider)
+    result = db[WRITER_LOCK_COLLECTION].update_one(
+        {"scope": scope, "owner_id": owner_id},
+        {
+            "$set": {
+                "updated_at": _datetime_iso(now),
+                "expires_at": _datetime_iso(
+                    now + timedelta(seconds=max(60, int(lease_seconds)))
+                ),
+            }
+        },
+    )
+    if int(getattr(result, "matched_count", 0)) != 1:
+        raise QFQSyncError(f"{scope} QFQ writer lease was lost")
+
+
+def _release_writer_lease(*, db, scope: str, owner_id: str) -> None:
+    db[WRITER_LOCK_COLLECTION].delete_one({"scope": scope, "owner_id": owner_id})
+
+
+def _ensure_marker_indexes(collection) -> None:
+    collection.create_index([("scope", 1)], unique=True, name="scope_unique")
+
+
+def get_qfq_marker(*, scope: str, db=DBQuantAxis) -> dict[str, Any] | None:
+    if scope not in FACTOR_COLLECTIONS:
+        raise ValueError(f"unsupported QFQ scope: {scope}")
+    marker = db[READY_COLLECTION].find_one({"scope": scope}, {"_id": 0})
+    return dict(marker) if marker else None
+
+
+def validate_qfq_marker(
+    marker: Mapping[str, Any] | None, *, scope: str
+) -> dict[str, Any]:
+    if not marker:
+        raise QFQSyncError(f"{scope} QFQ marker is missing")
+    if marker.get("scope") != scope:
+        raise QFQSyncError(f"{scope} QFQ marker scope mismatch")
+    if marker.get("source") != QFQ_SOURCE:
+        raise QFQSyncError(f"{scope} QFQ marker source mismatch")
+    if marker.get("schema_version") != QFQ_SCHEMA_VERSION:
+        raise QFQSyncError(f"{scope} QFQ marker schema mismatch")
+    active_slot = marker.get("active_slot")
+    slots = marker.get("slots")
+    if active_slot not in {"a", "b"} or not isinstance(slots, Mapping):
+        raise QFQSyncError(f"{scope} QFQ marker slots are invalid")
+    for slot in ("a", "b"):
+        document = slots.get(slot)
+        expected_collection = FACTOR_COLLECTIONS[scope][slot]
+        if not isinstance(document, Mapping):
+            raise QFQSyncError(f"{scope} QFQ slot {slot} is missing")
+        if document.get("collection") != expected_collection:
+            raise QFQSyncError(f"{scope} QFQ slot {slot} collection mismatch")
+        if not document.get("snapshot_id") or not document.get("factor_asof"):
+            raise QFQSyncError(f"{scope} QFQ slot {slot} metadata is incomplete")
+        if document.get("status") not in {"ready", "building", "failed"}:
+            raise QFQSyncError(f"{scope} QFQ slot {slot} status is invalid")
+    if slots[active_slot].get("status") != "ready":
+        raise QFQSyncError(f"{scope} active QFQ slot is not ready")
+    return dict(marker)
+
+
+def resolve_active_slot(*, scope: str, db=DBQuantAxis) -> dict[str, Any]:
+    marker = validate_qfq_marker(get_qfq_marker(scope=scope, db=db), scope=scope)
+    active_slot = str(marker["active_slot"])
+    return {
+        "scope": scope,
+        "slot": active_slot,
+        **dict(marker["slots"][active_slot]),
+    }
+
+
+def _new_slot_document(
+    *, scope: str, slot: str, snapshot_id: str, factor_asof: str, published_at: str
+) -> dict[str, Any]:
+    return {
+        "collection": FACTOR_COLLECTIONS[scope][slot],
+        "snapshot_id": snapshot_id,
+        "factor_asof": factor_asof,
+        "status": "ready",
+        "published_at": published_at,
+    }
+
+
+def _insert_bootstrap_marker(
+    *, db, scope: str, factor_asof: str, now_provider=None
+) -> dict[str, Any]:
+    published_at = _utc_iso(now_provider)
+    marker = {
+        "scope": scope,
+        "active_slot": "a",
+        "slots": {
+            slot: _new_slot_document(
+                scope=scope,
+                slot=slot,
+                snapshot_id=uuid.uuid4().hex,
+                factor_asof=factor_asof,
+                published_at=published_at,
+            )
+            for slot in ("a", "b")
+        },
+        "source": QFQ_SOURCE,
+        "schema_version": QFQ_SCHEMA_VERSION,
+    }
+    collection = db[READY_COLLECTION]
+    _ensure_marker_indexes(collection)
+    if collection.find_one({"scope": scope}) is not None:
+        raise QFQSyncError(f"{scope} QFQ marker already exists")
+    try:
+        collection.insert_one(marker)
+    except Exception as exc:
+        raise QFQSyncError(f"{scope} bootstrap marker insert failed") from exc
+    return marker
+
+
+def _inactive_slot_name(marker: Mapping[str, Any]) -> str:
+    return "b" if marker.get("active_slot") == "a" else "a"
+
+
+def _claim_inactive_slot(*, db, scope: str, marker: Mapping[str, Any]) -> str:
+    active_slot = str(marker["active_slot"])
+    inactive_slot = _inactive_slot_name(marker)
+    active_snapshot = marker["slots"][active_slot]["snapshot_id"]
+    result = db[READY_COLLECTION].update_one(
+        {
+            "scope": scope,
+            "active_slot": active_slot,
+            f"slots.{active_slot}.snapshot_id": active_snapshot,
+            f"slots.{inactive_slot}.status": {"$in": ["ready", "failed"]},
+        },
+        {"$set": {f"slots.{inactive_slot}.status": "building"}},
+    )
+    if int(getattr(result, "matched_count", 0)) != 1:
+        raise QFQSyncError(f"{scope} inactive QFQ slot claim lost")
+    return inactive_slot
+
+
+def _mark_inactive_failed(
+    *, db, scope: str, active_slot: str, active_snapshot: str, inactive_slot: str
+) -> None:
+    db[READY_COLLECTION].update_one(
+        {
+            "scope": scope,
+            "active_slot": active_slot,
+            f"slots.{active_slot}.snapshot_id": active_snapshot,
+            f"slots.{inactive_slot}.status": "building",
+        },
+        {"$set": {f"slots.{inactive_slot}.status": "failed"}},
+    )
+
+
+def _publish_inactive_slot(
+    *,
+    db,
+    scope: str,
+    marker: Mapping[str, Any],
+    inactive_slot: str,
+    factor_asof: str,
+    now_provider=None,
+) -> dict[str, Any]:
+    active_slot = str(marker["active_slot"])
+    active_snapshot = str(marker["slots"][active_slot]["snapshot_id"])
+    slot_document = _new_slot_document(
+        scope=scope,
+        slot=inactive_slot,
+        snapshot_id=uuid.uuid4().hex,
+        factor_asof=factor_asof,
+        published_at=_utc_iso(now_provider),
+    )
+    result = db[READY_COLLECTION].update_one(
+        {
+            "scope": scope,
+            "active_slot": active_slot,
+            f"slots.{active_slot}.snapshot_id": active_snapshot,
+            f"slots.{inactive_slot}.status": "building",
+        },
+        {
+            "$set": {
+                "active_slot": inactive_slot,
+                f"slots.{inactive_slot}": slot_document,
+            }
+        },
+    )
+    if int(getattr(result, "matched_count", 0)) != 1:
+        raise QFQSyncError(f"{scope} QFQ marker CAS publish lost")
+    return validate_qfq_marker(get_qfq_marker(scope=scope, db=db), scope=scope)
+
+
+def _rollback_active_slot_locked(
+    *, scope: str, db, now_provider=None
+) -> dict[str, Any]:
+    marker = validate_qfq_marker(get_qfq_marker(scope=scope, db=db), scope=scope)
+    active_slot = str(marker["active_slot"])
+    target_slot = _inactive_slot_name(marker)
+    if marker["slots"][target_slot].get("status") != "ready":
+        raise QFQSyncError(f"{scope} rollback slot is not ready")
+    result = db[READY_COLLECTION].update_one(
+        {
+            "scope": scope,
+            "active_slot": active_slot,
+            f"slots.{active_slot}.snapshot_id": marker["slots"][active_slot][
+                "snapshot_id"
+            ],
+            f"slots.{target_slot}.snapshot_id": marker["slots"][target_slot][
+                "snapshot_id"
+            ],
+            f"slots.{target_slot}.status": "ready",
+        },
+        {
+            "$set": {
+                "active_slot": target_slot,
+                f"slots.{target_slot}.published_at": _utc_iso(now_provider),
+            }
+        },
+    )
+    if int(getattr(result, "matched_count", 0)) != 1:
+        raise QFQSyncError(f"{scope} QFQ rollback CAS lost")
+    return validate_qfq_marker(get_qfq_marker(scope=scope, db=db), scope=scope)
+
+
+def rollback_active_slot(
+    *,
+    scope: str,
+    db=DBQuantAxis,
+    now_provider=None,
+    writer_lease_seconds: int = DEFAULT_WRITER_LEASE_SECONDS,
+) -> dict[str, Any]:
+    owner_id = _acquire_writer_lease(
+        db=db,
+        scope=scope,
+        now_provider=now_provider,
+        lease_seconds=writer_lease_seconds,
+    )
+    try:
+        return _rollback_active_slot_locked(
+            scope=scope, db=db, now_provider=now_provider
+        )
+    finally:
+        _release_writer_lease(db=db, scope=scope, owner_id=owner_id)
+
+
+def _recover_interrupted_build_locked(*, scope: str, db) -> dict[str, Any] | None:
+    """Mark a leftover inactive build failed before the single writer retries."""
+
+    marker = validate_qfq_marker(get_qfq_marker(scope=scope, db=db), scope=scope)
+    active_slot = str(marker["active_slot"])
+    inactive_slot = _inactive_slot_name(marker)
+    if marker["slots"][inactive_slot].get("status") != "building":
+        return None
+    result = db[READY_COLLECTION].update_one(
+        {
+            "scope": scope,
+            "active_slot": active_slot,
+            f"slots.{active_slot}.snapshot_id": marker["slots"][active_slot][
+                "snapshot_id"
+            ],
+            f"slots.{inactive_slot}.status": "building",
+        },
+        {"$set": {f"slots.{inactive_slot}.status": "failed"}},
+    )
+    if int(getattr(result, "matched_count", 0)) != 1:
+        raise QFQSyncError(f"{scope} interrupted build recovery CAS lost")
+    return validate_qfq_marker(get_qfq_marker(scope=scope, db=db), scope=scope)
+
+
+def recover_interrupted_build(
+    *,
+    scope: str,
+    db=DBQuantAxis,
+    now_provider=None,
+    writer_lease_seconds: int = DEFAULT_WRITER_LEASE_SECONDS,
+) -> dict[str, Any] | None:
+    owner_id = _acquire_writer_lease(
+        db=db,
+        scope=scope,
+        now_provider=now_provider,
+        lease_seconds=writer_lease_seconds,
+    )
+    try:
+        return _recover_interrupted_build_locked(scope=scope, db=db)
+    finally:
+        _release_writer_lease(db=db, scope=scope, owner_id=owner_id)
+
+
+class XtDataQfqClient:
+    def __init__(self, xtdata_module=None, *, port: int | None = None):
+        self.xtdata = xtdata_module
+        self.port = int(port or bootstrap_config.xtdata.port or 58610)
+        self.connected = False
+
+    def _get_xtdata(self):
+        if self.xtdata is None:
+            from xtquant import xtdata  # type: ignore
+
+            self.xtdata = xtdata
+        return self.xtdata
+
+    def load_daily_bars(
+        self,
+        code: str,
+        *,
+        market: str | None = None,
+        start_time: str = "",
+        end_time: str = "",
+    ) -> pd.DataFrame:
+        xtdata = self._get_xtdata()
+        if not self.connected and hasattr(xtdata, "connect"):
+            xtdata.connect(port=self.port)
+            self.connected = True
+        xt_code = to_xt_code(code, market=market)
+        if hasattr(xtdata, "download_history_data"):
+            xtdata.download_history_data(xt_code, "1d", start_time, end_time)
+        payload = xtdata.get_market_data(
+            field_list=["time", "close", "preClose"],
+            stock_list=[xt_code],
+            period="1d",
+            start_time=start_time,
+            end_time=end_time,
+            dividend_type="none",
+            fill_data=False,
+        )
+        return normalize_xtdata_bars(payload, code=xt_code)
+
+
+def _call_loader(
+    loader: Callable[..., Any], code: str, start_time: str, end_time: str
+) -> Any:
+    try:
+        return loader(code, start_time=start_time, end_time=end_time)
+    except TypeError:
+        try:
+            return loader(code, start_time, end_time)
+        except TypeError:
+            return loader(code)
+
+
+def _load_existing_factor_rows(
+    *, db, collection_name: str, code: str
+) -> list[dict[str, Any]]:
+    collection = db[collection_name]
+    query = {"code": normalize_code(code)}
+    projection = {"_id": 0, "code": 1, "date": 1, "adj": 1}
+    try:
+        cursor = collection.find(query, projection)
+    except TypeError:
+        cursor = collection.find(query)
+    try:
+        cursor = cursor.sort("date", 1)
+    except AttributeError:
+        pass
+    return [dict(row) for row in cursor]
+
+
+def _audit_code_rows(
+    *,
+    code: str,
+    rows: Iterable[Mapping[str, Any]],
+    expected_dates: Iterable[str],
+    bars: Any | None = None,
+) -> dict[str, Any]:
+    code6 = normalize_code(code)
+    return audit_factor_snapshot(
+        rows,
+        expected_dates_by_code={code6: list(expected_dates)},
+        included_codes=[code6],
+        require_exact_dates=True,
+        bars_by_code={code6: bars} if bars is not None else None,
+    )
+
+
+def _replace_code_rows(
+    *, collection, code: str, rows: Iterable[Mapping[str, Any]]
+) -> int:
+    code6 = normalize_code(code)
+    normalized = [
+        {
+            "code": code6,
+            "date": str(row["date"])[:10],
+            "adj": float(row["adj"]),
+        }
+        for row in rows
+    ]
+    collection.delete_many({"code": code6})
+    if normalized:
+        collection.insert_many(normalized, ordered=False)
+    return len(normalized)
+
+
+def _full_rebuild_code(
+    *,
+    collection,
+    code: str,
+    expected_dates: list[str],
+    loader: Callable[..., Any],
+    reason: str,
+) -> dict[str, Any]:
+    load_start, load_end, expected = _bfq_download_bounds(expected_dates)
+    bars = _call_loader(loader, code, load_start, load_end)
+    rows = compute_preclose_adj(bars, code=code).to_dict(orient="records")
+    audit = _audit_code_rows(code=code, rows=rows, expected_dates=expected, bars=bars)
+    if not audit["ok"]:
+        raise QFQSyncError(
+            f"full QFQ rebuild audit failed for code={code}", stats=audit
+        )
+    written = _replace_code_rows(collection=collection, code=code, rows=rows)
+    return {"mode": "full", "reason": reason, "rows_written": written}
+
+
+def _rows_form_exact_prefix(
+    *, rows: list[dict[str, Any]], expected_dates: list[str], code: str
+) -> bool:
+    if not rows or len(rows) > len(expected_dates):
+        return False
+    dates = [_date_key(row.get("date")) for row in rows]
+    prefix = expected_dates[: len(rows)]
+    audit = _audit_code_rows(code=code, rows=rows, expected_dates=prefix)
+    return bool(audit["ok"] and dates == prefix)
+
+
+def _reconcile_code(
+    *,
+    collection,
+    code: str,
+    expected_dates: list[str],
+    loader: Callable[..., Any],
+    tail_days: int,
+) -> dict[str, Any]:
+    existing = _load_existing_factor_rows(
+        db={collection.name: collection}, collection_name=collection.name, code=code
+    )
+    if not _rows_form_exact_prefix(
+        rows=existing, expected_dates=expected_dates, code=code
+    ):
+        return _full_rebuild_code(
+            collection=collection,
+            code=code,
+            expected_dates=expected_dates,
+            loader=loader,
+            reason="missing_or_invalid_prefix",
+        )
+
+    existing_dates = [str(row["date"])[:10] for row in existing]
+    last_existing = existing_dates[-1]
+    last_index = expected_dates.index(last_existing)
+    tail_start_index = max(0, last_index - max(2, int(tail_days)) + 1)
+    tail_dates = expected_dates[tail_start_index:]
+    bars = _call_loader(
+        loader,
+        code,
+        _xt_date_arg(tail_dates[0]),
+        _xt_date_arg(tail_dates[-1]),
+    )
+    tail_rows = compute_preclose_adj(bars, code=code).to_dict(orient="records")
+    tail_audit = _audit_code_rows(
+        code=code, rows=tail_rows, expected_dates=tail_dates, bars=bars
+    )
+    if not tail_audit["ok"]:
+        raise QFQSyncError(f"tail QFQ audit failed for code={code}", stats=tail_audit)
+    tail_by_date = {str(row["date"])[:10]: float(row["adj"]) for row in tail_rows}
+    if not math.isclose(tail_by_date[last_existing], 1.0, rel_tol=1e-10, abs_tol=1e-12):
+        return _full_rebuild_code(
+            collection=collection,
+            code=code,
+            expected_dates=expected_dates,
+            loader=loader,
+            reason="corporate_action_after_inactive_terminal",
+        )
+
+    existing_by_date = {str(row["date"])[:10]: float(row["adj"]) for row in existing}
+    overlap_dates = [date for date in tail_dates if date <= last_existing]
+    if any(
+        not math.isclose(
+            existing_by_date[date],
+            tail_by_date[date],
+            rel_tol=1e-10,
+            abs_tol=1e-12,
+        )
+        for date in overlap_dates
+    ):
+        return _full_rebuild_code(
+            collection=collection,
+            code=code,
+            expected_dates=expected_dates,
+            loader=loader,
+            reason="tail_revision",
+        )
+
+    missing_dates = [date for date in expected_dates if date > last_existing]
+    for date in missing_dates:
+        collection.update_one(
+            {"code": normalize_code(code), "date": date},
+            {
+                "$set": {
+                    "code": normalize_code(code),
+                    "date": date,
+                    "adj": tail_by_date[date],
+                }
+            },
+            upsert=True,
+        )
+    updated = _load_existing_factor_rows(
+        db={collection.name: collection}, collection_name=collection.name, code=code
+    )
+    audit = _audit_code_rows(code=code, rows=updated, expected_dates=expected_dates)
+    if not audit["ok"]:
+        raise QFQSyncError(
+            f"incremental QFQ output audit failed for code={code}", stats=audit
+        )
+    return {
+        "mode": "incremental" if missing_dates else "unchanged",
+        "reason": "ordinary_tail",
+        "rows_written": len(missing_dates),
+        "previous_last_date": last_existing,
+    }
+
+
+def _copy_factor_collection(*, db, source_name: str, target_name: str) -> None:
+    source = db[source_name]
+    try:
+        list(
+            source.aggregate(
+                [
+                    {"$project": {"_id": 0, "code": 1, "date": 1, "adj": 1}},
+                    {"$out": target_name},
+                ],
+                allowDiskUse=True,
+            )
+        )
+    except (AttributeError, NotImplementedError, TypeError):
+        target = db[target_name]
+        target.delete_many({})
+        batch: list[dict[str, Any]] = []
+        for row in source.find({}, {"_id": 0, "code": 1, "date": 1, "adj": 1}):
+            batch.append(dict(row))
+            if len(batch) >= 10_000:
+                target.insert_many(batch, ordered=False)
+                batch = []
+        if batch:
+            target.insert_many(batch, ordered=False)
+    _ensure_factor_indexes(db[target_name])
+
+
+def _count_documents(collection, query: Mapping[str, Any] | None = None) -> int:
+    try:
+        return int(collection.count_documents(dict(query or {})))
+    except AttributeError:
+        return len(list(collection.find(dict(query or {}))))
+
+
+def audit_qfq_slot(
+    *,
+    scope: str,
+    slot: str,
+    db=DBQuantAxis,
+    codes: Iterable[str] | None = None,
+    factor_asof: str | None = None,
+    progress_callback: Callable[[], None] | None = None,
+) -> dict[str, Any]:
+    if scope not in FACTOR_COLLECTIONS or slot not in {"a", "b"}:
+        raise ValueError(f"unsupported QFQ slot: {scope}/{slot}")
+    marker = get_qfq_marker(scope=scope, db=db)
+    if factor_asof is None and marker:
+        factor_asof = str(
+            marker.get("slots", {}).get(slot, {}).get("factor_asof") or ""
+        )
+    universe = load_factor_universe(kind=scope, db=db, codes=codes)
+    collection = db[FACTOR_COLLECTIONS[scope][slot]]
+    failures: list[dict[str, Any]] = []
+    rows = 0
+    checked_codes = 0
+    for code in universe["codes"]:
+        if progress_callback:
+            progress_callback()
+        expected = load_bfq_dates(kind=scope, code=code, db=db)
+        if factor_asof:
+            expected = [date for date in expected if date <= factor_asof]
+        if not expected:
+            continue
+        code_rows = _load_existing_factor_rows(
+            db=db, collection_name=collection.name, code=code
+        )
+        audit = _audit_code_rows(code=code, rows=code_rows, expected_dates=expected)
+        rows += len(code_rows)
+        checked_codes += 1
+        if not audit["ok"]:
+            failures.append({"code": code, "audit": audit})
+    if progress_callback:
+        progress_callback()
+    return {
+        "scope": scope,
+        "slot": slot,
+        "collection": collection.name,
+        "factor_asof": factor_asof,
+        "codes": checked_codes,
+        "rows": rows,
+        "failed": len(failures),
+        "failures": failures[:100],
+        "ok": not failures and checked_codes > 0,
+    }
+
+
+def _bootstrap_scope(
+    *,
+    scope: str,
+    target_date: str,
+    db,
+    codes: Iterable[str] | None,
+    loader: Callable[..., Any],
+    now_provider=None,
+    progress_callback: Callable[[], None] | None = None,
+) -> dict[str, Any]:
+    if get_qfq_marker(scope=scope, db=db):
+        raise QFQSyncError(f"{scope} QFQ bootstrap requires no marker")
+    universe = load_factor_universe(kind=scope, db=db, codes=codes)
+    collection_a = db[FACTOR_COLLECTIONS[scope]["a"]]
+    collection_a.delete_many({})
+    _ensure_factor_indexes(collection_a)
+    included: list[str] = []
+    rows_written = 0
+    for code in universe["codes"]:
+        if progress_callback:
+            progress_callback()
+        expected = [
+            date
+            for date in load_bfq_dates(kind=scope, code=code, db=db)
+            if date <= target_date
+        ]
+        if not expected:
+            continue
+        result = _full_rebuild_code(
+            collection=collection_a,
+            code=code,
+            expected_dates=expected,
+            loader=loader,
+            reason="bootstrap",
+        )
+        rows_written += int(result["rows_written"])
+        included.append(code)
+    if not included:
+        raise QFQSyncError(f"{scope} has no BFQ history to bootstrap")
+    audit_a = audit_qfq_slot(
+        scope=scope,
+        slot="a",
+        db=db,
+        codes=included,
+        factor_asof=target_date,
+        progress_callback=progress_callback,
+    )
+    if not audit_a["ok"]:
+        raise QFQSyncError(f"{scope} bootstrap slot A audit failed", stats=audit_a)
+    if progress_callback:
+        progress_callback()
+    _copy_factor_collection(
+        db=db,
+        source_name=FACTOR_COLLECTIONS[scope]["a"],
+        target_name=FACTOR_COLLECTIONS[scope]["b"],
+    )
+    audit_b = audit_qfq_slot(
+        scope=scope,
+        slot="b",
+        db=db,
+        codes=included,
+        factor_asof=target_date,
+        progress_callback=progress_callback,
+    )
+    if not audit_b["ok"] or audit_a["rows"] != audit_b["rows"]:
+        raise QFQSyncError(f"{scope} bootstrap slot B audit failed", stats=audit_b)
+    marker = _insert_bootstrap_marker(
+        db=db, scope=scope, factor_asof=target_date, now_provider=now_provider
+    )
+    return {
+        "scope": scope,
+        "mode": "bootstrap",
+        "factor_asof": target_date,
+        "codes": len(included),
+        "rows_written": rows_written,
+        "marker": marker,
+        "audit": {"a": audit_a, "b": audit_b},
+    }
+
+
+def _assert_reader_grace(
+    *, marker: Mapping[str, Any], min_grace_seconds: int, now_provider=None
+) -> None:
+    if min_grace_seconds <= 0:
+        return
+    active_slot = str(marker["active_slot"])
+    published_at = pd.Timestamp(marker["slots"][active_slot]["published_at"])
+    now = now_provider() if callable(now_provider) else datetime.now(timezone.utc)
+    now_ts = pd.Timestamp(now)
+    if published_at.tzinfo is None:
+        published_at = published_at.tz_localize("UTC")
+    if now_ts.tzinfo is None:
+        now_ts = now_ts.tz_localize("UTC")
+    elapsed = (
+        now_ts.tz_convert("UTC") - published_at.tz_convert("UTC")
+    ).total_seconds()
+    if elapsed < min_grace_seconds:
+        raise QFQSyncError(
+            "reader grace period has not elapsed",
+            stats={"elapsed_seconds": elapsed, "required_seconds": min_grace_seconds},
+        )
+
+
+def _update_scope(
+    *,
+    scope: str,
+    target_date: str,
+    db,
+    codes: Iterable[str] | None,
+    loader: Callable[..., Any],
+    tail_days: int,
+    min_grace_seconds: int,
+    force_full_rebuild: bool,
+    now_provider=None,
+    progress_callback: Callable[[], None] | None = None,
+) -> dict[str, Any]:
+    marker = validate_qfq_marker(get_qfq_marker(scope=scope, db=db), scope=scope)
+    active_slot = str(marker["active_slot"])
+    active_snapshot = str(marker["slots"][active_slot]["snapshot_id"])
+    active_asof = str(marker["slots"][active_slot]["factor_asof"])
+    if target_date < active_asof:
+        raise QFQSyncError(
+            f"{scope} QFQ target date predates active snapshot",
+            stats={"target_date": target_date, "active_factor_asof": active_asof},
+        )
+    if not force_full_rebuild and target_date <= active_asof:
+        return {
+            "scope": scope,
+            "mode": "noop",
+            "factor_asof": active_asof,
+            "marker": marker,
+        }
+    _assert_reader_grace(
+        marker=marker,
+        min_grace_seconds=min_grace_seconds,
+        now_provider=now_provider,
+    )
+    inactive_slot = _claim_inactive_slot(db=db, scope=scope, marker=marker)
+    collection = db[FACTOR_COLLECTIONS[scope][inactive_slot]]
+    stats = {"full": 0, "incremental": 0, "unchanged": 0, "rows_written": 0}
+    try:
+        _ensure_factor_indexes(collection)
+        universe = load_factor_universe(kind=scope, db=db, codes=codes)
+        included: list[str] = []
+        for code in universe["codes"]:
+            if progress_callback:
+                progress_callback()
+            expected = [
+                date
+                for date in load_bfq_dates(kind=scope, code=code, db=db)
+                if date <= target_date
+            ]
+            if not expected:
+                continue
+            if force_full_rebuild:
+                result = _full_rebuild_code(
+                    collection=collection,
+                    code=code,
+                    expected_dates=expected,
+                    loader=loader,
+                    reason="forced_full_rebuild",
+                )
+            else:
+                result = _reconcile_code(
+                    collection=collection,
+                    code=code,
+                    expected_dates=expected,
+                    loader=loader,
+                    tail_days=tail_days,
+                )
+            stats[str(result["mode"])] += 1
+            stats["rows_written"] += int(result["rows_written"])
+            included.append(code)
+        stale_codes = _distinct_codes(collection) - set(included)
+        if stale_codes:
+            raise QFQSyncError(
+                f"{scope} inactive slot contains codes outside BFQ universe",
+                stats={"stale_codes": sorted(stale_codes)[:100]},
+            )
+        audit = audit_qfq_slot(
+            scope=scope,
+            slot=inactive_slot,
+            db=db,
+            codes=included,
+            factor_asof=target_date,
+            progress_callback=progress_callback,
+        )
+        if not audit["ok"]:
+            raise QFQSyncError(f"{scope} inactive slot audit failed", stats=audit)
+        published = _publish_inactive_slot(
+            db=db,
+            scope=scope,
+            marker=marker,
+            inactive_slot=inactive_slot,
+            factor_asof=target_date,
+            now_provider=now_provider,
+        )
+        return {
+            "scope": scope,
+            "mode": "update",
+            "factor_asof": target_date,
+            "slot": inactive_slot,
+            "stats": stats,
+            "audit": audit,
+            "marker": published,
+        }
+    except Exception:
+        _mark_inactive_failed(
+            db=db,
+            scope=scope,
+            active_slot=active_slot,
+            active_snapshot=active_snapshot,
+            inactive_slot=inactive_slot,
+        )
+        raise
+
+
+def sync_qfq_factors(
+    *,
+    scope: str,
+    target_date: str,
+    db=DBQuantAxis,
+    codes: Iterable[str] | None = None,
+    bars_loader: Callable[..., Any] | None = None,
+    xtdata_client: XtDataQfqClient | None = None,
+    tail_days: int = DEFAULT_TAIL_AUDIT_DAYS,
+    min_grace_seconds: int = DEFAULT_READER_GRACE_SECONDS,
+    force_full_rebuild: bool = False,
+    writer_lease_seconds: int = DEFAULT_WRITER_LEASE_SECONDS,
+    now_provider=None,
+) -> dict[str, Any]:
+    scopes = [item.strip().lower() for item in str(scope).split(",") if item.strip()]
+    if not scopes or any(item not in FACTOR_COLLECTIONS for item in scopes):
+        raise ValueError(f"unsupported QFQ scope: {scope}")
+    target = _date_key(target_date)
+    if not target:
+        raise ValueError(f"invalid QFQ target date: {target_date}")
+    client = xtdata_client or XtDataQfqClient()
+    loader = bars_loader or client.load_daily_bars
+    result: dict[str, Any] = {
+        "source": QFQ_SOURCE,
+        "writer": QFQ_WRITER,
+        "scopes": scopes,
+        "by_scope": {},
+    }
+    for kind in scopes:
+        owner_id = _acquire_writer_lease(
+            db=db,
+            scope=kind,
+            now_provider=now_provider,
+            lease_seconds=writer_lease_seconds,
+        )
+
+        def heartbeat() -> None:
+            _refresh_writer_lease(
+                db=db,
+                scope=kind,
+                owner_id=owner_id,
+                now_provider=now_provider,
+                lease_seconds=writer_lease_seconds,
+            )
+
+        try:
+            marker = get_qfq_marker(scope=kind, db=db)
+            if marker is not None:
+                marker = validate_qfq_marker(marker, scope=kind)
+                inactive_slot = _inactive_slot_name(marker)
+                if marker["slots"][inactive_slot].get("status") == "building":
+                    _recover_interrupted_build_locked(scope=kind, db=db)
+            if marker is None:
+                scope_result = _bootstrap_scope(
+                    scope=kind,
+                    target_date=target,
+                    db=db,
+                    codes=codes,
+                    loader=loader,
+                    now_provider=now_provider,
+                    progress_callback=heartbeat,
+                )
+            else:
+                scope_result = _update_scope(
+                    scope=kind,
+                    target_date=target,
+                    db=db,
+                    codes=codes,
+                    loader=loader,
+                    tail_days=tail_days,
+                    min_grace_seconds=min_grace_seconds,
+                    force_full_rebuild=force_full_rebuild,
+                    now_provider=now_provider,
+                    progress_callback=heartbeat,
+                )
+            result["by_scope"][kind] = scope_result
+        finally:
+            _release_writer_lease(db=db, scope=kind, owner_id=owner_id)
+    result["ready"] = True
+    return result
+
+
+def sync_stock_adj_all(**kwargs: Any) -> dict[str, Any]:
+    return sync_qfq_factors(scope="stock", **kwargs)
+
+
+def sync_etf_adj_all(**kwargs: Any) -> dict[str, Any]:
+    return sync_qfq_factors(scope="etf", **kwargs)
+
+
+bootstrap_qfq = sync_qfq_factors
+incremental_qfq = sync_qfq_factors
+
+__all__ = [
+    "QFQ_DATA_NOT_READY",
+    "QFQSyncError",
+    "QFQ_SOURCE",
+    "QFQ_WRITER",
+    "XtDataQfqClient",
+    "audit_factor_snapshot",
+    "audit_qfq_slot",
+    "bootstrap_qfq",
+    "compute_preclose_adj",
+    "compute_qfq_factors",
+    "compute_xtdata_preclose_adj",
+    "get_qfq_marker",
+    "incremental_qfq",
+    "is_trading_etf",
+    "load_factor_universe",
+    "normalize_code",
+    "normalize_xtdata_bars",
+    "resolve_active_slot",
+    "recover_interrupted_build",
+    "rollback_active_slot",
+    "sync_etf_adj_all",
+    "sync_qfq_factors",
+    "sync_stock_adj_all",
+    "to_xt_code",
+]

--- a/freshquant/market_data/xtdata/qfq_worker.py
+++ b/freshquant/market_data/xtdata/qfq_worker.py
@@ -10,6 +10,7 @@ from freshquant.db import DBfreshquant, DBQuantAxis
 from freshquant.market_data.xtdata.qfq import (
     FACTOR_COLLECTIONS,
     QFQSyncError,
+    XtDataQfqClient,
     audit_qfq_slot,
     get_qfq_marker,
     rollback_active_slot,
@@ -85,6 +86,50 @@ def run_pending_once(
     return result
 
 
+def qfq_readiness_status(
+    *,
+    scopes: Iterable[str] = ("stock", "etf"),
+    factor_db=DBQuantAxis,
+    marker_db=DBfreshquant,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {"ready": True, "by_scope": {}}
+    for raw_scope in scopes:
+        scope = str(raw_scope).strip().lower()
+        postclose = latest_success_postclose_marker(scope=scope, marker_db=marker_db)
+        marker = get_qfq_marker(scope=scope, db=factor_db)
+        if postclose is None:
+            result["by_scope"][scope] = {"status": "missing_bfq_marker"}
+            result["ready"] = False
+            continue
+        if marker is None:
+            result["by_scope"][scope] = {"status": "missing_qfq_marker"}
+            result["ready"] = False
+            continue
+        try:
+            marker = validate_qfq_marker(marker, scope=scope)
+        except QFQSyncError as exc:
+            result["by_scope"][scope] = {
+                "status": "invalid_qfq_marker",
+                "error": str(exc),
+            }
+            result["ready"] = False
+            continue
+        active_slot = str(marker["active_slot"])
+        factor_asof = str(marker["slots"][active_slot]["factor_asof"])
+        target_date = str(postclose.get("trade_date") or "")[:10]
+        status = "ready" if factor_asof >= target_date else "stale"
+        result["by_scope"][scope] = {
+            "status": status,
+            "active_slot": active_slot,
+            "factor_asof": factor_asof,
+            "target_date": target_date,
+            "snapshot_id": marker["slots"][active_slot]["snapshot_id"],
+        }
+        if status != "ready":
+            result["ready"] = False
+    return result
+
+
 def run_forever(*, poll_seconds: int = 60, scopes=("stock", "etf")) -> None:
     delay = max(5, int(poll_seconds))
     while True:
@@ -126,9 +171,15 @@ def _build_parser() -> argparse.ArgumentParser:
     audit = subparsers.add_parser("audit")
     audit.add_argument("--scope", choices=sorted(FACTOR_COLLECTIONS), required=True)
     audit.add_argument("--slot", choices=["a", "b"])
+    audit.add_argument("--code")
+    audit.add_argument(
+        "--mode", choices=["structure", "tail", "full"], default="structure"
+    )
+    audit.add_argument("--tail-days", type=int, default=60)
 
     status = subparsers.add_parser("status")
     status.add_argument("--scope", choices=sorted(FACTOR_COLLECTIONS))
+    status.add_argument("--strict", action="store_true")
 
     rollback = subparsers.add_parser("rollback")
     rollback.add_argument("--scope", choices=sorted(FACTOR_COLLECTIONS), required=True)
@@ -137,6 +188,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
+    exit_code = 0
     if args.command == "worker":
         if args.once:
             payload = run_pending_once(scopes=args.scope)
@@ -158,16 +210,27 @@ def main(argv: list[str] | None = None) -> int:
     elif args.command == "audit":
         marker = validate_qfq_marker(get_qfq_marker(scope=args.scope), scope=args.scope)
         slot = args.slot or str(marker["active_slot"])
-        payload = audit_qfq_slot(scope=args.scope, slot=slot)
+        source_client = XtDataQfqClient() if args.mode in {"tail", "full"} else None
+        payload = audit_qfq_slot(
+            scope=args.scope,
+            slot=slot,
+            codes=[args.code] if args.code else None,
+            bars_loader=(source_client.load_daily_bars if source_client else None),
+            source_tail_days=args.tail_days if args.mode == "tail" else None,
+        )
         if not payload["ok"]:
             raise QFQSyncError(f"{args.scope}/{slot} audit failed", stats=payload)
     elif args.command == "status":
         scopes = [args.scope] if args.scope else sorted(FACTOR_COLLECTIONS)
-        payload = {scope: get_qfq_marker(scope=scope) for scope in scopes}
+        if args.strict:
+            payload = qfq_readiness_status(scopes=scopes)
+            exit_code = 0 if payload["ready"] else 1
+        else:
+            payload = {scope: get_qfq_marker(scope=scope) for scope in scopes}
     else:
         payload = rollback_active_slot(scope=args.scope)
     print(json.dumps(payload, ensure_ascii=False, default=str))
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/freshquant/market_data/xtdata/qfq_worker.py
+++ b/freshquant/market_data/xtdata/qfq_worker.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from freshquant.db import DBfreshquant, DBQuantAxis
+from freshquant.market_data.xtdata.qfq import (
+    FACTOR_COLLECTIONS,
+    QFQSyncError,
+    audit_qfq_slot,
+    get_qfq_marker,
+    rollback_active_slot,
+    sync_qfq_factors,
+    validate_qfq_marker,
+)
+
+POSTCLOSE_MARKER_COLLECTION = "dagster_pipeline_markers"
+PIPELINE_KEYS = {
+    "stock": "stock_postclose_ready",
+    "etf": "etf_postclose_ready",
+}
+
+
+def latest_success_postclose_marker(*, scope: str, marker_db=DBfreshquant):
+    if scope not in PIPELINE_KEYS:
+        raise ValueError(f"unsupported QFQ scope: {scope}")
+    collection = marker_db[POSTCLOSE_MARKER_COLLECTION]
+    return collection.find_one(
+        {"pipeline_key": PIPELINE_KEYS[scope], "status": "success"},
+        {"_id": 0},
+        sort=[("trade_date", -1)],
+    )
+
+
+def run_pending_once(
+    *,
+    scopes: Iterable[str] = ("stock", "etf"),
+    factor_db=DBQuantAxis,
+    marker_db=DBfreshquant,
+    sync_fn: Callable[..., dict[str, Any]] = sync_qfq_factors,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {"by_scope": {}}
+    for raw_scope in scopes:
+        scope = str(raw_scope).strip().lower()
+        if scope not in PIPELINE_KEYS:
+            raise ValueError(f"unsupported QFQ scope: {scope}")
+        try:
+            postclose = latest_success_postclose_marker(
+                scope=scope, marker_db=marker_db
+            )
+            if not postclose:
+                result["by_scope"][scope] = {"status": "waiting_for_bfq"}
+                continue
+            target_date = str(postclose.get("trade_date") or "")[:10]
+            marker = get_qfq_marker(scope=scope, db=factor_db)
+            if marker:
+                marker = validate_qfq_marker(marker, scope=scope)
+                active_slot = str(marker["active_slot"])
+                inactive_slot = "b" if active_slot == "a" else "a"
+                inactive_building = (
+                    marker["slots"][inactive_slot].get("status") == "building"
+                )
+                if not inactive_building and target_date <= str(
+                    marker["slots"][active_slot]["factor_asof"]
+                ):
+                    result["by_scope"][scope] = {
+                        "status": "current",
+                        "factor_asof": marker["slots"][active_slot]["factor_asof"],
+                    }
+                    continue
+            published = sync_fn(scope=scope, target_date=target_date, db=factor_db)
+            result["by_scope"][scope] = {
+                "status": "published",
+                "target_date": target_date,
+                "result": published,
+            }
+        except Exception as exc:  # noqa: BLE001
+            result["by_scope"][scope] = {
+                "status": "error",
+                "error": str(exc),
+            }
+    return result
+
+
+def run_forever(*, poll_seconds: int = 60, scopes=("stock", "etf")) -> None:
+    delay = max(5, int(poll_seconds))
+    while True:
+        try:
+            payload = run_pending_once(scopes=scopes)
+            print(json.dumps(payload, ensure_ascii=False, default=str), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                json.dumps(
+                    {"status": "error", "error": str(exc)},
+                    ensure_ascii=False,
+                ),
+                flush=True,
+            )
+        time.sleep(delay)
+
+
+def _scope_values(value: str) -> list[str]:
+    scopes = [item.strip().lower() for item in value.split(",") if item.strip()]
+    if not scopes or any(scope not in FACTOR_COLLECTIONS for scope in scopes):
+        raise argparse.ArgumentTypeError("scope must be stock, etf, or stock,etf")
+    return scopes
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="XTData QFQ shadow writer")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    worker = subparsers.add_parser("worker")
+    worker.add_argument("--scope", type=_scope_values, default=["stock", "etf"])
+    worker.add_argument("--poll-seconds", type=int, default=60)
+    worker.add_argument("--once", action="store_true")
+
+    build = subparsers.add_parser("build")
+    build.add_argument("--scope", choices=sorted(FACTOR_COLLECTIONS), required=True)
+    build.add_argument("--target-date", required=True)
+    build.add_argument("--full", action="store_true")
+
+    audit = subparsers.add_parser("audit")
+    audit.add_argument("--scope", choices=sorted(FACTOR_COLLECTIONS), required=True)
+    audit.add_argument("--slot", choices=["a", "b"])
+
+    status = subparsers.add_parser("status")
+    status.add_argument("--scope", choices=sorted(FACTOR_COLLECTIONS))
+
+    rollback = subparsers.add_parser("rollback")
+    rollback.add_argument("--scope", choices=sorted(FACTOR_COLLECTIONS), required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.command == "worker":
+        if args.once:
+            payload = run_pending_once(scopes=args.scope)
+            print(json.dumps(payload, ensure_ascii=False, default=str))
+            return int(
+                any(
+                    item.get("status") == "error"
+                    for item in payload.get("by_scope", {}).values()
+                )
+            )
+        run_forever(poll_seconds=args.poll_seconds, scopes=args.scope)
+        return 0
+    if args.command == "build":
+        payload = sync_qfq_factors(
+            scope=args.scope,
+            target_date=args.target_date,
+            force_full_rebuild=args.full,
+        )
+    elif args.command == "audit":
+        marker = validate_qfq_marker(get_qfq_marker(scope=args.scope), scope=args.scope)
+        slot = args.slot or str(marker["active_slot"])
+        payload = audit_qfq_slot(scope=args.scope, slot=slot)
+        if not payload["ok"]:
+            raise QFQSyncError(f"{args.scope}/{slot} audit failed", stats=payload)
+    elif args.command == "status":
+        scopes = [args.scope] if args.scope else sorted(FACTOR_COLLECTIONS)
+        payload = {scope: get_qfq_marker(scope=scope) for scope in scopes}
+    else:
+        payload = rollback_active_slot(scope=args.scope)
+    print(json.dumps(payload, ensure_ascii=False, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/freshquant/market_data/xtdata/strategy_consumer.py
+++ b/freshquant/market_data/xtdata/strategy_consumer.py
@@ -494,6 +494,8 @@ class StrategyConsumer:
         """
         kind: "stock" | "etf"
         """
+        if kind == "index":
+            return 1.0
         coll = "stock_adj" if kind == "stock" else "etf_adj"
         override_coll = "stock_adj_intraday" if kind == "stock" else "etf_adj_intraday"
         try:
@@ -525,6 +527,8 @@ class StrategyConsumer:
     def _apply_qfq_to_bar(
         self, *, kind: str, code_prefixed: str, bar: dict[str, Any]
     ) -> dict[str, Any]:
+        if kind == "index":
+            return bar
         dt: datetime | None = bar.get("datetime")
         if not isinstance(dt, datetime):
             return bar
@@ -555,6 +559,16 @@ class StrategyConsumer:
             pass
         return _is_etf(_base_code(code_prefixed))
 
+    def _is_real_index(self, code_prefixed: str) -> bool:
+        try:
+            from freshquant.carnation.enum_instrument import InstrumentType
+            from freshquant.instrument.general import query_instrument_type
+
+            return query_instrument_type(code_prefixed) == InstrumentType.INDEX_CN
+        except Exception:
+            code = str(code_prefixed or "").strip().lower()
+            return code.startswith(("sh000", "sz399"))
+
     def _load_window_from_db(self, *, code: str, period_backend: str) -> pd.DataFrame:
         """
         Load a max_bars window:
@@ -570,6 +584,7 @@ class StrategyConsumer:
 
         base6 = _base_code(code)
         is_index_like = self._is_index_like(code)
+        is_real_index = self._is_real_index(code)
 
         hist_coll = "index_min" if is_index_like else "stock_min"
         hist_df = _empty_bar_window_df()
@@ -617,21 +632,26 @@ class StrategyConsumer:
 
         start_date = start_dt.strftime("%Y-%m-%d")
         end_date = end_dt.strftime("%Y-%m-%d")
-        adj_coll = "etf_adj" if is_index_like else "stock_adj"
-        override_coll = "etf_adj_intraday" if is_index_like else "stock_adj_intraday"
-        adj_df = fetch_qfq_adj_df(
-            coll_name=adj_coll,
-            code=base6,
-            start_date=start_date,
-            end_date=end_date,
-            db=DBQuantAxis,
-        )
-        override = fetch_intraday_override(
-            coll_name=override_coll,
-            code=base6,
-            trade_date=end_date,
-            db=DBQuantAxis,
-        )
+        adj_df = None
+        override = None
+        if not is_real_index:
+            adj_coll = "etf_adj" if is_index_like else "stock_adj"
+            override_coll = (
+                "etf_adj_intraday" if is_index_like else "stock_adj_intraday"
+            )
+            adj_df = fetch_qfq_adj_df(
+                coll_name=adj_coll,
+                code=base6,
+                start_date=start_date,
+                end_date=end_date,
+                db=DBQuantAxis,
+            )
+            override = fetch_intraday_override(
+                coll_name=override_coll,
+                code=base6,
+                trade_date=end_date,
+                db=DBQuantAxis,
+            )
 
         merged = _normalize_bar_window_df(
             pd.concat([hist_df, rt_df], ignore_index=True)
@@ -641,12 +661,13 @@ class StrategyConsumer:
 
         merged = merged.drop_duplicates(subset=["datetime"], keep="last")
         merged = merged.sort_values("datetime")
-        merged = apply_qfq_with_intraday_override(
-            merged,
-            adj_df,
-            override=override,
-            datetime_col="datetime",
-        )
+        if not is_real_index:
+            merged = apply_qfq_with_intraday_override(
+                merged,
+                adj_df,
+                override=override,
+                datetime_col="datetime",
+            )
 
         if len(merged) > self.max_bars:
             merged = merged.iloc[-self.max_bars :]
@@ -1137,7 +1158,8 @@ class StrategyConsumer:
         }
 
         is_index_like = self._is_index_like(code)
-        kind = "etf" if is_index_like else "stock"
+        is_real_index = self._is_real_index(code)
+        kind = "index" if is_real_index else ("etf" if is_index_like else "stock")
         coll = "index_realtime" if is_index_like else "stock_realtime"
         bar_store = bar_raw
         bar_calc = self._apply_qfq_to_bar(kind=kind, code_prefixed=code, bar=bar_raw)

--- a/freshquant/quote/index.py
+++ b/freshquant/quote/index.py
@@ -1,5 +1,94 @@
+from datetime import datetime, timedelta
+
 from QUANTAXIS import QA_fetch_index_day_adv, QA_fetch_index_min_adv
-from freshquant.database.cache import redis_cache
+from QUANTAXIS.QAData.data_resample import QA_data_day_resample
+
+from freshquant.carnation.config import TIME_DELTA
+from freshquant.config import cfg
+from freshquant.data.index import (
+    fq_data_index_fetch_day,
+    fq_data_index_fetch_min,
+    fq_data_stock_resample_90min,
+)
+from freshquant.data.stock import fqDataStockResample3min
+from freshquant.database.cache import in_memory_cache, redis_cache
+from freshquant.quote.general import resampleStockOrIndex120min
+from freshquant.util.code import normalize_to_base_code
+
+
+def _resolve_index_history_days(period: str, bar_count: int = 0) -> int:
+    default_days = int(TIME_DELTA[period])
+    try:
+        requested = int(bar_count or 0)
+    except (TypeError, ValueError):
+        requested = 0
+    if requested <= 0:
+        return default_days
+    if period == "1d":
+        return -max(abs(default_days), int((requested + 30) * 1.2))
+    if period == "1w":
+        return -max(abs(default_days), int((requested * 7 + 60) * 1.2))
+    minute_map = {
+        "1m": 1,
+        "3m": 3,
+        "5m": 5,
+        "15m": 15,
+        "30m": 30,
+        "60m": 60,
+        "90m": 90,
+        "120m": 120,
+    }
+    minutes = minute_map.get(period)
+    if minutes:
+        bars_per_day = max(1, int(240 / minutes))
+        return -max(abs(default_days), int(((requested / bars_per_day) + 60) * 1.35))
+    return default_days
+
+
+@in_memory_cache.memoize(expiration=3)
+def queryIndexCandleSticks(code: str, period: str, endDate=None, bar_count=0):
+    """Fetch real Index candles without applying any QFQ factor."""
+    if endDate is None or endDate == "":
+        end = datetime.now() + timedelta(1)
+    else:
+        end = datetime.strptime(endDate, "%Y-%m-%d")
+    end = end.replace(hour=23, minute=59, second=59, microsecond=999, tzinfo=cfg.TZ)
+    short_code = normalize_to_base_code(code)
+    start = end + timedelta(days=_resolve_index_history_days(period, bar_count))
+
+    if period == "1m":
+        data = fq_data_index_fetch_min(short_code, "1min", start, end)
+    elif period == "3m":
+        data = fq_data_index_fetch_min(short_code, "1min", start, end)
+        data = fqDataStockResample3min(data) if data is not None else None
+    elif period in {"5m", "15m", "30m", "60m"}:
+        data = fq_data_index_fetch_min(
+            short_code, period.replace("m", "min"), start, end
+        )
+    elif period == "90m":
+        data = fq_data_index_fetch_min(short_code, "30min", start, end)
+        data = fq_data_stock_resample_90min(data) if data is not None else None
+    elif period == "120m":
+        data = fq_data_index_fetch_min(short_code, "60min", start, end)
+        data = resampleStockOrIndex120min(data) if data is not None else None
+    elif period == "1d":
+        data = fq_data_index_fetch_day(short_code, start, end)
+    elif period == "1w":
+        data = fq_data_index_fetch_day(short_code, start, end)
+        data = QA_data_day_resample(data, "w") if data is not None else None
+    else:
+        raise ValueError(f"unsupported index period: {period}")
+
+    if data is None or len(data) == 0:
+        return None
+    data = data.copy()
+    data.fillna(0, inplace=True)
+    if bar_count and len(data) > int(bar_count):
+        data = data.iloc[-int(bar_count) :].copy()
+    if "datetime" not in data.columns:
+        data["datetime"] = data.index
+    return data
+
 
 @redis_cache.memoize(expiration=900)
 def fq_quote_fetch_index_day_adv(code, start, end):
@@ -7,6 +96,7 @@ def fq_quote_fetch_index_day_adv(code, start, end):
     if data is not None:
         return data.data
     return
+
 
 if __name__ == "__main__":
     print(fq_quote_fetch_index_day_adv('000001', '2023-01-01', '2024-08-30'))

--- a/freshquant/quote/index.py
+++ b/freshquant/quote/index.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+import pandas as pd
 from QUANTAXIS import QA_fetch_index_day_adv, QA_fetch_index_min_adv
 from QUANTAXIS.QAData.data_resample import QA_data_day_resample
 
@@ -45,6 +46,17 @@ def _resolve_index_history_days(period: str, bar_count: int = 0) -> int:
     return default_days
 
 
+def _datetime_values(data):
+    if "date" in data.columns:
+        values = data["date"]
+    elif getattr(data.index, "nlevels", 1) > 1:
+        level = "date" if "date" in data.index.names else 0
+        values = data.index.get_level_values(level)
+    else:
+        values = data.index
+    return pd.to_datetime(values).to_numpy()
+
+
 @in_memory_cache.memoize(expiration=3)
 def queryIndexCandleSticks(code: str, period: str, endDate=None, bar_count=0):
     """Fetch real Index candles without applying any QFQ factor."""
@@ -86,7 +98,7 @@ def queryIndexCandleSticks(code: str, period: str, endDate=None, bar_count=0):
     if bar_count and len(data) > int(bar_count):
         data = data.iloc[-int(bar_count) :].copy()
     if "datetime" not in data.columns:
-        data["datetime"] = data.index
+        data["datetime"] = _datetime_values(data)
     return data
 
 

--- a/freshquant/tests/fixtures/qfq_xtdata_real_samples.json
+++ b/freshquant/tests/fixtures/qfq_xtdata_real_samples.json
@@ -1,0 +1,32 @@
+{
+  "captured_at": "2026-08-01",
+  "source": "XTData dividend_type=none/front, fill_data=false",
+  "samples": [
+    {
+      "code": "600381",
+      "kind": "stock",
+      "bars": [
+        {"date": "2012-05-11", "close": 8.68, "preClose": 9.39},
+        {"date": "2012-05-14", "close": 8.71, "preClose": 8.68},
+        {"date": "2012-05-15", "close": 5.31, "preClose": 5.12}
+      ],
+      "event_date": "2012-05-14",
+      "expected_event_qfq_close": 5.12,
+      "front_reference_normalized_close": 5.123529411764705,
+      "front_tolerance": 0.01
+    },
+    {
+      "code": "159995",
+      "kind": "etf",
+      "bars": [
+        {"date": "2026-07-03", "close": 3.0, "preClose": 3.019},
+        {"date": "2026-07-06", "close": 3.009, "preClose": 3.0},
+        {"date": "2026-07-07", "close": 1.501, "preClose": 1.505}
+      ],
+      "event_date": "2026-07-06",
+      "expected_event_qfq_close": 1.505,
+      "front_reference_normalized_close": 1.5045,
+      "front_tolerance": 0.001
+    }
+  ]
+}

--- a/freshquant/tests/test_adj_refresh_service.py
+++ b/freshquant/tests/test_adj_refresh_service.py
@@ -11,12 +11,18 @@ from freshquant.market_data.xtdata.adj_refresh_worker import (
 
 
 class InMemoryAdjRefreshRepository:
-    def __init__(self, base_adj_docs=None):
+    def __init__(self, base_adj_docs=None, shadow_adj_docs=None):
         self.base_adj_docs = dict(base_adj_docs or {})
+        self.shadow_adj_docs = dict(shadow_adj_docs or {})
         self.saved_docs = {"stock": [], "etf": []}
 
     def get_base_anchor(self, kind, code, base_anchor_date):
         return self.base_adj_docs.get((kind, code, base_anchor_date))
+
+    def get_snapshot_anchor(self, kind, code, base_anchor_date, snapshot):
+        return self.shadow_adj_docs.get(
+            (kind, code, base_anchor_date, snapshot.get("collection"))
+        )
 
     def upsert_intraday_override(self, kind, document):
         self.saved_docs[kind].append(dict(document))
@@ -123,7 +129,15 @@ def test_intraday_override_binds_to_active_shadow_snapshot():
                 "date": "2026-03-08",
                 "adj": 2.0,
             },
-        }
+        },
+        {
+            (
+                "stock",
+                "sz000001",
+                "2026-03-08",
+                "stock_adj_qfq_a",
+            ): {"date": "2026-03-08", "adj": 1.5}
+        },
     )
     service = AdjRefreshService(
         repository=repository,
@@ -139,6 +153,7 @@ def test_intraday_override_binds_to_active_shadow_snapshot():
         trade_date_provider=lambda: date(2026, 3, 9),
         prev_trade_date_provider=lambda: date(2026, 3, 8),
         snapshot_provider=lambda kind: {
+            "collection": f"{kind}_adj_qfq_a",
             "snapshot_id": f"{kind}-snapshot-v1",
             "factor_asof": "2026-03-08",
         },
@@ -149,6 +164,8 @@ def test_intraday_override_binds_to_active_shadow_snapshot():
     document = repository.saved_docs["stock"][0]
     assert document["base_snapshot_id"] == "stock-snapshot-v1"
     assert document["base_factor_asof"] == "2026-03-08"
+    assert document["anchor_scale"] == pytest.approx(1.2)
+    assert document["legacy_anchor_scale"] == pytest.approx(0.9)
 
 
 def test_worker_run_once_calls_sync_service():

--- a/freshquant/tests/test_adj_refresh_service.py
+++ b/freshquant/tests/test_adj_refresh_service.py
@@ -116,6 +116,41 @@ def test_sync_adj_refresh_once_uses_repository_anchor_date_for_xtdata_pair():
     assert repository.saved_docs["stock"][0]["anchor_scale"] == pytest.approx(0.9)
 
 
+def test_intraday_override_binds_to_active_shadow_snapshot():
+    repository = InMemoryAdjRefreshRepository(
+        {
+            ("stock", "sz000001", "2026-03-08"): {
+                "date": "2026-03-08",
+                "adj": 2.0,
+            },
+        }
+    )
+    service = AdjRefreshService(
+        repository=repository,
+        market_client=FakeXtDataAdjClient(
+            {
+                ("sz000001", "2026-03-08"): {
+                    "front_close": 18.0,
+                    "raw_close": 10.0,
+                }
+            }
+        ),
+        code_loader=lambda: ["sz000001"],
+        trade_date_provider=lambda: date(2026, 3, 9),
+        prev_trade_date_provider=lambda: date(2026, 3, 8),
+        snapshot_provider=lambda kind: {
+            "snapshot_id": f"{kind}-snapshot-v1",
+            "factor_asof": "2026-03-08",
+        },
+    )
+
+    service.sync_once()
+
+    document = repository.saved_docs["stock"][0]
+    assert document["base_snapshot_id"] == "stock-snapshot-v1"
+    assert document["base_factor_asof"] == "2026-03-08"
+
+
 def test_worker_run_once_calls_sync_service():
     service = FakeSyncService()
 

--- a/freshquant/tests/test_chanlun_service_stock_symbol_fallback.py
+++ b/freshquant/tests/test_chanlun_service_stock_symbol_fallback.py
@@ -61,6 +61,9 @@ def _install_chanlun_stubs(monkeypatch):
 
     instrument_general_module = types.ModuleType("freshquant.instrument.general")
     instrument_general_module.query_instrument_type = lambda code: None
+    instrument_general_module.infer_cn_instrument_type = (
+        lambda code: InstrumentType.STOCK_CN
+    )
 
     instrument_stock_module = types.ModuleType("freshquant.instrument.stock")
     instrument_stock_module.query_stock_map = lambda: {}
@@ -216,3 +219,41 @@ def test_resolve_security_symbol_and_type_uses_normalized_symbol_for_suffix_code
     assert observed_codes == ["sh204001"]
     assert resolved_symbol == "sh204001"
     assert instrument_type == InstrumentType.BOND_CN
+
+
+def test_get_data_v2_routes_index_to_bfq_fetcher(monkeypatch, chanlun_service):
+    captured = {}
+    instrument_index_module = types.ModuleType("freshquant.instrument.index")
+    instrument_index_module.query_index_map = lambda: {}
+    quote_index_module = types.ModuleType("freshquant.quote.index")
+
+    def fake_index(code, period, end_date, bar_count=0):
+        captured["args"] = (code, period, end_date, bar_count)
+        return pd.DataFrame(
+            {
+                "datetime": pd.to_datetime(["2026-03-11 09:35", "2026-03-11 09:40"]),
+                "open": [10.0, 10.2],
+                "high": [10.3, 10.4],
+                "low": [9.9, 10.1],
+                "close": [10.1, 10.3],
+                "volume": [1000, 1200],
+                "amount": [10000, 12360],
+            }
+        )
+
+    quote_index_module.queryIndexCandleSticks = fake_index
+    monkeypatch.setitem(
+        sys.modules, "freshquant.instrument.index", instrument_index_module
+    )
+    monkeypatch.setitem(sys.modules, "freshquant.quote.index", quote_index_module)
+    monkeypatch.setattr(
+        chanlun_service,
+        "query_instrument_type",
+        lambda _code: InstrumentType.INDEX_CN,
+    )
+
+    payload = chanlun_service.get_data_v2("sh000300", "5m", bar_count=7)
+
+    assert captured["args"] == ("sh000300", "5m", None, 7)
+    assert payload["instrumentType"] == InstrumentType.INDEX_CN
+    assert payload["close"] == [10.1, 10.3]

--- a/freshquant/tests/test_fqnext_host_runtime.py
+++ b/freshquant/tests/test_fqnext_host_runtime.py
@@ -46,6 +46,7 @@ def test_resolve_surface_programs_expands_market_and_order_management() -> None:
         "fqnext_realtime_xtdata_producer",
         "fqnext_realtime_xtdata_consumer",
         "fqnext_xtdata_adj_refresh_worker",
+        "fqnext_xtdata_qfq_worker",
         "fqnext_xtquant_broker",
         "fqnext_xt_account_sync_worker",
         "fqnext_xt_auto_repay_worker",
@@ -83,6 +84,7 @@ def test_resolve_target_programs_supports_restart_surfaces_without_program_arg()
         "fqnext_realtime_xtdata_producer",
         "fqnext_realtime_xtdata_consumer",
         "fqnext_xtdata_adj_refresh_worker",
+        "fqnext_xtdata_qfq_worker",
         "fqnext_guardian_event",
     ]
 
@@ -101,6 +103,7 @@ def test_resolve_target_programs_supports_stop_surfaces_without_program_arg() ->
         "fqnext_realtime_xtdata_producer",
         "fqnext_realtime_xtdata_consumer",
         "fqnext_xtdata_adj_refresh_worker",
+        "fqnext_xtdata_qfq_worker",
         "fqnext_guardian_event",
     ]
 
@@ -119,6 +122,7 @@ def test_resolve_target_programs_supports_wait_settled_without_program_arg() -> 
         "fqnext_realtime_xtdata_producer",
         "fqnext_realtime_xtdata_consumer",
         "fqnext_xtdata_adj_refresh_worker",
+        "fqnext_xtdata_qfq_worker",
         "fqnext_guardian_event",
     ]
 

--- a/freshquant/tests/test_fqnext_supervisor_config.py
+++ b/freshquant/tests/test_fqnext_supervisor_config.py
@@ -48,6 +48,14 @@ def test_build_supervisor_config_targets_canonical_repo_root() -> None:
         f"command={expected_root}/.venv/Scripts/python.exe -m freshquant.xt_auto_repay.worker"
         in config_text
     )
+    assert (
+        f"command={expected_root}/.venv/Scripts/python.exe -m "
+        "freshquant.market_data.xtdata.qfq_worker worker" in config_text
+    )
+    assert (
+        "programs=fqnext_xtdata_adj_refresh_worker,fqnext_xtdata_qfq_worker"
+        in config_text
+    )
 
 
 def test_inspect_supervisor_config_rejects_main_runtime_and_site_packages(

--- a/freshquant/tests/test_freshquant_deploy_plan.py
+++ b/freshquant/tests/test_freshquant_deploy_plan.py
@@ -41,6 +41,17 @@ def test_xt_auto_repay_paths_expand_to_order_management_host_runtime() -> None:
     assert "fqnext_xt_auto_repay_worker" in plan["host_programs"]
 
 
+def test_qfq_writer_path_restarts_reference_data_worker() -> None:
+    module = load_module()
+
+    plan = module.build_deploy_plan(
+        changed_paths=["freshquant/market_data/xtdata/qfq.py"]
+    )
+
+    assert plan["deployment_surfaces"] == ["market_data"]
+    assert "fqnext_xtdata_qfq_worker" in plan["host_programs"]
+
+
 def test_retired_runtime_paths_no_longer_emit_deploy_surface() -> None:
     module = load_module()
 

--- a/freshquant/tests/test_freshquant_deploy_plan.py
+++ b/freshquant/tests/test_freshquant_deploy_plan.py
@@ -52,6 +52,24 @@ def test_qfq_writer_path_restarts_reference_data_worker() -> None:
     assert "fqnext_xtdata_qfq_worker" in plan["host_programs"]
 
 
+def test_index_api_paths_require_api_deploy_and_health_checks() -> None:
+    module = load_module()
+
+    plan = module.build_deploy_plan(
+        changed_paths=[
+            "freshquant/data/index.py",
+            "freshquant/quote/index.py",
+            "freshquant/instrument/general.py",
+            "freshquant/chanlun_service.py",
+            "freshquant/chanlun_structure_service.py",
+        ]
+    )
+
+    assert plan["deployment_surfaces"] == ["api"]
+    assert plan["docker_services"] == ["fq_apiserver"]
+    assert "http://127.0.0.1:15000/api/runtime/health/summary" in plan["health_checks"]
+
+
 def test_retired_runtime_paths_no_longer_emit_deploy_surface() -> None:
     module = load_module()
 

--- a/freshquant/tests/test_index_bfq_routing.py
+++ b/freshquant/tests/test_index_bfq_routing.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pandas as pd
+import pytest
+
+import freshquant.chanlun_structure_service as structure_service
+import freshquant.data.index as index_data
+import freshquant.market_data.xtdata.strategy_consumer as strategy_consumer
+from freshquant.carnation.enum_instrument import InstrumentType
+from freshquant.instrument.general import infer_cn_instrument_type
+from freshquant.quote import index as index_quote
+
+
+class _EmptyCursor:
+    def sort(self, *_args, **_kwargs):
+        return self
+
+    def __iter__(self):
+        return iter(())
+
+
+class _EmptyCollection:
+    def find(self, *_args, **_kwargs):
+        return _EmptyCursor()
+
+
+class _EmptyDatabase:
+    def __getitem__(self, _name):
+        return _EmptyCollection()
+
+
+def _bars() -> pd.DataFrame:
+    now = pd.Timestamp("2026-07-22 09:35", tz="Asia/Shanghai")
+    return pd.DataFrame(
+        {
+            "datetime": [
+                now.to_pydatetime(),
+                (now + timedelta(minutes=5)).to_pydatetime(),
+            ],
+            "open": [10.0, 10.2],
+            "high": [10.3, 10.4],
+            "low": [9.9, 10.1],
+            "close": [10.1, 10.3],
+            "volume": [100.0, 120.0],
+            "amount": [1000.0, 1236.0],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("sz000001", InstrumentType.STOCK_CN),
+        ("600000.SH", InstrumentType.STOCK_CN),
+        ("sh520000", InstrumentType.ETF_CN),
+        ("530001.SH", InstrumentType.ETF_CN),
+        ("sh000300", InstrumentType.INDEX_CN),
+        ("000300.SH", InstrumentType.INDEX_CN),
+        ("sz399001", InstrumentType.INDEX_CN),
+        ("399001.SZ", InstrumentType.INDEX_CN),
+        ("920001.BJ", InstrumentType.STOCK_CN),
+    ],
+)
+def test_shared_cn_security_classification_boundaries(code, expected):
+    assert infer_cn_instrument_type(code) == expected
+
+
+def test_index_minute_fetch_does_not_call_to_qfq(monkeypatch):
+    class _IndexData:
+        data = _bars()
+
+        def to_qfq(self):
+            raise AssertionError("real Index must stay BFQ")
+
+    monkeypatch.setattr(
+        index_data,
+        "QA_fetch_index_min_adv",
+        lambda *_args, **_kwargs: _IndexData(),
+    )
+
+    result = index_data.fq_data_QA_fetch_index_min_adv(
+        "000300", "2026-01-01", "2026-01-02", "5min"
+    )
+
+    assert result["close"].tolist() == [10.1, 10.3]
+
+
+def test_index_quote_fetcher_preserves_bfq_values(monkeypatch):
+    source = _bars().copy()
+    source.index = source["datetime"]
+    monkeypatch.setattr(
+        index_quote, "fq_data_index_fetch_min", lambda *args, **kwargs: source
+    )
+
+    result = index_quote.queryIndexCandleSticks("sh000300", "5m")
+
+    assert result["close"].tolist() == [10.1, 10.3]
+    assert result["open"].tolist() == [10.0, 10.2]
+
+
+def test_strategy_consumer_index_read_never_reads_factor(monkeypatch):
+    consumer = object.__new__(strategy_consumer.StrategyConsumer)
+    consumer.max_bars = 32
+    consumer._is_index_like = lambda _code: True
+    consumer._is_real_index = lambda _code: True
+    monkeypatch.setattr(
+        strategy_consumer,
+        "_load_minute_history_from_quantaxis_db",
+        lambda **_kwargs: _bars(),
+    )
+    monkeypatch.setattr(strategy_consumer, "DBfreshquant", _EmptyDatabase())
+    monkeypatch.setattr(
+        strategy_consumer,
+        "fetch_qfq_adj_df",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("Index must not read adj")
+        ),
+    )
+
+    result = consumer._load_window_from_db(code="sh000300", period_backend="5min")
+
+    assert result["open"].tolist() == [10.0, 10.2]
+    assert result["close"].tolist() == [10.1, 10.3]
+
+
+def test_chanlun_structure_routes_index_to_bfq_fetcher(monkeypatch):
+    monkeypatch.setattr(
+        "freshquant.instrument.general.query_instrument_type",
+        infer_cn_instrument_type,
+    )
+    monkeypatch.setattr(
+        index_quote,
+        "queryIndexCandleSticks",
+        lambda *_args, **_kwargs: _bars(),
+    )
+
+    result = structure_service._fetch_kline_df("sh000300", "5m", None)
+
+    assert result["close"].tolist() == [10.1, 10.3]

--- a/freshquant/tests/test_index_bfq_routing.py
+++ b/freshquant/tests/test_index_bfq_routing.py
@@ -6,11 +6,17 @@ import pandas as pd
 import pytest
 
 import freshquant.chanlun_structure_service as structure_service
-import freshquant.data.index as index_data
 import freshquant.market_data.xtdata.strategy_consumer as strategy_consumer
 from freshquant.carnation.enum_instrument import InstrumentType
 from freshquant.instrument.general import infer_cn_instrument_type
-from freshquant.quote import index as index_quote
+
+
+@pytest.fixture(scope="module")
+def index_modules():
+    import freshquant.data.index as index_data
+    from freshquant.quote import index as index_quote
+
+    return index_data, index_quote
 
 
 class _EmptyCursor:
@@ -85,7 +91,9 @@ def test_shared_cn_security_classification_boundaries(code, expected):
     assert infer_cn_instrument_type(code) == expected
 
 
-def test_index_minute_fetch_does_not_call_to_qfq(monkeypatch):
+def test_index_minute_fetch_does_not_call_to_qfq(monkeypatch, index_modules):
+    index_data, _index_quote = index_modules
+
     class _IndexData:
         data = _bars()
 
@@ -105,7 +113,8 @@ def test_index_minute_fetch_does_not_call_to_qfq(monkeypatch):
     assert result["close"].tolist() == [10.1, 10.3]
 
 
-def test_index_quote_fetcher_preserves_bfq_values(monkeypatch):
+def test_index_quote_fetcher_preserves_bfq_values(monkeypatch, index_modules):
+    _index_data, index_quote = index_modules
     source = _bars().copy()
     source.index = source["datetime"]
     monkeypatch.setattr(
@@ -118,7 +127,10 @@ def test_index_quote_fetcher_preserves_bfq_values(monkeypatch):
     assert result["open"].tolist() == [10.0, 10.2]
 
 
-def test_index_realtime_query_uses_index_market_for_conflicting_code(monkeypatch):
+def test_index_realtime_query_uses_index_market_for_conflicting_code(
+    monkeypatch, index_modules
+):
+    index_data, _index_quote = index_modules
     source = _bars().copy()
     capture_db = _CaptureDatabase()
     monkeypatch.setattr(
@@ -144,7 +156,10 @@ def test_index_realtime_query_uses_index_market_for_conflicting_code(monkeypatch
     assert capture_db.collection.query["code"] == "sh000001"
 
 
-def test_index_weekly_resample_exposes_datetime_not_multiindex_tuple(monkeypatch):
+def test_index_weekly_resample_exposes_datetime_not_multiindex_tuple(
+    monkeypatch, index_modules
+):
+    _index_data, index_quote = index_modules
     dates = pd.to_datetime(["2026-07-17", "2026-07-24"])
     weekly = pd.DataFrame(
         {
@@ -199,7 +214,8 @@ def test_strategy_consumer_index_read_never_reads_factor(monkeypatch):
     assert result["close"].tolist() == [10.1, 10.3]
 
 
-def test_chanlun_structure_routes_index_to_bfq_fetcher(monkeypatch):
+def test_chanlun_structure_routes_index_to_bfq_fetcher(monkeypatch, index_modules):
+    _index_data, index_quote = index_modules
     monkeypatch.setattr(
         "freshquant.instrument.general.query_instrument_type",
         infer_cn_instrument_type,

--- a/freshquant/tests/test_index_bfq_routing.py
+++ b/freshquant/tests/test_index_bfq_routing.py
@@ -31,6 +31,24 @@ class _EmptyDatabase:
         return _EmptyCollection()
 
 
+class _CaptureCollection(_EmptyCollection):
+    def __init__(self):
+        self.query = None
+
+    def find(self, query, *_args, **_kwargs):
+        self.query = query
+        return _EmptyCursor()
+
+
+class _CaptureDatabase:
+    def __init__(self):
+        self.collection = _CaptureCollection()
+
+    def __getitem__(self, name):
+        assert name == "index_realtime"
+        return self.collection
+
+
 def _bars() -> pd.DataFrame:
     now = pd.Timestamp("2026-07-22 09:35", tz="Asia/Shanghai")
     return pd.DataFrame(
@@ -98,6 +116,62 @@ def test_index_quote_fetcher_preserves_bfq_values(monkeypatch):
 
     assert result["close"].tolist() == [10.1, 10.3]
     assert result["open"].tolist() == [10.0, 10.2]
+
+
+def test_index_realtime_query_uses_index_market_for_conflicting_code(monkeypatch):
+    source = _bars().copy()
+    capture_db = _CaptureDatabase()
+    monkeypatch.setattr(
+        index_data,
+        "fq_data_QA_fetch_index_min_adv",
+        lambda *_args, **_kwargs: source,
+    )
+    monkeypatch.setattr(index_data, "DBfreshquant", capture_db)
+    monkeypatch.setattr(
+        index_data,
+        "query_index_map",
+        lambda: {"000001": {"sse": "SH"}},
+    )
+
+    result = index_data.fq_data_index_fetch_min(
+        "000001",
+        "5min",
+        pd.Timestamp("2026-07-22 09:30"),
+        pd.Timestamp("2026-07-22 15:00"),
+    )
+
+    assert result is not None
+    assert capture_db.collection.query["code"] == "sh000001"
+
+
+def test_index_weekly_resample_exposes_datetime_not_multiindex_tuple(monkeypatch):
+    dates = pd.to_datetime(["2026-07-17", "2026-07-24"])
+    weekly = pd.DataFrame(
+        {
+            "open": [10.0, 10.2],
+            "high": [10.3, 10.4],
+            "low": [9.9, 10.1],
+            "close": [10.1, 10.3],
+            "volume": [100.0, 120.0],
+            "amount": [1000.0, 1236.0],
+        },
+        index=pd.MultiIndex.from_arrays(
+            [dates, ["000001", "000001"]], names=["date", "code"]
+        ),
+    )
+    monkeypatch.setattr(
+        index_quote,
+        "fq_data_index_fetch_day",
+        lambda *_args, **_kwargs: _bars(),
+    )
+    monkeypatch.setattr(
+        index_quote, "QA_data_day_resample", lambda *_args, **_kwargs: weekly
+    )
+
+    result = index_quote.queryIndexCandleSticks("sh000001", "1w")
+
+    assert result["datetime"].tolist() == list(dates)
+    assert all(hasattr(value, "strftime") for value in result["datetime"])
 
 
 def test_strategy_consumer_index_read_never_reads_factor(monkeypatch):

--- a/freshquant/tests/test_intraday_adj_override.py
+++ b/freshquant/tests/test_intraday_adj_override.py
@@ -41,6 +41,22 @@ def test_apply_qfq_with_intraday_override_keeps_trade_date_raw_and_rescales_hist
     assert out["close"].tolist() == [10.5, 11.5]
 
 
+def test_legacy_reader_uses_legacy_scale_when_override_is_snapshot_bound():
+    out = apply_qfq_with_intraday_override(
+        _bars(),
+        _base_adj(),
+        override={
+            "trade_date": "2026-03-09",
+            "anchor_scale": 0.8,
+            "legacy_anchor_scale": 0.5,
+            "base_snapshot_id": "stock-snapshot-v1",
+        },
+    )
+
+    assert out["open"].tolist() == [10.0, 11.0]
+    assert out["close"].tolist() == [10.5, 11.5]
+
+
 def test_apply_qfq_with_intraday_override_falls_back_to_base_adj_when_override_missing():
     out = apply_qfq_with_intraday_override(_bars(), _base_adj(), override=None)
 

--- a/freshquant/tests/test_market_data_assets.py
+++ b/freshquant/tests/test_market_data_assets.py
@@ -484,6 +484,7 @@ def test_stock_postclose_ready_asset_depends_on_quality_snapshot(monkeypatch):
         "refresh_quality_stock_universe_snapshot",
         "stock_day",
         "stock_min",
+        "stock_xdxr",
     ]
 
 
@@ -659,8 +660,15 @@ def test_stock_postclose_ready_asset_writes_marker(monkeypatch):
         },
         "2026-03-19 16:00:00",
         "2026-03-19 16:05:00",
+        "2026-03-19 16:10:00",
     )
 
+    assert module.stock_postclose_ready_asset.dependency_names == [
+        "refresh_quality_stock_universe_snapshot",
+        "stock_day",
+        "stock_min",
+        "stock_xdxr",
+    ]
     assert calls == [
         {
             "pipeline_key": "stock_postclose_ready",
@@ -670,6 +678,7 @@ def test_stock_postclose_ready_asset_writes_marker(monkeypatch):
                 "count": 18,
                 "source_version": "xgt_hot_blocks_v1",
                 "integrity_audited_dates": ["2026-03-19"],
+                "stock_xdxr_completed_at": "2026-03-19 16:10:00",
             },
         }
     ]

--- a/freshquant/tests/test_market_data_schedules.py
+++ b/freshquant/tests/test_market_data_schedules.py
@@ -13,9 +13,12 @@ def _prepare_schedule_import(monkeypatch):
     monkeypatch.syspath_prepend(str(project_src))
 
     class FakeSelection:
+        def __init__(self, assets=()):
+            self.asset_names = tuple(asset.name for asset in assets)
+
         @classmethod
         def assets(cls, *assets):
-            return cls()
+            return cls(assets)
 
         @classmethod
         def groups(cls, *groups):
@@ -35,9 +38,32 @@ def _prepare_schedule_import(monkeypatch):
     monkeypatch.setitem(sys.modules, "dagster", dagster)
 
     assets = ModuleType("fqdagster.defs.assets.market_data")
-    for name in ("bond_list", "etf_list", "future_list", "index_list", "stock_list"):
+    for name in (
+        "bond_list",
+        "etf_adj",
+        "etf_day",
+        "etf_list",
+        "etf_min",
+        "etf_postclose_ready_asset",
+        "etf_xdxr",
+        "future_list",
+        "index_day",
+        "index_list",
+        "index_min",
+        "stock_block",
+        "stock_day",
+        "stock_list",
+        "stock_min",
+        "stock_postclose_ready_asset",
+        "stock_xdxr",
+    ):
         setattr(assets, name, SimpleNamespace(name=name))
     monkeypatch.setitem(sys.modules, "fqdagster.defs.assets.market_data", assets)
+    postclose = ModuleType("fqdagster.defs.assets.postclose_ready")
+    postclose.refresh_quality_stock_universe_snapshot = SimpleNamespace(
+        name="refresh_quality_stock_universe_snapshot"
+    )
+    monkeypatch.setitem(sys.modules, "fqdagster.defs.assets.postclose_ready", postclose)
     sys.modules.pop("fqdagster.defs.schedules.market_data", None)
 
 
@@ -46,12 +72,35 @@ def test_stock_and_etf_jobs_bound_runtime_and_failed_run_retries(monkeypatch):
     module = importlib.import_module("fqdagster.defs.schedules.market_data")
 
     expected_tags = {
+        "freshquant/mongo_writer": "quantaxis_market_data",
         "dagster/max_concurrent_runs": "1",
         "dagster/max_retries": "2",
         "dagster/max_runtime": "28800",
     }
     assert module.stock_data_job.tags == expected_tags
     assert module.etf_data_job.tags == expected_tags
+    assert set(module.stock_data_job.selection.asset_names) == {
+        "stock_list",
+        "stock_block",
+        "stock_day",
+        "stock_min",
+        "stock_xdxr",
+        "refresh_quality_stock_universe_snapshot",
+        "stock_postclose_ready_asset",
+    }
+    assert set(module.etf_data_job.selection.asset_names) == {
+        "etf_list",
+        "etf_day",
+        "etf_min",
+        "etf_xdxr",
+        "etf_adj",
+        "etf_postclose_ready_asset",
+    }
+    assert set(module.index_data_job.selection.asset_names) == {
+        "index_list",
+        "index_day",
+        "index_min",
+    }
 
 
 def test_dagster_instance_disables_resume_for_default_run_launcher():
@@ -61,3 +110,23 @@ def test_dagster_instance_disables_resume_for_default_run_launcher():
 
     assert config["run_launcher"]["class"] == "DefaultRunLauncher"
     assert config["run_monitoring"]["max_resume_run_attempts"] == 0
+    assert {
+        "key": "freshquant/mongo_writer",
+        "value": "quantaxis_market_data",
+        "limit": 1,
+    } in config["run_coordinator"]["config"]["tag_concurrency_limits"]
+
+
+def test_dagster_schedule_does_not_import_xtdata_qfq_writer():
+    repo_root = Path(__file__).resolve().parents[2]
+    assets_text = (
+        repo_root
+        / "morningglory"
+        / "fqdagster"
+        / "src"
+        / "fqdagster"
+        / "defs"
+        / "assets"
+        / "market_data.py"
+    ).read_text(encoding="utf-8")
+    assert "market_data.xtdata.qfq" not in assets_text

--- a/freshquant/tests/test_runtime_post_deploy_check.py
+++ b/freshquant/tests/test_runtime_post_deploy_check.py
@@ -442,6 +442,13 @@ def test_verify_passes_when_required_runtime_state_is_restored(tmp_path: Path) -
                 "CommandLine": "python -m freshquant.market_data.xtdata.adj_refresh_worker",
             },
             {
+                "ProcessId": 407,
+                "Name": "python.exe",
+                "CommandLine": (
+                    "python -m freshquant.market_data.xtdata.qfq_worker worker"
+                ),
+            },
+            {
                 "ProcessId": 404,
                 "Name": "python.exe",
                 "CommandLine": "python -m fqxtrade.xtquant.broker",

--- a/freshquant/tests/test_runtime_post_deploy_check.py
+++ b/freshquant/tests/test_runtime_post_deploy_check.py
@@ -27,6 +27,13 @@ def test_runtime_post_deploy_check_resolves_python_without_py_launcher() -> None
     assert "Get-Command py -ErrorAction SilentlyContinue" in script_text
 
 
+def test_runtime_post_deploy_check_runs_strict_qfq_readiness_for_market_data() -> None:
+    script_text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "freshquant.market_data.xtdata.qfq_worker" in script_text
+    assert "'status', '--strict'" in script_text
+
+
 def _run_powershell(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
     executable = shutil.which("powershell") or shutil.which("pwsh")
     if executable is None:
@@ -221,13 +228,13 @@ def test_capture_baseline_treats_absent_live_container_as_missing_without_error(
         "\n".join(
             [
                 "#!/usr/bin/env sh",
-                'if [ \"$1\" = \"ps\" ]; then',
+                'if [ "$1" = "ps" ]; then',
                 "  printf '%s\\n' fq_mongodb",
                 "  exit 0",
                 "fi",
-                'if [ \"$1\" = \"inspect\" ]; then',
-                '  if [ \"$2\" = \"fq_mongodb\" ]; then',
-                "    printf '%s\\n' '[{\"Name\":\"fq_mongodb\",\"State\":{\"Status\":\"running\",\"Health\":{\"Status\":\"healthy\"}}}]'",
+                'if [ "$1" = "inspect" ]; then',
+                '  if [ "$2" = "fq_mongodb" ]; then',
+                '    printf \'%s\\n\' \'[{"Name":"fq_mongodb","State":{"Status":"running","Health":{"Status":"healthy"}}}]\'',
                 "    exit 0",
                 "  fi",
                 "  exit 1",

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from collections.abc import Iterable, Mapping
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -485,6 +486,134 @@ def test_stale_writer_lease_is_reclaimed_and_released():
     assert not db["qfq_writer_locks"].rows
 
 
+def test_writer_lease_heartbeats_while_one_loader_call_is_blocked(monkeypatch):
+    db = _stock_db(["2026-01-02"])
+    loader_started = threading.Event()
+    background_refresh = threading.Event()
+    main_thread = threading.current_thread()
+    original_refresh = qfq._refresh_writer_lease
+
+    def observe_refresh(**kwargs):
+        if loader_started.is_set() and threading.current_thread() is not main_thread:
+            background_refresh.set()
+        return original_refresh(**kwargs)
+
+    def blocking_loader(*_args, **_kwargs):
+        loader_started.set()
+        assert background_refresh.wait(timeout=1.0)
+        return _bars([("2026-01-02", 10.0, 0.0)])
+
+    monkeypatch.setattr(qfq, "_refresh_writer_lease", observe_refresh)
+
+    qfq.sync_stock_adj_all(
+        target_date="2026-01-02",
+        db=db,
+        bars_loader=blocking_loader,
+        writer_heartbeat_seconds=0.01,
+    )
+
+    assert background_refresh.is_set()
+    assert not db["qfq_writer_locks"].rows
+
+
+def test_writer_lease_fences_publish_from_background_heartbeat_failure(monkeypatch):
+    refresh_started = threading.Event()
+    allow_failure = threading.Event()
+    published = threading.Event()
+    errors = []
+
+    def failing_refresh(**_kwargs):
+        refresh_started.set()
+        assert allow_failure.wait(timeout=1.0)
+        raise RuntimeError("lease lost")
+
+    monkeypatch.setattr(qfq, "_refresh_writer_lease", failing_refresh)
+    heartbeat = qfq._WriterLeaseHeartbeat(
+        db=object(),
+        scope="stock",
+        owner_id="writer",
+        lease_seconds=30,
+        heartbeat_seconds=0.01,
+    )
+    heartbeat.start()
+    assert refresh_started.wait(timeout=1.0)
+
+    def run_publish():
+        try:
+            heartbeat.run_fenced_publish(lambda: published.set())
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    publish_thread = threading.Thread(target=run_publish)
+    publish_thread.start()
+    allow_failure.set()
+    publish_thread.join(timeout=1.0)
+    heartbeat.stop()
+
+    assert not publish_thread.is_alive()
+    assert not published.is_set()
+    assert len(errors) == 1
+    assert isinstance(errors[0], qfq.QFQSyncError)
+
+
+def test_bootstrap_heartbeat_failure_before_publish_does_not_create_marker(monkeypatch):
+    db = _stock_db(["2026-01-02"])
+
+    def fail_fenced_publish(self, callback):
+        self._failure = RuntimeError("lease lost")
+        return original_fenced_publish(self, callback)
+
+    original_fenced_publish = qfq._WriterLeaseHeartbeat.run_fenced_publish
+    monkeypatch.setattr(
+        qfq._WriterLeaseHeartbeat,
+        "run_fenced_publish",
+        fail_fenced_publish,
+    )
+
+    with pytest.raises(qfq.QFQSyncError, match="heartbeat failed"):
+        qfq.sync_stock_adj_all(
+            target_date="2026-01-02",
+            db=db,
+            bars_loader=_loader_for({"000001": [("2026-01-02", 10.0, 0.0)]}),
+        )
+
+    assert not db["qfq_ready"].rows
+
+
+def test_update_heartbeat_failure_before_publish_keeps_active_marker(monkeypatch):
+    dates = ["2026-01-02", "2026-01-05"]
+    payload = {"000001": [(dates[0], 10.0, 0.0)]}
+    db = _stock_db(dates[:1])
+    loader = _loader_for(payload)
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    active_before = qfq.resolve_active_slot(scope="stock", db=db)
+    payload["000001"].append((dates[1], 10.0, 10.0))
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+
+    def fail_fenced_publish(self, callback):
+        self._failure = RuntimeError("lease lost")
+        return original_fenced_publish(self, callback)
+
+    original_fenced_publish = qfq._WriterLeaseHeartbeat.run_fenced_publish
+    monkeypatch.setattr(
+        qfq._WriterLeaseHeartbeat,
+        "run_fenced_publish",
+        fail_fenced_publish,
+    )
+
+    with pytest.raises(qfq.QFQSyncError, match="heartbeat failed"):
+        qfq.sync_stock_adj_all(
+            target_date=dates[1],
+            db=db,
+            bars_loader=loader,
+            min_grace_seconds=0,
+        )
+
+    active_after = qfq.resolve_active_slot(scope="stock", db=db)
+    assert active_after["slot"] == active_before["slot"]
+    assert active_after["factor_asof"] == active_before["factor_asof"]
+
+
 def test_inactive_slot_catches_up_from_its_own_terminal_without_writing_active():
     dates = ["2026-01-02", "2026-01-05", "2026-01-06"]
     rows = [
@@ -676,6 +805,15 @@ def test_forced_full_rebuild_repairs_revision_older_than_tail_window():
     assert repaired[dates[0]] == pytest.approx(0.8)
 
 
+def test_forced_full_rebuild_rejects_explicit_code_subset():
+    with pytest.raises(ValueError, match="codes must be omitted"):
+        qfq.sync_stock_adj_all(
+            target_date="2026-01-05",
+            codes=["000001"],
+            force_full_rebuild=True,
+        )
+
+
 def test_forced_full_rebuild_rejects_factor_asof_regression():
     dates = ["2026-01-02", "2026-01-05"]
     rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
@@ -693,6 +831,50 @@ def test_forced_full_rebuild_rejects_factor_asof_regression():
         )
 
     assert qfq.resolve_active_slot(scope="stock", db=db)["factor_asof"] == dates[1]
+
+
+def test_forced_full_rebuild_removes_codes_outside_current_universe():
+    dates = ["2026-01-02", "2026-01-05"]
+    rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
+    db = _stock_db(dates[:1])
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    db["stock_adj_qfq_b"].rows.append({"code": "600999", "date": dates[0], "adj": 1.0})
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+
+    result = qfq.sync_stock_adj_all(
+        target_date=dates[1],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+        force_full_rebuild=True,
+    )
+
+    assert result["by_scope"]["stock"]["stats"]["stale_codes_removed"] == 1
+    assert {row["code"] for row in db["stock_adj_qfq_b"].rows} == {"000001"}
+    assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "b"
+
+
+def test_source_audit_detects_recurrence_corruption_that_structure_audit_misses():
+    dates = ["2026-01-02", "2026-01-05", "2026-01-06"]
+    rows = [
+        (dates[0], 10.0, 0.0),
+        (dates[1], 9.0, 8.0),
+        (dates[2], 9.0, 9.0),
+    ]
+    db = _stock_db(dates)
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[-1], db=db, bars_loader=loader)
+    db["stock_adj_qfq_a"].rows[0]["adj"] = 0.123456
+
+    structure = qfq.audit_qfq_slot(scope="stock", slot="a", db=db)
+    source = qfq.audit_qfq_slot(scope="stock", slot="a", db=db, bars_loader=loader)
+
+    assert structure["ok"] is True
+    assert structure["audit_mode"] == "structure"
+    assert source["ok"] is False
+    assert source["audit_mode"] == "full_source"
+    assert source["failures"][0]["audit"]["recurrence_errors"]
 
 
 def test_stale_inactive_code_fails_closed_and_keeps_active():

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -1,0 +1,895 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from freshquant.market_data.xtdata import qfq
+
+
+def _get_path(document, path):
+    value = document
+    for part in path.split("."):
+        if not isinstance(value, Mapping) or part not in value:
+            return None
+        value = value[part]
+    return value
+
+
+def _set_path(document, path, value):
+    target = document
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = target.setdefault(part, {})
+    target[parts[-1]] = value
+
+
+def _matches(document, query):
+    for key, expected in (query or {}).items():
+        value = _get_path(document, key)
+        if isinstance(expected, Mapping):
+            if "$in" in expected and value not in expected["$in"]:
+                return False
+            if "$lte" in expected and not (
+                value is not None and value <= expected["$lte"]
+            ):
+                return False
+            if "$gte" in expected and not (
+                value is not None and value >= expected["$gte"]
+            ):
+                return False
+        elif value != expected:
+            return False
+    return True
+
+
+class _Result:
+    def __init__(self, *, matched_count=0, deleted_count=0):
+        self.matched_count = matched_count
+        self.modified_count = matched_count
+        self.deleted_count = deleted_count
+
+
+class _Cursor:
+    def __init__(self, rows: Iterable[Mapping]):
+        self.rows = [dict(row) for row in rows]
+
+    def sort(self, field, direction):
+        self.rows.sort(
+            key=lambda row: _get_path(row, field), reverse=int(direction) < 0
+        )
+        return self
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+class _Collection:
+    def __init__(self, db, name, rows=()):
+        self.db = db
+        self.name = name
+        self.rows = [dict(row) for row in rows]
+        self.writes = 0
+
+    def find(self, query=None, projection=None):
+        rows = []
+        for source in self.rows:
+            if not _matches(source, query or {}):
+                continue
+            row = dict(source)
+            if projection:
+                included = [key for key, enabled in projection.items() if enabled]
+                if included:
+                    row = {key: row[key] for key in included if key in row}
+                else:
+                    row = {
+                        key: value
+                        for key, value in row.items()
+                        if projection.get(key, 1)
+                    }
+            rows.append(row)
+        return _Cursor(rows)
+
+    def find_one(self, query=None, projection=None, sort=None):
+        cursor = self.find(query, projection)
+        if sort:
+            for field, direction in reversed(sort):
+                cursor.sort(field, direction)
+        return next(iter(cursor), None)
+
+    def distinct(self, field):
+        return list(
+            {_get_path(row, field) for row in self.rows if _get_path(row, field)}
+        )
+
+    def insert_one(self, document):
+        self.rows.append(dict(document))
+        self.writes += 1
+        return _Result(matched_count=1)
+
+    def insert_many(self, documents, ordered=False):
+        values = [dict(document) for document in documents]
+        self.rows.extend(values)
+        self.writes += len(values)
+        return _Result(matched_count=len(values))
+
+    def delete_many(self, query=None):
+        before = len(self.rows)
+        self.rows = [row for row in self.rows if not _matches(row, query or {})]
+        deleted = before - len(self.rows)
+        self.writes += deleted
+        return _Result(deleted_count=deleted)
+
+    def delete_one(self, query=None):
+        for index, row in enumerate(self.rows):
+            if not _matches(row, query or {}):
+                continue
+            self.rows.pop(index)
+            self.writes += 1
+            return _Result(deleted_count=1)
+        return _Result()
+
+    def update_one(self, query, update, upsert=False):
+        if self.db.fail_marker_cas and self.name == qfq.READY_COLLECTION:
+            return _Result()
+        for row in self.rows:
+            if not _matches(row, query):
+                continue
+            for path, value in update.get("$set", {}).items():
+                _set_path(row, path, value)
+            self.writes += 1
+            return _Result(matched_count=1)
+        if upsert:
+            row = {
+                key: value
+                for key, value in query.items()
+                if not isinstance(value, Mapping) and "." not in key
+            }
+            for path, value in update.get("$setOnInsert", {}).items():
+                _set_path(row, path, value)
+            for path, value in update.get("$set", {}).items():
+                _set_path(row, path, value)
+            self.rows.append(row)
+            self.writes += 1
+            return _Result(matched_count=1)
+        return _Result()
+
+    def create_index(self, *args, **kwargs):
+        return kwargs.get("name", "idx")
+
+    def count_documents(self, query):
+        return len(list(self.find(query)))
+
+
+class _DB:
+    def __init__(self, **collections):
+        self.collections = {}
+        self.fail_marker_cas = False
+        for name, rows in collections.items():
+            self.collections[name] = _Collection(self, name, rows)
+
+    def __getitem__(self, name):
+        return self.collections.setdefault(name, _Collection(self, name))
+
+
+def _bars(rows):
+    return pd.DataFrame(rows, columns=["time", "close", "preClose"])
+
+
+def _loader_for(rows_by_code):
+    def load(code, *, start_time, end_time):
+        start = pd.Timestamp(start_time).strftime("%Y-%m-%d")
+        end = pd.Timestamp(end_time).strftime("%Y-%m-%d")
+        rows = [row for row in rows_by_code[code] if start <= str(row[0])[:10] <= end]
+        return _bars(rows)
+
+    return load
+
+
+def _stock_db(dates, *, code="000001"):
+    return _DB(
+        stock_list=[{"code": code, "name": "Stock"}],
+        stock_day=[{"code": code, "date": date} for date in dates],
+    )
+
+
+def test_compute_preclose_adj_uses_actual_xtdata_axis():
+    result = qfq.compute_preclose_adj(
+        _bars(
+            [
+                ("2026-01-02", 10.0, 0.0),
+                ("2026-01-05", 9.0, 8.0),
+                ("2026-01-06", 9.1, 9.0),
+            ]
+        ),
+        code="000001",
+    )
+
+    assert result["date"].tolist() == ["2026-01-02", "2026-01-05", "2026-01-06"]
+    assert result["adj"].tolist() == pytest.approx([0.8, 1.0, 1.0])
+
+
+@pytest.mark.parametrize("first_preclose", [0.0, float("nan")])
+def test_first_preclose_is_unused(first_preclose):
+    result = qfq.compute_preclose_adj(
+        _bars(
+            [
+                ("2026-01-02", 10.0, first_preclose),
+                ("2026-01-05", 10.0, 10.0),
+            ]
+        ),
+        code="000001",
+    )
+    assert result["adj"].tolist() == [1.0, 1.0]
+
+
+@pytest.mark.parametrize("used_preclose", [0.0, float("nan"), float("inf")])
+def test_used_preclose_must_be_positive_and_finite(used_preclose):
+    with pytest.raises(qfq.QFQSyncError, match="used preClose"):
+        qfq.compute_preclose_adj(
+            _bars(
+                [
+                    ("2026-01-02", 10.0, 0.0),
+                    ("2026-01-05", 10.0, used_preclose),
+                ]
+            ),
+            code="000001",
+        )
+
+
+@pytest.mark.parametrize("close", [0.0, float("nan"), float("inf")])
+def test_close_must_be_positive_and_finite_even_for_single_bar(close):
+    with pytest.raises(qfq.QFQSyncError, match="close values"):
+        qfq.compute_preclose_adj(
+            _bars([("2026-01-02", close, 0.0)]),
+            code="000001",
+        )
+
+
+def test_normalize_xtdata_field_table_payload():
+    payload = {
+        "time": pd.DataFrame(
+            [["2026-01-02", "2026-01-05"]], index=["000001.SZ"], columns=[0, 1]
+        ),
+        "close": pd.DataFrame([[10.0, 9.0]], index=["000001.SZ"], columns=[0, 1]),
+        "preClose": pd.DataFrame([[0.0, 8.0]], index=["000001.SZ"], columns=[0, 1]),
+    }
+
+    result = qfq.normalize_xtdata_bars(payload, code="000001.SZ")
+    assert result[["date", "close", "preClose"]].to_dict("records") == [
+        {"date": "2026-01-02", "close": 10.0, "preClose": 0.0},
+        {"date": "2026-01-05", "close": 9.0, "preClose": 8.0},
+    ]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-01-02",
+        "20260102",
+        20260102,
+        1767312000,
+        1767312000000,
+        date(2026, 1, 2),
+        datetime(2026, 1, 2, 15, 30),
+        pd.Timestamp("2026-01-02"),
+    ],
+)
+def test_canonical_date_values_use_fast_path(monkeypatch, value):
+    monkeypatch.setattr(
+        qfq,
+        "_parse_timestamp",
+        lambda _value: (_ for _ in ()).throw(
+            AssertionError("canonical dates must not use pandas parsing")
+        ),
+    )
+
+    assert qfq._date_key(value) == "2026-01-02"
+
+
+@pytest.mark.parametrize("code", ["920001", "430001", "830001"])
+def test_to_xt_code_maps_beijing_markets(code):
+    assert qfq.to_xt_code(code) == f"{code}.BJ"
+
+
+def test_factor_universe_includes_historical_codes_and_excludes_real_indexes():
+    db = _DB(
+        stock_list=[{"code": "000001"}],
+        stock_day=[
+            {"code": "000001", "date": "2026-01-02"},
+            {"code": "600999", "date": "2010-01-04"},
+        ],
+        stock_adj=[{"code": "601999", "date": "2011-01-04", "adj": 1.0}],
+        etf_list=[{"code": "510050", "name": "ETF"}],
+        index_day=[
+            {"code": "510050", "date": "2026-01-02"},
+            {"code": "159995", "date": "2026-01-02"},
+            {"code": "000001", "date": "2026-01-02"},
+            {"code": "399001", "date": "2026-01-02"},
+        ],
+    )
+
+    assert qfq.load_factor_universe(kind="stock", db=db)["codes"] == [
+        "000001",
+        "600999",
+        "601999",
+    ]
+    assert qfq.load_factor_universe(kind="etf", db=db)["codes"] == [
+        "159995",
+        "510050",
+    ]
+
+
+def test_load_bfq_dates_sorts_in_memory_without_mongo_date_sort():
+    class _UnsortedCursor:
+        def sort(self, *_args, **_kwargs):
+            raise AssertionError("Mongo date sort must not bypass the code index")
+
+        def __iter__(self):
+            return iter(
+                [
+                    {"date": "2026-01-05"},
+                    {"date": "2026-01-02"},
+                    {"date": "2026-01-05"},
+                ]
+            )
+
+    class _BfqCollection:
+        def find(self, query, projection):
+            assert query == {"code": "000001"}
+            assert projection == {"_id": 0, "date": 1}
+            return _UnsortedCursor()
+
+    db = _DB()
+    db.collections["stock_day"] = _BfqCollection()
+
+    assert qfq.load_bfq_dates(kind="stock", code="000001", db=db) == [
+        "2026-01-02",
+        "2026-01-05",
+    ]
+
+
+def test_audit_checks_terminal_factor_and_recurrence():
+    bars = _bars(
+        [
+            ("2026-01-02", 10.0, 0.0),
+            ("2026-01-05", 9.0, 8.0),
+        ]
+    )
+    valid = [
+        {"code": "000001", "date": "2026-01-02", "adj": 0.8},
+        {"code": "000001", "date": "2026-01-05", "adj": 1.0},
+    ]
+    assert qfq.audit_factor_snapshot(
+        valid,
+        expected_dates_by_code={"000001": ["2026-01-02", "2026-01-05"]},
+        included_codes=["000001"],
+        require_exact_dates=True,
+        bars_by_code={"000001": bars},
+    )["ok"]
+
+    invalid = [dict(row) for row in valid]
+    invalid[0]["adj"] = 0.9
+    audit = qfq.audit_factor_snapshot(
+        invalid,
+        expected_dates_by_code={"000001": ["2026-01-02", "2026-01-05"]},
+        included_codes=["000001"],
+        require_exact_dates=True,
+        bars_by_code={"000001": bars},
+    )
+    assert audit["recurrence_errors"] == [("000001", "2026-01-02")]
+
+    invalid[-1]["adj"] = 0.5
+    audit = qfq.audit_factor_snapshot(
+        invalid,
+        expected_dates_by_code={"000001": ["2026-01-02", "2026-01-05"]},
+        included_codes=["000001"],
+        require_exact_dates=True,
+    )
+    assert audit["terminal_not_one"] == ["000001"]
+
+
+def test_bootstrap_builds_both_slots_before_atomic_marker_insert():
+    dates = ["2026-01-02", "2026-01-05"]
+    db = _stock_db(dates)
+    loader = _loader_for({"000001": [(dates[0], 10.0, 0.0), (dates[1], 9.0, 8.0)]})
+
+    result = qfq.sync_stock_adj_all(target_date=dates[-1], db=db, bars_loader=loader)
+
+    assert result["by_scope"]["stock"]["mode"] == "bootstrap"
+    rows_a = db["stock_adj_qfq_a"].rows
+    rows_b = db["stock_adj_qfq_b"].rows
+    assert rows_a == rows_b
+    marker = db["qfq_ready"].rows[0]
+    assert set(marker) == {
+        "scope",
+        "active_slot",
+        "slots",
+        "source",
+        "schema_version",
+    }
+    assert marker["active_slot"] == "a"
+    assert marker["slots"]["a"]["status"] == "ready"
+    assert marker["slots"]["b"]["status"] == "ready"
+    assert marker["slots"]["a"]["collection"] == "stock_adj_qfq_a"
+    assert marker["slots"]["b"]["collection"] == "stock_adj_qfq_b"
+
+
+def test_bootstrap_failure_never_creates_ready_marker():
+    db = _stock_db(["2026-01-02"])
+
+    with pytest.raises(RuntimeError, match="download failed"):
+        qfq.sync_stock_adj_all(
+            target_date="2026-01-02",
+            db=db,
+            bars_loader=lambda *args, **kwargs: (_ for _ in ()).throw(
+                RuntimeError("download failed")
+            ),
+        )
+
+    assert not db["qfq_ready"].rows
+    assert not db["qfq_writer_locks"].rows
+
+
+def test_live_writer_lease_blocks_bootstrap_before_shadow_write():
+    now = datetime(2026, 1, 2, 8, 0, tzinfo=timezone.utc)
+    db = _stock_db(["2026-01-02"])
+    db["qfq_writer_locks"].rows.append(
+        {
+            "scope": "stock",
+            "owner_id": "other-writer",
+            "acquired_at": "2026-01-02T07:55:00Z",
+            "updated_at": "2026-01-02T07:59:00Z",
+            "expires_at": "2026-01-02T08:30:00Z",
+        }
+    )
+
+    with pytest.raises(qfq.QFQSyncError, match="writer lease is held"):
+        qfq.sync_stock_adj_all(
+            target_date="2026-01-02",
+            db=db,
+            bars_loader=_loader_for({"000001": [("2026-01-02", 10.0, 0.0)]}),
+            now_provider=lambda: now,
+        )
+
+    assert not db["stock_adj_qfq_a"].rows
+    assert not db["qfq_ready"].rows
+
+
+def test_stale_writer_lease_is_reclaimed_and_released():
+    now = datetime(2026, 1, 2, 8, 0, tzinfo=timezone.utc)
+    db = _stock_db(["2026-01-02"])
+    db["qfq_writer_locks"].rows.append(
+        {
+            "scope": "stock",
+            "owner_id": "crashed-writer",
+            "acquired_at": "2026-01-02T06:00:00Z",
+            "updated_at": "2026-01-02T06:00:00Z",
+            "expires_at": "2026-01-02T07:00:00Z",
+        }
+    )
+
+    qfq.sync_stock_adj_all(
+        target_date="2026-01-02",
+        db=db,
+        bars_loader=_loader_for({"000001": [("2026-01-02", 10.0, 0.0)]}),
+        now_provider=lambda: now,
+    )
+
+    assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "a"
+    assert not db["qfq_writer_locks"].rows
+
+
+def test_inactive_slot_catches_up_from_its_own_terminal_without_writing_active():
+    dates = ["2026-01-02", "2026-01-05", "2026-01-06"]
+    rows = [
+        (date, 10.0, 0.0 if index == 0 else 10.0) for index, date in enumerate(dates)
+    ]
+    db = _stock_db(dates[:1])
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    db["stock_day"].rows.extend({"code": "000001", "date": date} for date in dates[1:])
+    active_writes_before = db["stock_adj_qfq_a"].writes
+
+    result = qfq.sync_stock_adj_all(
+        target_date=dates[-1],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+    )
+
+    assert result["by_scope"]["stock"]["stats"]["incremental"] == 1
+    assert db["stock_adj_qfq_a"].writes == active_writes_before
+    assert [row["date"] for row in db["stock_adj_qfq_b"].rows] == dates
+    assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "b"
+
+
+def test_company_action_rebuilds_only_inactive_code_history():
+    dates = ["2026-01-02", "2026-01-05", "2026-01-06"]
+    rows = [
+        (dates[0], 10.0, 0.0),
+        (dates[1], 10.0, 10.0),
+        (dates[2], 9.0, 8.0),
+    ]
+    db = _stock_db(dates[:1])
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    db["stock_day"].rows.extend({"code": "000001", "date": date} for date in dates[1:])
+    active_rows = [dict(row) for row in db["stock_adj_qfq_a"].rows]
+
+    result = qfq.sync_stock_adj_all(
+        target_date=dates[-1],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+    )
+
+    stats = result["by_scope"]["stock"]["stats"]
+    assert stats["full"] == 1
+    assert db["stock_adj_qfq_a"].rows == active_rows
+    factors = {row["date"]: row["adj"] for row in db["stock_adj_qfq_b"].rows}
+    assert factors == pytest.approx({dates[0]: 0.8, dates[1]: 0.8, dates[2]: 1.0})
+
+
+def test_failed_inactive_build_keeps_active_and_marks_inactive_failed():
+    dates = ["2026-01-02", "2026-01-05"]
+    rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
+    db = _stock_db(dates[:1])
+    qfq.sync_stock_adj_all(
+        target_date=dates[0], db=db, bars_loader=_loader_for({"000001": rows})
+    )
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+    marker_before = qfq.get_qfq_marker(scope="stock", db=db)
+
+    with pytest.raises(RuntimeError, match="tail failed"):
+        qfq.sync_stock_adj_all(
+            target_date=dates[1],
+            db=db,
+            min_grace_seconds=0,
+            bars_loader=lambda *args, **kwargs: (_ for _ in ()).throw(
+                RuntimeError("tail failed")
+            ),
+        )
+
+    marker_after = qfq.get_qfq_marker(scope="stock", db=db)
+    assert marker_after["active_slot"] == marker_before["active_slot"]
+    assert marker_after["slots"]["b"]["status"] == "failed"
+
+
+def test_failed_inactive_build_is_retried_and_published():
+    dates = ["2026-01-02", "2026-01-05"]
+    rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
+    db = _stock_db(dates[:1])
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+
+    with pytest.raises(RuntimeError, match="tail failed"):
+        qfq.sync_stock_adj_all(
+            target_date=dates[1],
+            db=db,
+            min_grace_seconds=0,
+            bars_loader=lambda *args, **kwargs: (_ for _ in ()).throw(
+                RuntimeError("tail failed")
+            ),
+        )
+
+    result = qfq.sync_stock_adj_all(
+        target_date=dates[1],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+    )
+
+    assert result["by_scope"]["stock"]["mode"] == "update"
+    assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "b"
+
+
+def test_interrupted_build_is_recovered_only_after_writer_lease_acquisition():
+    dates = ["2026-01-02", "2026-01-05"]
+    rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
+    db = _stock_db(dates[:1])
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+    db["qfq_ready"].rows[0]["slots"]["b"]["status"] = "building"
+
+    result = qfq.sync_stock_adj_all(
+        target_date=dates[1],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+    )
+
+    assert result["by_scope"]["stock"]["mode"] == "update"
+    assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "b"
+
+
+def test_historical_bfq_axis_change_rebuilds_inactive_code():
+    dates = ["2026-01-02", "2026-01-05", "2026-01-06", "2026-01-07"]
+    rows = [
+        (date, 10.0, 0.0 if index == 0 else 10.0) for index, date in enumerate(dates)
+    ]
+    db = _stock_db([dates[0], dates[2]])
+    payload = {"000001": [rows[0], rows[2]]}
+    loader = _loader_for(payload)
+    qfq.sync_stock_adj_all(target_date=dates[2], db=db, bars_loader=loader)
+    payload["000001"] = rows
+    db["stock_day"].rows.extend(
+        [
+            {"code": "000001", "date": dates[1]},
+            {"code": "000001", "date": dates[3]},
+        ]
+    )
+
+    result = qfq.sync_stock_adj_all(
+        target_date=dates[3],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+    )
+
+    assert result["by_scope"]["stock"]["stats"]["full"] == 1
+    assert [row["date"] for row in db["stock_adj_qfq_b"].rows] == dates
+
+
+def test_forced_full_rebuild_repairs_revision_older_than_tail_window():
+    dates = (
+        pd.date_range("2026-01-02", periods=71, freq="B").strftime("%Y-%m-%d").tolist()
+    )
+    rows = [
+        [date_value, 10.0, 0.0 if index == 0 else 10.0]
+        for index, date_value in enumerate(dates)
+    ]
+    payload = {"000001": [tuple(row) for row in rows[:70]]}
+    db = _stock_db(dates[:70])
+    loader = _loader_for(payload)
+    qfq.sync_stock_adj_all(target_date=dates[69], db=db, bars_loader=loader)
+
+    rows[1][2] = 8.0
+    payload["000001"] = [tuple(row) for row in rows]
+    db["stock_day"].rows.append({"code": "000001", "date": dates[70]})
+    daily = qfq.sync_stock_adj_all(
+        target_date=dates[70],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+    )
+    assert daily["by_scope"]["stock"]["stats"]["incremental"] == 1
+    assert db["stock_adj_qfq_b"].rows[0]["adj"] == pytest.approx(1.0)
+
+    rebuilt = qfq.sync_stock_adj_all(
+        target_date=dates[70],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+        force_full_rebuild=True,
+    )
+
+    assert rebuilt["by_scope"]["stock"]["stats"]["full"] == 1
+    repaired = {row["date"]: row["adj"] for row in db["stock_adj_qfq_a"].rows}
+    assert repaired[dates[0]] == pytest.approx(0.8)
+
+
+def test_forced_full_rebuild_rejects_factor_asof_regression():
+    dates = ["2026-01-02", "2026-01-05"]
+    rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
+    db = _stock_db(dates)
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[1], db=db, bars_loader=loader)
+
+    with pytest.raises(qfq.QFQSyncError, match="predates active snapshot"):
+        qfq.sync_stock_adj_all(
+            target_date=dates[0],
+            db=db,
+            bars_loader=loader,
+            min_grace_seconds=0,
+            force_full_rebuild=True,
+        )
+
+    assert qfq.resolve_active_slot(scope="stock", db=db)["factor_asof"] == dates[1]
+
+
+def test_stale_inactive_code_fails_closed_and_keeps_active():
+    dates = ["2026-01-02", "2026-01-05"]
+    rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
+    db = _stock_db(dates[:1])
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    db["stock_adj_qfq_b"].rows.append({"code": "600999", "date": dates[0], "adj": 1.0})
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+
+    with pytest.raises(qfq.QFQSyncError, match="outside BFQ universe"):
+        qfq.sync_stock_adj_all(
+            target_date=dates[1],
+            db=db,
+            bars_loader=loader,
+            min_grace_seconds=0,
+        )
+
+    marker = qfq.get_qfq_marker(scope="stock", db=db)
+    assert marker["active_slot"] == "a"
+    assert marker["slots"]["b"]["status"] == "failed"
+
+
+def test_index_creation_failure_marks_claimed_inactive_slot_failed():
+    dates = ["2026-01-02", "2026-01-05"]
+    rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
+    db = _stock_db(dates[:1])
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+
+    def fail_index(*args, **kwargs):
+        raise RuntimeError("duplicate factor rows")
+
+    db["stock_adj_qfq_b"].create_index = fail_index
+
+    with pytest.raises(RuntimeError, match="duplicate factor rows"):
+        qfq.sync_stock_adj_all(
+            target_date=dates[1],
+            db=db,
+            bars_loader=loader,
+            min_grace_seconds=0,
+        )
+
+    marker = qfq.get_qfq_marker(scope="stock", db=db)
+    assert marker["active_slot"] == "a"
+    assert marker["slots"]["b"]["status"] == "failed"
+
+
+def test_marker_cas_failure_keeps_old_active_visible():
+    dates = ["2026-01-02", "2026-01-05"]
+    rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
+    db = _stock_db(dates[:1])
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+    original_update = db["qfq_ready"].update_one
+    calls = 0
+
+    def fail_publish(query, update, upsert=False):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            return _Result()
+        return original_update(query, update, upsert=upsert)
+
+    db["qfq_ready"].update_one = fail_publish
+
+    with pytest.raises(qfq.QFQSyncError, match="CAS publish lost"):
+        qfq.sync_stock_adj_all(
+            target_date=dates[1],
+            db=db,
+            bars_loader=loader,
+            min_grace_seconds=0,
+        )
+
+    assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "a"
+
+
+def test_rollback_swaps_only_between_ready_slots():
+    dates = ["2026-01-02", "2026-01-05"]
+    rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
+    db = _stock_db(dates[:1])
+    loader = _loader_for({"000001": rows})
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+    qfq.sync_stock_adj_all(
+        target_date=dates[1], db=db, bars_loader=loader, min_grace_seconds=0
+    )
+
+    assert qfq.rollback_active_slot(scope="stock", db=db)["active_slot"] == "a"
+    db["qfq_ready"].rows[0]["slots"]["b"]["status"] = "building"
+    with pytest.raises(qfq.QFQSyncError, match="rollback slot is not ready"):
+        qfq.rollback_active_slot(scope="stock", db=db)
+
+
+def test_rollback_refreshes_activation_time_for_reader_grace():
+    db = _stock_db(["2026-01-02"])
+    loader = _loader_for({"000001": [("2026-01-02", 10.0, 0.0)]})
+    qfq.sync_stock_adj_all(target_date="2026-01-02", db=db, bars_loader=loader)
+    republished_at = datetime(2026, 1, 6, 8, 0, tzinfo=timezone.utc)
+
+    marker = qfq.rollback_active_slot(
+        scope="stock", db=db, now_provider=lambda: republished_at
+    )
+
+    assert marker["active_slot"] == "b"
+    assert marker["slots"]["b"]["published_at"] == "2026-01-06T08:00:00Z"
+
+
+def test_rollback_respects_live_writer_lease():
+    now = datetime(2026, 1, 6, 8, 0, tzinfo=timezone.utc)
+    db = _stock_db(["2026-01-02"])
+    loader = _loader_for({"000001": [("2026-01-02", 10.0, 0.0)]})
+    qfq.sync_stock_adj_all(target_date="2026-01-02", db=db, bars_loader=loader)
+    db["qfq_writer_locks"].rows.append(
+        {
+            "scope": "stock",
+            "owner_id": "active-builder",
+            "expires_at": "2026-01-06T09:00:00Z",
+        }
+    )
+
+    with pytest.raises(qfq.QFQSyncError, match="writer lease is held"):
+        qfq.rollback_active_slot(scope="stock", db=db, now_provider=lambda: now)
+
+    assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "a"
+
+
+def test_reader_grace_blocks_immediate_reuse_of_old_active_slot():
+    dates = ["2026-01-02", "2026-01-05"]
+    rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]
+    db = _stock_db(dates[:1])
+    now = datetime(2026, 1, 5, 8, 0, tzinfo=timezone.utc)
+    qfq.sync_stock_adj_all(
+        target_date=dates[0],
+        db=db,
+        bars_loader=_loader_for({"000001": rows}),
+        now_provider=lambda: now,
+    )
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+
+    with pytest.raises(qfq.QFQSyncError, match="grace period"):
+        qfq.sync_stock_adj_all(
+            target_date=dates[1],
+            db=db,
+            bars_loader=_loader_for({"000001": rows}),
+            now_provider=lambda: now + timedelta(seconds=299),
+        )
+
+
+def test_xtdata_client_uses_configured_port_and_none_dividend(monkeypatch):
+    calls = []
+
+    class _XtData:
+        def connect(self, *, port):
+            calls.append(("connect", port))
+
+        def download_history_data(self, *args):
+            calls.append(("download", args))
+
+        def get_market_data(self, **kwargs):
+            calls.append(("get", kwargs))
+            return {"000001.SZ": _bars([("2026-01-02", 10.0, 0.0)])}
+
+    monkeypatch.setattr(
+        qfq,
+        "bootstrap_config",
+        SimpleNamespace(xtdata=SimpleNamespace(port=58611)),
+    )
+    client = qfq.XtDataQfqClient(_XtData())
+    result = client.load_daily_bars(
+        "000001", start_time="20260102", end_time="20260102"
+    )
+
+    assert len(result) == 1
+    assert calls[0] == ("connect", 58611)
+    assert calls[-1][1]["dividend_type"] == "none"
+    assert calls[-1][1]["fill_data"] is False
+
+
+def test_real_xtdata_stock_and_etf_action_fixtures():
+    fixture_path = Path(__file__).parent / "fixtures" / "qfq_xtdata_real_samples.json"
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    assert payload["source"].startswith("XTData")
+    for sample in payload["samples"]:
+        bars = pd.DataFrame(sample["bars"])
+        factors = qfq.compute_preclose_adj(bars, code=sample["code"])
+        merged = bars.merge(factors[["date", "adj"]], on="date")
+        event = merged.loc[merged["date"] == sample["event_date"]].iloc[0]
+        adjusted_close = float(event["close"]) * float(event["adj"])
+        assert adjusted_close == pytest.approx(
+            sample["expected_event_qfq_close"], abs=1e-12
+        )
+        assert adjusted_close == pytest.approx(
+            sample["front_reference_normalized_close"],
+            abs=sample["front_tolerance"],
+        )

--- a/freshquant/tests/test_xtdata_qfq_worker.py
+++ b/freshquant/tests/test_xtdata_qfq_worker.py
@@ -298,3 +298,72 @@ def test_build_full_passes_force_full_rebuild(monkeypatch, capsys):
     )
     assert calls[0]["force_full_rebuild"] is True
     assert '"ready": true' in capsys.readouterr().out
+
+
+def test_strict_status_reports_active_snapshot_lag():
+    marker_db = _DB(
+        dagster_pipeline_markers=[
+            {
+                "pipeline_key": "stock_postclose_ready",
+                "trade_date": "2026-01-05",
+                "status": "success",
+            }
+        ]
+    )
+    factor_db = _DB(qfq_ready=[_marker(asof="2026-01-02")])
+
+    result = qfq_worker.qfq_readiness_status(
+        scopes=["stock"], marker_db=marker_db, factor_db=factor_db
+    )
+
+    assert result["ready"] is False
+    assert result["by_scope"]["stock"]["status"] == "stale"
+
+
+def test_status_strict_returns_nonzero_when_shadow_is_not_ready(monkeypatch, capsys):
+    monkeypatch.setattr(
+        qfq_worker,
+        "qfq_readiness_status",
+        lambda **_kwargs: {
+            "ready": False,
+            "by_scope": {"stock": {"status": "missing_qfq_marker"}},
+        },
+    )
+
+    assert qfq_worker.main(["status", "--scope", "stock", "--strict"]) == 1
+    assert '"ready": false' in capsys.readouterr().out
+
+
+def test_audit_full_passes_source_loader_and_single_code(monkeypatch, capsys):
+    calls = []
+    client = type("Client", (), {"load_daily_bars": lambda *args, **kwargs: None})()
+    monkeypatch.setattr(qfq_worker, "XtDataQfqClient", lambda: client)
+    monkeypatch.setattr(
+        qfq_worker,
+        "get_qfq_marker",
+        lambda **_kwargs: _marker(),
+    )
+    monkeypatch.setattr(
+        qfq_worker,
+        "audit_qfq_slot",
+        lambda **kwargs: calls.append(kwargs) or {"ok": True},
+    )
+
+    assert (
+        qfq_worker.main(
+            [
+                "audit",
+                "--scope",
+                "stock",
+                "--mode",
+                "full",
+                "--code",
+                "000001",
+            ]
+        )
+        == 0
+    )
+    assert calls[0]["codes"] == ["000001"]
+    assert calls[0]["bars_loader"] is not None
+    assert calls[0]["source_tail_days"] is None
+    assert '"ok": true' in capsys.readouterr().out

--- a/freshquant/tests/test_xtdata_qfq_worker.py
+++ b/freshquant/tests/test_xtdata_qfq_worker.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from freshquant.market_data.xtdata import qfq_worker
+
+
+def _get(document, path):
+    value = document
+    for part in path.split("."):
+        if not isinstance(value, Mapping):
+            return None
+        value = value.get(part)
+    return value
+
+
+def _set(document, path, value):
+    target = document
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = target.setdefault(part, {})
+    target[parts[-1]] = value
+
+
+def _matches(document, query):
+    for key, expected in query.items():
+        value = _get(document, key)
+        if isinstance(expected, Mapping) and "$in" in expected:
+            if value not in expected["$in"]:
+                return False
+        elif value != expected:
+            return False
+    return True
+
+
+class _Result:
+    matched_count = 1
+
+
+class _Collection:
+    def __init__(self, rows=()):
+        self.rows = [dict(row) for row in rows]
+
+    def find_one(self, query, projection=None, sort=None):
+        rows = [row for row in self.rows if _matches(row, query)]
+        for field, direction in reversed(sort or []):
+            rows.sort(key=lambda row: _get(row, field), reverse=direction < 0)
+        if not rows:
+            return None
+        row = dict(rows[0])
+        if projection:
+            row = {key: value for key, value in row.items() if projection.get(key, 1)}
+        return row
+
+    def update_one(self, query, update, upsert=False):
+        for row in self.rows:
+            if _matches(row, query):
+                for path, value in update.get("$set", {}).items():
+                    _set(row, path, value)
+                return _Result()
+        result = _Result()
+        result.matched_count = 0
+        return result
+
+
+class _DB:
+    def __init__(self, **collections):
+        self.collections = {
+            name: _Collection(rows) for name, rows in collections.items()
+        }
+
+    def __getitem__(self, name):
+        return self.collections.setdefault(name, _Collection())
+
+
+def _marker(*, scope="stock", active="a", asof="2026-01-02", inactive_status="ready"):
+    prefix = "stock" if scope == "stock" else "etf"
+    return {
+        "scope": scope,
+        "active_slot": active,
+        "slots": {
+            "a": {
+                "collection": f"{prefix}_adj_qfq_a",
+                "snapshot_id": "snapshot-a",
+                "factor_asof": asof,
+                "status": "ready" if active == "a" else inactive_status,
+                "published_at": "2026-01-02T08:00:00Z",
+            },
+            "b": {
+                "collection": f"{prefix}_adj_qfq_b",
+                "snapshot_id": "snapshot-b",
+                "factor_asof": asof,
+                "status": "ready" if active == "b" else inactive_status,
+                "published_at": "2026-01-02T08:00:00Z",
+            },
+        },
+        "source": "xtdata_preclose",
+        "schema_version": 1,
+    }
+
+
+def test_worker_consumes_latest_success_marker_for_each_scope():
+    marker_db = _DB(
+        dagster_pipeline_markers=[
+            {
+                "pipeline_key": "stock_postclose_ready",
+                "trade_date": "2026-01-05",
+                "status": "failed",
+            },
+            {
+                "pipeline_key": "stock_postclose_ready",
+                "trade_date": "2026-01-02",
+                "status": "success",
+            },
+            {
+                "pipeline_key": "etf_postclose_ready",
+                "trade_date": "2026-01-03",
+                "status": "success",
+            },
+        ]
+    )
+    calls = []
+
+    def sync_fn(**kwargs):
+        calls.append(kwargs)
+        return {"ready": True}
+
+    result = qfq_worker.run_pending_once(
+        marker_db=marker_db,
+        factor_db=_DB(),
+        sync_fn=sync_fn,
+    )
+
+    assert [(call["scope"], call["target_date"]) for call in calls] == [
+        ("stock", "2026-01-02"),
+        ("etf", "2026-01-03"),
+    ]
+    assert result["by_scope"]["stock"]["status"] == "published"
+
+
+def test_worker_skips_scope_when_active_snapshot_is_current():
+    marker_db = _DB(
+        dagster_pipeline_markers=[
+            {
+                "pipeline_key": "stock_postclose_ready",
+                "trade_date": "2026-01-02",
+                "status": "success",
+            }
+        ]
+    )
+    factor_db = _DB(qfq_ready=[_marker()])
+
+    result = qfq_worker.run_pending_once(
+        scopes=["stock"],
+        marker_db=marker_db,
+        factor_db=factor_db,
+        sync_fn=lambda **kwargs: (_ for _ in ()).throw(AssertionError("unexpected")),
+    )
+
+    assert result["by_scope"]["stock"] == {
+        "status": "current",
+        "factor_asof": "2026-01-02",
+    }
+
+
+def test_worker_delegates_interrupted_build_recovery_to_locked_sync():
+    marker_db = _DB(
+        dagster_pipeline_markers=[
+            {
+                "pipeline_key": "stock_postclose_ready",
+                "trade_date": "2026-01-05",
+                "status": "success",
+            }
+        ]
+    )
+    factor_db = _DB(qfq_ready=[_marker(inactive_status="building")])
+    observed = []
+
+    def sync_fn(**kwargs):
+        observed.append(factor_db["qfq_ready"].rows[0]["slots"]["b"]["status"])
+        return {"ready": True}
+
+    qfq_worker.run_pending_once(
+        scopes=["stock"],
+        marker_db=marker_db,
+        factor_db=factor_db,
+        sync_fn=sync_fn,
+    )
+
+    assert observed == ["building"]
+
+
+def test_worker_delegates_interrupted_build_even_when_active_is_current():
+    marker_db = _DB(
+        dagster_pipeline_markers=[
+            {
+                "pipeline_key": "stock_postclose_ready",
+                "trade_date": "2026-01-02",
+                "status": "success",
+            }
+        ]
+    )
+    factor_db = _DB(qfq_ready=[_marker(inactive_status="building")])
+    calls = []
+
+    qfq_worker.run_pending_once(
+        scopes=["stock"],
+        marker_db=marker_db,
+        factor_db=factor_db,
+        sync_fn=lambda **kwargs: calls.append(kwargs) or {"ready": True},
+    )
+
+    assert len(calls) == 1
+
+
+def test_worker_waits_when_bfq_marker_is_missing():
+    called = []
+    result = qfq_worker.run_pending_once(
+        scopes=["stock"],
+        marker_db=_DB(),
+        factor_db=_DB(),
+        sync_fn=lambda **kwargs: called.append(kwargs),
+    )
+    assert not called
+    assert result["by_scope"]["stock"]["status"] == "waiting_for_bfq"
+
+
+def test_worker_scope_failure_does_not_block_other_scope():
+    marker_db = _DB(
+        dagster_pipeline_markers=[
+            {
+                "pipeline_key": "stock_postclose_ready",
+                "trade_date": "2026-01-05",
+                "status": "success",
+            },
+            {
+                "pipeline_key": "etf_postclose_ready",
+                "trade_date": "2026-01-05",
+                "status": "success",
+            },
+        ]
+    )
+    calls = []
+
+    def sync_fn(**kwargs):
+        calls.append(kwargs["scope"])
+        if kwargs["scope"] == "stock":
+            raise RuntimeError("stock sync failed")
+        return {"ready": True}
+
+    result = qfq_worker.run_pending_once(
+        marker_db=marker_db,
+        factor_db=_DB(),
+        sync_fn=sync_fn,
+    )
+
+    assert calls == ["stock", "etf"]
+    assert result["by_scope"]["stock"]["status"] == "error"
+    assert result["by_scope"]["etf"]["status"] == "published"
+
+
+def test_worker_once_returns_nonzero_when_any_scope_errors(monkeypatch, capsys):
+    monkeypatch.setattr(
+        qfq_worker,
+        "run_pending_once",
+        lambda **_kwargs: {
+            "by_scope": {
+                "stock": {"status": "error", "error": "sync failed"},
+                "etf": {"status": "published"},
+            }
+        },
+    )
+
+    assert qfq_worker.main(["worker", "--once"]) == 1
+    assert '"status": "error"' in capsys.readouterr().out
+
+
+def test_build_full_passes_force_full_rebuild(monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(
+        qfq_worker,
+        "sync_qfq_factors",
+        lambda **kwargs: calls.append(kwargs) or {"ready": True},
+    )
+
+    assert (
+        qfq_worker.main(
+            [
+                "build",
+                "--scope",
+                "stock",
+                "--target-date",
+                "2026-01-05",
+                "--full",
+            ]
+        )
+        == 0
+    )
+    assert calls[0]["force_full_rebuild"] is True
+    assert '"ready": true' in capsys.readouterr().out

--- a/morningglory/fqdagster/src/fqdagster/defs/assets/market_data.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/assets/market_data.py
@@ -525,6 +525,7 @@ def stock_postclose_ready_asset(
     refresh_quality_stock_universe_snapshot: dict,
     stock_day: str,
     stock_min: str,
+    stock_xdxr: str,
 ) -> dict:
     trade_date = (
         str(refresh_quality_stock_universe_snapshot.get("trade_date") or "")
@@ -538,6 +539,7 @@ def stock_postclose_ready_asset(
             refresh_quality_stock_universe_snapshot.get("source_version") or ""
         ).strip(),
         "integrity_audited_dates": list(integrity.get("audited_dates") or []),
+        "stock_xdxr_completed_at": stock_xdxr,
     }
     upsert_postclose_marker(
         "stock_postclose_ready",

--- a/morningglory/fqdagster/src/fqdagster/defs/schedules/market_data.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/schedules/market_data.py
@@ -1,7 +1,8 @@
 """Market data schedules using asset-based approach.
 
-This module defines schedules that trigger asset materialization.
-Each schedule targets the root asset (list assets), and dependent assets are automatically triggered.
+This module defines schedules that trigger asset materialization. Stock, ETF,
+and Index jobs use explicit whitelists so unrelated downstream assets cannot
+join a market-data run.
 """
 
 from typing import cast
@@ -14,29 +15,52 @@ from dagster import (
 )
 from fqdagster.defs.assets.market_data import (
     bond_list,
+    etf_adj,
+    etf_day,
     etf_list,
+    etf_min,
+    etf_postclose_ready_asset,
+    etf_xdxr,
     future_list,
+    index_day,
     index_list,
+    index_min,
+    stock_block,
+    stock_day,
     stock_list,
+    stock_min,
+    stock_postclose_ready_asset,
+    stock_xdxr,
+)
+from fqdagster.defs.assets.postclose_ready import (
+    refresh_quality_stock_universe_snapshot,
 )
 
 from freshquant.config import cfg
 
 TIME_ZONE = cast(str, getattr(cfg, "TIME_ZONE", "Asia/Shanghai"))
+MONGO_WRITER_TAG = {"freshquant/mongo_writer": "quantaxis_market_data"}
+BOUNDED_MARKET_JOB_TAGS = {
+    **MONGO_WRITER_TAG,
+    "dagster/max_concurrent_runs": "1",
+    "dagster/max_retries": "2",
+    "dagster/max_runtime": "28800",
+}
 
-# Define asset jobs that will materialize the root assets and their dependencies
+# Define market-data asset jobs.
 stock_data_job = define_asset_job(
     name="stock_data_job",
-    description="Materialize stock data assets starting from stock_list",
-    selection=(
-        AssetSelection.assets(stock_list).downstream()
-        - AssetSelection.groups("cjsd_data")
+    description="Materialize the explicit Stock market-data asset whitelist",
+    selection=AssetSelection.assets(
+        stock_list,
+        stock_block,
+        stock_day,
+        stock_min,
+        stock_xdxr,
+        refresh_quality_stock_universe_snapshot,
+        stock_postclose_ready_asset,
     ),
-    tags={
-        "dagster/max_concurrent_runs": "1",
-        "dagster/max_retries": "2",
-        "dagster/max_runtime": "28800",
-    },
+    tags=BOUNDED_MARKET_JOB_TAGS,
 )
 
 future_data_job = define_asset_job(
@@ -48,13 +72,16 @@ future_data_job = define_asset_job(
 
 etf_data_job = define_asset_job(
     name="etf_data_job",
-    description="Materialize ETF data assets starting from etf_list",
-    selection=AssetSelection.assets(etf_list).downstream(),
-    tags={
-        "dagster/max_concurrent_runs": "1",
-        "dagster/max_retries": "2",
-        "dagster/max_runtime": "28800",
-    },
+    description="Materialize the explicit ETF market-data asset whitelist",
+    selection=AssetSelection.assets(
+        etf_list,
+        etf_day,
+        etf_min,
+        etf_xdxr,
+        etf_adj,
+        etf_postclose_ready_asset,
+    ),
+    tags=BOUNDED_MARKET_JOB_TAGS,
 )
 
 bond_data_job = define_asset_job(
@@ -66,9 +93,9 @@ bond_data_job = define_asset_job(
 
 index_data_job = define_asset_job(
     name="index_data_job",
-    description="Materialize index data assets starting from index_list",
-    selection=AssetSelection.assets(index_list).downstream(),
-    tags={"dagster/max_concurrent_runs": "1"},
+    description="Materialize the explicit BFQ Index market-data asset whitelist",
+    selection=AssetSelection.assets(index_list, index_day, index_min),
+    tags=BOUNDED_MARKET_JOB_TAGS,
 )
 
 # Schedule definitions

--- a/morningglory/fqdagsterconfig/dagster.yaml
+++ b/morningglory/fqdagsterconfig/dagster.yaml
@@ -17,6 +17,9 @@ run_coordinator:
     tag_concurrency_limits:
       - key: "dagster/backfill"
         limit: 10
+      - key: "freshquant/mongo_writer"
+        value: "quantaxis_market_data"
+        limit: 1
 compute_logs:
   module: dagster.core.storage.local_compute_log_manager
   class: LocalComputeLogManager

--- a/script/check_freshquant_runtime_post_deploy.ps1
+++ b/script/check_freshquant_runtime_post_deploy.ps1
@@ -989,6 +989,58 @@ function Get-ProcessChecks {
     }
 }
 
+function Get-QfqReadinessChecks {
+    param([string[]]$DeploymentSurfaces)
+
+    $targeted = @($DeploymentSurfaces) -contains 'market_data'
+    if (-not $targeted) {
+        return @{
+            Checks = @()
+            Warnings = @()
+            Failures = @()
+        }
+    }
+
+    $usingSnapshots = (
+        -not [string]::IsNullOrWhiteSpace($DockerSnapshotPath) -or
+        -not [string]::IsNullOrWhiteSpace($ServiceSnapshotPath) -or
+        -not [string]::IsNullOrWhiteSpace($ProcessSnapshotPath) -or
+        -not [string]::IsNullOrWhiteSpace($SupervisorSnapshotPath)
+    )
+    if ($usingSnapshots) {
+        return @{
+            Checks = @([pscustomobject]@{
+                id = 'xtdata_qfq_readiness'
+                required = $true
+                status = 'skipped_for_test_snapshots'
+                passed = $true
+                output = $null
+            })
+            Warnings = @('QFQ readiness command skipped because runtime snapshots were injected.')
+            Failures = @()
+        }
+    }
+
+    $commandResult = Invoke-PythonCommand -Arguments @('-m', 'freshquant.market_data.xtdata.qfq_worker', 'status', '--strict')
+    $output = (($commandResult.output | Out-String).Trim())
+    $passed = ($commandResult.available -and $commandResult.success)
+    $failures = @()
+    if (-not $passed) {
+        $failures = @("QFQ readiness check failed: $output")
+    }
+    return @{
+        Checks = @([pscustomobject]@{
+            id = 'xtdata_qfq_readiness'
+            required = $true
+            status = if ($passed) { 'ready' } else { 'not_ready' }
+            passed = $passed
+            output = $output
+        })
+        Warnings = @()
+        Failures = $failures
+    }
+}
+
 function Get-SupervisorConfigChecks {
     param(
         [Parameter(Mandatory = $true)]$SupervisorConfigState,
@@ -1091,6 +1143,7 @@ $result = [ordered]@{
     docker_checks = @()
     service_checks = @()
     process_checks = @()
+    readiness_checks = @()
     supervisor_config_checks = @()
     warnings = @()
     failures = @()
@@ -1134,14 +1187,16 @@ foreach ($surface in $deploymentSurfaces) {
 $dockerChecks = Get-DockerChecks -CurrentEntries $dockerBaseline -RequiredContainerNames @($requiredContainerNames)
 $serviceChecks = Get-ServiceChecks -CurrentEntries $serviceBaseline -Baseline $baseline -DeploymentSurfaces $deploymentSurfaces
 $processChecks = Get-ProcessChecks -CurrentEntries $processBaseline -Baseline $baseline -DeploymentSurfaces $deploymentSurfaces
+$readinessChecks = Get-QfqReadinessChecks -DeploymentSurfaces $deploymentSurfaces
 $supervisorConfigChecks = Get-SupervisorConfigChecks -SupervisorConfigState $supervisorConfigState -DeploymentSurfaces $deploymentSurfaces
 
 $result.docker_checks = $dockerChecks.Checks
 $result.service_checks = $serviceChecks.Checks
 $result.process_checks = $processChecks.Checks
+$result.readiness_checks = $readinessChecks.Checks
 $result.supervisor_config_checks = $supervisorConfigChecks.Checks
-$result.warnings = @($serviceChecks.Warnings + $processChecks.Warnings + $supervisorConfigChecks.Warnings)
-$result.failures = @($dockerChecks.Failures + $serviceChecks.Failures + $processChecks.Failures + $supervisorConfigChecks.Failures)
+$result.warnings = @($serviceChecks.Warnings + $processChecks.Warnings + $readinessChecks.Warnings + $supervisorConfigChecks.Warnings)
+$result.failures = @($dockerChecks.Failures + $serviceChecks.Failures + $processChecks.Failures + $readinessChecks.Failures + $supervisorConfigChecks.Failures)
 $result.passed = ($result.failures.Count -eq 0)
 
 $verifyJson = $result | ConvertTo-Json -Depth 12

--- a/script/check_freshquant_runtime_post_deploy.ps1
+++ b/script/check_freshquant_runtime_post_deploy.ps1
@@ -254,6 +254,12 @@ $processSpecs = @(
         SupervisorProgram = 'fqnext_xtdata_adj_refresh_worker'
     },
     [pscustomobject]@{
+        Id = 'xtdata_qfq_worker'
+        Surface = 'market_data'
+        Pattern = 'python -m freshquant.market_data.xtdata.qfq_worker worker'
+        SupervisorProgram = 'fqnext_xtdata_qfq_worker'
+    },
+    [pscustomobject]@{
         Id = 'xt_account_sync_worker'
         Surfaces = @('position_management', 'order_management')
         Pattern = 'python -m freshquant.xt_account_sync.worker'

--- a/script/fqnext_host_runtime.py
+++ b/script/fqnext_host_runtime.py
@@ -41,6 +41,7 @@ SURFACE_PROGRAMS = {
         "fqnext_realtime_xtdata_producer",
         "fqnext_realtime_xtdata_consumer",
         "fqnext_xtdata_adj_refresh_worker",
+        "fqnext_xtdata_qfq_worker",
     ],
     "guardian": ["fqnext_guardian_event"],
     "position_management": ["fqnext_xt_account_sync_worker"],

--- a/script/fqnext_supervisor_config.py
+++ b/script/fqnext_supervisor_config.py
@@ -26,6 +26,7 @@ PROGRAM_NAMES = (
     "fqnext_tpsl_worker",
     "fqnext_xtquant_broker",
     "fqnext_xtdata_adj_refresh_worker",
+    "fqnext_xtdata_qfq_worker",
 )
 
 
@@ -155,8 +156,17 @@ autostart=true
 autorestart=true
 startsecs=5
 
+[program:fqnext_xtdata_qfq_worker]
+command={python_executable} -m freshquant.market_data.xtdata.qfq_worker worker
+directory={root}
+stdout_logfile=D:/fqdata/log/fqnext_xtdata_qfq_worker.log
+stderr_logfile=D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log
+autostart=true
+autorestart=true
+startsecs=5
+
 [group:fqnext_reference_data]
-programs=fqnext_xtdata_adj_refresh_worker
+programs=fqnext_xtdata_adj_refresh_worker,fqnext_xtdata_qfq_worker
 
 [group:fqnext_trading_chain]
 programs=fqnext_realtime_xtdata_producer,fqnext_realtime_xtdata_consumer,fqnext_guardian_event,fqnext_xt_account_sync_worker,fqnext_xt_auto_repay_worker,fqnext_tpsl_worker,fqnext_xtquant_broker

--- a/script/freshquant_deploy_plan.py
+++ b/script/freshquant_deploy_plan.py
@@ -64,6 +64,7 @@ HOST_SURFACE_PROGRAMS = {
         "fqnext_realtime_xtdata_producer",
         "fqnext_realtime_xtdata_consumer",
         "fqnext_xtdata_adj_refresh_worker",
+        "fqnext_xtdata_qfq_worker",
     ],
     "guardian": ["fqnext_guardian_event"],
     "position_management": ["fqnext_xt_account_sync_worker"],

--- a/script/freshquant_deploy_plan.py
+++ b/script/freshquant_deploy_plan.py
@@ -161,6 +161,31 @@ PATH_RULES: tuple[PathRule, ...] = (
         surfaces=("api",),
     ),
     ExactRule(
+        label="index-data-api",
+        exact_path="freshquant/data/index.py",
+        surfaces=("api",),
+    ),
+    ExactRule(
+        label="index-quote-api",
+        exact_path="freshquant/quote/index.py",
+        surfaces=("api",),
+    ),
+    ExactRule(
+        label="instrument-routing-api",
+        exact_path="freshquant/instrument/general.py",
+        surfaces=("api",),
+    ),
+    ExactRule(
+        label="chanlun-api",
+        exact_path="freshquant/chanlun_service.py",
+        surfaces=("api",),
+    ),
+    ExactRule(
+        label="chanlun-structure-api",
+        exact_path="freshquant/chanlun_structure_service.py",
+        surfaces=("api",),
+    ),
+    ExactRule(
         label="freshquant-package-root",
         exact_path="freshquant/__init__.py",
         surfaces=FRESHQUANT_SHARED_RUNTIME_SURFACES,


### PR DESCRIPTION
## 背景

Issue #467 要解决 Stock / ETF 前复权因子来源不一致、旧 XDXR 链存在缺因子与静默回退，以及真正 Index 被误走复权路径的问题。

历史 Draft PR #470 尝试一次完成数据构建、reader 激活和消费者迁移，变更面过大，且缺少完整的 A/B 发布、快照边界与回切协议。本 PR 从最新 `main` 重做双 PR 方案的 `Prepare / Prove` 阶段：先建立可审计、可回切的 XTData `preClose` shadow 数据链，再由 PR2 激活 Stock / ETF 线上 reader。

## 本 PR 实现

- 以 XTData BFQ 日线 `preClose` 逆向递推 Stock / ETF QFQ 因子。
- 建立固定 A/B shadow 集合：`stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`。
- 建立每 scope 单文档双槽 `qfq_ready` marker：writer 只写 inactive slot，审计通过后用旧 `active_slot + snapshot_id` 做 CAS 发布；rollback 同样使用 CAS；旧 active slot 经过 reader grace 后才能复用。
- 建立 `qfq_writer_locks` heartbeat lease：后台周期续租覆盖长时间 XTData / Mongo 操作；最终续租、owner 校验与 marker insert/CAS 在同一互斥发布区；heartbeat 失败时不创建 marker、不切 active。
- 支持 bootstrap、每日 inactive-slot 日更、公司行为整 code rebuild、`build --full`、结构/尾部/全量 source audit、单 code audit、status 和 rollback。
- `build --full` 清理 universe 外 stale code；公共 API 拒绝 `force_full_rebuild=True` 与显式 `codes` 同时使用。
- 新增 Windows `fqnext_xtdata_qfq_worker`，消费 Stock / ETF Dagster success marker，并接入 Supervisor、严格 readiness 和 post-deploy verify。
- intraday override 保存 shadow `base_snapshot_id/base_factor_asof/anchor_scale`，同时保留旧 reader 使用的 `legacy_anchor_scale`。
- 真正 Index 的日线、分钟线、实时合并固定 BFQ；修复 `000001` Index 市场解析和周线 MultiIndex datetime。
- 同步部署计划与 `docs/current/**`。

## PR1 Shadow 边界

- Stock / ETF 在线 reader **仍读取** `quantaxis.stock_adj` / `quantaxis.etf_adj`。
- 现有 `stock_xdxr`、`etf_xdxr -> etf_adj` writer **继续运行**。
- `qfq_ready.active_slot` 只表示 shadow 管道内部已发布槽位，不代表线上 reader 已切换。
- 本 PR 不引入 Stock / ETF 严格 reader、503 合同、缓存版本绑定或消费者迁移。
- 真正 Index 的 BFQ 修复会随 PR1 部署生效。

## 关联

- Refs #467
- 历史 Draft PR：#470
- 本 PR 为 PR1/2；Issue 等 PR2 完成后再关闭。

## 验证

完整本地 preflight 基于 `8fc45509`，base 为 `github/main@c969a7f2`；测试收集隔离修复 HEAD 为 `0d883332`：

- QFQ、worker、Index BFQ、override、deploy/post-deploy 聚焦套件：`117 passed`
- 完整 FreshQuant 测试：`1492 passed in 106.77s`
- Playwright browser smoke：`7 passed`
- Frontend unit：`512 passed`
- Frontend production build：通过
- `docs-current-guard`、Black、Mypy、isort、全部 pre-commit hooks、`git diff --check`：通过
- CI compatibility：固定 `uv==0.11.29`，兼容锁文件中的 legacy `interval==1.0.0` source archive
- [x] GitHub CI run `30700316274` 全绿
- [x] Review discussions：当前 `0` 个未解决

## 部署影响

受影响运行面：

- `freshquant/market_data/**`：部署 market-data surface，加载新 Supervisor 配置并重启 reference-data worker。
- `morningglory/fqdagster/**` / config：重部署 Dagster webserver / daemon。
- Index data / quote / Chanlun 路径：重建并部署 API Server。

`fqnext_xtdata_qfq_worker` 配置为 `autostart=true`。若已有成功的 post-close marker 且尚无 `qfq_ready`，启动后会开始全市场 bootstrap，因此部署前需确认 XTData、Mongo、磁盘空间和盘后窗口。

## PR2 前置 Gate

PR2 仅在 PR1 合并、正式部署并取得以下证据后开始：

- [ ] Stock / ETF 全市场 slot A bootstrap 审计通过
- [ ] Mongo A -> B copy 后双槽行数、唯一键和抽样内容一致
- [ ] 至少一个真实交易日 daily shadow 成功
- [ ] 普通增量与公司行为整 code rebuild 均有运行证据
- [ ] 分层样本与 XTData `dividend_type=front` 对账通过
- [ ] 运行时长、写入量和 Mongo 峰值空间满足 post-close SLA
- [ ] marker CAS 失败保持旧 active，rollback drill 成功
- [ ] `sh000001` / `sz399001` API 返回 200 且保持 BFQ
- [ ] 根据全市场容量确定自动 `build --full` 频率

PR2 再负责 shared strict reader、503 合同、override rebind、Redis/常驻窗口版本绑定、全部消费者与 `sunflower/QUANTAXIS/**` 旁路迁移；strict-reader health 通过后才停止旧 writer。

## 回滚

- shadow 异常时停止 QFQ worker，并用 CAS 将 marker 回切旧槽位；现有 Stock / ETF reader 与旧集合不受影响。
- Index BFQ 属于本 PR 的线上变更，发生回归时按正式部署版本回退 API。
