### PR TITLE
fix: unblock XTData QFQ bootstrap

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -69,6 +69,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - `quantaxis.qfq_ready` 对每个 scope 使用一个原子双槽 marker；构建 inactive slot 期间 active slot 保持只读，inactive slot 审计成功后才切换。
 - `quantaxis.qfq_writer_locks` 对每个 scope 只允许一个带过期时间并由后台线程持续续期的 writer lease；单次 XTData 请求或 Mongo `$out` 阻塞时仍续租，发布前重新核对 owner。中断的 `building` 仅由下一位 lease owner 恢复，人工 build / rollback 不与 Supervisor worker 并发写。
 - 首次 bootstrap 先构建并审计 A，再复制和审计 B，之后发布双槽 marker；日更只对 inactive slot 写入。
+- XTData field-table 以日期列为交易日，epoch 回退按 Asia/Shanghai 还原；因子先在完整 XTData 实际日期轴递推，再投影到有效 BFQ coverage。BFQ 中 `vol` 与 `amount` 同时等于 QASU 浮点哨兵的占位行不进入 coverage，运行结果和 audit 会记录排除计数与原因；任何其余有效 BFQ 日期缺少 XTData source 时仍 fail closed。
 - 当前 Stock / ETF 在线 reader 和旧 `stock_xdxr`、`etf_xdxr -> etf_adj` writer 均未切换；A/B 发布不会改变现有 Kline 或策略读取结果。
 - 真实 Index 走 BFQ 日线/分钟线和 `index_realtime`，不读取 ETF/Stock 因子，也不进入 QFQ shadow scope。
 

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -62,6 +62,7 @@
 - worker 从 `freshquant.dagster_pipeline_markers` 读取 `pipeline_key=stock_postclose_ready` / `etf_postclose_ready` 的最新成功文档，再把目标交易日传给 XTData QFQ writer。
 - `stock_postclose_ready` 在股票日线、分钟线、质量股票池快照和旧 `stock_xdxr` writer 完成后发布；`etf_postclose_ready` 在 ETF 日线/分钟线及旧 `etf_xdxr -> etf_adj` writer 完成后发布。
 - shadow 快照与发布 marker 写在 QuantAxis Mongo：数据集合为 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`，marker 集合为 `qfq_ready`；`qfq_writer_locks` 以 scope 唯一后台 heartbeat lease 强制 worker、人工 build 与 rollback 串行，单次 XTData 下载或 Mongo `$out` 阻塞期间也会持续续租，发布前再次核对 owner。
+- QFQ coverage 排除 `vol/amount` 同时命中 QASU 浮点哨兵的 BFQ 占位行；XTData 多出的真实交易日仍参与完整递推，之后才投影到有效 BFQ 日期。bootstrap、update 与 audit JSON 的 `coverage` 字段记录 sentinel 和无有效历史标的计数。
 - 当前 Stock / ETF 在线 reader 继续读取 `stock_adj` / `etf_adj`，旧 writer 继续运行；QFQ worker 的发布只更新 shadow 链。
 - 真实 Index 当前固定读取 BFQ 日线/分钟线与 `index_realtime`，不读取 `stock_adj`、`etf_adj` 或 QFQ shadow 集合。
 - 运维 CLI 入口为 `python -m freshquant.market_data.xtdata.qfq_worker`，子命令为 `worker`、`build`、`audit`、`status`、`rollback`；`status --strict` 检查 active 截止日是否追平盘后 ready marker，`audit --mode structure|tail|full` 分别执行结构、近期 XTData 递推和全历史 XTData 递推审计。

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -697,6 +697,7 @@ Get-Content D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log -Tail 200
 - XTData 连接或历史下载失败时，先恢复 MiniQMT / XTData 端口，再重新执行 `worker --once`；worker 会把中断的 inactive `building` 状态恢复为可重试的 `failed`。
 - 返回 `writer lease is held` 时，先确认 Supervisor worker 或人工 build / rollback 是否仍在运行；正常 lease 会持续续期并在命令结束时释放，崩溃遗留 lease 到期后由下一轮原子接管，不要并发启动第二个 writer。
 - `audit --mode structure` 只确认 Mongo 结构；递推或 XTData source 对账必须用 `--mode tail|full`。审计失败时保留 active slot，修复源数据或日期轴后用 `build --scope <stock|etf> --target-date YYYY-MM-DD` 重建 inactive slot；不要手工修改 `active_slot` 或在 active 集合上原地修补。
+- `coverage.sentinel_rows_excluded` / `codes_with_sentinel_rows` 表示 BFQ 中精确 QASU 浮点占位行已被排除，`skipped[].reason=sentinel_only_bfq_history` 表示该标的没有可交易 BFQ 历史；这不等同于允许任意 XTData 空结果。只要存在非占位 BFQ 日期而 XTData 缺源，full/tail audit 仍返回 `QFQ_DATA_NOT_READY`。
 - 怀疑 XTData 修订发生在默认 60 个交易日回看窗口之前时，使用同一 active 截止日执行 `build --scope <stock|etf> --target-date YYYY-MM-DD --full`；该命令重算整个 inactive scope，且不接受早于 active `factor_asof` 的日期。
 - 回切前先确认另一槽为 `ready` 并单独执行 `audit --slot <a|b>`，然后使用 `rollback --scope <stock|etf>`；回切只更新原子 marker。
 - 页面或策略结果未变化是当前边界：Stock / ETF 在线 reader 仍读取 `stock_adj` / `etf_adj`，A/B 集合是 shadow 数据。真实 Index 则固定使用 BFQ，不读取 ETF 因子。

--- a/freshquant/market_data/xtdata/qfq.py
+++ b/freshquant/market_data/xtdata/qfq.py
@@ -46,6 +46,8 @@ WRITER_LOCK_COLLECTION = "qfq_writer_locks"
 DEFAULT_TAIL_AUDIT_DAYS = 60
 DEFAULT_READER_GRACE_SECONDS = 300
 DEFAULT_WRITER_LEASE_SECONDS = 3600
+XTDATA_TRADING_TIMEZONE = timezone(timedelta(hours=8))
+BFQ_SENTINEL_VALUE = 5.877471754e-39
 ETF_OPEN_FUND_HINTS = (
     "开放式",
     "联接",
@@ -112,6 +114,32 @@ def _date_key(value: Any) -> str | None:
     return parsed.strftime("%Y-%m-%d")
 
 
+def _xtdata_date_key(value: Any) -> str | None:
+    if isinstance(value, (int, float, np.integer, np.floating)) and not isinstance(
+        value, (bool, np.bool_)
+    ):
+        number = float(value)
+        if math.isfinite(number):
+            try:
+                if number > 10_000_000_000:
+                    return (
+                        datetime.fromtimestamp(
+                            number / 1000, tz=XTDATA_TRADING_TIMEZONE
+                        )
+                        .date()
+                        .isoformat()
+                    )
+                if number > 1_000_000_000:
+                    return (
+                        datetime.fromtimestamp(number, tz=XTDATA_TRADING_TIMEZONE)
+                        .date()
+                        .isoformat()
+                    )
+            except (OSError, OverflowError, ValueError):
+                return None
+    return _date_key(value)
+
+
 def _xt_date_arg(value: Any) -> str:
     """Format a BFQ boundary in the date form accepted by XTData."""
 
@@ -172,6 +200,20 @@ def _row_key(frame: pd.DataFrame, code: str | None) -> Any:
     return frame.index[0] if len(frame.index) == 1 else None
 
 
+def _field_column_date(value: Any) -> str | None:
+    if isinstance(value, (date, datetime)):
+        return _date_key(value)
+    text = str(value).strip()
+    if (len(text) == 8 and text.isdigit()) or (
+        len(text) == 10
+        and text[4] == "-"
+        and text[7] == "-"
+        and text.replace("-", "").isdigit()
+    ):
+        return _date_key(text)
+    return None
+
+
 def _field_table_to_rows(
     payload: Mapping[str, Any], code: str | None
 ) -> pd.DataFrame | None:
@@ -191,16 +233,24 @@ def _field_table_to_rows(
         return None
 
     # ``get_market_data`` returns field -> DataFrame(index=code, columns=time).
-    sample = next(
-        (value for value in fields.values() if isinstance(value, pd.DataFrame)), None
-    )
-    if sample is not None and not sample.empty:
+    tables = [value for value in fields.values() if isinstance(value, pd.DataFrame)]
+    sample = next((value for value in tables if not value.empty), None)
+    if (
+        tables
+        and sample is None
+        and all(isinstance(value, pd.DataFrame) for value in fields.values())
+    ):
+        return pd.DataFrame()
+    if sample is not None:
         key = _row_key(sample, code)
         if key is not None:
             columns = list(sample.columns)
             rows: list[dict[str, Any]] = []
             for column in columns:
-                row: dict[str, Any] = {"time": column}
+                column_date = _field_column_date(column)
+                row: dict[str, Any] = (
+                    {"date": column_date} if column_date else {"time": column}
+                )
                 for field_name, value in fields.items():
                     if isinstance(value, pd.DataFrame) and key in value.index:
                         row[field_name] = value.loc[key].get(column)
@@ -292,7 +342,7 @@ def normalize_xtdata_bars(payload: Any, *, code: str | None = None) -> pd.DataFr
     if "close" not in frame.columns or "preClose" not in frame.columns:
         raise QFQSyncError(f"XTData daily bars missing close/preClose for code={code}")
     source_dates = frame["date"] if "date" in frame.columns else frame["time"]
-    frame["date"] = [_date_key(value) or "" for value in source_dates]
+    frame["date"] = [_xtdata_date_key(value) or "" for value in source_dates]
     frame["close"] = pd.to_numeric(frame["close"], errors="coerce")
     frame["preClose"] = pd.to_numeric(frame["preClose"], errors="coerce")
     frame = frame.loc[frame["date"].astype(bool)].copy()
@@ -442,23 +492,47 @@ def load_factor_universe(
     }
 
 
-def load_bfq_dates(*, kind: str, code: str, db=DBQuantAxis) -> list[str]:
-    """Return the actual BFQ trading-date axis for one included instrument."""
+def _is_bfq_sentinel_row(row: Mapping[str, Any]) -> bool:
+    volume = row.get("vol", row.get("volume"))
+    amount = row.get("amount")
+    if volume is None or amount is None:
+        return False
+    try:
+        values = (float(volume), float(amount))
+    except (TypeError, ValueError):
+        return False
+    return all(
+        math.isfinite(value)
+        and math.isclose(value, BFQ_SENTINEL_VALUE, rel_tol=1e-9, abs_tol=0.0)
+        for value in values
+    )
 
+
+def _load_bfq_coverage(*, kind: str, code: str, db=DBQuantAxis) -> dict[str, Any]:
     if kind not in BFQ_COLLECTIONS:
         raise ValueError(f"unsupported BFQ kind: {kind}")
     code6 = normalize_code(code)
     collection = db[BFQ_COLLECTIONS[kind]]
     query = {"code": code6}
-    projection = {"_id": 0, "date": 1}
+    projection = {
+        "_id": 0,
+        "date": 1,
+        "vol": 1,
+        "volume": 1,
+        "amount": 1,
+    }
     try:
         cursor = collection.find(query, projection)
     except TypeError:
         cursor = collection.find(query)
     dates: list[str] = []
+    sentinel_dates: list[str] = []
     invalid: list[Any] = []
     for row in cursor:
         value = row.get("date") if isinstance(row, Mapping) else None
+        if isinstance(row, Mapping) and _is_bfq_sentinel_row(row):
+            sentinel_dates.append(_date_key(value) or str(value))
+            continue
         key = _date_key(value)
         if key is None:
             invalid.append(value)
@@ -469,7 +543,56 @@ def load_bfq_dates(*, kind: str, code: str, db=DBQuantAxis) -> list[str]:
             f"{kind} BFQ history contains invalid dates for code={code6}",
             stats={"kind": kind, "code": code6, "invalid_dates": invalid[:20]},
         )
-    return sorted(set(dates))
+    return {
+        "dates": sorted(set(dates)),
+        "sentinel_rows": len(sentinel_dates),
+        "sentinel_dates": sorted(set(sentinel_dates))[:20],
+    }
+
+
+def load_bfq_dates(*, kind: str, code: str, db=DBQuantAxis) -> list[str]:
+    """Return valid BFQ trading dates, excluding explicit QASU filler rows."""
+
+    return _load_bfq_coverage(kind=kind, code=code, db=db)["dates"]
+
+
+def _new_bfq_coverage_summary() -> dict[str, Any]:
+    return {
+        "sentinel_rows_excluded": 0,
+        "codes_with_sentinel_rows": 0,
+        "skipped_codes": 0,
+        "skipped": [],
+    }
+
+
+def _select_bfq_dates(
+    *,
+    code: str,
+    coverage: Mapping[str, Any],
+    target_date: str | None,
+    summary: dict[str, Any],
+) -> list[str]:
+    sentinel_rows = int(coverage.get("sentinel_rows") or 0)
+    if sentinel_rows:
+        summary["sentinel_rows_excluded"] += sentinel_rows
+        summary["codes_with_sentinel_rows"] += 1
+    dates = list(coverage.get("dates") or ())
+    selected = [date for date in dates if not target_date or date <= target_date]
+    if selected:
+        return selected
+    if sentinel_rows and not dates:
+        reason = "sentinel_only_bfq_history"
+    elif dates and target_date:
+        reason = "no_bfq_history_by_target"
+    else:
+        reason = "no_bfq_history"
+    summary["skipped_codes"] += 1
+    if len(summary["skipped"]) < 100:
+        item: dict[str, Any] = {"code": normalize_code(code), "reason": reason}
+        if sentinel_rows:
+            item["sentinel_rows"] = sentinel_rows
+        summary["skipped"].append(item)
+    return []
 
 
 def _bfq_download_bounds(
@@ -518,6 +641,7 @@ def audit_factor_snapshot(
     terminal_not_one: list[str] = []
     recurrence_errors: list[tuple[str, str]] = []
     missing_dates: list[tuple[str, str]] = []
+    source_missing_dates: list[tuple[str, str]] = []
     extra_dates: list[tuple[str, str]] = []
     for code in sorted({normalize_code(c) for c in (included_codes or by_code)}):
         code_rows = by_code.get(code, [])
@@ -562,33 +686,32 @@ def audit_factor_snapshot(
         if bars_payload is not None and normalized:
             bars = normalize_xtdata_bars(bars_payload, code=code)
             factors = {date: factor for date, factor in normalized}
-            bar_dates = set(bars["date"])
+            source_rows = compute_preclose_adj(bars, code=code)
+            source_factors = dict(
+                zip(source_rows["date"], source_rows["adj"], strict=True)
+            )
             if require_exact_dates:
-                missing_dates.extend(
-                    (code, date) for date in sorted(bar_dates - set(factors))
+                source_missing_dates.extend(
+                    (code, date) for date in sorted(set(factors) - set(source_factors))
                 )
-                extra_dates.extend(
-                    (code, date) for date in sorted(set(factors) - bar_dates)
-                )
-            for index in range(len(bars) - 1):
-                date = str(bars.iloc[index]["date"])
-                next_date = str(bars.iloc[index + 1]["date"])
-                if date not in factors or next_date not in factors:
+            for factor_date, factor in factors.items():
+                source_factor = source_factors.get(factor_date)
+                if source_factor is None:
                     continue
-                expected = factors[next_date] * (
-                    float(bars.iloc[index + 1]["preClose"])
-                    / float(bars.iloc[index]["close"])
-                )
                 if not math.isclose(
-                    factors[date], expected, rel_tol=rel_tol, abs_tol=1e-12
+                    factor,
+                    float(source_factor),
+                    rel_tol=rel_tol,
+                    abs_tol=1e-12,
                 ):
-                    recurrence_errors.append((code, date))
+                    recurrence_errors.append((code, factor_date))
     return {
         "codes": len(set(by_code) | set(expected_map)),
         "rows": len(rows),
-        "missing": len(missing_codes) + len(missing_dates),
+        "missing": len(missing_codes) + len(missing_dates) + len(source_missing_dates),
         "missing_codes": missing_codes,
         "missing_dates": missing_dates,
+        "source_missing_dates": source_missing_dates,
         "extra": len(extra_dates),
         "extra_dates": extra_dates,
         "invalid": invalid,
@@ -598,6 +721,7 @@ def audit_factor_snapshot(
         "ok": (
             not missing_codes
             and not missing_dates
+            and not source_missing_dates
             and not extra_dates
             and invalid == 0
             and duplicates == 0
@@ -1179,7 +1303,12 @@ def _full_rebuild_code(
 ) -> dict[str, Any]:
     load_start, load_end, expected = _bfq_download_bounds(expected_dates)
     bars = _call_loader(loader, code, load_start, load_end)
-    rows = compute_preclose_adj(bars, code=code).to_dict(orient="records")
+    expected_set = set(expected)
+    rows = [
+        row
+        for row in compute_preclose_adj(bars, code=code).to_dict(orient="records")
+        if str(row["date"])[:10] in expected_set
+    ]
     audit = _audit_code_rows(code=code, rows=rows, expected_dates=expected, bars=bars)
     if not audit["ok"]:
         raise QFQSyncError(
@@ -1233,7 +1362,12 @@ def _reconcile_code(
         _xt_date_arg(tail_dates[0]),
         _xt_date_arg(tail_dates[-1]),
     )
-    tail_rows = compute_preclose_adj(bars, code=code).to_dict(orient="records")
+    tail_date_set = set(tail_dates)
+    tail_rows = [
+        row
+        for row in compute_preclose_adj(bars, code=code).to_dict(orient="records")
+        if str(row["date"])[:10] in tail_date_set
+    ]
     tail_audit = _audit_code_rows(
         code=code, rows=tail_rows, expected_dates=tail_dates, bars=bars
     )
@@ -1353,12 +1487,17 @@ def audit_qfq_slot(
     failures: list[dict[str, Any]] = []
     rows = 0
     checked_codes = 0
+    coverage_summary = _new_bfq_coverage_summary()
     for code in universe["codes"]:
         if progress_callback:
             progress_callback()
-        expected = load_bfq_dates(kind=scope, code=code, db=db)
-        if factor_asof:
-            expected = [date for date in expected if date <= factor_asof]
+        coverage = _load_bfq_coverage(kind=scope, code=code, db=db)
+        expected = _select_bfq_dates(
+            code=code,
+            coverage=coverage,
+            target_date=factor_asof,
+            summary=coverage_summary,
+        )
         if not expected:
             continue
         code_rows = _load_existing_factor_rows(
@@ -1400,6 +1539,7 @@ def audit_qfq_slot(
         ),
         "codes": checked_codes,
         "rows": rows,
+        "coverage": coverage_summary,
         "failed": len(failures),
         "failures": failures[:100],
         "ok": not failures and checked_codes > 0,
@@ -1425,14 +1565,17 @@ def _bootstrap_scope(
     _ensure_factor_indexes(collection_a)
     included: list[str] = []
     rows_written = 0
+    coverage_summary = _new_bfq_coverage_summary()
     for code in universe["codes"]:
         if progress_callback:
             progress_callback()
-        expected = [
-            date
-            for date in load_bfq_dates(kind=scope, code=code, db=db)
-            if date <= target_date
-        ]
+        coverage = _load_bfq_coverage(kind=scope, code=code, db=db)
+        expected = _select_bfq_dates(
+            code=code,
+            coverage=coverage,
+            target_date=target_date,
+            summary=coverage_summary,
+        )
         if not expected:
             continue
         result = _full_rebuild_code(
@@ -1491,6 +1634,7 @@ def _bootstrap_scope(
         "factor_asof": target_date,
         "codes": len(included),
         "rows_written": rows_written,
+        "coverage": coverage_summary,
         "marker": marker,
         "audit": {"a": audit_a, "b": audit_b},
     }
@@ -1563,6 +1707,7 @@ def _update_scope(
         "rows_written": 0,
         "stale_codes_removed": 0,
     }
+    coverage_summary = _new_bfq_coverage_summary()
     try:
         _ensure_factor_indexes(collection)
         universe = load_factor_universe(kind=scope, db=db, codes=codes)
@@ -1570,11 +1715,13 @@ def _update_scope(
         for code in universe["codes"]:
             if progress_callback:
                 progress_callback()
-            expected = [
-                date
-                for date in load_bfq_dates(kind=scope, code=code, db=db)
-                if date <= target_date
-            ]
+            coverage = _load_bfq_coverage(kind=scope, code=code, db=db)
+            expected = _select_bfq_dates(
+                code=code,
+                coverage=coverage,
+                target_date=target_date,
+                summary=coverage_summary,
+            )
             if not expected:
                 continue
             if force_full_rebuild:
@@ -1639,6 +1786,7 @@ def _update_scope(
             "factor_asof": target_date,
             "slot": inactive_slot,
             "stats": stats,
+            "coverage": coverage_summary,
             "audit": audit,
             "marker": published,
         }

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -268,6 +268,32 @@ def test_normalize_xtdata_field_table_payload():
     ]
 
 
+def test_normalize_xtdata_field_table_uses_trading_date_columns():
+    payload = {
+        "time": pd.DataFrame(
+            [[670608000000]],
+            index=["000001.SZ"],
+            columns=["19910403"],
+        ),
+        "close": pd.DataFrame([[14.6]], index=["000001.SZ"], columns=["19910403"]),
+        "preClose": pd.DataFrame([[0.0]], index=["000001.SZ"], columns=["19910403"]),
+    }
+
+    result = qfq.normalize_xtdata_bars(payload, code="000001.SZ")
+
+    assert result["date"].tolist() == ["1991-04-03"]
+
+
+def test_normalize_xtdata_empty_field_table_reports_no_daily_bars():
+    empty = pd.DataFrame(index=["158000.SZ"])
+
+    with pytest.raises(qfq.QFQSyncError, match="returned no daily bars"):
+        qfq.normalize_xtdata_bars(
+            {"time": empty, "close": empty, "preClose": empty},
+            code="158000.SZ",
+        )
+
+
 @pytest.mark.parametrize(
     "value",
     [
@@ -291,6 +317,15 @@ def test_canonical_date_values_use_fast_path(monkeypatch, value):
     )
 
     assert qfq._date_key(value) == "2026-01-02"
+
+
+def test_normalize_xtdata_epoch_uses_shanghai_trading_date():
+    result = qfq.normalize_xtdata_bars(
+        pd.DataFrame({"time": [670608000000], "close": [14.6], "preClose": [0.0]}),
+        code="000001.SZ",
+    )
+
+    assert result["date"].tolist() == ["1991-04-03"]
 
 
 @pytest.mark.parametrize("code", ["920001", "430001", "830001"])
@@ -343,7 +378,13 @@ def test_load_bfq_dates_sorts_in_memory_without_mongo_date_sort():
     class _BfqCollection:
         def find(self, query, projection):
             assert query == {"code": "000001"}
-            assert projection == {"_id": 0, "date": 1}
+            assert projection == {
+                "_id": 0,
+                "date": 1,
+                "vol": 1,
+                "volume": 1,
+                "amount": 1,
+            }
             return _UnsortedCursor()
 
     db = _DB()
@@ -352,6 +393,47 @@ def test_load_bfq_dates_sorts_in_memory_without_mongo_date_sort():
     assert qfq.load_bfq_dates(kind="stock", code="000001", db=db) == [
         "2026-01-02",
         "2026-01-05",
+    ]
+
+
+def test_load_bfq_dates_excludes_qasu_tiny_volume_amount_sentinel():
+    db = _DB(
+        stock_day=[
+            {
+                "code": "000001",
+                "date": "1991-09-29",
+                "vol": 930.0,
+                "amount": 1_355_000.0,
+            },
+            {
+                "code": "000001",
+                "date": "1991-09-30",
+                "open": 14.55,
+                "high": 14.65,
+                "low": 14.5,
+                "close": 14.6,
+                "vol": 5.877471754e-39,
+                "amount": 5.877471754e-39,
+            },
+            {
+                "code": "000001",
+                "date": "1991-10-01",
+                "vol": 0.0,
+                "amount": 0.0,
+            },
+            {
+                "code": "000001",
+                "date": "1991-10-02",
+                "vol": 5.877471754e-39,
+                "amount": 1.0,
+            },
+        ]
+    )
+
+    assert qfq.load_bfq_dates(kind="stock", code="000001", db=db) == [
+        "1991-09-29",
+        "1991-10-01",
+        "1991-10-02",
     ]
 
 
@@ -395,6 +477,23 @@ def test_audit_checks_terminal_factor_and_recurrence():
     assert audit["terminal_not_one"] == ["000001"]
 
 
+def test_source_audit_classifies_bfq_factor_without_xtdata_as_source_missing():
+    audit = qfq.audit_factor_snapshot(
+        [
+            {"code": "000001", "date": "2026-01-02", "adj": 1.0},
+            {"code": "000001", "date": "2026-01-05", "adj": 1.0},
+        ],
+        expected_dates_by_code={"000001": ["2026-01-02", "2026-01-05"]},
+        included_codes=["000001"],
+        require_exact_dates=True,
+        bars_by_code={"000001": _bars([("2026-01-02", 10.0, 0.0)])},
+    )
+
+    assert audit["ok"] is False
+    assert audit["source_missing_dates"] == [("000001", "2026-01-05")]
+    assert audit["extra_dates"] == []
+
+
 def test_bootstrap_builds_both_slots_before_atomic_marker_insert():
     dates = ["2026-01-02", "2026-01-05"]
     db = _stock_db(dates)
@@ -419,6 +518,123 @@ def test_bootstrap_builds_both_slots_before_atomic_marker_insert():
     assert marker["slots"]["b"]["status"] == "ready"
     assert marker["slots"]["a"]["collection"] == "stock_adj_qfq_a"
     assert marker["slots"]["b"]["collection"] == "stock_adj_qfq_b"
+
+
+def test_bootstrap_computes_on_xtdata_superset_then_projects_to_bfq_axis():
+    expected_dates = ["2026-01-02", "2026-01-06"]
+    db = _stock_db(expected_dates)
+    loader = _loader_for(
+        {
+            "000001": [
+                ("2026-01-02", 10.0, 0.0),
+                ("2026-01-05", 9.0, 8.0),
+                ("2026-01-06", 9.0, 9.0),
+            ]
+        }
+    )
+
+    qfq.sync_stock_adj_all(target_date=expected_dates[-1], db=db, bars_loader=loader)
+
+    rows = db["stock_adj_qfq_a"].rows
+    assert [row["date"] for row in rows] == expected_dates
+    assert [row["adj"] for row in rows] == pytest.approx([0.8, 1.0])
+    assert qfq.audit_qfq_slot(scope="stock", slot="a", db=db, bars_loader=loader)["ok"]
+
+
+def test_bootstrap_fails_when_valid_bfq_date_is_missing_from_xtdata():
+    dates = ["2026-01-02", "2026-01-05"]
+    db = _stock_db(dates)
+    loader = _loader_for({"000001": [(dates[0], 10.0, 0.0)]})
+
+    with pytest.raises(qfq.QFQSyncError, match="full QFQ rebuild audit failed"):
+        qfq.sync_stock_adj_all(target_date=dates[-1], db=db, bars_loader=loader)
+
+    assert not db["qfq_ready"].rows
+
+
+def test_bootstrap_skips_sentinel_only_etf_with_audited_reason():
+    sentinel = 5.877471754e-39
+    db = _DB(
+        etf_list=[
+            {"code": "158000", "name": "Placeholder ETF"},
+            {"code": "510050", "name": "Tradable ETF"},
+        ],
+        index_day=[
+            {
+                "code": "158000",
+                "date": "2026-07-30",
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1.0,
+                "vol": sentinel,
+                "amount": sentinel,
+            },
+            {
+                "code": "158000",
+                "date": "2026-07-31",
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1.0,
+                "vol": sentinel,
+                "amount": sentinel,
+            },
+            {
+                "code": "510050",
+                "date": "2026-07-31",
+                "vol": 100.0,
+                "amount": 250.0,
+            },
+        ],
+    )
+    calls = []
+
+    def loader(code, *, start_time, end_time):
+        calls.append((code, start_time, end_time))
+        return _bars([("2026-07-31", 2.5, 0.0)])
+
+    result = qfq.sync_etf_adj_all(target_date="2026-07-31", db=db, bars_loader=loader)
+
+    assert [call[0] for call in calls] == ["510050"]
+    coverage = result["by_scope"]["etf"]["coverage"]
+    assert coverage["sentinel_rows_excluded"] == 2
+    assert coverage["codes_with_sentinel_rows"] == 1
+    assert coverage["skipped_codes"] == 1
+    assert coverage["skipped"][0] == {
+        "code": "158000",
+        "reason": "sentinel_only_bfq_history",
+        "sentinel_rows": 2,
+    }
+
+
+def test_bootstrap_does_not_exclude_near_miss_sentinel_bfq_row():
+    sentinel = 5.877471754e-39
+    db = _DB(
+        etf_list=[{"code": "510050", "name": "Tradable ETF"}],
+        index_day=[
+            {
+                "code": "510050",
+                "date": "2026-07-31",
+                "vol": sentinel,
+                "amount": 1.0,
+            }
+        ],
+    )
+    empty = pd.DataFrame(index=["510050.SH"])
+
+    with pytest.raises(qfq.QFQSyncError, match="returned no daily bars"):
+        qfq.sync_etf_adj_all(
+            target_date="2026-07-31",
+            db=db,
+            bars_loader=lambda *_args, **_kwargs: {
+                "time": empty,
+                "close": empty,
+                "preClose": empty,
+            },
+        )
+
+    assert not db["qfq_ready"].rows
 
 
 def test_bootstrap_failure_never_creates_ready_marker():
@@ -636,6 +852,56 @@ def test_inactive_slot_catches_up_from_its_own_terminal_without_writing_active()
     assert db["stock_adj_qfq_a"].writes == active_writes_before
     assert [row["date"] for row in db["stock_adj_qfq_b"].rows] == dates
     assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "b"
+
+
+def test_incremental_update_projects_xtdata_superset_to_bfq_dates():
+    bfq_dates = ["2026-01-02", "2026-01-06"]
+    payload = {"000001": [(bfq_dates[0], 10.0, 0.0)]}
+    db = _stock_db(bfq_dates[:1])
+    loader = _loader_for(payload)
+    qfq.sync_stock_adj_all(target_date=bfq_dates[0], db=db, bars_loader=loader)
+    payload["000001"] = [
+        (bfq_dates[0], 10.0, 0.0),
+        ("2026-01-05", 11.0, 10.0),
+        (bfq_dates[1], 12.0, 11.0),
+    ]
+    db["stock_day"].rows.append({"code": "000001", "date": bfq_dates[1]})
+
+    result = qfq.sync_stock_adj_all(
+        target_date=bfq_dates[1],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+    )
+
+    assert result["by_scope"]["stock"]["stats"]["incremental"] == 1
+    assert [row["date"] for row in db["stock_adj_qfq_b"].rows] == bfq_dates
+    assert [row["adj"] for row in db["stock_adj_qfq_b"].rows] == [1.0, 1.0]
+
+
+def test_xtdata_only_corporate_action_day_forces_full_rebuild():
+    bfq_dates = ["2026-01-02", "2026-01-06"]
+    payload = {"000001": [(bfq_dates[0], 10.0, 0.0)]}
+    db = _stock_db(bfq_dates[:1])
+    loader = _loader_for(payload)
+    qfq.sync_stock_adj_all(target_date=bfq_dates[0], db=db, bars_loader=loader)
+    payload["000001"] = [
+        (bfq_dates[0], 10.0, 0.0),
+        ("2026-01-05", 9.0, 8.0),
+        (bfq_dates[1], 9.0, 9.0),
+    ]
+    db["stock_day"].rows.append({"code": "000001", "date": bfq_dates[1]})
+
+    result = qfq.sync_stock_adj_all(
+        target_date=bfq_dates[1],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+    )
+
+    assert result["by_scope"]["stock"]["stats"]["full"] == 1
+    factors = {row["date"]: row["adj"] for row in db["stock_adj_qfq_b"].rows}
+    assert factors == pytest.approx({bfq_dates[0]: 0.8, bfq_dates[1]: 1.0})
 
 
 def test_company_action_rebuilds_only_inactive_code_history():


### PR DESCRIPTION
## 背景

PR1 #484 已部署到正式运行面，但 Stock/ETF QFQ bootstrap 稳定失败：
- Stock XTData epoch 被按 UTC 日期解释，交易日整体前移一天。
- BFQ coverage 包含 QASU/TDX 占位行；ETF `158000` 只有占位历史且 XTData 无真实日线。
- XTData 历史可比 BFQ coverage 多出真实交易日，原实现直接要求日期集合完全相等。

Related to #467. 本 PR 只解除 PR1 bootstrap 阻塞，不切换线上 Stock/ETF reader。

## 目标

- 在 XTData normalize 边界按 Asia/Shanghai 还原 epoch，并优先采用 field-table 的日期列。
- 仅排除 `vol` 与 `amount` 同时精确命中 QASU 浮点哨兵的 BFQ 占位行，记录 coverage 计数与原因。
- 在完整 XTData 实际日期轴计算因子，再投影到有效 BFQ 日期；有效 BFQ 缺 XTData source 时继续 fail closed。
- 让 full/tail source audit 对投影后的因子做正确对账，并单列 `source_missing_dates`。

## 范围

- `freshquant/market_data/xtdata/qfq.py`
- QFQ bootstrap、增量、source audit 与 sentinel 回归测试
- `docs/current/**` 当前运行和排障口径

## 非目标

- 不切换 Stock/ETF 线上 reader。
- 不修改 True Index BFQ 路由。
- 不改变 A/B marker、lease、CAS、rollback 协议。
- 不停止旧 `stock_adj` / `etf_adj` writer。
- 不关闭 Issue #467；PR2 生产 gates 与 reader 激活仍在后续完成。

## 验收

- [x] 新生产签名回归先复现为 `6 failed, 1 passed`
- [x] QFQ writer/worker：`74 passed`
- [x] 完整 Python suite：`1503 passed`
- [x] docs-current guard、全部 pre-commit hooks、mypy、Black、isort 通过
- [x] 独立代码审查无阻塞项
- [x] 只读真实回放：`000001` BFQ 8421 / XTData 8458，投影 full-source audit `ok=true`
- [x] 只读真实回放：`158000` 两条 sentinel 行被识别，valid BFQ coverage 为 0
- [ ] GitHub CI 全绿且 review discussions 为 0
- [ ] 合并后正式部署、Stock/ETF bootstrap、同 SHA Verify 与 PR2 gates

## 部署影响

直接变更属于 `market_data` surface，需要通过正式 deploy 重启 XTData market-data programs，并重新启动 QFQ worker执行 Stock 后 ETF bootstrap。由于当前 formal state 的 `last_success_sha` 仍早于 PR1，合并后的正式 deploy 计划预计仍会包含 PR1 累积的 API、Dagster、market_data、guardian、position_management、tpsl、order_management 七个 surface；以正式 deploy plan 机器输出为准。