### PR TITLE
fix: page XTData QFQ history prefixes

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -70,6 +70,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - `quantaxis.qfq_writer_locks` 对每个 scope 只允许一个带过期时间并由后台线程持续续期的 writer lease；单次 XTData 请求或 Mongo `$out` 阻塞时仍续租，发布前重新核对 owner。中断的 `building` 仅由下一位 lease owner 恢复，人工 build / rollback 不与 Supervisor worker 并发写。
 - 首次 bootstrap 先构建并审计 A，再复制和审计 B，之后发布双槽 marker；日更只对 inactive slot 写入。
 - XTData field-table 以日期列为交易日，epoch 回退按 Asia/Shanghai 还原；因子先在完整 XTData 实际日期轴递推，再投影到有效 BFQ coverage。BFQ 中 `vol` 与 `amount` 同时等于 QASU 浮点哨兵的占位行不进入 coverage，运行结果和 audit 会记录排除计数与原因；任何其余有效 BFQ 日期缺少 XTData source 时仍 fail closed。
+- XTData 长区间下载只返回近期后缀时，QFQ client 会以当前最早缓存日的前一日为边界继续向前分页，直至覆盖请求起点；任一页未把最早日期向前推进时立即报错，不发布不完整快照。
 - 当前 Stock / ETF 在线 reader 和旧 `stock_xdxr`、`etf_xdxr -> etf_adj` writer 均未切换；A/B 发布不会改变现有 Kline 或策略读取结果。
 - 真实 Index 走 BFQ 日线/分钟线和 `index_realtime`，不读取 ETF/Stock 因子，也不进入 QFQ shadow scope。
 

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -695,6 +695,7 @@ Get-Content D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log -Tail 200
 
 - `worker --once` 返回 `waiting_for_bfq` 时，先在 Dagster 核对最新 `stock_data_job` / `etf_data_job`，以及 `freshquant.dagster_pipeline_markers` 中相应 `pipeline_key` 的成功文档；QFQ worker 不绕过 BFQ ready gate。
 - XTData 连接或历史下载失败时，先恢复 MiniQMT / XTData 端口，再重新执行 `worker --once`；worker 会把中断的 inactive `building` 状态恢复为可重试的 `failed`。
+- 出现 `XTData history prefix download made no progress` 时，保留 worker 停止状态并检查 QMT 下载任务和本地历史缓存；该错误表示向前分页后最早交易日未变化，重复启动 worker 不会形成完整快照。
 - 返回 `writer lease is held` 时，先确认 Supervisor worker 或人工 build / rollback 是否仍在运行；正常 lease 会持续续期并在命令结束时释放，崩溃遗留 lease 到期后由下一轮原子接管，不要并发启动第二个 writer。
 - `audit --mode structure` 只确认 Mongo 结构；递推或 XTData source 对账必须用 `--mode tail|full`。审计失败时保留 active slot，修复源数据或日期轴后用 `build --scope <stock|etf> --target-date YYYY-MM-DD` 重建 inactive slot；不要手工修改 `active_slot` 或在 active 集合上原地修补。
 - `coverage.sentinel_rows_excluded` / `codes_with_sentinel_rows` 表示 BFQ 中精确 QASU 浮点占位行已被排除，`skipped[].reason=sentinel_only_bfq_history` 表示该标的没有可交易 BFQ 历史；这不等同于允许任意 XTData 空结果。只要存在非占位 BFQ 日期而 XTData 缺源，full/tail audit 仍返回 `QFQ_DATA_NOT_READY`。

--- a/freshquant/market_data/xtdata/qfq.py
+++ b/freshquant/market_data/xtdata/qfq.py
@@ -1217,16 +1217,41 @@ class XtDataQfqClient:
         xt_code = to_xt_code(code, market=market)
         if hasattr(xtdata, "download_history_data"):
             xtdata.download_history_data(xt_code, "1d", start_time, end_time)
-        payload = xtdata.get_market_data(
-            field_list=["time", "close", "preClose"],
-            stock_list=[xt_code],
-            period="1d",
-            start_time=start_time,
-            end_time=end_time,
-            dividend_type="none",
-            fill_data=False,
-        )
-        return normalize_xtdata_bars(payload, code=xt_code)
+
+        def load_bars() -> pd.DataFrame:
+            payload = xtdata.get_market_data(
+                field_list=["time", "close", "preClose"],
+                stock_list=[xt_code],
+                period="1d",
+                start_time=start_time,
+                end_time=end_time,
+                dividend_type="none",
+                fill_data=False,
+            )
+            return normalize_xtdata_bars(payload, code=xt_code)
+
+        bars = load_bars()
+        requested_start = _date_key(start_time)
+        earliest = _date_key(bars.iloc[0]["date"])
+        while (
+            hasattr(xtdata, "download_history_data")
+            and requested_start
+            and earliest
+            and earliest > requested_start
+        ):
+            prefix_end = _xt_date_arg(date.fromisoformat(earliest) - timedelta(days=1))
+            xtdata.download_history_data(xt_code, "1d", start_time, prefix_end)
+            next_bars = load_bars()
+            next_earliest = _date_key(next_bars.iloc[0]["date"])
+            if not next_earliest or next_earliest >= earliest:
+                raise QFQSyncError(
+                    "XTData history prefix download made no progress "
+                    f"for code={xt_code}: earliest={earliest}, "
+                    f"prefix_end={prefix_end}"
+                )
+            bars = next_bars
+            earliest = next_earliest
+        return bars
 
 
 def _call_loader(

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -1323,6 +1323,70 @@ def test_xtdata_client_uses_configured_port_and_none_dividend(monkeypatch):
     assert calls[-1][1]["fill_data"] is False
 
 
+def test_xtdata_client_downloads_missing_history_prefix():
+    calls = []
+
+    class _XtData:
+        def connect(self, *, port):
+            calls.append(("connect", port))
+
+        def download_history_data(self, *args):
+            calls.append(("download", args))
+
+        def get_market_data(self, **kwargs):
+            calls.append(("get", kwargs))
+            download_count = sum(call[0] == "download" for call in calls)
+            rows = [
+                ("2024-09-03", 10.0, 10.0),
+                ("2026-07-31", 10.0, 10.0),
+            ]
+            if download_count > 1:
+                rows.insert(0, ("1994-01-04", 10.0, 10.0))
+            if download_count > 2:
+                rows.insert(0, ("1991-01-29", 10.0, 0.0))
+            return {"000002.SZ": _bars(rows)}
+
+    result = qfq.XtDataQfqClient(_XtData()).load_daily_bars(
+        "000002", start_time="19910129", end_time="20260731"
+    )
+
+    assert result["date"].tolist() == [
+        "1991-01-29",
+        "1994-01-04",
+        "2024-09-03",
+        "2026-07-31",
+    ]
+    assert [call for call in calls if call[0] == "download"] == [
+        ("download", ("000002.SZ", "1d", "19910129", "20260731")),
+        ("download", ("000002.SZ", "1d", "19910129", "20240902")),
+        ("download", ("000002.SZ", "1d", "19910129", "19940103")),
+    ]
+
+
+def test_xtdata_client_fails_when_history_prefix_makes_no_progress():
+    class _XtData:
+        def connect(self, *, port):
+            pass
+
+        def download_history_data(self, *args):
+            pass
+
+        def get_market_data(self, **kwargs):
+            return {
+                "000002.SZ": _bars(
+                    [
+                        ("2024-09-03", 10.0, 0.0),
+                        ("2026-07-31", 10.0, 10.0),
+                    ]
+                )
+            }
+
+    with pytest.raises(qfq.QFQSyncError, match="prefix download made no progress"):
+        qfq.XtDataQfqClient(_XtData()).load_daily_bars(
+            "000002", start_time="19910129", end_time="20260731"
+        )
+
+
 def test_real_xtdata_stock_and_etf_action_fixtures():
     fixture_path = Path(__file__).parent / "fixtures" / "qfq_xtdata_real_samples.json"
     payload = json.loads(fixture_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Background

Issue #467 PR1 shadow bootstrap fails on older Stock/ETF symbols because a long XTData history request can populate only a recent suffix. The writer then correctly rejects the incomplete BFQ date axis.

## Changes

- Continue downloading historical prefixes using the day before the current earliest cached bar until the requested start date is covered.
- Fail closed with `QFQSyncError` when a prefix download does not move the earliest cached date.
- Add multi-page and no-progress regression coverage.
- Document the runtime and troubleshooting behavior in `docs/current/**`.

## Scope

This remains a PR1 Prepare/Prove correction. Stock/ETF online readers and legacy `stock_adj` / `etf_adj` writers are unchanged. True indexes remain BFQ.

## Validation

- Local preflight: `1505 passed`
- Focused QFQ/deploy/runtime tests: `140 passed`
- Real XTData full audit:
  - `000009`: BFQ `8357` rows, `1991-06-25..2026-07-31`
  - `missing=0`, `extra=0`, `invalid=0`, `duplicates=0`, `ok=true`
- Existing real samples:
  - `000002`: full audit `ok=true`
  - `159001`: full audit `ok=true`

## Acceptance

- CI is green and review discussions are resolved.
- Merge to remote `main`.
- Formal deploy the merged tip, resume Stock then ETF bootstrap, and complete same-SHA Verify.

## Deployment impact

Touches `freshquant/market_data/**`; formal deployment must restart and verify the market-data host surface. The broader current deploy plan still verifies API, Dagster, guardian, position management, TPSL, and order management surfaces.

Related to #467.