### PR TITLE
fix: bridge audited XTData QFQ source gaps

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -69,7 +69,10 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - `quantaxis.qfq_ready` 对每个 scope 使用一个原子双槽 marker；构建 inactive slot 期间 active slot 保持只读，inactive slot 审计成功后才切换。
 - `quantaxis.qfq_writer_locks` 对每个 scope 只允许一个带过期时间并由后台线程持续续期的 writer lease；单次 XTData 请求或 Mongo `$out` 阻塞时仍续租，发布前重新核对 owner。中断的 `building` 仅由下一位 lease owner 恢复，人工 build / rollback 不与 Supervisor worker 并发写。
 - 首次 bootstrap 先构建并审计 A，再复制和审计 B，之后发布双槽 marker；日更只对 inactive slot 写入。
-- XTData field-table 以日期列为交易日，epoch 回退按 Asia/Shanghai 还原；因子先在完整 XTData 实际日期轴递推，再投影到有效 BFQ coverage。BFQ 中 `vol` 与 `amount` 同时等于 QASU 浮点哨兵的占位行不进入 coverage，运行结果和 audit 会记录排除计数与原因；任何其余有效 BFQ 日期缺少 XTData source 时仍 fail closed。
+- XTData field-table 以日期列为交易日，epoch 回退按 Asia/Shanghai 还原；`dividend_type=none` 日线的 `preClose` 仍是 canonical 因子来源，常规边先在真实 XTData 日期轴递推，再投影到有效 BFQ coverage。
+- BFQ 中 `vol` 与 `amount` 同时等于 QASU 浮点哨兵的占位行不进入 coverage。Stock 另以 `stock_xdxr` 中最早满足 `category=5`、`shares_before=0`、`shares_after>0` 的初始股本记录作为上市边界，排除更早 BFQ 行；运行结果和 audit 分别记录 sentinel 与 `prelisting_rows_excluded`、`codes_with_prelisting_rows`、`prelisting[]`。
+- BFQ-only 日期仅在两个真实 XTData bar 之间，且同日期轴的 `front_ratio.close / none.close` 在缺口两端容差内相等时桥接；该稀疏边按无调整处理，缺失日期写入相同因子，并记录 `source_gap_rows_bridged`、`codes_with_source_gaps`、`source_gaps[]`。
+- `front_ratio` 只证明缺口未跨公司行为，不参与 canonical 因子计算；前后缀缺口、proof 缺失、none/front_ratio 日期轴不一致或两端比率变化均 fail closed，不发布 marker。
 - XTData 长区间下载只返回近期后缀时，QFQ client 会以当前最早缓存日的前一日为边界继续向前分页，直至覆盖请求起点；任一页未把最早日期向前推进时立即报错，不发布不完整快照。
 - 当前 Stock / ETF 在线 reader 和旧 `stock_xdxr`、`etf_xdxr -> etf_adj` writer 均未切换；A/B 发布不会改变现有 Kline 或策略读取结果。
 - 真实 Index 走 BFQ 日线/分钟线和 `index_realtime`，不读取 ETF/Stock 因子，也不进入 QFQ shadow scope。

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -698,7 +698,10 @@ Get-Content D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log -Tail 200
 - 出现 `XTData history prefix download made no progress` 时，保留 worker 停止状态并检查 QMT 下载任务和本地历史缓存；该错误表示向前分页后最早交易日未变化，重复启动 worker 不会形成完整快照。
 - 返回 `writer lease is held` 时，先确认 Supervisor worker 或人工 build / rollback 是否仍在运行；正常 lease 会持续续期并在命令结束时释放，崩溃遗留 lease 到期后由下一轮原子接管，不要并发启动第二个 writer。
 - `audit --mode structure` 只确认 Mongo 结构；递推或 XTData source 对账必须用 `--mode tail|full`。审计失败时保留 active slot，修复源数据或日期轴后用 `build --scope <stock|etf> --target-date YYYY-MM-DD` 重建 inactive slot；不要手工修改 `active_slot` 或在 active 集合上原地修补。
-- `coverage.sentinel_rows_excluded` / `codes_with_sentinel_rows` 表示 BFQ 中精确 QASU 浮点占位行已被排除，`skipped[].reason=sentinel_only_bfq_history` 表示该标的没有可交易 BFQ 历史；这不等同于允许任意 XTData 空结果。只要存在非占位 BFQ 日期而 XTData 缺源，full/tail audit 仍返回 `QFQ_DATA_NOT_READY`。
+- `coverage.sentinel_rows_excluded` / `codes_with_sentinel_rows` 表示 BFQ 中精确 QASU 浮点占位行已被排除，`skipped[].reason=sentinel_only_bfq_history` 表示该标的没有可交易 BFQ 历史。`prelisting_rows_excluded` / `codes_with_prelisting_rows` / `prelisting[]` 则表示按 Stock XDXR 初始股本边界排除的上市前 BFQ 脏行，两类排除相互独立。
+- `source_gap_rows_bridged > 0` 表示 BFQ-only 内部日期已通过缺口两端 `front_ratio.close / none.close` 恒定证明；从 `source_gaps[].windows` 查看 code、边界和日期。`front_ratio` 只作证明，canonical 因子仍由 `none.preClose` 递推。
+- `unbounded XTData source gap` 表示缺失 BFQ 日期位于当前 XTData source 首条之前或末条之后，缺少两个真实边界；检查 QMT 历史缓存和下载范围，恢复 source 后重建 inactive slot。
+- `XTData source gap crosses an adjustment` 表示缺口虽有界，但两端 proof ratio 已变化，可能跨越公司行为；恢复缺失 XTData bars 后重建 inactive slot，active marker 保持不变。`requires front_ratio proof` 或 `front_ratio date axis mismatch` 同样表示证明链不成立。
 - 怀疑 XTData 修订发生在默认 60 个交易日回看窗口之前时，使用同一 active 截止日执行 `build --scope <stock|etf> --target-date YYYY-MM-DD --full`；该命令重算整个 inactive scope，且不接受早于 active `factor_asof` 的日期。
 - 回切前先确认另一槽为 `ready` 并单独执行 `audit --slot <a|b>`，然后使用 `rollback --scope <stock|etf>`；回切只更新原子 marker。
 - 页面或策略结果未变化是当前边界：Stock / ETF 在线 reader 仍读取 `stock_adj` / `etf_adj`，A/B 集合是 shadow 数据。真实 Index 则固定使用 BFQ，不读取 ETF 因子。

--- a/freshquant/market_data/xtdata/qfq.py
+++ b/freshquant/market_data/xtdata/qfq.py
@@ -11,6 +11,7 @@ import math
 import re
 import threading
 import uuid
+from bisect import bisect_left
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
@@ -393,6 +394,144 @@ def compute_preclose_adj(bars: Any, *, code: str | None = None) -> pd.DataFrame:
     return result
 
 
+def _project_preclose_adj_to_bfq_dates(
+    bars: Any,
+    *,
+    code: str,
+    expected_dates: Iterable[str],
+    front_ratio_bars: Any | None = None,
+    rel_tol: float = 1e-10,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Project a source factor axis while proving any bounded source gaps."""
+
+    day = normalize_xtdata_bars(bars, code=code)
+    expected = sorted(
+        {
+            key
+            for key in (_date_key(value) for value in expected_dates)
+            if key is not None
+        }
+    )
+    source_dates = day["date"].tolist()
+    source_date_set = set(source_dates)
+    missing = [value for value in expected if value not in source_date_set]
+    if not missing:
+        factors = compute_preclose_adj(day, code=code)
+        expected_set = set(expected)
+        rows = [
+            row
+            for row in factors.to_dict(orient="records")
+            if str(row["date"])[:10] in expected_set
+        ]
+        return rows, {"source_gap_rows_bridged": 0, "source_gap_windows": []}
+
+    gap_windows: dict[tuple[str, str], list[str]] = {}
+    for missing_date in missing:
+        index = bisect_left(source_dates, missing_date)
+        if index == 0 or index == len(source_dates):
+            raise QFQSyncError(
+                f"unbounded XTData source gap for code={normalize_code(code)}",
+                stats={
+                    "missing_dates": missing[:20],
+                    "gap_position": "prefix" if index == 0 else "suffix",
+                },
+            )
+        gap_windows.setdefault(
+            (source_dates[index - 1], source_dates[index]), []
+        ).append(missing_date)
+
+    if front_ratio_bars is None:
+        raise QFQSyncError(
+            f"XTData source gap requires front_ratio proof for code={normalize_code(code)}",
+            stats={"missing_dates": missing[:20]},
+        )
+    front = normalize_xtdata_bars(front_ratio_bars, code=code)
+    if front["date"].tolist() != source_dates:
+        raise QFQSyncError(
+            f"XTData front_ratio date axis mismatch for code={normalize_code(code)}",
+            stats={
+                "none_dates": len(source_dates),
+                "front_ratio_dates": len(front),
+            },
+        )
+
+    close = day["close"].to_numpy(dtype=float)
+    preclose = day["preClose"].to_numpy(dtype=float)
+    proof = front["close"].to_numpy(dtype=float) / close
+    if not np.isfinite(proof).all() or (proof <= 0).any():
+        raise QFQSyncError(
+            f"invalid XTData front_ratio proof for code={normalize_code(code)}"
+        )
+    ratios = preclose[1:] / close[:-1]
+    date_indexes = {value: index for index, value in enumerate(source_dates)}
+    windows: list[dict[str, Any]] = []
+    for (left_date, right_date), gap_dates in sorted(gap_windows.items()):
+        left_index = date_indexes[left_date]
+        right_index = date_indexes[right_date]
+        if right_index != left_index + 1:
+            raise QFQSyncError(
+                f"invalid XTData source gap bounds for code={normalize_code(code)}"
+            )
+        if not math.isclose(
+            float(proof[left_index]),
+            float(proof[right_index]),
+            rel_tol=rel_tol,
+            abs_tol=1e-12,
+        ):
+            raise QFQSyncError(
+                f"XTData source gap crosses an adjustment for code={normalize_code(code)}",
+                stats={
+                    "left_date": left_date,
+                    "right_date": right_date,
+                    "missing_dates": gap_dates[:20],
+                    "left_front_ratio": float(proof[left_index]),
+                    "right_front_ratio": float(proof[right_index]),
+                },
+            )
+        ratios[left_index] = 1.0
+        windows.append(
+            {
+                "left_date": left_date,
+                "right_date": right_date,
+                "dates": gap_dates[:20],
+                "rows": len(gap_dates),
+            }
+        )
+
+    factors = np.ones(len(day), dtype=float)
+    factors[:-1] = np.cumprod(ratios[::-1])[::-1]
+    if not np.isfinite(factors).all() or (factors <= 0).any():
+        raise QFQSyncError(
+            f"invalid bridged QFQ factors for code={normalize_code(code)}"
+        )
+    factor_by_date = dict(zip(source_dates, factors, strict=True))
+    for (left_date, right_date), gap_dates in gap_windows.items():
+        factor = float(factor_by_date[right_date])
+        if not math.isclose(
+            float(factor_by_date[left_date]),
+            factor,
+            rel_tol=rel_tol,
+            abs_tol=1e-12,
+        ):
+            raise QFQSyncError(
+                f"bridged XTData factor is discontinuous for code={normalize_code(code)}"
+            )
+        for missing_date in gap_dates:
+            factor_by_date[missing_date] = factor
+    rows = [
+        {
+            "code": normalize_code(code),
+            "date": value,
+            "adj": float(factor_by_date[value]),
+        }
+        for value in expected
+    ]
+    return rows, {
+        "source_gap_rows_bridged": len(missing),
+        "source_gap_windows": windows,
+    }
+
+
 # Names used by callers and older migration notes.
 compute_qfq_factors = compute_preclose_adj
 compute_xtdata_preclose_adj = compute_preclose_adj
@@ -508,6 +647,34 @@ def _is_bfq_sentinel_row(row: Mapping[str, Any]) -> bool:
     )
 
 
+def _initial_stock_capital_date(*, code: str, db) -> str | None:
+    """Return the audited IPO boundary encoded by the first capital record."""
+
+    projection = {
+        "_id": 0,
+        "date": 1,
+        "shares_before": 1,
+        "shares_after": 1,
+    }
+    try:
+        cursor = db["stock_xdxr"].find(
+            {"code": normalize_code(code), "category": 5}, projection
+        )
+    except (AttributeError, KeyError, TypeError):
+        return None
+    candidates: list[str] = []
+    for row in cursor:
+        try:
+            before = float(row.get("shares_before"))
+            after = float(row.get("shares_after"))
+        except (TypeError, ValueError):
+            continue
+        key = _date_key(row.get("date"))
+        if key and math.isclose(before, 0.0, rel_tol=0.0, abs_tol=1e-12) and after > 0:
+            candidates.append(key)
+    return min(candidates) if candidates else None
+
+
 def _load_bfq_coverage(*, kind: str, code: str, db=DBQuantAxis) -> dict[str, Any]:
     if kind not in BFQ_COLLECTIONS:
         raise ValueError(f"unsupported BFQ kind: {kind}")
@@ -527,7 +694,11 @@ def _load_bfq_coverage(*, kind: str, code: str, db=DBQuantAxis) -> dict[str, Any
         cursor = collection.find(query)
     dates: list[str] = []
     sentinel_dates: list[str] = []
+    prelisting_dates: list[str] = []
     invalid: list[Any] = []
+    listing_date = (
+        _initial_stock_capital_date(code=code6, db=db) if kind == "stock" else None
+    )
     for row in cursor:
         value = row.get("date") if isinstance(row, Mapping) else None
         if isinstance(row, Mapping) and _is_bfq_sentinel_row(row):
@@ -536,6 +707,8 @@ def _load_bfq_coverage(*, kind: str, code: str, db=DBQuantAxis) -> dict[str, Any
         key = _date_key(value)
         if key is None:
             invalid.append(value)
+        elif listing_date and key < listing_date:
+            prelisting_dates.append(key)
         else:
             dates.append(key)
     if invalid:
@@ -547,6 +720,9 @@ def _load_bfq_coverage(*, kind: str, code: str, db=DBQuantAxis) -> dict[str, Any
         "dates": sorted(set(dates)),
         "sentinel_rows": len(sentinel_dates),
         "sentinel_dates": sorted(set(sentinel_dates))[:20],
+        "listing_date": listing_date,
+        "prelisting_rows": len(prelisting_dates),
+        "prelisting_dates": sorted(set(prelisting_dates))[:20],
     }
 
 
@@ -560,6 +736,12 @@ def _new_bfq_coverage_summary() -> dict[str, Any]:
     return {
         "sentinel_rows_excluded": 0,
         "codes_with_sentinel_rows": 0,
+        "prelisting_rows_excluded": 0,
+        "codes_with_prelisting_rows": 0,
+        "prelisting": [],
+        "source_gap_rows_bridged": 0,
+        "codes_with_source_gaps": 0,
+        "source_gaps": [],
         "skipped_codes": 0,
         "skipped": [],
     }
@@ -576,6 +758,19 @@ def _select_bfq_dates(
     if sentinel_rows:
         summary["sentinel_rows_excluded"] += sentinel_rows
         summary["codes_with_sentinel_rows"] += 1
+    prelisting_rows = int(coverage.get("prelisting_rows") or 0)
+    if prelisting_rows:
+        summary["prelisting_rows_excluded"] += prelisting_rows
+        summary["codes_with_prelisting_rows"] += 1
+        if len(summary["prelisting"]) < 100:
+            summary["prelisting"].append(
+                {
+                    "code": normalize_code(code),
+                    "listing_date": coverage.get("listing_date"),
+                    "rows": prelisting_rows,
+                    "dates": list(coverage.get("prelisting_dates") or ()),
+                }
+            )
     dates = list(coverage.get("dates") or ())
     selected = [date for date in dates if not target_date or date <= target_date]
     if selected:
@@ -593,6 +788,24 @@ def _select_bfq_dates(
             item["sentinel_rows"] = sentinel_rows
         summary["skipped"].append(item)
     return []
+
+
+def _record_source_gap_summary(
+    summary: dict[str, Any], *, code: str, stats: Mapping[str, Any]
+) -> None:
+    rows = int(stats.get("source_gap_rows_bridged") or 0)
+    if not rows:
+        return
+    summary["source_gap_rows_bridged"] += rows
+    summary["codes_with_source_gaps"] += 1
+    if len(summary["source_gaps"]) < 100:
+        summary["source_gaps"].append(
+            {
+                "code": normalize_code(code),
+                "rows": rows,
+                "windows": list(stats.get("source_gap_windows") or ()),
+            }
+        )
 
 
 def _bfq_download_bounds(
@@ -625,6 +838,7 @@ def audit_factor_snapshot(
     included_codes: Iterable[str] | None = None,
     require_exact_dates: bool = False,
     bars_by_code: Mapping[str, Any] | None = None,
+    source_factors_by_code: Mapping[str, Iterable[Mapping[str, Any]]] | None = None,
     rel_tol: float = 1e-10,
 ) -> dict[str, Any]:
     rows = [dict(item) for item in (documents or ())]
@@ -682,14 +896,21 @@ def audit_factor_snapshot(
             normalized[-1][1], 1.0, rel_tol=0.0, abs_tol=1e-12
         ):
             terminal_not_one.append(code)
+        source_payload = (source_factors_by_code or {}).get(code)
         bars_payload = (bars_by_code or {}).get(code)
-        if bars_payload is not None and normalized:
-            bars = normalize_xtdata_bars(bars_payload, code=code)
+        if (source_payload is not None or bars_payload is not None) and normalized:
             factors = {date: factor for date, factor in normalized}
-            source_rows = compute_preclose_adj(bars, code=code)
-            source_factors = dict(
-                zip(source_rows["date"], source_rows["adj"], strict=True)
-            )
+            if source_payload is not None:
+                source_factors = {
+                    key: float(row["adj"])
+                    for row in source_payload
+                    if (key := _date_key(row.get("date"))) is not None
+                }
+            else:
+                source_rows = compute_preclose_adj(bars_payload, code=code)
+                source_factors = dict(
+                    zip(source_rows["date"], source_rows["adj"], strict=True)
+                )
             if require_exact_dates:
                 source_missing_dates.extend(
                     (code, date) for date in sorted(set(factors) - set(source_factors))
@@ -1209,6 +1430,7 @@ class XtDataQfqClient:
         market: str | None = None,
         start_time: str = "",
         end_time: str = "",
+        dividend_type: str = "none",
     ) -> pd.DataFrame:
         xtdata = self._get_xtdata()
         if not self.connected and hasattr(xtdata, "connect"):
@@ -1225,7 +1447,7 @@ class XtDataQfqClient:
                 period="1d",
                 start_time=start_time,
                 end_time=end_time,
-                dividend_type="none",
+                dividend_type=dividend_type,
                 fill_data=False,
             )
             return normalize_xtdata_bars(payload, code=xt_code)
@@ -1247,11 +1469,32 @@ class XtDataQfqClient:
                 raise QFQSyncError(
                     "XTData history prefix download made no progress "
                     f"for code={xt_code}: earliest={earliest}, "
-                    f"prefix_end={prefix_end}"
+                    f"prefix_end={prefix_end}",
+                    stats={
+                        "failure": "history_prefix_no_progress",
+                        "earliest": earliest,
+                        "prefix_end": prefix_end,
+                    },
                 )
             bars = next_bars
             earliest = next_earliest
         return bars
+
+    def load_front_ratio_bars(
+        self,
+        code: str,
+        *,
+        market: str | None = None,
+        start_time: str = "",
+        end_time: str = "",
+    ) -> pd.DataFrame:
+        return self.load_daily_bars(
+            code,
+            market=market,
+            start_time=start_time,
+            end_time=end_time,
+            dividend_type="front_ratio",
+        )
 
 
 def _call_loader(
@@ -1264,6 +1507,66 @@ def _call_loader(
             return loader(code, start_time, end_time)
         except TypeError:
             return loader(code)
+
+
+def _project_loaded_bars(
+    bars: Any,
+    *,
+    code: str,
+    expected_dates: list[str],
+    front_ratio_loader: Callable[..., Any] | None,
+    load_start: str,
+    load_end: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    normalized = normalize_xtdata_bars(bars, code=code)
+    source_dates = set(normalized["date"])
+    needs_gap_proof = any(value not in source_dates for value in expected_dates)
+    front_ratio_bars = None
+    if needs_gap_proof and front_ratio_loader is not None:
+        front_ratio_bars = _call_loader(front_ratio_loader, code, load_start, load_end)
+    return _project_preclose_adj_to_bfq_dates(
+        normalized,
+        code=code,
+        expected_dates=expected_dates,
+        front_ratio_bars=front_ratio_bars,
+    )
+
+
+def _load_projected_bars(
+    loader: Callable[..., Any],
+    *,
+    code: str,
+    expected_dates: list[str],
+    front_ratio_loader: Callable[..., Any] | None,
+    load_start: str,
+    load_end: str,
+    context_start: str | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    try:
+        bars = _call_loader(loader, code, load_start, load_end)
+        return _project_loaded_bars(
+            bars,
+            code=code,
+            expected_dates=expected_dates,
+            front_ratio_loader=front_ratio_loader,
+            load_start=load_start,
+            load_end=load_end,
+        )
+    except QFQSyncError as error:
+        needs_context = error.stats.get("gap_position") == "prefix" or (
+            error.stats.get("failure") == "history_prefix_no_progress"
+        )
+        if not context_start or context_start == load_start or not needs_context:
+            raise
+    bars = _call_loader(loader, code, context_start, load_end)
+    return _project_loaded_bars(
+        bars,
+        code=code,
+        expected_dates=expected_dates,
+        front_ratio_loader=front_ratio_loader,
+        load_start=context_start,
+        load_end=load_end,
+    )
 
 
 def _load_existing_factor_rows(
@@ -1289,6 +1592,7 @@ def _audit_code_rows(
     rows: Iterable[Mapping[str, Any]],
     expected_dates: Iterable[str],
     bars: Any | None = None,
+    source_rows: Iterable[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     code6 = normalize_code(code)
     return audit_factor_snapshot(
@@ -1297,6 +1601,9 @@ def _audit_code_rows(
         included_codes=[code6],
         require_exact_dates=True,
         bars_by_code={code6: bars} if bars is not None else None,
+        source_factors_by_code=(
+            {code6: source_rows} if source_rows is not None else None
+        ),
     )
 
 
@@ -1324,23 +1631,36 @@ def _full_rebuild_code(
     code: str,
     expected_dates: list[str],
     loader: Callable[..., Any],
+    front_ratio_loader: Callable[..., Any] | None,
     reason: str,
 ) -> dict[str, Any]:
     load_start, load_end, expected = _bfq_download_bounds(expected_dates)
     bars = _call_loader(loader, code, load_start, load_end)
-    expected_set = set(expected)
-    rows = [
-        row
-        for row in compute_preclose_adj(bars, code=code).to_dict(orient="records")
-        if str(row["date"])[:10] in expected_set
-    ]
-    audit = _audit_code_rows(code=code, rows=rows, expected_dates=expected, bars=bars)
+    rows, source_stats = _project_loaded_bars(
+        bars,
+        code=code,
+        expected_dates=expected,
+        front_ratio_loader=front_ratio_loader,
+        load_start=load_start,
+        load_end=load_end,
+    )
+    audit = _audit_code_rows(
+        code=code,
+        rows=rows,
+        expected_dates=expected,
+        source_rows=rows,
+    )
     if not audit["ok"]:
         raise QFQSyncError(
             f"full QFQ rebuild audit failed for code={code}", stats=audit
         )
     written = _replace_code_rows(collection=collection, code=code, rows=rows)
-    return {"mode": "full", "reason": reason, "rows_written": written}
+    return {
+        "mode": "full",
+        "reason": reason,
+        "rows_written": written,
+        **source_stats,
+    }
 
 
 def _rows_form_exact_prefix(
@@ -1360,6 +1680,7 @@ def _reconcile_code(
     code: str,
     expected_dates: list[str],
     loader: Callable[..., Any],
+    front_ratio_loader: Callable[..., Any] | None,
     tail_days: int,
 ) -> dict[str, Any]:
     existing = _load_existing_factor_rows(
@@ -1373,6 +1694,7 @@ def _reconcile_code(
             code=code,
             expected_dates=expected_dates,
             loader=loader,
+            front_ratio_loader=front_ratio_loader,
             reason="missing_or_invalid_prefix",
         )
 
@@ -1381,20 +1703,20 @@ def _reconcile_code(
     last_index = expected_dates.index(last_existing)
     tail_start_index = max(0, last_index - max(2, int(tail_days)) + 1)
     tail_dates = expected_dates[tail_start_index:]
-    bars = _call_loader(
+    tail_rows, source_stats = _load_projected_bars(
         loader,
-        code,
-        _xt_date_arg(tail_dates[0]),
-        _xt_date_arg(tail_dates[-1]),
+        code=code,
+        expected_dates=tail_dates,
+        front_ratio_loader=front_ratio_loader,
+        load_start=_xt_date_arg(tail_dates[0]),
+        load_end=_xt_date_arg(tail_dates[-1]),
+        context_start=_xt_date_arg(expected_dates[0]),
     )
-    tail_date_set = set(tail_dates)
-    tail_rows = [
-        row
-        for row in compute_preclose_adj(bars, code=code).to_dict(orient="records")
-        if str(row["date"])[:10] in tail_date_set
-    ]
     tail_audit = _audit_code_rows(
-        code=code, rows=tail_rows, expected_dates=tail_dates, bars=bars
+        code=code,
+        rows=tail_rows,
+        expected_dates=tail_dates,
+        source_rows=tail_rows,
     )
     if not tail_audit["ok"]:
         raise QFQSyncError(f"tail QFQ audit failed for code={code}", stats=tail_audit)
@@ -1405,6 +1727,7 @@ def _reconcile_code(
             code=code,
             expected_dates=expected_dates,
             loader=loader,
+            front_ratio_loader=front_ratio_loader,
             reason="corporate_action_after_inactive_terminal",
         )
 
@@ -1424,6 +1747,7 @@ def _reconcile_code(
             code=code,
             expected_dates=expected_dates,
             loader=loader,
+            front_ratio_loader=front_ratio_loader,
             reason="tail_revision",
         )
 
@@ -1453,6 +1777,7 @@ def _reconcile_code(
         "reason": "ordinary_tail",
         "rows_written": len(missing_dates),
         "previous_last_date": last_existing,
+        **source_stats,
     }
 
 
@@ -1497,6 +1822,7 @@ def audit_qfq_slot(
     codes: Iterable[str] | None = None,
     factor_asof: str | None = None,
     bars_loader: Callable[..., Any] | None = None,
+    front_ratio_loader: Callable[..., Any] | None = None,
     source_tail_days: int | None = None,
     progress_callback: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
@@ -1529,13 +1855,24 @@ def audit_qfq_slot(
             db=db, collection_name=collection.name, code=code
         )
         audit_dates = expected
-        bars = None
+        source_rows = None
         audit_rows = code_rows
         if bars_loader is not None:
             if source_tail_days is not None:
                 audit_dates = expected[-max(2, int(source_tail_days)) :]
             load_start, load_end, audit_dates = _bfq_download_bounds(audit_dates)
-            bars = _call_loader(bars_loader, code, load_start, load_end)
+            source_rows, source_stats = _load_projected_bars(
+                bars_loader,
+                code=code,
+                expected_dates=audit_dates,
+                front_ratio_loader=front_ratio_loader,
+                load_start=load_start,
+                load_end=load_end,
+                context_start=(
+                    _xt_date_arg(expected[0]) if source_tail_days is not None else None
+                ),
+            )
+            _record_source_gap_summary(coverage_summary, code=code, stats=source_stats)
             audit_date_set = set(audit_dates)
             audit_rows = [
                 row for row in code_rows if _date_key(row.get("date")) in audit_date_set
@@ -1544,7 +1881,7 @@ def audit_qfq_slot(
             code=code,
             rows=audit_rows,
             expected_dates=audit_dates,
-            bars=bars,
+            source_rows=source_rows,
         )
         rows += len(audit_rows)
         checked_codes += 1
@@ -1578,6 +1915,7 @@ def _bootstrap_scope(
     db,
     codes: Iterable[str] | None,
     loader: Callable[..., Any],
+    front_ratio_loader: Callable[..., Any] | None,
     now_provider=None,
     progress_callback: Callable[[], None] | None = None,
     publish_callback: Callable[[Callable[[], Any]], Any] | None = None,
@@ -1608,8 +1946,10 @@ def _bootstrap_scope(
             code=code,
             expected_dates=expected,
             loader=loader,
+            front_ratio_loader=front_ratio_loader,
             reason="bootstrap",
         )
+        _record_source_gap_summary(coverage_summary, code=code, stats=result)
         rows_written += int(result["rows_written"])
         included.append(code)
     if not included:
@@ -1695,6 +2035,7 @@ def _update_scope(
     db,
     codes: Iterable[str] | None,
     loader: Callable[..., Any],
+    front_ratio_loader: Callable[..., Any] | None,
     tail_days: int,
     min_grace_seconds: int,
     force_full_rebuild: bool,
@@ -1755,6 +2096,7 @@ def _update_scope(
                     code=code,
                     expected_dates=expected,
                     loader=loader,
+                    front_ratio_loader=front_ratio_loader,
                     reason="forced_full_rebuild",
                 )
             else:
@@ -1763,10 +2105,12 @@ def _update_scope(
                     code=code,
                     expected_dates=expected,
                     loader=loader,
+                    front_ratio_loader=front_ratio_loader,
                     tail_days=tail_days,
                 )
             stats[str(result["mode"])] += 1
             stats["rows_written"] += int(result["rows_written"])
+            _record_source_gap_summary(coverage_summary, code=code, stats=result)
             included.append(code)
         stale_codes = _distinct_codes(collection) - set(included)
         if stale_codes and force_full_rebuild:
@@ -1833,6 +2177,7 @@ def sync_qfq_factors(
     db=DBQuantAxis,
     codes: Iterable[str] | None = None,
     bars_loader: Callable[..., Any] | None = None,
+    front_ratio_loader: Callable[..., Any] | None = None,
     xtdata_client: XtDataQfqClient | None = None,
     tail_days: int = DEFAULT_TAIL_AUDIT_DAYS,
     min_grace_seconds: int = DEFAULT_READER_GRACE_SECONDS,
@@ -1853,6 +2198,9 @@ def sync_qfq_factors(
         )
     client = xtdata_client or XtDataQfqClient()
     loader = bars_loader or client.load_daily_bars
+    gap_proof_loader = front_ratio_loader
+    if gap_proof_loader is None and bars_loader is None:
+        gap_proof_loader = client.load_front_ratio_bars
     result: dict[str, Any] = {
         "source": QFQ_SOURCE,
         "writer": QFQ_WRITER,
@@ -1891,6 +2239,7 @@ def sync_qfq_factors(
                     db=db,
                     codes=codes,
                     loader=loader,
+                    front_ratio_loader=gap_proof_loader,
                     now_provider=now_provider,
                     progress_callback=lease_heartbeat.pulse,
                     publish_callback=lease_heartbeat.run_fenced_publish,
@@ -1902,6 +2251,7 @@ def sync_qfq_factors(
                     db=db,
                     codes=codes,
                     loader=loader,
+                    front_ratio_loader=gap_proof_loader,
                     tail_days=tail_days,
                     min_grace_seconds=min_grace_seconds,
                     force_full_rebuild=force_full_rebuild,

--- a/freshquant/market_data/xtdata/qfq_worker.py
+++ b/freshquant/market_data/xtdata/qfq_worker.py
@@ -216,6 +216,9 @@ def main(argv: list[str] | None = None) -> int:
             slot=slot,
             codes=[args.code] if args.code else None,
             bars_loader=(source_client.load_daily_bars if source_client else None),
+            front_ratio_loader=(
+                source_client.load_front_ratio_bars if source_client else None
+            ),
             source_tail_days=args.tail_days if args.mode == "tail" else None,
         )
         if not payload["ok"]:

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -437,6 +437,43 @@ def test_load_bfq_dates_excludes_qasu_tiny_volume_amount_sentinel():
     ]
 
 
+def test_load_bfq_dates_excludes_rows_before_initial_share_capital_date():
+    db = _DB(
+        stock_day=[
+            {"code": "000012", "date": "1992-01-07", "vol": 820.0},
+            {"code": "000012", "date": "1992-02-28", "vol": 232.0},
+        ],
+        stock_xdxr=[
+            {
+                "code": "000012",
+                "date": "1992-02-28",
+                "category": 5,
+                "shares_before": 0.0,
+                "shares_after": 10_753.25,
+            }
+        ],
+    )
+
+    assert qfq.load_bfq_dates(kind="stock", code="000012", db=db) == ["1992-02-28"]
+
+
+def test_later_capital_change_does_not_define_a_listing_boundary():
+    db = _DB(
+        stock_day=[{"code": "000012", "date": "1992-01-07"}],
+        stock_xdxr=[
+            {
+                "code": "000012",
+                "date": "1992-02-28",
+                "category": 5,
+                "shares_before": 100.0,
+                "shares_after": 200.0,
+            }
+        ],
+    )
+
+    assert qfq.load_bfq_dates(kind="stock", code="000012", db=db) == ["1992-01-07"]
+
+
 def test_audit_checks_terminal_factor_and_recurrence():
     bars = _bars(
         [
@@ -546,10 +583,115 @@ def test_bootstrap_fails_when_valid_bfq_date_is_missing_from_xtdata():
     db = _stock_db(dates)
     loader = _loader_for({"000001": [(dates[0], 10.0, 0.0)]})
 
-    with pytest.raises(qfq.QFQSyncError, match="full QFQ rebuild audit failed"):
+    with pytest.raises(qfq.QFQSyncError, match="unbounded XTData source gap"):
         qfq.sync_stock_adj_all(target_date=dates[-1], db=db, bars_loader=loader)
 
     assert not db["qfq_ready"].rows
+
+
+def test_bootstrap_bridges_bounded_source_gap_with_constant_front_ratio():
+    dates = ["2026-01-02", "2026-01-05", "2026-01-06"]
+    db = _stock_db(dates)
+    none_loader = _loader_for({"000001": [(dates[0], 10.0, 0.0), (dates[2], 8.0, 9.0)]})
+    front_ratio_loader = _loader_for(
+        {"000001": [(dates[0], 5.0, 0.0), (dates[2], 4.0, 4.5)]}
+    )
+
+    result = qfq.sync_stock_adj_all(
+        target_date=dates[-1],
+        db=db,
+        bars_loader=none_loader,
+        front_ratio_loader=front_ratio_loader,
+    )
+
+    rows = db["stock_adj_qfq_a"].rows
+    assert [row["date"] for row in rows] == dates
+    assert [row["adj"] for row in rows] == [1.0, 1.0, 1.0]
+    coverage = result["by_scope"]["stock"]["coverage"]
+    assert coverage["source_gap_rows_bridged"] == 1
+    assert coverage["codes_with_source_gaps"] == 1
+    assert coverage["source_gaps"][0]["windows"][0]["dates"] == [dates[1]]
+
+    audit = qfq.audit_qfq_slot(
+        scope="stock",
+        slot="a",
+        db=db,
+        bars_loader=none_loader,
+        front_ratio_loader=front_ratio_loader,
+    )
+    assert audit["ok"]
+    assert audit["coverage"]["source_gap_rows_bridged"] == 1
+
+
+def test_bootstrap_rejects_source_gap_that_crosses_an_adjustment():
+    dates = ["2026-01-02", "2026-01-05", "2026-01-06"]
+    db = _stock_db(dates)
+    none_loader = _loader_for({"000001": [(dates[0], 10.0, 0.0), (dates[2], 8.0, 9.0)]})
+    changed_front_ratio = _loader_for(
+        {"000001": [(dates[0], 5.0, 0.0), (dates[2], 3.2, 4.5)]}
+    )
+
+    with pytest.raises(qfq.QFQSyncError, match="crosses an adjustment"):
+        qfq.sync_stock_adj_all(
+            target_date=dates[-1],
+            db=db,
+            bars_loader=none_loader,
+            front_ratio_loader=changed_front_ratio,
+        )
+
+    assert not db["qfq_ready"].rows
+
+
+def test_bootstrap_rejects_unbounded_source_gap():
+    dates = ["2026-01-02", "2026-01-05"]
+    db = _stock_db(dates)
+
+    with pytest.raises(qfq.QFQSyncError, match="unbounded XTData source gap"):
+        qfq.sync_stock_adj_all(
+            target_date=dates[-1],
+            db=db,
+            bars_loader=_loader_for({"000001": [(dates[1], 10.0, 0.0)]}),
+        )
+
+    assert not db["qfq_ready"].rows
+
+
+def test_bootstrap_reports_prelisting_bfq_exclusion():
+    db = _DB(
+        stock_list=[{"code": "000012", "name": "Stock"}],
+        stock_day=[
+            {"code": "000012", "date": "1992-01-07", "vol": 820.0},
+            {"code": "000012", "date": "1992-02-28", "vol": 232.0},
+        ],
+        stock_xdxr=[
+            {
+                "code": "000012",
+                "date": "1992-02-28",
+                "category": 5,
+                "shares_before": 0.0,
+                "shares_after": 10_753.25,
+            }
+        ],
+    )
+
+    result = qfq.sync_stock_adj_all(
+        target_date="1992-02-28",
+        db=db,
+        bars_loader=_loader_for({"000012": [("1992-02-28", 10.5, 0.0)]}),
+    )
+
+    coverage = result["by_scope"]["stock"]["coverage"]
+    assert coverage["prelisting_rows_excluded"] == 1
+    assert coverage["codes_with_prelisting_rows"] == 1
+    assert coverage["prelisting"] == [
+        {
+            "code": "000012",
+            "listing_date": "1992-02-28",
+            "rows": 1,
+            "dates": ["1992-01-07"],
+        }
+    ]
+    assert [row["date"] for row in db["stock_adj_qfq_a"].rows] == ["1992-02-28"]
 
 
 def test_bootstrap_skips_sentinel_only_etf_with_audited_reason():
@@ -877,6 +1019,131 @@ def test_incremental_update_projects_xtdata_superset_to_bfq_dates():
     assert result["by_scope"]["stock"]["stats"]["incremental"] == 1
     assert [row["date"] for row in db["stock_adj_qfq_b"].rows] == bfq_dates
     assert [row["adj"] for row in db["stock_adj_qfq_b"].rows] == [1.0, 1.0]
+
+
+def test_incremental_update_bridges_bounded_source_gap():
+    dates = ["2026-01-02", "2026-01-05", "2026-01-06"]
+    none_payload = {"000001": [(dates[0], 10.0, 0.0)]}
+    front_payload = {"000001": [(dates[0], 5.0, 0.0)]}
+    db = _stock_db(dates[:1])
+    none_loader = _loader_for(none_payload)
+    front_loader = _loader_for(front_payload)
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=none_loader)
+    db["stock_day"].rows.extend(
+        {"code": "000001", "date": value} for value in dates[1:]
+    )
+    none_payload["000001"] = [(dates[0], 10.0, 0.0), (dates[2], 8.0, 9.0)]
+    front_payload["000001"] = [(dates[0], 5.0, 0.0), (dates[2], 4.0, 4.5)]
+
+    result = qfq.sync_stock_adj_all(
+        target_date=dates[-1],
+        db=db,
+        bars_loader=none_loader,
+        front_ratio_loader=front_loader,
+        min_grace_seconds=0,
+    )
+
+    assert result["by_scope"]["stock"]["stats"]["incremental"] == 1
+    assert result["by_scope"]["stock"]["coverage"]["source_gap_rows_bridged"] == 1
+    assert [row["date"] for row in db["stock_adj_qfq_b"].rows] == dates
+    assert [row["adj"] for row in db["stock_adj_qfq_b"].rows] == [1.0, 1.0, 1.0]
+
+
+def test_incremental_update_reloads_context_when_tail_starts_on_source_gap():
+    dates = [
+        "2026-01-02",
+        "2026-01-05",
+        "2026-01-06",
+        "2026-01-07",
+        "2026-01-08",
+        "2026-01-09",
+        "2026-01-12",
+    ]
+    none_payload = {
+        "000001": [
+            (value, 10.0, 0.0 if index == 0 else 10.0)
+            for index, value in enumerate(dates)
+            if value != dates[3]
+        ]
+    }
+    front_payload = {
+        "000001": [
+            (value, 5.0, 0.0 if index == 0 else 5.0)
+            for index, value in enumerate(dates)
+            if value != dates[3]
+        ]
+    }
+    db = _stock_db(dates[:-1])
+    none_loader = _loader_for(none_payload)
+    front_loader = _loader_for(front_payload)
+    qfq.sync_stock_adj_all(
+        target_date=dates[-2],
+        db=db,
+        bars_loader=none_loader,
+        front_ratio_loader=front_loader,
+    )
+    db["stock_day"].rows.append({"code": "000001", "date": dates[-1]})
+
+    result = qfq.sync_stock_adj_all(
+        target_date=dates[-1],
+        db=db,
+        bars_loader=none_loader,
+        front_ratio_loader=front_loader,
+        tail_days=3,
+        min_grace_seconds=0,
+    )
+
+    assert result["by_scope"]["stock"]["stats"]["incremental"] == 1
+    assert result["by_scope"]["stock"]["coverage"]["source_gap_rows_bridged"] == 1
+    assert [row["date"] for row in db["stock_adj_qfq_b"].rows] == dates
+
+
+def test_tail_audit_reloads_context_when_window_starts_on_source_gap():
+    dates = [
+        "2026-01-02",
+        "2026-01-05",
+        "2026-01-06",
+        "2026-01-07",
+        "2026-01-08",
+        "2026-01-09",
+    ]
+    none_loader = _loader_for(
+        {
+            "000001": [
+                (value, 10.0, 0.0 if index == 0 else 10.0)
+                for index, value in enumerate(dates)
+                if value != dates[3]
+            ]
+        }
+    )
+    front_loader = _loader_for(
+        {
+            "000001": [
+                (value, 5.0, 0.0 if index == 0 else 5.0)
+                for index, value in enumerate(dates)
+                if value != dates[3]
+            ]
+        }
+    )
+    db = _stock_db(dates)
+    qfq.sync_stock_adj_all(
+        target_date=dates[-1],
+        db=db,
+        bars_loader=none_loader,
+        front_ratio_loader=front_loader,
+    )
+
+    audit = qfq.audit_qfq_slot(
+        scope="stock",
+        slot="a",
+        db=db,
+        bars_loader=none_loader,
+        front_ratio_loader=front_loader,
+        source_tail_days=3,
+    )
+
+    assert audit["ok"]
+    assert audit["coverage"]["source_gap_rows_bridged"] == 1
 
 
 def test_xtdata_only_corporate_action_day_forces_full_rebuild():
@@ -1321,6 +1588,9 @@ def test_xtdata_client_uses_configured_port_and_none_dividend(monkeypatch):
     assert calls[0] == ("connect", 58611)
     assert calls[-1][1]["dividend_type"] == "none"
     assert calls[-1][1]["fill_data"] is False
+
+    client.load_front_ratio_bars("000001", start_time="20260102", end_time="20260102")
+    assert calls[-1][1]["dividend_type"] == "front_ratio"
 
 
 def test_xtdata_client_downloads_missing_history_prefix():

--- a/freshquant/tests/test_xtdata_qfq_worker.py
+++ b/freshquant/tests/test_xtdata_qfq_worker.py
@@ -336,7 +336,14 @@ def test_status_strict_returns_nonzero_when_shadow_is_not_ready(monkeypatch, cap
 
 def test_audit_full_passes_source_loader_and_single_code(monkeypatch, capsys):
     calls = []
-    client = type("Client", (), {"load_daily_bars": lambda *args, **kwargs: None})()
+    client = type(
+        "Client",
+        (),
+        {
+            "load_daily_bars": lambda *args, **kwargs: None,
+            "load_front_ratio_bars": lambda *args, **kwargs: None,
+        },
+    )()
     monkeypatch.setattr(qfq_worker, "XtDataQfqClient", lambda: client)
     monkeypatch.setattr(
         qfq_worker,
@@ -365,5 +372,6 @@ def test_audit_full_passes_source_loader_and_single_code(monkeypatch, capsys):
     )
     assert calls[0]["codes"] == ["000001"]
     assert calls[0]["bars_loader"] is not None
+    assert calls[0]["front_ratio_loader"] is not None
     assert calls[0]["source_tail_days"] is None
     assert '"ok": true' in capsys.readouterr().out


### PR DESCRIPTION
## 背景

PR1 QFQ shadow pipeline 已部署到 `989ef16e`，但生产 bootstrap 在 Stock `000012` 与 ETF `159735` 上稳定 fail closed。只读证据确认两类源异常：

- 少量 Stock BFQ 行早于 XDXR 初始股本/上市边界。
- XTData 在内部漏掉真实成交日，直接在稀疏 `preClose` 轴递推会制造伪复权跳变。

Related to #467.

## 变更

- Stock coverage 审计式排除早于首条 `category=5, shares_before=0, shares_after>0` 初始股本记录的 BFQ 行，并输出独立计数。
- 仅对有两个真实 XTData 边界、且两端 `front_ratio.close / none.close` 一致的内部 BFQ-only 缺口做 bridge。
- canonical 因子仍由 `dividend_type=none` 的 `preClose` 递推；`front_ratio` 仅证明缺口没有跨公司行为。
- prefix/suffix、proof 缺失、日期轴不一致、跨公司行为或因子不一致继续 fail closed。
- full rebuild、incremental tail、full/tail audit 使用同一规则；tail 在窗口首日命中已 bridge 日期时自动加载左侧上下文。
- 同步 `docs/current/**` 与排障字段。

## 验证

- Focused QFQ tests: `85 passed`
- Related market-data / Index tests: `191 passed`
- Formal local preflight:
  - docs-current-guard passed
  - pre-commit passed
  - pytest `1514 passed`
- 真实只读投影：
  - `000012`: 排除 1 条 pre-listing 行，bridge 9 条内部缺口，投影审计通过
  - `159735`: bridge 1 条内部缺口，投影审计通过

## 部署影响

命中 `freshquant/market_data/**`：合并后仅基于最新 remote-main SHA 走 official formal deploy，先验证 `000012/159735`，再启动单实例 Stock → ETF bootstrap；两个 scope ready 后执行 full audit 与同 SHA Verify。Stock/ETF 在线 reader 仍留到 PR2 切换。