### PR TITLE
feat: activate strict Stock and ETF QFQ readers (PR2a)

### DIFF
--- a/docs/current/architecture.md
+++ b/docs/current/architecture.md
@@ -33,13 +33,15 @@
 
 ## 当前行情复权边界
 
-- Stock / ETF 线上读取链仍使用 `quantaxis.stock_adj` / `quantaxis.etf_adj`；现有 `stock_xdxr`、`etf_xdxr -> etf_adj` 写入链继续运行。
-- `freshquant.market_data.xtdata.qfq` 以 XTData 日线 `preClose` 生成独立的 Stock / ETF QFQ shadow 快照：
+- Stock / ETF 线上读取统一由 `freshquant.data.qfq_reader` 解析 `quantaxis.qfq_ready` 指向的 active A/B 快照；reader 每次请求重新解析 marker，不缓存 collection pointer。
+- `freshquant.market_data.xtdata.qfq` 以 XTData 日线 `preClose` 生成 Stock / ETF QFQ A/B 快照：
   - Stock：`stock_adj_qfq_a` / `stock_adj_qfq_b`
   - ETF：`etf_adj_qfq_a` / `etf_adj_qfq_b`
   - `quantaxis.qfq_ready` 以每个 `scope` 的单文档保存 `active_slot` 与两个槽位的快照元数据。
-- shadow writer 只构建 inactive slot，审计通过后再原子切换 `active_slot`；`worker`、人工 `build` 与 `rollback` 共用 `qfq_writer_locks` 的 scope 唯一 lease，回滚也只切换 marker，不改写 active 集合。
-- 当前 Stock / ETF reader 尚未读取 `*_adj_qfq_a/b`，因此 shadow 快照发布不会改变 API、策略或实时 Kline 的复权结果。
+- writer 只构建 inactive slot，审计通过后再原子切换 `active_slot`；`worker`、人工 `build` 与 `rollback` 共用 `qfq_writer_locks` 的 scope 唯一 lease。回滚会先将仍需生效的 intraday override 重新绑定到目标 snapshot，再以 CAS 切换 marker；factor A/B 集合本身不改写。
+- reader 要求 active slot 为 `ready`，并严格校验请求 bar 的日期覆盖、正因子、重复键、source exclusion 和 snapshot-bound intraday override；证明失败统一抛出 `QFQ_DATA_NOT_READY`，三条 Stock Kline API 统一返回 HTTP 503。
+- Redis Kline key/payload 与 StrategyConsumer 常驻窗口绑定 effective adjustment version（active `snapshot_id` 加匹配的 override version）；版本变化时旧 cache miss、常驻窗口重载。
+- 旧 `stock_adj` / `etf_adj` 不再是线上 reader 真值。
 - 真实 Index 的日线、分钟线和实时合并固定使用 BFQ；Index 路径不读取 Stock / ETF 因子，实时数据读取 `freshquant.index_realtime`。
 
 ## 订单相关核心调用链

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -197,18 +197,18 @@ powershell -ExecutionPolicy Bypass -File script/install_fqnext_supervisord_resta
 | `freshquant/xt_account_sync/**` | XT 主动查询统一 worker（仓位管理 + 订单管理） | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface position_management -DeploymentSurface order_management -BridgeIfServiceUnavailable` |
 | `freshquant/xt_auto_repay/**` | XT 自动还款 worker | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface order_management -BridgeIfServiceUnavailable` |
 | `freshquant/tpsl/**` | TPSL | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface tpsl -BridgeIfServiceUnavailable` |
-| `freshquant/market_data/**` | XTData producer / consumer、adj refresh worker、QFQ shadow worker | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface market_data -BridgeIfServiceUnavailable`；必要时重新 prewarm |
+| `freshquant/market_data/**` | XTData producer / consumer、adj refresh worker、QFQ A/B worker | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface market_data -BridgeIfServiceUnavailable`；必要时重新 prewarm |
 | `freshquant/data/index.py` / `freshquant/quote/index.py` / `freshquant/instrument/general.py` / `freshquant/chanlun_service.py` / `freshquant/chanlun_structure_service.py` | Index BFQ API / 分类 / Chanlun 读取链 | 重建 `fq_apiserver` |
 | `freshquant/strategy/**` 或 `freshquant/signal/**` | Guardian | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface guardian -BridgeIfServiceUnavailable` |
 | `sunflower/QUANTAXIS/**` | QAWebServer 与依赖 QUANTAXIS 的宿主机策略链路 | 重建 `fq_qawebserver`；同步重启受影响宿主机 Guardian / strategy 进程 |
 | `freshquant/data/gantt*` / `freshquant/shouban30_pool_service.py` | Gantt/Shouban30 读模型与 API | 重建 API；必要时重跑 Dagster 任务 |
-| `freshquant/data/etf_adj_sync.py` | ETF 前复权 xdxr/adj Dagster 同步链路 | 重建 `fq_apiserver` 镜像并重启 `fq_dagster_webserver` / `fq_dagster_daemon` |
+| `freshquant/data/etf_adj_sync.py` | ETF legacy xdxr/adj 过渡写入链（已非在线 reader 真值） | 重建 `fq_apiserver` 镜像并重启 `fq_dagster_webserver` / `fq_dagster_daemon` |
 | `freshquant/daily_screening/**` | 每日选股 API 与 `fqscreening` 读模型 | 重建 API；如改动影响自动任务语义，补跑 Dagster 每日筛选任务 |
 | `morningglory/fqwebui/**` | Web UI | 重建 `fq_webui` |
 | `morningglory/fqdagster/**` / `morningglory/fqdagsterconfig/**` | Dagster | 重启 `fq_dagster_webserver` 与 `fq_dagster_daemon` |
 | `third_party/tradingagents-cn/**` | TradingAgents-CN | 重建 `ta_backend` 与 `ta_frontend` |
 
-### XTData QFQ shadow worker
+### XTData QFQ A/B worker 与 reader 激活
 
 `fqnext_xtdata_qfq_worker` 属于 `market_data` 宿主机 surface。部署后先确认 Supervisor 状态，再检查两个 scope 的 marker 与 active slot：
 
@@ -238,7 +238,9 @@ powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mod
 & D:\fqpack\freshquant-2026.2.23\.venv\Scripts\python.exe -m freshquant.market_data.xtdata.qfq_worker rollback --scope stock
 ```
 
-该 worker 当前只发布 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b` shadow 快照；部署它不会切换仍在读取 `stock_adj` / `etf_adj` 的线上 Stock / ETF 消费者，也不替代现有 XDXR / ETF adj writer。Dagster ready asset 或 `dagster.yaml` 同时变更时，还必须按 `dagster` surface 重部署 webserver / daemon。`check_freshquant_runtime_post_deploy.ps1 -Mode Verify` 对 `market_data` surface 会自动执行 `status --strict`，marker 缺失或落后时 health gate 失败。
+部署 reader 前必须先确认 Stock / ETF active slot 均为 `ready` 且 full audit 通过。激活后 Stock / ETF API、StrategyConsumer、Chan、ATR/holding/threshold 统一读取 marker 指向的 A/B 快照；marker/coverage/override 证明失败返回 `QFQ_DATA_NOT_READY`，三条 Stock Kline API 返回 HTTP 503。StrategyConsumer 必须先成功写 raw realtime bar，再做 QFQ 派生；Redis key/payload 与常驻窗口绑定 effective adjustment version。Dagster ready asset 或 `dagster.yaml` 同时变更时，还必须按 `dagster` surface 重部署 webserver / daemon。`check_freshquant_runtime_post_deploy.ps1 -Mode Verify` 对 `market_data` surface 会自动执行 `status --strict`，marker 缺失或落后时 health gate 失败。
+
+PR2a reader 激活期间，旧 Stock / ETF factor writer 可能仍由现有 Dagster 依赖链执行，但其输出已不是在线读取真值；`stock_adj` / `etf_adj` 继续保留用于过渡观察。回退时先用 CAS 将 marker 切回上一 ready slot，清理或等待旧 adjustment-version Redis key 失效，再重启 API 与 StrategyConsumer 使常驻窗口按回切后的 snapshot reload。
 
 - `script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces` 当前会先做 surface reconcile；若首次重启失败且启用了 `-BridgeIfServiceUnavailable`，即使 `fqnext-supervisord` service 仍是 `Running`，也允许触发一次管理员桥接
 - 管理员桥接恢复后，脚本会先确认目标 programs 是否已经 settled 到 `RUNNING`；只有仍未恢复时，才继续补做第二次 `restart-surfaces`
@@ -319,7 +321,7 @@ powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mod
 
 - API 蓝图能返回，不是只监听端口。
 - Web UI 页面不是空白页。
-- XTData 相关修改后，producer/consumer 日志持续产出，Redis 队列不持续堆积；涉及 QFQ shadow writer 时，`fqnext_xtdata_qfq_worker` 为 `RUNNING`，且 `status --strict` / active-slot `audit --mode full` 通过。
+- XTData 相关修改后，producer/consumer 日志持续产出，Redis 队列不持续堆积；涉及 QFQ A/B writer/reader 时，`fqnext_xtdata_qfq_worker` 为 `RUNNING`，`status --strict` / active-slot `audit --mode full` 通过，Stock / ETF strict-reader health 与 versioned cache/window reload 通过。
 - 宿主机 deployment surface 修改后，`fqnext-supervisord` 保持 `Running`，且 `script/fqnext_host_runtime_ctl.ps1 -Mode Status` 能返回目标 program 为 `RUNNING`。
 - 如果本轮有实际 deploy，`check_freshquant_runtime_post_deploy.ps1` 的 verify 结果必须 `passed=true`，且 `failures` 为空。
 

--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -2,13 +2,13 @@
 
 ## 职责
 
-XTData 链路负责把宿主机 XTData 行情转换成 FreshQuant 可消费的实时事件流，并维护独立的盘后 QFQ shadow 快照。它承担五件事：
+XTData 链路负责把宿主机 XTData 行情转换成 FreshQuant 可消费的实时事件流，并维护盘后 QFQ A/B 快照。它承担五件事：
 
 - 从 XTQuant 订阅当前监控池的全量行情。
 - 把 tick 推入 Redis 分片队列。
 - 合成 1 分钟 bar，并继续向下游发布 bar close 事件。
 - 在 consumer 侧做 prewarm、结构计算、实时缓存与运行观测。
-- 在盘后 BFQ ready 后，以 XTData 日线 `preClose` 构建和审计 Stock / ETF A/B QFQ shadow 快照。
+- 在盘后 BFQ ready 后，以 XTData 日线 `preClose` 构建和审计 Stock / ETF A/B QFQ 快照，供共享 strict reader 在线读取。
 
 ## 入口
 
@@ -16,7 +16,7 @@ XTData 链路负责把宿主机 XTData 行情转换成 FreshQuant 可消费的�
   - `python -m freshquant.market_data.xtdata.market_producer`
 - consumer
   - `python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
-- QFQ shadow worker
+- QFQ A/B worker
   - `python -m freshquant.market_data.xtdata.qfq_worker worker`
 - QFQ 运维 CLI
   - `python -m freshquant.market_data.xtdata.qfq_worker status --strict`
@@ -61,14 +61,14 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - `OneMinuteBarGenerator` 和 `StrategyConsumer` 都会通过 FreshQuant A 股交易日历拦截非交易日 bar；周末/节假日 tick 不生成 bar，非交易日 `BAR_CLOSE` 不写入 `stock_realtime/index_realtime`。
 - consumer prewarm、股票分钟线 API 拼接与 ETF/index K 线查询都会过滤非交易日 realtime 行，避免历史脏数据继续进入 Redis Kline cache 或 `/api/stock_data` 返回值。
 
-### QFQ shadow 链
+### QFQ A/B 链
 
-`Dagster Stock/ETF BFQ + 旧复权 writer -> postclose ready marker -> fqnext_xtdata_qfq_worker -> XTData preClose -> inactive A/B slot -> audit -> qfq_ready active_slot`
+`Dagster Stock/ETF BFQ + 过渡期 legacy writer -> postclose ready marker -> fqnext_xtdata_qfq_worker -> XTData incremental -> inactive A/B slot -> full audit -> qfq_ready active_slot CAS`
 
 - Stock 数据集合为 `stock_adj_qfq_a` / `stock_adj_qfq_b`，ETF 数据集合为 `etf_adj_qfq_a` / `etf_adj_qfq_b`。
 - `quantaxis.qfq_ready` 对每个 scope 使用一个原子双槽 marker；构建 inactive slot 期间 active slot 保持只读，inactive slot 审计成功后才切换。
 - `quantaxis.qfq_writer_locks` 对每个 scope 只允许一个带过期时间并由后台线程持续续期的 writer lease；单次 XTData 请求或 Mongo `$out` 阻塞时仍续租，发布前重新核对 owner。中断的 `building` 仅由下一位 lease owner 恢复，人工 build / rollback 不与 Supervisor worker 并发写。
-- 首次 bootstrap 先构建并审计 A，再复制和审计 B，之后发布双槽 marker；日更只对 inactive slot 写入。
+- 首次 bootstrap / 历史 backfill 只通过人工 `qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD [--full]` 执行：先构建并审计 A，再复制和审计 B，之后发布双槽 marker。正常 worker 缺少 marker 时返回 `bootstrap_required`；日更只对 inactive slot 写入。
 - XTData field-table 以日期列为交易日，epoch 回退按 Asia/Shanghai 还原；`dividend_type=none` 日线的 `preClose` 仍是 canonical 因子来源，常规边先在真实 XTData 日期轴递推，再投影到有效 BFQ coverage。
 - BFQ 中 `vol` 与 `amount` 同时等于 QASU 浮点哨兵的占位行不进入 coverage。Stock 优先以 `stock_xdxr` 中最早满足 `category=5`、`shares_before=0`、`shares_after>0` 的初始股本记录作为上市边界；缺少该记录时才回退 XTData instrument detail 的 `OpenDate`，ETF 也使用同一证据。只有 `OpenDate` 不晚于最后一条有效 BFQ 时才将其解释为上市边界；若 `IsTrading=false`、`OpenDate` 晚于全部有效 BFQ，且该边界之后还有 QASU sentinel 证据，则分类为 `nontrading_terminal_history`，仅从当前 QFQ build universe 排除并保留 BFQ 历史；该旧生命周期没有 XTData `preClose` 因子时 reader 仍 fail closed。缺失、无效或缺少任一终止证据的 `OpenDate` 不排除 BFQ，source 前后缀缺口仍 fail closed。
 - BFQ-only 日期仅在两个真实 XTData bar 之间，且同日期轴的 `front_ratio.close / none.close` 在缺口两端容差内相等时桥接；该稀疏边按无调整处理，缺失日期写入相同因子，并记录 `source_gap_rows_bridged`、`codes_with_source_gaps`、`source_gaps[]`。
@@ -76,8 +76,10 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - 完整 source 区间下载后仍无 `none` bars 的 code 同样不生成空因子或 `1.0`，并记录 `{code, reason=source_empty_bars}`。A/B 各自保留自己的 `source_exclusions[]`，rollback 随 slot 一起恢复。tail 请求为空必须先用完整 BFQ 区间复核；`front_ratio` proof 为空不属于该分类，继续 fail closed。
 - primary `none` loader 完成单调前缀分页后仍报告 `history_prefix_no_progress` 时，该 code 记录 `{code, reason=source_prefix_unavailable}` 并从本轮 slot 隔离；同一错误来自 `front_ratio` proof loader 时仍中止 scope。普通 unbounded prefix/suffix、proof 缺失和日期轴不一致不进入该分类。
 - XTData 长区间下载只返回近期后缀时，QFQ client 会以当前最早缓存日的前一日为边界继续向前分页，直至覆盖请求起点；任一页未把最早日期向前推进时立即报错，不发布不完整快照。
-- 当前 Stock / ETF 在线 reader 和旧 `stock_xdxr`、`etf_xdxr -> etf_adj` writer 均未切换；A/B 发布不会改变现有 Kline 或策略读取结果。
-- 真实 Index 走 BFQ 日线/分钟线和 `index_realtime`，不读取 ETF/Stock 因子，也不进入 QFQ shadow scope。
+- Stock / ETF 在线 reader 统一使用 `freshquant.data.qfq_reader`：每个请求重新解析 marker 指向的 active slot，严格验证 snapshot、请求日期覆盖、正因子、重复键、source exclusion 与 snapshot-bound override；失败统一为 `QFQ_DATA_NOT_READY`，Stock Kline API 映射 HTTP 503。
+- StrategyConsumer 先落 raw realtime bar，再执行严格 QFQ 派生；Redis Kline key/payload 和常驻窗口绑定 effective adjustment version，版本变化后旧缓存 miss、窗口 reload。
+- 旧 `stock_xdxr`、`etf_xdxr`、`etf_adj` asset 在 PR2a 过渡期仍可能由现有 schedule 执行，但 `stock_adj` / `etf_adj` 已不再作为在线读取真值。
+- 真实 Index 走 BFQ 日线/分钟线和 `index_realtime`，不读取 ETF/Stock 因子，也不进入 QFQ scope。
 
 ## 存储
 
@@ -163,9 +165,10 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - 检查 tick 分片队列是否有目标 code。
 - 检查 producer 是否在向 `REDIS_TICK_QUEUE_PREFIX:<shard>` 推送。
 
-### QFQ shadow 不更新
+### QFQ A/B 不更新或 reader 返回 503
 
 - 检查 `fqnext_xtdata_qfq_worker` Supervisor 状态与 `D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log`。
 - 执行 `python -m freshquant.market_data.xtdata.qfq_worker worker --once`，区分 `waiting_for_bfq`、`current`、`published` 与错误结果。
 - 执行 `status --strict` 核对 active 截止日与盘后 marker，执行 `audit --scope stock|etf --mode full` 对 active slot 做 XTData source-aware 审计；快速排查可先用 `--mode structure`。
-- 页面仍读取旧 Stock / ETF 因子；shadow 集合已更新但页面未变化，不代表 QFQ worker 失败。
+- 若 active slot 已更新但页面仍是旧结果，核对响应/Redis payload 的 `adjustment_version` 与 marker `snapshot_id`；旧 version key 不应被新 reader 命中。
+- `QFQ_DATA_NOT_READY/503` 时先核对 active slot `status=ready`、请求 code/date coverage、`source_exclusions[]` 和 intraday override 的 `base_snapshot_id`，不回退到 BFQ 或 `1.0`。

--- a/docs/current/reference/etf-data.md
+++ b/docs/current/reference/etf-data.md
@@ -24,8 +24,7 @@ ETF 在 FreshQuant 中与 A 股共用大部分接口，但有几处语义不同�
 - `python -m freshquant.cli etf save`
   - 同步 `etf_list`
   - 同步 `index_day/index_min` 口径的 ETF 历史数据
-  - 同步 `quantaxis.etf_xdxr`
-  - 重算 `quantaxis.etf_adj`
+  - 过渡期仍同步 `quantaxis.etf_xdxr` 并重算 `quantaxis.etf_adj`，但两者已不是在线 reader 真值
 
 ## 与普通 A 股的差异
 
@@ -35,10 +34,10 @@ ETF 在 FreshQuant 中与 A 股共用大部分接口，但有几处语义不同�
 
 ETF 当前前复权链路：
 
-- `TDX get_xdxr_info -> quantaxis.etf_xdxr -> quantaxis.etf_adj -> /api/stock_data`
-- `category=11` 的扩缩股事件会写入 `suogu`
-- 页面日线/分钟线会读取 `etf_adj`；如果 `etf_xdxr` 缺失，前复权会整段退化成 `adj=1.0`
-- `sync_etf_xdxr_all()` 当前默认在上游返回空结果时保留旧 `etf_xdxr`，避免单次空响应把历史扩缩股事件清空
+- `ETF BFQ ready -> XTData preClose -> etf_adj_qfq_a/b inactive slot -> full audit -> qfq_ready active_slot -> freshquant.data.qfq_reader`
+- 页面、策略与共享 QuantAxis 适配层每次读取 active marker，严格校验 snapshot、coverage、正因子、重复键、source exclusion 与 snapshot-bound intraday override
+- 合同不满足时返回 `QFQ_DATA_NOT_READY`；Stock/ETF Kline HTTP 路由映射为 503，不回退 `adj=1.0` 或 legacy 集合
+- `quantaxis.etf_xdxr` / `quantaxis.etf_adj` 在 PR2a 过渡期仍可能由现有 schedule 更新，但不再是在线 reader 真值
 
 ## 当前排查
 
@@ -54,9 +53,7 @@ ETF 当前前复权链路：
 
 ### ETF 前复权在扩缩股日前后不连续
 
-- 先查 `quantaxis.etf_xdxr` 是否存在目标 ETF 的 `category=11` / `suogu`
-- 再查 `quantaxis.etf_adj` 是否在事件日前生成了 `adj<1`
-- 最后查 `/api/stock_data?period=1d&symbol=<code>&endDate=<date>` 是否已经返回复权后的 close
-- 如果历史事件缺失，先执行：
-  - `python -m freshquant.cli etf.xdxr save --code 512000`
-  - `python -m freshquant.cli etf.adj save --code 512000`
+- 执行 `python -m freshquant.market_data.xtdata.qfq_worker status --scope etf --strict`，核对 active snapshot 的 `factor_asof`
+- 对目标代码执行 `python -m freshquant.market_data.xtdata.qfq_worker audit --scope etf --mode full --code 512000`
+- 核对 `quantaxis.qfq_ready` 指向的 active collection、该 code 的 factor coverage 与响应 `adjustment_version`
+- 若 active slot 审计失败，在 QFQ writer 独占 lease 下人工执行 `build --scope etf --target-date YYYY-MM-DD`；不手工修改 marker，不回填 legacy `etf_adj`

--- a/docs/current/reference/market-data.md
+++ b/docs/current/reference/market-data.md
@@ -6,7 +6,7 @@ FreshQuant 当前同时使用三类行情来源：
 
 - XTData / XTQuant
   - 实时 tick 和分钟 bar 的唯一正式入口
-  - Stock / ETF QFQ shadow 快照的 `preClose` 权威来源
+  - Stock / ETF QFQ canonical 快照的 `preClose` 权威来源
 - QuantAxis / Mongo 历史库
   - Kline、结构计算、历史回看使用的主要历史数据来源
 - Redis realtime cache
@@ -18,7 +18,7 @@ FreshQuant 当前同时使用三类行情来源：
   - `python -m freshquant.market_data.xtdata.market_producer`
 - 实时 consumer
   - `python -m freshquant.market_data.xtdata.strategy_consumer --prewarm`
-- QFQ shadow worker / 运维 CLI
+- QFQ canonical worker / 运维 CLI
   - `python -m freshquant.market_data.xtdata.qfq_worker worker`
   - `python -m freshquant.market_data.xtdata.qfq_worker status --strict`
   - `python -m freshquant.market_data.xtdata.qfq_worker audit --scope <stock|etf> --mode <structure|tail|full> [--code CODE]`
@@ -46,9 +46,9 @@ FreshQuant 当前同时使用三类行情来源：
 - 指定 `endDate` 时，以历史查询为准
 - TDX 股票日线对未上市/暂无源数据代码返回空结果时按 no-op 处理，不执行空批量写入；连接、抓取或真实写库异常仍由 Dagster 标记为失败
 - 股票除权除息复权计算使用显式列赋值与 `DataFrame.ffill()`，避免 Pandas 3.0 链式 `inplace`/`fillna(method=...)` 兼容性问题，计算口径不变
-- Stock / ETF 在线读取仍使用 `quantaxis.stock_adj` / `quantaxis.etf_adj`，现有 `stock_xdxr`、`etf_xdxr -> etf_adj` writer 继续运行
-- XTData `preClose` QFQ writer 维护独立 shadow 集合：`stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`；`quantaxis.qfq_ready` 保存每个 scope 的 active slot 与双槽快照元数据
-- shadow writer 只在 inactive slot 构建并审计，审计成功且 writer lease owner 仍匹配后原子切换 marker；当前 Stock / ETF reader 尚未读取这些 A/B 集合
+- Stock / ETF 在线读取统一使用 `freshquant.data.qfq_reader`，按 `quantaxis.qfq_ready` 指向的 active slot 读取 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`
+- XTData `preClose` QFQ writer 只在 inactive slot 构建并审计，审计成功且 writer lease owner 仍匹配后原子切换 marker；reader 每次请求重新解析 marker，并对 snapshot、coverage、source exclusion 与 override fail closed
+- Redis Kline 与 StrategyConsumer 常驻窗口绑定 effective adjustment version；旧 `stock_adj` / `etf_adj` 不再是 reader 真值，PR2a 过渡期旧 writer 仍可能运行且旧集合继续保留
 - 完整历史请求后仍无 source bars、有界内部 source gap 两端 adjustment proof 不一致，或 primary source 前缀分页稳定报告 `history_prefix_no_progress` 的 code，不写推断因子或 `1.0`，从当前 snapshot 隔离，并在对应 slot `source_exclusions[]` 分别记录 `source_empty_bars`、`source_adjustment_gap_unproven` 或 `source_prefix_unavailable`；A/B 与 rollback 各自保留该审计边界
 - `audit --mode structure` 检查 Mongo 结构合同，并读取 XTData instrument `OpenDate` / `IsTrading` 元数据以区分上市前 BFQ 覆盖与 `nontrading_terminal_history`，但不加载 source bars；`tail/full` 另会加载 XTData source bars 并验证 `preClose` 递推，正式发布门禁使用 `full`
 - 真实 Index 日线、分钟线与 realtime merge 固定为 BFQ，实时表使用 `freshquant.index_realtime`，不读取 ETF 或 Stock 复权因子
@@ -56,10 +56,10 @@ FreshQuant 当前同时使用三类行情来源：
 Dagster 盘后桥接口径当前新增两条 ready asset：
 
 - `stock_postclose_ready_asset`
-  - 依赖股票日线、分钟线、`quality_stock_universe` 快照刷新与旧 `stock_xdxr` writer
+  - 依赖股票日线、分钟线、`quality_stock_universe` 快照刷新与过渡期旧 `stock_xdxr` writer
   - 成功后写入 `freshquant.dagster_pipeline_markers` 中 `pipeline_key=stock_postclose_ready` 的文档
 - `etf_postclose_ready_asset`
-  - 依赖旧 `etf_xdxr -> etf_adj` writer 和通过日线/五周期完整性门禁的 `etf_min`
+  - 依赖过渡期旧 `etf_xdxr -> etf_adj` writer 和通过日线/五周期完整性门禁的 `etf_min`
   - 成功后写入 `freshquant.dagster_pipeline_markers` 中 `pipeline_key=etf_postclose_ready` 的文档
 
 其中：
@@ -68,7 +68,7 @@ Dagster 盘后桥接口径当前新增两条 ready asset：
 - `etf_data_job` 仍由工作日 `16:00` schedule 驱动
 - `stock_postclose_ready` 是 Gantt / Daily Screening 盘后链路的正式股票侧就绪信号
 - `etf_postclose_ready` 当前仅保留给 ETF 扩展链路，不是每日选股硬门禁
-- Windows `fqnext_xtdata_qfq_worker` 消费上述两个 success marker，更新对应 scope 的 QFQ shadow 快照
+- Windows `fqnext_xtdata_qfq_worker` 消费上述两个 success marker，更新对应 scope 的 QFQ canonical 快照；缺失 `qfq_ready` 时只报告 `bootstrap_required`，首次全历史构建由人工 `build` 执行
 
 ## 当前常见字段语义
 

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -8,7 +8,7 @@
 - Mongo 通过 `127.0.0.1:27027` 接入 Docker `fq_mongodb`；宿主机链路不要再使用 `127.0.0.1:27017`。
 - `fqnext-supervisord` 宿主机底座与其托管的交易/运行链 Python 进程。
 - Guardian monitor。
-- XTData producer / consumer / adj refresh worker / QFQ shadow worker（XTData producer 启动阶段遇到可重试的 XTData 连接失败时会在进程内退避重试；交易时段若订阅链 stale，则先 `resubscribe`，持续 stale 再升级为 `xtdata.connect() + resubscribe`。`xtdata_adj_refresh_worker` 在启动或计划刷新遇到可重试的 XTData 连接失败时，会退避后重建新的 refresh service / XTData client 再继续同步。`fqnext_xtdata_qfq_worker` 读取 Dagster 盘后 ready marker，再以 XTData `preClose` 更新 Stock / ETF A/B shadow 快照。）
+- XTData producer / consumer / adj refresh worker / QFQ canonical worker（XTData producer 启动阶段遇到可重试的 XTData 连接失败时会在进程内退避重试；交易时段若订阅链 stale，则先 `resubscribe`，持续 stale 再升级为 `xtdata.connect() + resubscribe`。`xtdata_adj_refresh_worker` 在启动或计划刷新遇到可重试的 XTData 连接失败时，会退避后重建新的 refresh service / XTData client 再继续同步。`fqnext_xtdata_qfq_worker` 读取 Dagster 盘后 ready marker，再以 XTData `preClose` 更新 Stock / ETF A/B canonical 快照。）
 - XT account sync worker（作为 XT 账户数据的增量补偿同步入口，默认每 15 秒轮询 `assets / credit_detail / positions / orders / trades`；其中 `credit_detail` 保持高频刷新以驱动仓位管理状态，只把新增 `orders / trades` 送入 ingest；`credit_subjects` 只在启动和每日计划时间做低频同步，并在启动时做一次单标的实时仓位 fallback 种子刷新；若 `positions` 快照为空或严重缩水、但同轮 `credit_detail.market_value` 仍显著为正，则该轮快照会进入 quarantine，不覆盖 `xt_positions`，也不触发自动平账；这个 quarantine 现在也覆盖小账户单票/双票严重缩水的场景，同时 worker 会记录 warning 说明 quarantine 原因；对 `xtquant connect/subscribe` 可重试失败，worker 会在退避后重建新的 XT sync service/client 再继续同步）。
 - XT auto repay worker（默认每 30 分钟低频巡检一次已同步的 `credit_detail` 快照，只处理普通融资负债；盘中命中候选后才即时执行一次 `query_credit_detail()` 二次确认，再走 `CREDIT_DIRECT_CASH_REPAY`；固定在 `14:55` 做日终硬结算、`15:05` 做一次补偿重试；`broker_submit_mode=observe_only` 时只记录事件，不真实提交还款）。
 - TPSL tick listener。
@@ -56,15 +56,17 @@
 - 冷记忆目录：`.codex/memory`
 - 热记忆 Mongo database：`fq_memory`
 
-## XTData QFQ shadow 运行口径
+## XTData QFQ A/B 运行口径
 
 - Supervisor program 为 `fqnext_xtdata_qfq_worker`，并与 `fqnext_xtdata_adj_refresh_worker` 同属 `fqnext_reference_data` group；它运行在 Windows 宿主机，默认每 60 秒检查一次盘后就绪状态。
 - worker 从 `freshquant.dagster_pipeline_markers` 读取 `pipeline_key=stock_postclose_ready` / `etf_postclose_ready` 的最新成功文档，再把目标交易日传给 XTData QFQ writer。
-- `stock_postclose_ready` 在股票日线、分钟线、质量股票池快照和旧 `stock_xdxr` writer 完成后发布；`etf_postclose_ready` 在 ETF 日线/分钟线及旧 `etf_xdxr -> etf_adj` writer 完成后发布。
-- shadow 快照与发布 marker 写在 QuantAxis Mongo：数据集合为 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`，marker 集合为 `qfq_ready`；`qfq_writer_locks` 以 scope 唯一后台 heartbeat lease 强制 worker、人工 build 与 rollback 串行，单次 XTData 下载或 Mongo `$out` 阻塞期间也会持续续租，发布前再次核对 owner。
+- `stock_postclose_ready` 在股票日线、分钟线、质量股票池快照和过渡期旧 `stock_xdxr` writer 完成后发布；`etf_postclose_ready` 在 ETF 日线/分钟线及过渡期旧 `etf_xdxr -> etf_adj` writer 完成后发布。
+- A/B 快照与发布 marker 写在 QuantAxis Mongo：数据集合为 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`，marker 集合为 `qfq_ready`；`qfq_writer_locks` 以 scope 唯一后台 heartbeat lease 强制 worker、人工 build 与 rollback 串行，单次 XTData 下载或 Mongo `$out` 阻塞期间也会持续续租，发布前再次核对 owner。
 - QFQ coverage 排除 `vol/amount` 同时命中 QASU 浮点哨兵的 BFQ 占位行；XTData 多出的真实交易日仍参与完整递推，之后才投影到有效 BFQ 日期。bootstrap、update 与 audit JSON 的 `coverage` 字段记录 sentinel 和无有效历史标的计数。
-- 当前 Stock / ETF 在线 reader 继续读取 `stock_adj` / `etf_adj`，旧 writer 继续运行；QFQ worker 的发布只更新 shadow 链。
-- 真实 Index 当前固定读取 BFQ 日线/分钟线与 `index_realtime`，不读取 `stock_adj`、`etf_adj` 或 QFQ shadow 集合。
+- Stock / ETF 在线 reader 每次请求从 `qfq_ready` 解析 active slot；marker、coverage、factor 或 snapshot-bound override 不满足合同时 fail closed 为 `QFQ_DATA_NOT_READY`。Redis Kline 与 StrategyConsumer 常驻窗口按 effective adjustment version 隔离，marker/override 版本变化会 miss/reload。
+- 旧 `stock_xdxr`、`etf_xdxr`、`etf_adj` asset 在 PR2a 过渡期仍可能由现有 schedule 执行；`stock_adj` / `etf_adj` 集合继续保留但不再作为在线真值。
+- 真实 Index 当前固定读取 BFQ 日线/分钟线与 `index_realtime`，不读取 `stock_adj`、`etf_adj` 或 QFQ A/B 集合。
+- 首次 bootstrap 与历史 backfill 只通过人工 `qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD [--full]` 执行；正常 worker 遇到缺失 `qfq_ready` marker 返回 `bootstrap_required`，不自动构建全历史。
 - 运维 CLI 入口为 `python -m freshquant.market_data.xtdata.qfq_worker`，子命令为 `worker`、`build`、`audit`、`status`、`rollback`；`status --strict` 检查 active 截止日是否追平盘后 ready marker，`audit --mode structure|tail|full` 分别执行结构、近期 XTData 递推和全历史 XTData 递推审计。
 
 ## 会话与记忆口径

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -617,12 +617,12 @@ docker exec fqnext_20260223-fq_mongodb-1 mongosh --quiet --eval 'const c=db.getS
 
 ## ETF 前复权未生效但 Dagster run 显示成功
 
-本节排查当前线上 `etf_xdxr -> etf_adj` 旧写入链；Stock / ETF 在线 reader 仍消费这条链。
+本节只排查 PR2a 过渡期仍可能由现有 schedule 执行的 `etf_xdxr -> etf_adj` 旧写入链。Stock / ETF 在线 reader 已改为读取 `qfq_ready` marker 指向的 A/B 快照；旧集合不再是在线读取真值。
 
 现象：
 
 - KlineSlim / ETF 日线在拆分、扩缩股之后仍显示 bfq 价格
-- `quantaxis.etf_xdxr` 缺少目标 ETF 的历史事件，但 Dagster `etf_data_schedule` 显示成功
+- 过渡期 Dagster run 或人工执行 legacy `etf.xdxr` / `etf.adj` 后，`quantaxis.etf_xdxr` 仍缺少目标 ETF 的历史事件
 - `quantaxis.etf_adj` 在事件日前后仍全部为 `1.0`
 
 先检查：
@@ -649,7 +649,7 @@ print(sync_etf_xdxr_all(codes=['512800']))
 - 当前实现会对 ETF xdxr 首次空结果做 fresh connection retry，并在全量同步时周期性重建 TDX 连接
 - 当前实现会在 batch host 连接失败时自动切到下一个可用 HQ host；fresh connection retry 的目标 host 若连不上，也会继续轮转其他 HQ host，而不是把 run 记成成功或打成 `bool` context manager 异常
 - retry 仍超时或为空时，优先核对该 code 在不同 TDX host 上是否一致为空；对确实为空但库里已有历史回填的 ETF，允许保留旧文档
-- Dagster `etf_xdxr` 资产会对本次同步中 `empty/preserved` 的可疑 code 追加一次近期覆盖审计；如果近窗口内源侧有事件但库里没有，或者所有 HQ host 都不可达，asset 会直接 fail，不再把 run 记成成功
+- Dagster `etf_xdxr` asset 会对本次同步中 `empty/preserved` 的可疑 code 追加一次近期覆盖审计；如果近窗口内源侧有事件但库里没有，或者所有 HQ host 都不可达，asset 会直接 fail
 - 如果 API / KlineSlim 在 `/api/stock_data` 上直接报 `redis.exceptions.ConnectionError: Error 111 connecting to 127.0.0.1:6379`，优先检查 Docker compose 是否把宿主机 `.env` 里的 Redis 地址误透传进容器；正式口径应由 `docker/compose.parallel.yaml` 显式覆盖为 `FRESHQUANT_REDIS__HOST=fq_redis`、`FRESHQUANT_REDIS__PORT=6379`
 - 如果 compose Redis 覆盖修复已经 merge，但 formal deploy 的 `plan.json` 仍显示 `deployment_required=false`，优先检查 changed paths 是否包含 `docker/compose.parallel.yaml`；当前正式口径要求这类 compose 运行时变更必须触发全量受管 Docker 并行环境容器重建/重启。
 - 对单券立即修复可执行：
@@ -670,14 +670,14 @@ print(audit_recent_etf_xdxr_coverage(recent_days=365))
 '@ | py -3.12 -m uv run -`
 - 正式修复后，重新部署 Dagster，并再跑一次 formal deploy health check / runtime verify
 
-## XTData QFQ shadow 快照不更新或审计失败
+## XTData QFQ 快照不更新、reader 503 或审计失败
 
 现象：
 
 - `fqnext_xtdata_qfq_worker` 为 `FATAL` / `BACKOFF`，或 stderr 持续出现 `QFQ_DATA_NOT_READY`
 - `quantaxis.qfq_ready` 缺少 `scope=stock` / `scope=etf` 文档，active slot 的 `factor_asof` 落后于对应盘后 ready marker
 - inactive slot 长时间停在 `building` / `failed`，或 `audit` 返回日期轴、唯一性、非正因子、末日因子或递推恒等式错误
-- `stock_adj_qfq_a/b` / `etf_adj_qfq_a/b` 已更新，但页面或策略结果没有变化
+- `stock_adj_qfq_a/b` / `etf_adj_qfq_a/b` 已更新，但页面或策略仍返回旧版本，或 Stock Kline API 返回 `QFQ_DATA_NOT_READY/503`
 
 先检查：
 
@@ -694,6 +694,7 @@ Get-Content D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log -Tail 200
 处理：
 
 - `worker --once` 返回 `waiting_for_bfq` 时，先在 Dagster 核对最新 `stock_data_job` / `etf_data_job`，以及 `freshquant.dagster_pipeline_markers` 中相应 `pipeline_key` 的成功文档；QFQ worker 不绕过 BFQ ready gate。
+- `worker --once` 返回 `bootstrap_required` 时，在确认没有其他 QFQ writer/lease 后人工执行 `build --scope <stock|etf> --target-date YYYY-MM-DD [--full]`；正常 worker 不自动触发首次全历史 bootstrap。
 - XTData 连接或历史下载失败时，先恢复 MiniQMT / XTData 端口，再重新执行 `worker --once`；worker 会把中断的 inactive `building` 状态恢复为可重试的 `failed`。
 - 出现 `XTData history prefix download made no progress` 时，先核对 error 的 source role：primary `none` loader 会把该 code 记录为 `source_prefix_unavailable`，其余 code 审计通过时 worker 可继续发布；若 scope 内所有 code 均被隔离，update 拒绝发布空 ready snapshot 并保留 active slot。来自 `front_ratio` proof loader 的同类错误仍中止 scope。两种情况都应检查 QMT 下载任务和本地历史缓存，再决定是否重建 inactive slot。
 - 返回 `writer lease is held` 时，先确认 Supervisor worker 或人工 build / rollback 是否仍在运行；正常 lease 会持续续期并在命令结束时释放，崩溃遗留 lease 到期后由下一轮原子接管，不要并发启动第二个 writer。
@@ -705,8 +706,8 @@ Get-Content D:/fqdata/log/fqnext_xtdata_qfq_worker_err.log -Tail 200
 - `XTData source gap crosses an adjustment` 的稳定 failure code 是 `source_adjustment_gap_unproven`；bootstrap/update 对该 code 做 per-code fail-closed exclusion，其他 code 可继续发布。`unbounded XTData source gap`、`requires front_ratio proof`、`front_ratio date axis mismatch` 及其他 proof 错误仍中止 scope。
 - `history_prefix_no_progress` 只有来自 primary `none` loader 时映射为 `source_prefix_unavailable`；来自 `front_ratio` proof loader 时仍中止 scope。它不同于 projection 发现的普通 unbounded prefix/suffix，后者继续阻断发布。
 - 怀疑 XTData 修订发生在默认 60 个交易日回看窗口之前时，使用同一 active 截止日执行 `build --scope <stock|etf> --target-date YYYY-MM-DD --full`；该命令重算整个 inactive scope，且不接受早于 active `factor_asof` 的日期。
-- 回切前先确认另一槽为 `ready` 并单独执行 `audit --slot <a|b>`，然后使用 `rollback --scope <stock|etf>`；回切只更新原子 marker。
-- 页面或策略结果未变化是当前边界：Stock / ETF 在线 reader 仍读取 `stock_adj` / `etf_adj`，A/B 集合是 shadow 数据。真实 Index 则固定使用 BFQ，不读取 ETF 因子。
+- 回切前先确认另一槽为 `ready` 并单独执行 `audit --slot <a|b>`，然后使用 `rollback --scope <stock|etf>`；命令会先将仍需生效的 intraday override 重新绑定到目标 snapshot，再以 CAS 切换 marker，factor A/B 集合本身不改写。
+- Stock / ETF 在线 reader 每次请求重新解析 active slot；先核对 marker 的 `snapshot_id/factor_asof/source_exclusions`、请求日期覆盖和同 snapshot 的 intraday override。Redis Kline key/payload 与 StrategyConsumer 常驻窗口均绑定 effective adjustment version；marker 或 override 版本变化后应 miss/reload，不要复制旧版本 cache key。真实 Index 固定使用 BFQ，不读取 Stock / ETF 因子。
 
 ## xt_account_sync worker 启动即 Fatal
 
@@ -811,32 +812,29 @@ print(inspect.signature(resolve_stock_account))
 
 ## ETF 前复权错误
 
-本节排查当前线上 `etf_adj` 消费链；`etf_adj_qfq_a/b` 是独立 shadow 集合。
+本节排查当前线上 XTData QFQ A/B 消费链。
 
 现象：
 - ETF 在页面上跨扩缩股日出现价格断层
 - 例如事件日后 close 约为事件日前的一半，但事件日前没有按前复权回落
+- API 返回 `QFQ_DATA_NOT_READY/503`
 
 先检查：
-- `python -m freshquant.cli etf.xdxr save --code 512000`
-- `python -m freshquant.cli etf.adj save --code 512000`
-- `python -m freshquant.cli etf.xdxr save --code 512800`
-- `python -m freshquant.cli etf.adj save --code 512800`
-- 查询 `quantaxis.etf_xdxr` 是否存在 `category=11` / `suogu`
-- 查询 `quantaxis.etf_adj` 是否在事件日前生成了 `adj=0.5` 这类因子
+- `python -m freshquant.market_data.xtdata.qfq_worker status --scope etf --strict`
+- `python -m freshquant.market_data.xtdata.qfq_worker audit --scope etf --mode full --code 512000`
+- 查询 `quantaxis.qfq_ready` 指向的 `etf_adj_qfq_a/b` active collection，核对该 code 的日期 coverage、`snapshot_id` 与正因子
 - 请求 `/api/stock_data?period=1d&symbol=512000&endDate=2025-08-08`
 
 常见根因：
-- `quantaxis.etf_xdxr` 缺失扩缩股事件，导致 `etf_adj` 整段生成成 `1.0`
-- ETF 历史库已更新，但没有重跑 `etf_xdxr -> etf_adj`
-- 旧实现把上游空响应当真，单次同步把已有 `etf_xdxr` 清空
+- active marker 落后最新 `etf_postclose_ready`，或 active slot 没有覆盖请求日期
+- 请求 code 被 active slot `source_exclusions[]` 审计隔离
+- intraday override 的 `base_snapshot_id` 与当前 active snapshot 不一致
+- Redis Kline / StrategyConsumer 常驻窗口仍绑定旧 `adjustment_version`
 
 处理：
-- 优先重跑 `etf.xdxr` 和 `etf.adj`
-- 如果是全市场历史缺口，执行一次 ETF 全量回填：
-  - `python -m freshquant.cli etf.xdxr save`
-  - `python -m freshquant.cli etf.adj save`
-- 如果库里 `etf_adj` 已正确，而页面仍错误，再查 `/api/stock_data` 所在运行面是否仍在读旧库或旧容器
+- active slot 审计失败时，在单一 writer lease 下执行 `build --scope etf --target-date YYYY-MM-DD`；首次 bootstrap / 全历史 backfill 需要人工入口，正常 worker 不自动执行
+- audit 通过后核对 marker CAS 与 reader deploy SHA，再重启受影响 reader/consumer 运行面以清空常驻旧版本
+- 不手工修改 `active_slot`，不把 legacy `etf_adj` 回填成在线真值
 
 ## Web 页面空白
 

--- a/freshquant/KlineDataTool.py
+++ b/freshquant/KlineDataTool.py
@@ -128,7 +128,6 @@ def get_future_data_v2(symbol, period, endDate=None, monitor=1):
     return kline_data
 
 
-@in_memory_cache.memoize(expiration=3)
 def get_stock_data(
     symbol,
     period,

--- a/freshquant/chanlun_structure_service.py
+++ b/freshquant/chanlun_structure_service.py
@@ -305,8 +305,34 @@ def _get_realtime_cache_payload(
     if not is_supported_realtime_period(period_backend):
         return None
 
+    from freshquant.carnation.enum_instrument import InstrumentType
+    from freshquant.data.qfq_reader import resolve_qfq_read_metadata
+    from freshquant.instrument.general import query_instrument_type
+    from freshquant.trading.trade_date_guard import is_cn_a_trade_date
+
+    instrument_type = query_instrument_type(symbol)
+    if instrument_type == InstrumentType.INDEX_CN:
+        adjustment_version = "bfq"
+    elif instrument_type in {InstrumentType.STOCK_CN, InstrumentType.ETF_CN}:
+        scope = "etf" if instrument_type == InstrumentType.ETF_CN else "stock"
+        today = pd.Timestamp.now(tz="Asia/Shanghai").strftime("%Y-%m-%d")
+        metadata, _override = resolve_qfq_read_metadata(
+            scope=scope,
+            code=symbol,
+            trade_date=today if is_cn_a_trade_date(today) else None,
+        )
+        adjustment_version = metadata.effective_version
+    else:
+        return None
+
     try:
-        cached = redis_db.get(get_redis_cache_key(symbol, period_backend))
+        cached = redis_db.get(
+            get_redis_cache_key(
+                symbol,
+                period_backend,
+                adjustment_version=adjustment_version,
+            )
+        )
     except Exception as exc:  # pragma: no cover
         logging.warning(
             "chanlun_structure redis read failed for %s %s: %s", symbol, period, exc
@@ -406,8 +432,12 @@ def get_chanlun_structure(
             )
 
     if df is None:
+        from freshquant.data.qfq_reader import QFQDataNotReadyError
+
         try:
             df = _fetch_kline_df(symbol, period, end_date)
+        except QFQDataNotReadyError:
+            raise
         except Exception as exc:
             return {
                 "ok": False,

--- a/freshquant/data/astock/holding.py
+++ b/freshquant/data/astock/holding.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from freshquant.carnation.enum_instrument import InstrumentType
 from freshquant.config import settings
+from freshquant.data.qfq_reader import apply_qfq_to_bars
 from freshquant.database.cache import (
     get_cache_version,
     in_memory_cache,
@@ -122,12 +123,11 @@ def accStockTrades(acc: List, cur: Dict):
     return acc
 
 
-@in_memory_cache.memoize(expiration=900)
 def _compute_atr_last_stock(
     inst_code_base: str, date_str: str, period: int
 ) -> tuple[float, float]:
     """
-    计算 A 股个股在给定周期下的最新 ATR 值，并使用内存缓存避免重复计算。
+    计算 A 股个股在给定周期下的最新 ATR 值。
     """
     from QUANTAXIS.QAFetch.QAQuery_Advance import QA_fetch_stock_day_adv
     from talib import ATR
@@ -136,7 +136,12 @@ def _compute_atr_last_stock(
     start_date = (dt - timedelta(days=60)).strftime("%Y-%m-%d")
     end_date = dt.strftime("%Y-%m-%d")
     data = QA_fetch_stock_day_adv(inst_code_base, start_date, end_date)
-    data = data.to_qfq().data
+    data, _metadata = apply_qfq_to_bars(
+        data.data,
+        scope="stock",
+        code=inst_code_base,
+        date_col="date",
+    )
     atr_value = ATR(data.high.values, data.low.values, data.close.values, period)
     return float(atr_value[-1]), float(data.close.values[-1])
 
@@ -160,7 +165,6 @@ def _compute_atr_last_index(
     return float(atr_value[-1]), float(data.close.values[-1])
 
 
-@in_memory_cache.memoize(expiration=900)
 def _query_grid_interval(inst_code_base: str, date_str: str) -> float:
     instrument_code = normalize_to_inst_code_with_suffix(inst_code_base)
     cfg = get_grid_interval_config(instrument_code)
@@ -200,7 +204,7 @@ def accArrangedStockTrades(acc: List, cur: Dict, lotAmount: int):
                 acc = insertStockPosition(acc, item)
                 cur["quantity"] = cur["quantity"] - quantity
                 cur["amount"] = cur["amount"] - quantity * item["price"]
-                code = cur.get("symbol") or cur.get("code")
+                code = str(cur.get("symbol") or cur.get("code") or "")
                 date_str = datetime.strptime(str(cur["date"]), "%Y%m%d").strftime(
                     "%Y-%m-%d"
                 )

--- a/freshquant/data/qfq_reader.py
+++ b/freshquant/data/qfq_reader.py
@@ -1,0 +1,532 @@
+"""Strict Stock/ETF QFQ reads from the active A/B snapshot."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Iterable, Mapping
+
+import pandas as pd
+
+from freshquant.db import DBQuantAxis
+from freshquant.util.code import normalize_to_base_code
+
+QFQ_DATA_NOT_READY = "QFQ_DATA_NOT_READY"
+QFQ_DATA_NOT_READY_HTTP_STATUS = 503
+
+
+class QFQDataNotReadyError(RuntimeError):
+    """A Stock/ETF result cannot be proven against a ready QFQ snapshot."""
+
+    error_code = QFQ_DATA_NOT_READY
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        scope: str | None = None,
+        code: str | None = None,
+        missing_dates: Iterable[str] | None = None,
+    ) -> None:
+        self.scope = str(scope or "")
+        self.code = normalize_to_base_code(code or "")
+        self.missing_dates = tuple(str(value)[:10] for value in (missing_dates or ()))
+        details = [message]
+        if self.scope:
+            details.append(f"scope={self.scope}")
+        if self.code:
+            details.append(f"code={self.code}")
+        if self.missing_dates:
+            details.append(f"missing_dates={list(self.missing_dates)[:10]}")
+        super().__init__(f"{QFQ_DATA_NOT_READY}: {' '.join(details)}")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "error_code": self.error_code,
+            "message": str(self),
+            "scope": self.scope,
+            "code": self.code,
+            "missing_dates": list(self.missing_dates),
+        }
+
+
+@dataclass(frozen=True)
+class QFQReadMetadata:
+    scope: str
+    collection: str
+    snapshot_id: str
+    factor_asof: str
+    effective_version: str
+    active_slot: str
+    published_at: str
+    source_exclusions: tuple[dict[str, object], ...] = ()
+    override_version: str | None = None
+
+
+def _normalize_scope(scope: str) -> str:
+    value = str(scope or "").strip().lower()
+    if value not in {"stock", "etf"}:
+        raise ValueError(f"unsupported QFQ scope: {scope}")
+    return value
+
+
+def _normalize_date(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        parsed = pd.Timestamp(value)
+    except (TypeError, ValueError):
+        return None
+    if pd.isna(parsed):
+        return None
+    return parsed.strftime("%Y-%m-%d")
+
+
+def _extract_bar_dates(
+    bars: pd.DataFrame,
+    *,
+    date_col: str | None,
+    datetime_col: str,
+) -> pd.Series:
+    values: Any
+    if date_col and date_col in bars.columns:
+        values = bars[date_col]
+    elif datetime_col in bars.columns:
+        values = bars[datetime_col]
+    elif "date" in bars.columns:
+        values = bars["date"]
+    elif isinstance(bars.index, pd.MultiIndex):
+        index_name = "date" if "date" in bars.index.names else "datetime"
+        if index_name not in bars.index.names:
+            raise QFQDataNotReadyError("bars have no trading-date axis")
+        values = bars.index.get_level_values(index_name)
+    elif isinstance(bars.index, pd.DatetimeIndex):
+        values = bars.index
+    else:
+        raise QFQDataNotReadyError("bars have no trading-date axis")
+
+    parsed = pd.to_datetime(values, errors="coerce")
+    normalized = pd.Series(parsed, index=bars.index).dt.strftime("%Y-%m-%d")
+    if normalized.isna().any():
+        raise QFQDataNotReadyError("bars contain invalid trading dates")
+    return normalized
+
+
+def _find_active_override(
+    *,
+    db,
+    scope: str,
+    code: str,
+    trade_date: str | None,
+    snapshot_id: str,
+    factor_asof: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    if not trade_date or trade_date <= factor_asof:
+        return None, None
+
+    collection = f"{scope}_adj_intraday"
+    try:
+        document = db[collection].find_one(
+            {"code": code, "trade_date": trade_date}, projection={"_id": 0}
+        )
+    except Exception as exc:
+        raise QFQDataNotReadyError(
+            f"intraday override lookup failed: {exc}", scope=scope, code=code
+        ) from exc
+    if not document:
+        return None, None
+    if not isinstance(document, Mapping):
+        raise QFQDataNotReadyError(
+            "intraday override is malformed", scope=scope, code=code
+        )
+    if str(document.get("base_snapshot_id") or "") != snapshot_id:
+        raise QFQDataNotReadyError(
+            "intraday override snapshot mismatch", scope=scope, code=code
+        )
+    override_asof = str(document.get("base_factor_asof") or "")
+    if override_asof and override_asof != factor_asof:
+        raise QFQDataNotReadyError(
+            "intraday override factor_asof mismatch", scope=scope, code=code
+        )
+    status = str(document.get("status") or "").strip().lower()
+    if status and status not in {"active", "ready"}:
+        raise QFQDataNotReadyError(
+            "intraday override is not active", scope=scope, code=code
+        )
+    try:
+        anchor_scale = float(document["anchor_scale"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise QFQDataNotReadyError(
+            "intraday override anchor_scale is invalid", scope=scope, code=code
+        ) from exc
+    if not math.isfinite(anchor_scale) or anchor_scale <= 0:
+        raise QFQDataNotReadyError(
+            "intraday override anchor_scale must be finite and positive",
+            scope=scope,
+            code=code,
+        )
+    override_version = str(
+        document.get("version") or document.get("updated_at") or ""
+    ).strip()
+    if not override_version:
+        raise QFQDataNotReadyError(
+            "intraday override version is missing", scope=scope, code=code
+        )
+    return dict(document), override_version
+
+
+def resolve_qfq_read_metadata(
+    *,
+    scope: str,
+    code: str,
+    trade_date: str | date | datetime | None = None,
+    db=None,
+) -> tuple[QFQReadMetadata, dict[str, Any] | None]:
+    """Resolve the marker on every call; never retain a collection pointer."""
+
+    scope = _normalize_scope(scope)
+    code = normalize_to_base_code(code)
+    if not code:
+        raise ValueError("QFQ code is required")
+    database = db if db is not None else DBQuantAxis
+    try:
+        from freshquant.market_data.xtdata.qfq import resolve_active_slot
+
+        active = resolve_active_slot(scope=scope, db=database)
+    except Exception as exc:
+        raise QFQDataNotReadyError(
+            f"active QFQ snapshot is not ready: {exc}", scope=scope, code=code
+        ) from exc
+
+    normalized_exclusions: list[dict[str, object]] = []
+    try:
+        for item in active.get("source_exclusions") or ():
+            if not isinstance(item, Mapping):
+                raise TypeError("source exclusion is not a mapping")
+            exclusion: dict[str, object] = dict(item)
+            exclusion_code = normalize_to_base_code(str(item.get("code") or ""))
+            exclusion_reason = str(item.get("reason") or "").strip()
+            if (
+                len(exclusion_code) != 6
+                or not exclusion_code.isdigit()
+                or not exclusion_reason
+            ):
+                raise ValueError("source exclusion is incomplete")
+            exclusion["code"] = exclusion_code
+            exclusion["reason"] = exclusion_reason
+            normalized_exclusions.append(exclusion)
+    except (TypeError, ValueError) as exc:
+        raise QFQDataNotReadyError(
+            "active QFQ source exclusions are malformed", scope=scope, code=code
+        ) from exc
+    source_exclusions = tuple(normalized_exclusions)
+    if any(str(item.get("code") or "") == code for item in source_exclusions):
+        raise QFQDataNotReadyError(
+            "code is excluded from the active QFQ snapshot",
+            scope=scope,
+            code=code,
+        )
+
+    snapshot_id = str(active.get("snapshot_id") or "")
+    collection = str(active.get("collection") or "")
+    factor_asof = _normalize_date(active.get("factor_asof"))
+    active_slot = str(active.get("slot") or "").strip()
+    published_at = str(active.get("published_at") or "").strip()
+    if (
+        not snapshot_id
+        or not collection
+        or not factor_asof
+        or not active_slot
+        or not published_at
+    ):
+        raise QFQDataNotReadyError(
+            "active QFQ snapshot metadata is incomplete", scope=scope, code=code
+        )
+    trade_date_key = _normalize_date(trade_date)
+    if trade_date is not None and not trade_date_key:
+        raise QFQDataNotReadyError("QFQ trade_date is invalid", scope=scope, code=code)
+    override, override_version = _find_active_override(
+        db=database,
+        scope=scope,
+        code=code,
+        trade_date=trade_date_key,
+        snapshot_id=snapshot_id,
+        factor_asof=factor_asof,
+    )
+    if trade_date_key and trade_date_key > factor_asof and override is None:
+        raise QFQDataNotReadyError(
+            "snapshot-bound intraday override is missing",
+            scope=scope,
+            code=code,
+            missing_dates=[trade_date_key],
+        )
+    effective_version = snapshot_id
+    if override_version:
+        effective_version = f"{snapshot_id}:{override_version}"
+    return (
+        QFQReadMetadata(
+            scope=scope,
+            collection=collection,
+            snapshot_id=snapshot_id,
+            factor_asof=factor_asof,
+            effective_version=effective_version,
+            active_slot=active_slot,
+            published_at=published_at,
+            source_exclusions=source_exclusions,
+            override_version=override_version,
+        ),
+        override,
+    )
+
+
+def resolve_qfq_scope_metadata(
+    *,
+    scope: str,
+    trade_date: str | date | datetime | None = None,
+    db=None,
+) -> QFQReadMetadata:
+    """Freeze one scope to its active canonical snapshot without a code override."""
+
+    scope = _normalize_scope(scope)
+    database = db if db is not None else DBQuantAxis
+    try:
+        from freshquant.market_data.xtdata.qfq import resolve_active_slot
+
+        active = resolve_active_slot(scope=scope, db=database)
+    except Exception as exc:
+        raise QFQDataNotReadyError(
+            f"active QFQ snapshot is not ready: {exc}", scope=scope
+        ) from exc
+
+    normalized_exclusions: list[dict[str, object]] = []
+    try:
+        for item in active.get("source_exclusions") or ():
+            if not isinstance(item, Mapping):
+                raise TypeError("source exclusion is not a mapping")
+            exclusion: dict[str, object] = dict(item)
+            exclusion_code = normalize_to_base_code(str(item.get("code") or ""))
+            exclusion_reason = str(item.get("reason") or "").strip()
+            if (
+                len(exclusion_code) != 6
+                or not exclusion_code.isdigit()
+                or not exclusion_reason
+            ):
+                raise ValueError("source exclusion is incomplete")
+            exclusion["code"] = exclusion_code
+            exclusion["reason"] = exclusion_reason
+            normalized_exclusions.append(exclusion)
+    except (TypeError, ValueError) as exc:
+        raise QFQDataNotReadyError(
+            "active QFQ source exclusions are malformed", scope=scope
+        ) from exc
+    source_exclusions = tuple(normalized_exclusions)
+    snapshot_id = str(active.get("snapshot_id") or "")
+    collection = str(active.get("collection") or "")
+    factor_asof = _normalize_date(active.get("factor_asof"))
+    active_slot = str(active.get("slot") or "").strip()
+    published_at = str(active.get("published_at") or "").strip()
+    if (
+        not snapshot_id
+        or not collection
+        or not factor_asof
+        or not active_slot
+        or not published_at
+    ):
+        raise QFQDataNotReadyError(
+            "active QFQ snapshot metadata is incomplete", scope=scope
+        )
+    trade_date_key = _normalize_date(trade_date)
+    if trade_date is not None and not trade_date_key:
+        raise QFQDataNotReadyError("scope freeze trade_date is invalid", scope=scope)
+    if trade_date_key and trade_date_key > factor_asof:
+        raise QFQDataNotReadyError(
+            "active QFQ snapshot is behind the requested scope freeze",
+            scope=scope,
+            missing_dates=[trade_date_key],
+        )
+    return QFQReadMetadata(
+        scope=scope,
+        collection=collection,
+        snapshot_id=snapshot_id,
+        factor_asof=factor_asof,
+        effective_version=snapshot_id,
+        active_slot=active_slot,
+        published_at=published_at,
+        source_exclusions=source_exclusions,
+        override_version=None,
+    )
+
+
+def _read_factor_series(
+    *,
+    scope: str,
+    code: str,
+    dates: pd.Series,
+    db,
+) -> tuple[pd.Series, QFQReadMetadata]:
+    unique_dates = sorted(set(dates.tolist()))
+    trade_date = unique_dates[-1]
+    metadata, override = resolve_qfq_read_metadata(
+        scope=scope, code=code, trade_date=trade_date, db=db
+    )
+    canonical_dates = [value for value in unique_dates if value <= metadata.factor_asof]
+    uncovered_dates = [value for value in unique_dates if value > metadata.factor_asof]
+    if len(uncovered_dates) > 1:
+        raise QFQDataNotReadyError(
+            "active QFQ snapshot is behind the requested bars",
+            scope=scope,
+            code=code,
+            missing_dates=uncovered_dates,
+        )
+
+    documents: list[dict[str, Any]] = []
+    if canonical_dates:
+        try:
+            cursor = (
+                db[metadata.collection]
+                .find(
+                    {
+                        "code": code,
+                        "date": {
+                            "$gte": canonical_dates[0],
+                            "$lte": canonical_dates[-1],
+                        },
+                    },
+                    {"_id": 0, "code": 1, "date": 1, "adj": 1},
+                )
+                .sort("date", 1)
+            )
+            documents = [dict(item) for item in cursor]
+        except Exception as exc:
+            raise QFQDataNotReadyError(
+                f"QFQ factor lookup failed: {exc}", scope=scope, code=code
+            ) from exc
+
+    factors_by_date: dict[str, float] = {}
+    duplicates: set[str] = set()
+    for document in documents:
+        document_code = normalize_to_base_code(document.get("code") or code)
+        date_key = _normalize_date(document.get("date"))
+        try:
+            value = float(document["adj"])
+        except (KeyError, TypeError, ValueError):
+            value = float("nan")
+        if (
+            document_code != code
+            or not date_key
+            or not math.isfinite(value)
+            or value <= 0
+        ):
+            raise QFQDataNotReadyError(
+                "active QFQ factor row is invalid", scope=scope, code=code
+            )
+        if date_key in factors_by_date:
+            duplicates.add(date_key)
+        factors_by_date[date_key] = value
+    if duplicates:
+        raise QFQDataNotReadyError(
+            "active QFQ factor rows are duplicated", scope=scope, code=code
+        )
+
+    missing_dates = [value for value in canonical_dates if value not in factors_by_date]
+    if missing_dates:
+        raise QFQDataNotReadyError(
+            "active QFQ snapshot does not cover the requested bars",
+            scope=scope,
+            code=code,
+            missing_dates=missing_dates,
+        )
+
+    factor = dates.map(factors_by_date).astype(float)
+    if uncovered_dates:
+        override_date = str((override or {}).get("trade_date") or "")
+        if override_date != uncovered_dates[0]:
+            raise QFQDataNotReadyError(
+                "intraday override does not prove the uncovered date",
+                scope=scope,
+                code=code,
+                missing_dates=uncovered_dates,
+            )
+        factor.loc[dates == override_date] = 1.0
+    if override is not None:
+        anchor_scale = float(override["anchor_scale"])
+        override_date = str(override["trade_date"])
+        factor.loc[dates < override_date] = (
+            factor.loc[dates < override_date] * anchor_scale
+        )
+        factor.loc[dates == override_date] = 1.0
+    if factor.isna().any():
+        raise QFQDataNotReadyError(
+            "active QFQ factor result is incomplete", scope=scope, code=code
+        )
+    return factor, metadata
+
+
+def apply_qfq_to_bars(
+    bars: pd.DataFrame,
+    *,
+    scope: str,
+    code: str,
+    db=None,
+    date_col: str | None = None,
+    datetime_col: str = "datetime",
+    ohlc_cols: Iterable[str] = ("open", "high", "low", "close"),
+) -> tuple[pd.DataFrame, QFQReadMetadata]:
+    if bars is None or len(bars) == 0:
+        raise QFQDataNotReadyError(
+            "QFQ bars are empty", scope=_normalize_scope(scope), code=code
+        )
+    database = db if db is not None else DBQuantAxis
+    code = normalize_to_base_code(code)
+    dates = _extract_bar_dates(bars, date_col=date_col, datetime_col=datetime_col)
+    factor, metadata = _read_factor_series(
+        scope=scope, code=code, dates=dates, db=database
+    )
+    result = bars.copy()
+    factor_values = factor.to_numpy(dtype=float)
+    for column in ohlc_cols:
+        if column in result.columns:
+            values = pd.to_numeric(result[column], errors="coerce").to_numpy(
+                dtype=float
+            )
+            result[column] = values * factor_values
+    result.attrs["qfq_effective_version"] = metadata.effective_version
+    result.attrs["qfq_snapshot_id"] = metadata.snapshot_id
+    return result, metadata
+
+
+def read_qfq_factor(
+    *,
+    scope: str,
+    code: str,
+    trade_date: str | date | datetime,
+    db=None,
+) -> tuple[float, QFQReadMetadata]:
+    date_key = _normalize_date(trade_date)
+    if not date_key:
+        raise QFQDataNotReadyError(
+            "factor date is invalid", scope=_normalize_scope(scope), code=code
+        )
+    database = db if db is not None else DBQuantAxis
+    dates = pd.Series([date_key])
+    factor, metadata = _read_factor_series(
+        scope=scope,
+        code=normalize_to_base_code(code),
+        dates=dates,
+        db=database,
+    )
+    return float(factor.iloc[0]), metadata
+
+
+__all__ = [
+    "QFQ_DATA_NOT_READY",
+    "QFQ_DATA_NOT_READY_HTTP_STATUS",
+    "QFQDataNotReadyError",
+    "QFQReadMetadata",
+    "apply_qfq_to_bars",
+    "read_qfq_factor",
+    "resolve_qfq_read_metadata",
+    "resolve_qfq_scope_metadata",
+]

--- a/freshquant/data/stock.py
+++ b/freshquant/data/stock.py
@@ -7,11 +7,7 @@ from QUANTAXIS import QA_fetch_stock_day_adv, QA_fetch_stock_min_adv
 from QUANTAXIS.QAUtil.QADate import QA_util_datetime_to_strdatetime, QA_util_time_stamp
 from talib import ATR
 
-from freshquant.data.adj_intraday import (
-    apply_qfq_with_intraday_override,
-    fetch_intraday_override,
-    fetch_qfq_adj_df,
-)
+from freshquant.data.qfq_reader import apply_qfq_to_bars
 from freshquant.database.cache import redis_cache
 from freshquant.db import DBfreshquant
 from freshquant.trading.trade_date_guard import is_cn_a_trade_date
@@ -41,28 +37,16 @@ def _apply_stock_qfq(
     start: datetime | None,
     end: datetime | None,
 ) -> pd.DataFrame:
-    if data is None or len(data) == 0 or start is None or end is None:
+    if data is None or len(data) == 0:
         return data
-    start_date = start.strftime("%Y-%m-%d")
-    end_date = end.strftime("%Y-%m-%d")
     base_code = normalize_to_base_code(code)
-    adj = fetch_qfq_adj_df(
-        coll_name="stock_adj",
-        code=base_code,
-        start_date=start_date,
-        end_date=end_date,
-    )
-    override = fetch_intraday_override(
-        coll_name="stock_adj_intraday",
-        code=base_code,
-        trade_date=end_date,
-    )
-    return apply_qfq_with_intraday_override(
+    adjusted, _metadata = apply_qfq_to_bars(
         data,
-        adj,
-        override=override,
+        scope="stock",
+        code=base_code,
         datetime_col="datetime",
     )
+    return adjusted
 
 
 def _filter_trade_date_realtime_rows(rows: pd.DataFrame) -> pd.DataFrame:
@@ -386,7 +370,6 @@ def fq_data_stock_resample_120min(data):
     return data
 
 
-@redis_cache.memoize(expiration=60 * 60 * 24)
 def fq_data_stock_fetch_atr(
     code: str,
     start: Optional[datetime] = None,

--- a/freshquant/market_data/xtdata/adj_refresh_service.py
+++ b/freshquant/market_data/xtdata/adj_refresh_service.py
@@ -6,6 +6,7 @@ from datetime import date, datetime, timezone
 from typing import Any
 
 from freshquant.bootstrap_config import bootstrap_config
+from freshquant.data.qfq_reader import QFQDataNotReadyError
 from freshquant.db import DBQuantAxis
 from freshquant.market_data.xtdata.pools import (
     load_monitor_codes,
@@ -48,12 +49,9 @@ def _default_code_loader() -> list[str]:
 
 
 def _default_snapshot_provider(kind: str) -> dict[str, Any] | None:
-    try:
-        from freshquant.market_data.xtdata.qfq import resolve_active_slot
+    from freshquant.market_data.xtdata.qfq import resolve_active_slot
 
-        return resolve_active_slot(scope=kind, db=DBQuantAxis)
-    except Exception:
-        return None
+    return resolve_active_slot(scope=kind, db=DBQuantAxis)
 
 
 def _is_retryable_xtdata_error(error: Exception) -> bool:
@@ -257,14 +255,55 @@ class AdjRefreshService:
             "base_anchor_date": base_anchor_date,
             "updated_at": updated_at,
         }
-        snapshots = {kind: self.snapshot_provider(kind) for kind in ("stock", "etf")}
+        codes = list(self.code_loader() or [])
+        required_kinds = {
+            "etf" if _is_index_like_code(code) else "stock" for code in codes
+        }
+        snapshots: dict[str, dict[str, Any]] = {}
+        for kind in required_kinds:
+            try:
+                snapshot = self.snapshot_provider(kind)
+            except Exception as exc:
+                raise QFQDataNotReadyError(
+                    f"active QFQ snapshot resolution failed: {exc}", scope=kind
+                ) from exc
+            if not isinstance(snapshot, dict) or not all(
+                str(snapshot.get(field) or "").strip()
+                for field in ("collection", "snapshot_id", "factor_asof")
+            ):
+                raise QFQDataNotReadyError(
+                    "active QFQ snapshot metadata is incomplete", scope=kind
+                )
+            snapshots[kind] = snapshot
 
-        for code in list(self.code_loader() or []):
+        for code in codes:
             kind = "etf" if _is_index_like_code(code) else "stock"
-            anchor_doc = self.repository.get_base_anchor(kind, code, base_anchor_date)
-            if not anchor_doc or anchor_doc.get("adj") in (None, 0):
+            snapshot = snapshots[kind]
+            snapshot_anchor_loader = getattr(
+                self.repository, "get_snapshot_anchor", None
+            )
+            if not callable(snapshot_anchor_loader):
+                raise QFQDataNotReadyError(
+                    "active QFQ snapshot anchor reader is unavailable",
+                    scope=kind,
+                    code=code,
+                )
+            try:
+                snapshot_anchor = snapshot_anchor_loader(
+                    kind, code, base_anchor_date, snapshot
+                )
+            except Exception as exc:
+                raise QFQDataNotReadyError(
+                    f"active QFQ snapshot anchor lookup failed: {exc}",
+                    scope=kind,
+                    code=code,
+                ) from exc
+            legacy_anchor = self.repository.get_base_anchor(
+                kind, code, base_anchor_date
+            )
+            if not snapshot_anchor or snapshot_anchor.get("adj") in (None, 0):
                 continue
-            effective_anchor_date = str(anchor_doc.get("date") or base_anchor_date)
+            effective_anchor_date = str(snapshot_anchor.get("date") or base_anchor_date)
 
             close_pair = self.market_client.get_daily_close_pair(
                 code, effective_anchor_date
@@ -274,40 +313,25 @@ class AdjRefreshService:
 
             raw_close = float(close_pair.get("raw_close") or 0.0)
             front_close = float(close_pair.get("front_close") or 0.0)
-            base_adj = float(anchor_doc.get("adj") or 0.0)
-            if raw_close <= 0 or front_close <= 0 or base_adj <= 0:
+            anchor_adj = float(snapshot_anchor.get("adj") or 0.0)
+            if raw_close <= 0 or front_close <= 0 or anchor_adj <= 0:
                 continue
 
             target_adj = front_close / raw_close
-            legacy_anchor_scale = target_adj / base_adj
             document = {
                 "code": normalize_to_base_code(code),
                 "trade_date": trade_date,
                 "base_anchor_date": effective_anchor_date,
-                "anchor_scale": float(legacy_anchor_scale),
-                "legacy_anchor_scale": float(legacy_anchor_scale),
+                "anchor_scale": float(target_adj / anchor_adj),
+                "base_snapshot_id": str(snapshot["snapshot_id"]),
+                "base_factor_asof": str(snapshot["factor_asof"]),
                 "source": "xtdata_front_raw",
                 "updated_at": updated_at,
             }
-            snapshot = snapshots.get(kind) or {}
-            snapshot_anchor_loader = getattr(
-                self.repository, "get_snapshot_anchor", None
-            )
-            snapshot_anchor = (
-                snapshot_anchor_loader(kind, code, base_anchor_date, snapshot)
-                if snapshot.get("snapshot_id") and snapshot_anchor_loader
-                else None
-            )
-            snapshot_anchor_date = str((snapshot_anchor or {}).get("date") or "")
-            snapshot_adj = float((snapshot_anchor or {}).get("adj") or 0.0)
-            if (
-                snapshot.get("snapshot_id")
-                and snapshot_anchor_date == effective_anchor_date
-                and snapshot_adj > 0
-            ):
-                document["anchor_scale"] = float(target_adj / snapshot_adj)
-                document["base_snapshot_id"] = str(snapshot["snapshot_id"])
-                document["base_factor_asof"] = str(snapshot.get("factor_asof") or "")
+            legacy_anchor_date = str((legacy_anchor or {}).get("date") or "")
+            legacy_adj = float((legacy_anchor or {}).get("adj") or 0.0)
+            if legacy_anchor_date == effective_anchor_date and legacy_adj > 0:
+                document["legacy_anchor_scale"] = float(target_adj / legacy_adj)
             self.repository.upsert_intraday_override(kind, document)
             result["count"] += 1
             result[f"{kind}_count"] += 1

--- a/freshquant/market_data/xtdata/qfq.py
+++ b/freshquant/market_data/xtdata/qfq.py
@@ -38,6 +38,10 @@ FACTOR_COLLECTIONS = {
     },
 }
 LEGACY_FACTOR_COLLECTIONS = {"stock": "stock_adj", "etf": "etf_adj"}
+INTRADAY_OVERRIDE_COLLECTIONS = {
+    "stock": "stock_adj_intraday",
+    "etf": "etf_adj_intraday",
+}
 # BFQ is the coverage authority for each factor universe.  ``index_day`` is
 # intentionally used for ETF history because QUANTAXIS stores exchange-traded
 # funds in that collection alongside real indexes.
@@ -1415,6 +1419,197 @@ def _mark_inactive_failed(
     )
 
 
+def _snapshot_anchor_factor(
+    *, db, collection: str, code: str, anchor_date: str
+) -> float:
+    document = db[collection].find_one(
+        {"code": code, "date": {"$lte": anchor_date}},
+        projection={"_id": 0, "date": 1, "adj": 1},
+        sort=[("date", -1)],
+    )
+    document_date = _date_key((document or {}).get("date"))
+    try:
+        factor = float((document or {})["adj"])
+    except (KeyError, TypeError, ValueError):
+        factor = float("nan")
+    if document_date != anchor_date or not math.isfinite(factor) or factor <= 0:
+        raise QFQSyncError(
+            f"snapshot override anchor is unavailable for code={code} "
+            f"date={anchor_date} collection={collection}"
+        )
+    return factor
+
+
+def _restore_intraday_override_bindings(*, db, scope: str, changes) -> None:
+    collection = db[INTRADAY_OVERRIDE_COLLECTIONS[scope]]
+    failures: list[dict[str, str]] = []
+    for change in reversed(changes):
+        update: dict[str, Any] = {"$set": dict(change["before"])}
+        if not change["before_has_factor_asof"]:
+            update["$unset"] = {"base_factor_asof": ""}
+        result = collection.update_one(change["restore_query"], update)
+        if int(getattr(result, "matched_count", 0)) != 1:
+            failures.append(
+                {
+                    "code": change["code"],
+                    "trade_date": change["trade_date"],
+                }
+            )
+    if failures:
+        raise QFQSyncError(
+            f"{scope} intraday override binding restore lost",
+            stats={"failures": failures},
+        )
+
+
+def _rebind_intraday_overrides(
+    *,
+    db,
+    scope: str,
+    source_slot: Mapping[str, Any],
+    target_slot: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    target_factor_asof = _date_key(target_slot.get("factor_asof"))
+    if not target_factor_asof:
+        raise QFQSyncError(f"{scope} target QFQ factor_asof is invalid")
+    source_snapshot = str(source_slot.get("snapshot_id") or "")
+    target_snapshot = str(target_slot.get("snapshot_id") or "")
+    source_collection = str(source_slot.get("collection") or "")
+    target_collection = str(target_slot.get("collection") or "")
+    if not all(
+        (source_snapshot, target_snapshot, source_collection, target_collection)
+    ):
+        raise QFQSyncError(f"{scope} QFQ override rebind metadata is incomplete")
+
+    collection = db[INTRADAY_OVERRIDE_COLLECTIONS[scope]]
+    documents = [dict(item) for item in collection.find({}, {"_id": 0})]
+    changes: list[dict[str, Any]] = []
+    try:
+        for document in documents:
+            status = str(document.get("status") or "").strip().lower()
+            if status and status not in {"active", "ready"}:
+                continue
+            trade_date = _date_key(document.get("trade_date"))
+            if not trade_date or trade_date <= target_factor_asof:
+                continue
+            raw_code = str(document.get("code") or "").strip()
+            code = normalize_code(raw_code)
+            if raw_code != code or not code:
+                raise QFQSyncError(f"{scope} intraday override code is invalid")
+            bound_snapshot = str(document.get("base_snapshot_id") or "")
+            if bound_snapshot not in {source_snapshot, target_snapshot}:
+                raise QFQSyncError(
+                    f"{scope} intraday override snapshot is stale for "
+                    f"code={code} trade_date={trade_date}"
+                )
+            source_factor_asof = str(source_slot.get("factor_asof") or "")
+            bound_factor_asof = str(document.get("base_factor_asof") or "")
+            anchor_date = _date_key(document.get("base_anchor_date"))
+            if not anchor_date:
+                raise QFQSyncError(
+                    f"{scope} intraday override anchor date is invalid for code={code}"
+                )
+            try:
+                source_scale = float(document["anchor_scale"])
+            except (KeyError, TypeError, ValueError):
+                source_scale = float("nan")
+            if not math.isfinite(source_scale) or source_scale <= 0:
+                raise QFQSyncError(
+                    f"{scope} intraday override anchor scale is invalid for code={code}"
+                )
+            if bound_snapshot == target_snapshot:
+                if bound_factor_asof != target_factor_asof:
+                    raise QFQSyncError(
+                        f"{scope} intraday override factor_asof is stale for "
+                        f"code={code} trade_date={trade_date}"
+                    )
+                _snapshot_anchor_factor(
+                    db=db,
+                    collection=target_collection,
+                    code=code,
+                    anchor_date=anchor_date,
+                )
+                continue
+            if bound_factor_asof and bound_factor_asof != source_factor_asof:
+                raise QFQSyncError(
+                    f"{scope} intraday override factor_asof is stale for "
+                    f"code={code} trade_date={trade_date}"
+                )
+            source_factor = _snapshot_anchor_factor(
+                db=db,
+                collection=source_collection,
+                code=code,
+                anchor_date=anchor_date,
+            )
+            target_factor = _snapshot_anchor_factor(
+                db=db,
+                collection=target_collection,
+                code=code,
+                anchor_date=anchor_date,
+            )
+            target_scale = source_factor * source_scale / target_factor
+            if not math.isfinite(target_scale) or target_scale <= 0:
+                raise QFQSyncError(
+                    f"{scope} rebound intraday override scale is invalid for code={code}"
+                )
+
+            before_has_factor_asof = "base_factor_asof" in document
+            before = {
+                "base_snapshot_id": source_snapshot,
+                "anchor_scale": source_scale,
+            }
+            if before_has_factor_asof:
+                before["base_factor_asof"] = document.get("base_factor_asof")
+            after = {
+                "base_snapshot_id": target_snapshot,
+                "base_factor_asof": target_factor_asof,
+                "anchor_scale": float(target_scale),
+            }
+            update_query: dict[str, Any] = {
+                "code": code,
+                "trade_date": trade_date,
+                "base_snapshot_id": source_snapshot,
+                "anchor_scale": source_scale,
+            }
+            if before_has_factor_asof:
+                update_query["base_factor_asof"] = document.get("base_factor_asof")
+            if "updated_at" in document:
+                update_query["updated_at"] = document.get("updated_at")
+            result = collection.update_one(update_query, {"$set": after})
+            if int(getattr(result, "matched_count", 0)) != 1:
+                raise QFQSyncError(
+                    f"{scope} intraday override rebind CAS lost for "
+                    f"code={code} trade_date={trade_date}"
+                )
+            restore_query = {
+                "code": code,
+                "trade_date": trade_date,
+                "base_snapshot_id": target_snapshot,
+                "base_factor_asof": target_factor_asof,
+                "anchor_scale": float(target_scale),
+            }
+            if "updated_at" in document:
+                restore_query["updated_at"] = document.get("updated_at")
+            changes.append(
+                {
+                    "code": code,
+                    "trade_date": trade_date,
+                    "before": before,
+                    "before_has_factor_asof": before_has_factor_asof,
+                    "restore_query": restore_query,
+                }
+            )
+    except Exception:
+        try:
+            _restore_intraday_override_bindings(db=db, scope=scope, changes=changes)
+        except Exception as restore_error:
+            raise QFQSyncError(
+                f"{scope} intraday override rebind failed and restore failed"
+            ) from restore_error
+        raise
+    return changes
+
+
 def _publish_inactive_slot(
     *,
     db,
@@ -1435,21 +1630,69 @@ def _publish_inactive_slot(
         published_at=_utc_iso(now_provider),
         source_exclusions=source_exclusions,
     )
-    result = db[READY_COLLECTION].update_one(
-        {
-            "scope": scope,
-            "active_slot": active_slot,
-            f"slots.{active_slot}.snapshot_id": active_snapshot,
-            f"slots.{inactive_slot}.status": "building",
-        },
-        {
-            "$set": {
-                "active_slot": inactive_slot,
-                f"slots.{inactive_slot}": slot_document,
-            }
-        },
+    rebound_overrides = _rebind_intraday_overrides(
+        db=db,
+        scope=scope,
+        source_slot=marker["slots"][active_slot],
+        target_slot=slot_document,
     )
+    try:
+        result = db[READY_COLLECTION].update_one(
+            {
+                "scope": scope,
+                "active_slot": active_slot,
+                f"slots.{active_slot}.snapshot_id": active_snapshot,
+                f"slots.{inactive_slot}.status": "building",
+            },
+            {
+                "$set": {
+                    "active_slot": inactive_slot,
+                    f"slots.{inactive_slot}": slot_document,
+                }
+            },
+        )
+    except Exception as exc:
+        try:
+            current = validate_qfq_marker(
+                get_qfq_marker(scope=scope, db=db), scope=scope
+            )
+        except Exception as read_error:
+            raise QFQSyncError(
+                f"{scope} QFQ marker publish outcome is unknown"
+            ) from read_error
+        current_active = str(current["active_slot"])
+        if (
+            current_active == inactive_slot
+            and str(current["slots"][inactive_slot].get("snapshot_id") or "")
+            == slot_document["snapshot_id"]
+        ):
+            return current
+        if (
+            current_active == active_slot
+            and str(current["slots"][active_slot].get("snapshot_id") or "")
+            == active_snapshot
+        ):
+            try:
+                _restore_intraday_override_bindings(
+                    db=db, scope=scope, changes=rebound_overrides
+                )
+            except Exception as restore_error:
+                raise QFQSyncError(
+                    f"{scope} QFQ marker publish failed and override restore failed"
+                ) from restore_error
+            raise QFQSyncError(f"{scope} QFQ marker publish failed") from exc
+        raise QFQSyncError(
+            f"{scope} QFQ marker publish outcome is inconsistent",
+            stats={
+                "expected_source_slot": active_slot,
+                "expected_target_slot": inactive_slot,
+                "observed_active_slot": current_active,
+            },
+        ) from exc
     if int(getattr(result, "matched_count", 0)) != 1:
+        _restore_intraday_override_bindings(
+            db=db, scope=scope, changes=rebound_overrides
+        )
         raise QFQSyncError(f"{scope} QFQ marker CAS publish lost")
     return validate_qfq_marker(get_qfq_marker(scope=scope, db=db), scope=scope)
 
@@ -1462,26 +1705,72 @@ def _rollback_active_slot_locked(
     target_slot = _inactive_slot_name(marker)
     if marker["slots"][target_slot].get("status") != "ready":
         raise QFQSyncError(f"{scope} rollback slot is not ready")
-    result = db[READY_COLLECTION].update_one(
-        {
-            "scope": scope,
-            "active_slot": active_slot,
-            f"slots.{active_slot}.snapshot_id": marker["slots"][active_slot][
-                "snapshot_id"
-            ],
-            f"slots.{target_slot}.snapshot_id": marker["slots"][target_slot][
-                "snapshot_id"
-            ],
-            f"slots.{target_slot}.status": "ready",
-        },
-        {
-            "$set": {
-                "active_slot": target_slot,
-                f"slots.{target_slot}.published_at": _utc_iso(now_provider),
-            }
-        },
+    rebound_overrides = _rebind_intraday_overrides(
+        db=db,
+        scope=scope,
+        source_slot=marker["slots"][active_slot],
+        target_slot=marker["slots"][target_slot],
     )
+    source_snapshot = str(marker["slots"][active_slot]["snapshot_id"])
+    target_snapshot = str(marker["slots"][target_slot]["snapshot_id"])
+    try:
+        result = db[READY_COLLECTION].update_one(
+            {
+                "scope": scope,
+                "active_slot": active_slot,
+                f"slots.{active_slot}.snapshot_id": source_snapshot,
+                f"slots.{target_slot}.snapshot_id": target_snapshot,
+                f"slots.{target_slot}.status": "ready",
+            },
+            {
+                "$set": {
+                    "active_slot": target_slot,
+                    f"slots.{target_slot}.published_at": _utc_iso(now_provider),
+                }
+            },
+        )
+    except Exception as exc:
+        try:
+            current = validate_qfq_marker(
+                get_qfq_marker(scope=scope, db=db), scope=scope
+            )
+        except Exception as read_error:
+            raise QFQSyncError(
+                f"{scope} QFQ rollback marker outcome is unknown"
+            ) from read_error
+        current_active = str(current["active_slot"])
+        if (
+            current_active == target_slot
+            and str(current["slots"][target_slot].get("snapshot_id") or "")
+            == target_snapshot
+        ):
+            return current
+        if (
+            current_active == active_slot
+            and str(current["slots"][active_slot].get("snapshot_id") or "")
+            == source_snapshot
+        ):
+            try:
+                _restore_intraday_override_bindings(
+                    db=db, scope=scope, changes=rebound_overrides
+                )
+            except Exception as restore_error:
+                raise QFQSyncError(
+                    f"{scope} QFQ rollback marker failed and override restore failed"
+                ) from restore_error
+            raise QFQSyncError(f"{scope} QFQ rollback marker failed") from exc
+        raise QFQSyncError(
+            f"{scope} QFQ rollback marker outcome is inconsistent",
+            stats={
+                "expected_source_slot": active_slot,
+                "expected_target_slot": target_slot,
+                "observed_active_slot": current_active,
+            },
+        ) from exc
     if int(getattr(result, "matched_count", 0)) != 1:
+        _restore_intraday_override_bindings(
+            db=db, scope=scope, changes=rebound_overrides
+        )
         raise QFQSyncError(f"{scope} QFQ rollback CAS lost")
     return validate_qfq_marker(get_qfq_marker(scope=scope, db=db), scope=scope)
 

--- a/freshquant/market_data/xtdata/qfq_worker.py
+++ b/freshquant/market_data/xtdata/qfq_worker.py
@@ -57,21 +57,26 @@ def run_pending_once(
                 continue
             target_date = str(postclose.get("trade_date") or "")[:10]
             marker = get_qfq_marker(scope=scope, db=factor_db)
-            if marker:
-                marker = validate_qfq_marker(marker, scope=scope)
-                active_slot = str(marker["active_slot"])
-                inactive_slot = "b" if active_slot == "a" else "a"
-                inactive_building = (
-                    marker["slots"][inactive_slot].get("status") == "building"
-                )
-                if not inactive_building and target_date <= str(
-                    marker["slots"][active_slot]["factor_asof"]
-                ):
-                    result["by_scope"][scope] = {
-                        "status": "current",
-                        "factor_asof": marker["slots"][active_slot]["factor_asof"],
-                    }
-                    continue
+            if marker is None:
+                result["by_scope"][scope] = {
+                    "status": "bootstrap_required",
+                    "target_date": target_date,
+                }
+                continue
+            marker = validate_qfq_marker(marker, scope=scope)
+            active_slot = str(marker["active_slot"])
+            inactive_slot = "b" if active_slot == "a" else "a"
+            inactive_building = (
+                marker["slots"][inactive_slot].get("status") == "building"
+            )
+            if not inactive_building and target_date <= str(
+                marker["slots"][active_slot]["factor_asof"]
+            ):
+                result["by_scope"][scope] = {
+                    "status": "current",
+                    "factor_asof": marker["slots"][active_slot]["factor_asof"],
+                }
+                continue
             published = sync_fn(scope=scope, target_date=target_date, db=factor_db)
             result["by_scope"][scope] = {
                 "status": "published",
@@ -155,7 +160,7 @@ def _scope_values(value: str) -> list[str]:
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="XTData QFQ shadow writer")
+    parser = argparse.ArgumentParser(description="XTData QFQ canonical writer")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     worker = subparsers.add_parser("worker")

--- a/freshquant/market_data/xtdata/strategy_consumer.py
+++ b/freshquant/market_data/xtdata/strategy_consumer.py
@@ -17,11 +17,7 @@ import pandas as pd
 from loguru import logger
 
 from freshquant.analysis.fullcalc_wrapper import run_fullcalc
-from freshquant.data.adj_intraday import (
-    apply_qfq_with_intraday_override,
-    fetch_intraday_override,
-    fetch_qfq_adj_df,
-)
+from freshquant.data.qfq_reader import apply_qfq_to_bars, read_qfq_factor
 from freshquant.db import DBfreshquant, DBQuantAxis
 from freshquant.market_data.xtdata.chanlun_payload import build_chanlun_payload
 from freshquant.market_data.xtdata.coalesce import CoalescingScheduler
@@ -328,6 +324,7 @@ class StrategyConsumer:
 
         self._lock = threading.Lock()
         self._windows: dict[tuple[str, str], pd.DataFrame] = {}
+        self._window_versions: dict[str, str] = {}
         self._futures: dict[tuple[str, str], Any] = {}
         self._last_bar_ts: dict[tuple[str, str], int] = {}
         self._known_codes: set[str] = set()
@@ -435,6 +432,7 @@ class StrategyConsumer:
                 if df is None or df.empty:
                     continue
                 key = (code, period)
+                adjustment_version = str(df.attrs.get("qfq_effective_version") or "")
                 try:
                     bar_time = int(pd.to_datetime(df["datetime"].iloc[-1]).timestamp())
                 except Exception:
@@ -447,9 +445,11 @@ class StrategyConsumer:
                         ["datetime", "open", "high", "low", "close", "volume", "amount"]
                     ].copy(),
                     "model_ids": self._model_ids_for(code, period),
+                    "adjustment_version": adjustment_version,
                 }
                 with self._lock:
                     self._windows[key] = df
+                    self._window_versions[code] = adjustment_version
                     if bar_time > 0:
                         self._last_bar_ts[key] = bar_time
                 self._scheduler.update(key, meta)
@@ -496,54 +496,46 @@ class StrategyConsumer:
         """
         if kind == "index":
             return 1.0
-        coll = "stock_adj" if kind == "stock" else "etf_adj"
-        override_coll = "stock_adj_intraday" if kind == "stock" else "etf_adj_intraday"
-        try:
-            override = fetch_intraday_override(
-                coll_name=override_coll,
-                code=base_code6,
-                trade_date=date_str,
-                db=DBQuantAxis,
-            )
-            if override is not None:
-                return 1.0
-        except Exception:
-            pass
-
-        factor = 1.0
-        try:
-            doc = DBQuantAxis[coll].find_one(
-                {"code": str(base_code6), "date": {"$lte": str(date_str)}},
-                sort=[("date", -1)],
-                projection={"_id": 0, "date": 1, "adj": 1},
-            )
-            if doc and doc.get("adj") is not None:
-                factor = float(doc["adj"])
-        except Exception:
-            factor = 1.0
-
-        return float(factor)
+        factor, _metadata = read_qfq_factor(
+            scope=kind,
+            code=base_code6,
+            trade_date=date_str,
+            db=DBQuantAxis,
+        )
+        return factor
 
     def _apply_qfq_to_bar(
         self, *, kind: str, code_prefixed: str, bar: dict[str, Any]
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], str]:
         if kind == "index":
-            return bar
+            return bar, "bfq"
         dt: datetime | None = bar.get("datetime")
         if not isinstance(dt, datetime):
-            return bar
+            raise ValueError("bar datetime is required for QFQ")
         base = _base_code(code_prefixed)
         date_str = dt.strftime("%Y-%m-%d")
-        factor = self._get_qfq_factor(kind=kind, base_code6=base, date_str=date_str)
+        factor, metadata = read_qfq_factor(
+            scope=kind,
+            code=base,
+            trade_date=date_str,
+            db=DBQuantAxis,
+        )
         if abs(float(factor) - 1.0) < 1e-9:
-            return bar
+            return bar, metadata.effective_version
         out = dict(bar)
         for col in ("open", "high", "low", "close"):
             try:
                 out[col] = float(out.get(col) or 0.0) * float(factor)
             except Exception:
                 continue
-        return out
+        return out, metadata.effective_version
+
+    def _asset_kind(self, code_prefixed: str) -> str:
+        if self._is_real_index(code_prefixed):
+            return "index"
+        if self._is_index_like(code_prefixed):
+            return "etf"
+        return "stock"
 
     def _is_index_like(self, code_prefixed: str) -> bool:
         try:
@@ -583,8 +575,8 @@ class StrategyConsumer:
         )
 
         base6 = _base_code(code)
-        is_index_like = self._is_index_like(code)
-        is_real_index = self._is_real_index(code)
+        asset_kind = self._asset_kind(code)
+        is_index_like = asset_kind in {"etf", "index"}
 
         hist_coll = "index_min" if is_index_like else "stock_min"
         hist_df = _empty_bar_window_df()
@@ -630,29 +622,6 @@ class StrategyConsumer:
         rt_df = pd.DataFrame(list(rt_cur))
         rt_df = _filter_trade_date_bar_df(rt_df)
 
-        start_date = start_dt.strftime("%Y-%m-%d")
-        end_date = end_dt.strftime("%Y-%m-%d")
-        adj_df = None
-        override = None
-        if not is_real_index:
-            adj_coll = "etf_adj" if is_index_like else "stock_adj"
-            override_coll = (
-                "etf_adj_intraday" if is_index_like else "stock_adj_intraday"
-            )
-            adj_df = fetch_qfq_adj_df(
-                coll_name=adj_coll,
-                code=base6,
-                start_date=start_date,
-                end_date=end_date,
-                db=DBQuantAxis,
-            )
-            override = fetch_intraday_override(
-                coll_name=override_coll,
-                code=base6,
-                trade_date=end_date,
-                db=DBQuantAxis,
-            )
-
         merged = _normalize_bar_window_df(
             pd.concat([hist_df, rt_df], ignore_index=True)
         )
@@ -661,17 +630,22 @@ class StrategyConsumer:
 
         merged = merged.drop_duplicates(subset=["datetime"], keep="last")
         merged = merged.sort_values("datetime")
-        if not is_real_index:
-            merged = apply_qfq_with_intraday_override(
+        if asset_kind != "index":
+            merged, metadata = apply_qfq_to_bars(
                 merged,
-                adj_df,
-                override=override,
+                scope=asset_kind,
+                code=base6,
+                db=DBQuantAxis,
                 datetime_col="datetime",
             )
+            effective_version = metadata.effective_version
+        else:
+            effective_version = "bfq"
 
         if len(merged) > self.max_bars:
             merged = merged.iloc[-self.max_bars :]
         merged = merged.reset_index(drop=True)
+        merged.attrs["qfq_effective_version"] = effective_version
         return merged
 
     def _submit_fullcalc(self, key: tuple[str, str], meta: dict[str, Any]) -> None:
@@ -708,7 +682,13 @@ class StrategyConsumer:
                 bar_time_ts=meta.get("bar_time"),
             )
 
-            cache_key = get_redis_cache_key(payload.code, payload.period_backend)
+            adjustment_version = str(meta.get("adjustment_version") or "")
+            payload.data["adjustment_version"] = adjustment_version
+            cache_key = get_redis_cache_key(
+                payload.code,
+                payload.period_backend,
+                adjustment_version=adjustment_version,
+            )
             redis_db.set(
                 cache_key,
                 json.dumps(payload.data, ensure_ascii=False),
@@ -891,6 +871,7 @@ class StrategyConsumer:
                 continue
             if df is None or df.empty:
                 continue
+            adjustment_version = str(df.attrs.get("qfq_effective_version") or "")
             try:
                 bar_time = int(pd.to_datetime(df["datetime"].iloc[-1]).timestamp())
             except Exception:
@@ -903,9 +884,11 @@ class StrategyConsumer:
                     ["datetime", "open", "high", "low", "close", "volume", "amount"]
                 ].copy(),
                 "model_ids": self._model_ids_for(code, period),
+                "adjustment_version": adjustment_version,
             }
             with self._lock:
                 self._windows[key] = df
+                self._window_versions[code] = adjustment_version
                 if bar_time > 0:
                     self._last_bar_ts[key] = bar_time
             self._scheduler.update(key, meta)
@@ -919,6 +902,7 @@ class StrategyConsumer:
             df = self._load_window_from_db(code=code, period_backend=period)
             if df is None or df.empty:
                 continue
+            adjustment_version = str(df.attrs.get("qfq_effective_version") or "")
             try:
                 bar_time = int(pd.to_datetime(df["datetime"].iloc[-1]).timestamp())
             except Exception:
@@ -931,9 +915,11 @@ class StrategyConsumer:
                     ["datetime", "open", "high", "low", "close", "volume", "amount"]
                 ].copy(),
                 "model_ids": self._model_ids_for(code, period),
+                "adjustment_version": adjustment_version,
             }
             with self._lock:
                 self._windows[key] = df
+                self._window_versions[code] = adjustment_version
                 if bar_time > 0:
                     self._last_bar_ts[key] = bar_time
             self._scheduler.update(key, meta)
@@ -1157,12 +1143,9 @@ class StrategyConsumer:
             "source": "xtdata",
         }
 
-        is_index_like = self._is_index_like(code)
-        is_real_index = self._is_real_index(code)
-        kind = "index" if is_real_index else ("etf" if is_index_like else "stock")
-        coll = "index_realtime" if is_index_like else "stock_realtime"
+        kind = self._asset_kind(code)
+        coll = "index_realtime" if kind in {"etf", "index"} else "stock_realtime"
         bar_store = bar_raw
-        bar_calc = self._apply_qfq_to_bar(kind=kind, code_prefixed=code, bar=bar_raw)
 
         try:
             upsert_realtime_bars(
@@ -1170,6 +1153,20 @@ class StrategyConsumer:
             )
         except Exception as e:
             logger.error(f"[Consumer] save realtime failed {code} {period}: {e}")
+            return
+
+        bar_calc, adjustment_version = self._apply_qfq_to_bar(
+            kind=kind, code_prefixed=code, bar=bar_raw
+        )
+        window_versions = getattr(self, "_window_versions", None)
+        if window_versions is None:
+            window_versions = {}
+            self._window_versions = window_versions
+        previous_version = window_versions.get(code)
+        if previous_version and previous_version != adjustment_version:
+            self._warm_code_from_db(code=code)
+            return
+        window_versions[code] = adjustment_version
 
         key = (code, period)
 
@@ -1233,6 +1230,7 @@ class StrategyConsumer:
                     ["datetime", "open", "high", "low", "close", "volume", "amount"]
                 ].copy(),
                 "model_ids": model_ids,
+                "adjustment_version": adjustment_version,
             }
             if self._catchup_mode:
                 self._dirty_latest[key] = meta

--- a/freshquant/quantaxis/qadata/qadatastruct.py
+++ b/freshquant/quantaxis/qadata/qadatastruct.py
@@ -20,35 +20,25 @@ from QUANTAXIS.QAData.data_resample import (
 )
 from QUANTAXIS.QAUtil import (
     DATABASE,
-    QA_util_code_tolist,
-    QA_util_date_valid,
     QA_util_log_info,
     QA_util_to_json_from_pandas,
 )
 
+from freshquant.data.qfq_reader import apply_qfq_to_bars
 
-def _QA_fetch_stock_adj(code, start, end, format='pd', collections=DATABASE.stock_adj):
-    """获取股票复权系数 ADJ"""
 
-    start = str(start)[0:10]
-    end = str(end)[0:10]
-    # code= [code] if isinstance(code,str) else code
-
-    # code checking
-    code = QA_util_code_tolist(code)
-
-    if QA_util_date_valid(end):
-
-        cursor = collections.find(
-            {'code': {'$in': code}, "date": {"$lte": end, "$gte": start}},
-            {"_id": 0},
-            batch_size=10000,
+def _apply_strict_stock_qfq(data: pd.DataFrame) -> pd.DataFrame:
+    adjusted = []
+    for code in data.index.get_level_values("code").unique():
+        code_data = data.xs(code, level="code", drop_level=False)
+        code_adjusted, _metadata = apply_qfq_to_bars(
+            code_data,
+            scope="stock",
+            code=str(code),
+            ohlc_cols=("open", "high", "low", "close", "high_limit", "low_limit"),
         )
-        # res=[QA_util_dict_remove_key(data, '_id') for data in cursor]
-
-        res = pd.DataFrame([item for item in cursor])
-        res.date = pd.to_datetime(res.date, utc=False)
-        return res.set_index('date', drop=False)
+        adjusted.append(code_adjusted)
+    return pd.concat(adjusted).sort_index()
 
 
 class QA_DataStruct_Stock_day(_quotation_base):
@@ -89,35 +79,8 @@ class QA_DataStruct_Stock_day(_quotation_base):
             #     return self.new(pd.concat(list(map(
             #         lambda x: QA_data_stock_to_fq(self.data[self.data['code'] == x]), self.code))), self.type, 'qfq')
             else:
-                try:
-                    date = self.date
-                    adj = _QA_fetch_stock_adj(
-                        list(self.code), str(date[0])[0:10], str(date[-1])[0:10]
-                    ).set_index(['date', 'code'])
-                    data = self.data.join(adj)
-                    data['adj'].fillna(method='ffill', inplace=True)
-                    for col in ['open', 'high', 'low', 'close']:
-                        data[col] = data[col] * data['adj']
-                    # data['volume'] = data['volume'] / \
-                    #     data['adj'] if 'volume' in data.columns else data['vol']/data['adj']
-
-                    data['volume'] = (
-                        data['volume'] if 'volume' in data.columns else data['vol']
-                    )
-                    try:
-                        data['high_limit'] = data['high_limit'] * data['adj']
-                        data['low_limit'] = data['high_limit'] * data['adj']
-                    except:
-                        pass
-                    return self.new(data, self.type, 'qfq')
-                except Exception as e:
-                    print(e)
-                    print('use old model qfq')
-                    return self.new(
-                        self.groupby(level=1).apply(QA_data_stock_to_fq, 'qfq'),
-                        self.type,
-                        'qfq',
-                    )
+                data = _apply_strict_stock_qfq(self.data)
+                return self.new(data, self.type, 'qfq')
         else:
             QA_util_log_info(
                 'none support type for qfq Current type is: %s' % self.if_fq
@@ -284,39 +247,8 @@ class QA_DataStruct_Stock_min(_quotation_base):
             #     data.if_fq = 'qfq'
             #     return data
             else:
-                try:
-                    date = self.date
-                    adj = _QA_fetch_stock_adj(
-                        self.code.to_list(), str(date[0])[0:10], str(date[-1])[0:10]
-                    )
-                    adj = adj.assign(date=adj.date.apply(lambda x: x.date())).set_index(
-                        ['date', 'code']
-                    )
-                    u = self.data.reset_index()
-                    u = u.assign(date=u.datetime.apply(lambda x: x.date()))
-                    u = u.set_index(['date', 'code'], drop=False)
-
-                    data = u.join(adj).set_index(['datetime', 'code'])
-                    data['adj'].fillna(method='ffill', inplace=True)
-                    for col in ['open', 'high', 'low', 'close']:
-                        data[col] = data[col] * data['adj']
-                    # data['volume'] = data['volume'] / \
-                    #     data['adj']
-                    # data['volume'] = data['volume']  if 'volume' in data.columns else data['vol']
-                    try:
-                        data['high_limit'] = data['high_limit'] * data['adj']
-                        data['low_limit'] = data['high_limit'] * data['adj']
-                    except:
-                        pass
-                    return self.new(data, self.type, 'qfq')
-                except Exception as e:
-                    print(e)
-                    print('use old model qfq')
-                    return self.new(
-                        self.groupby(level=1).apply(QA_data_stock_to_fq, 'qfq'),
-                        self.type,
-                        'qfq',
-                    )
+                data = _apply_strict_stock_qfq(self.data)
+                return self.new(data, self.type, 'qfq')
 
         else:
             QA_util_log_info(

--- a/freshquant/quote/etf.py
+++ b/freshquant/quote/etf.py
@@ -4,38 +4,17 @@ from datetime import datetime, time, timedelta
 
 import pandas as pd
 import pymongo
-from loguru import logger
 from QUANTAXIS import QA_fetch_index_day_adv, QA_fetch_index_min_adv
 from QUANTAXIS.QAData.data_resample import QA_data_day_resample
 from QUANTAXIS.QAUtil.QADate import QA_util_datetime_to_strdatetime, QA_util_time_stamp
 
 from freshquant.carnation.config import TIME_DELTA, TZ
-from freshquant.data.adj_intraday import (
-    apply_qfq_with_intraday_override,
-    fetch_intraday_override,
-    fetch_qfq_adj_df,
-)
-from freshquant.database.cache import in_memory_cache, redis_cache
+from freshquant.data.qfq_reader import apply_qfq_to_bars
+from freshquant.database.cache import redis_cache
 from freshquant.db import DBfreshquant
 from freshquant.quote.general import resample3min, resampleStockOrIndex120min
 from freshquant.trading.trade_date_guard import is_cn_a_trade_date
 from freshquant.util.code import fq_util_code_append_market_code, normalize_to_base_code
-
-
-def _fetch_etf_adj(
-    code: str, start: datetime | None, end: datetime | None
-) -> pd.DataFrame | None:
-    if start is None or end is None:
-        return None
-    docs = fetch_qfq_adj_df(
-        coll_name="etf_adj",
-        code=normalize_to_base_code(code),
-        start_date=start.strftime("%Y-%m-%d"),
-        end_date=end.strftime("%Y-%m-%d"),
-    )
-    if len(docs) == 0:
-        return None
-    return docs
 
 
 def _resolve_etf_history_days(period: str, bar_count=0):
@@ -82,7 +61,6 @@ def _filter_trade_date_realtime_rows(rows: pd.DataFrame) -> pd.DataFrame:
     return rows.loc[mask].copy()
 
 
-@in_memory_cache.memoize(expiration=3)
 def queryEtfCandleSticks(code: str, period: str, endDate=None, bar_count=0):
     if endDate is None or endDate == "":
         end = datetime.now() + timedelta(1)
@@ -193,25 +171,12 @@ def queryEtfCandleSticksDay(code, start=None, end=None):
         data = pd.concat([data, realtime_data_list])
         data.drop_duplicates(subset="datetime", keep="first", inplace=True)
 
-    adj = _fetch_etf_adj(code, start_dt, end_dt)
-    if adj is None or len(adj) == 0:
-        start_s = start_dt.strftime("%Y-%m-%d") if start_dt else "N/A"
-        end_s = end_dt.strftime("%Y-%m-%d") if end_dt else "N/A"
-        logger.warning(
-            f"etf_adj missing for {normalize_to_base_code(code)} [{start_s},{end_s}]"
-        )
-    else:
-        override = fetch_intraday_override(
-            coll_name="etf_adj_intraday",
-            code=code,
-            trade_date=end_dt.strftime("%Y-%m-%d"),
-        )
-        data = apply_qfq_with_intraday_override(
-            data,
-            adj,
-            override=override,
-            datetime_col="datetime",
-        )
+    data, _metadata = apply_qfq_to_bars(
+        data,
+        scope="etf",
+        code=normalize_to_base_code(code),
+        datetime_col="datetime",
+    )
 
     data = data.round(
         {"open": 3, "high": 3, "low": 3, "close": 3, "volume": 2, "amount": 2}
@@ -285,25 +250,12 @@ def queryEtfCandleSticksMin(code, frequence, start=None, end=None):
         data = pd.concat([data, realtime_data_list])
         data.drop_duplicates(subset="datetime", keep="first", inplace=True)
 
-    adj = _fetch_etf_adj(code, start, end)
-    if adj is None or len(adj) == 0:
-        start_s = start.strftime("%Y-%m-%d") if start else "N/A"
-        end_s = end.strftime("%Y-%m-%d") if end else "N/A"
-        logger.warning(
-            f"etf_adj missing for {normalize_to_base_code(code)} [{start_s},{end_s}]"
-        )
-    else:
-        override = fetch_intraday_override(
-            coll_name="etf_adj_intraday",
-            code=code,
-            trade_date=end.strftime("%Y-%m-%d") if end else None,
-        )
-        data = apply_qfq_with_intraday_override(
-            data,
-            adj,
-            override=override,
-            datetime_col="datetime",
-        )
+    data, _metadata = apply_qfq_to_bars(
+        data,
+        scope="etf",
+        code=normalize_to_base_code(code),
+        datetime_col="datetime",
+    )
 
     data = data.round(
         {"open": 3, "high": 3, "low": 3, "close": 3, "volume": 2, "amount": 2}

--- a/freshquant/quote/stock.py
+++ b/freshquant/quote/stock.py
@@ -1,11 +1,19 @@
 # -*- coding: utf-8 -*-
 
 from QUANTAXIS import QA_fetch_stock_day_adv
-from freshquant.database.cache import redis_cache
 
-@redis_cache.memoize(expiration=900)
+from freshquant.data.qfq_reader import apply_qfq_to_bars
+from freshquant.util.code import normalize_to_base_code
+
+
 def fq_quote_QA_fetch_stock_day_adv(code, start, end):
     data = QA_fetch_stock_day_adv(code, start, end)
     if data is not None:
-        return data.to_qfq().data
+        adjusted, _metadata = apply_qfq_to_bars(
+            data.data,
+            scope="stock",
+            code=normalize_to_base_code(code),
+            date_col="date",
+        )
+        return adjusted
     return

--- a/freshquant/rear/stock/routes.py
+++ b/freshquant/rear/stock/routes.py
@@ -24,11 +24,17 @@ from freshquant.data.astock.holding import (
     get_stock_hold_position,
     get_stock_positions,
 )
+from freshquant.data.qfq_reader import (
+    QFQ_DATA_NOT_READY_HTTP_STATUS,
+    QFQDataNotReadyError,
+    resolve_qfq_read_metadata,
+)
 from freshquant.db import DBfreshquant
 from freshquant.instrument.general import query_instrument_info, query_instrument_type
 from freshquant.position.cn_future import queryArrangedCnFutureFillList
 from freshquant.research.cjsd.main import getCjsdList
 from freshquant.trading.dt import fq_trading_fetch_trade_dates
+from freshquant.trading.trade_date_guard import is_cn_a_trade_date
 from freshquant.util.code import fq_util_code_append_market_code_suffix
 from freshquant.util.encoder import FqJsonEncoder
 from freshquant.util.period import (
@@ -107,7 +113,12 @@ def _get_realtime_stock_data_from_cache(symbol, period, end_date):
     if not is_supported_realtime_period(period_backend):
         return None
 
-    cache_key = get_redis_cache_key(symbol, period_backend)
+    adjustment_version = _resolve_qfq_cache_version(symbol)
+    if adjustment_version is None:
+        return None
+    cache_key = get_redis_cache_key(
+        symbol, period_backend, adjustment_version=adjustment_version
+    )
     try:
         cached = redis_db.get(cache_key)
     except Exception as exc:  # pragma: no cover
@@ -128,6 +139,33 @@ def _get_realtime_stock_data_from_cache(symbol, period, end_date):
         return None
 
     return payload if isinstance(payload, dict) else None
+
+
+def _resolve_qfq_cache_version(symbol):
+    instrument_type = query_instrument_type(symbol)
+    if instrument_type == InstrumentType.INDEX_CN:
+        return "bfq"
+    if instrument_type == InstrumentType.ETF_CN:
+        scope = "etf"
+    elif instrument_type == InstrumentType.STOCK_CN:
+        scope = "stock"
+    else:
+        return None
+    today = datetime.now().strftime("%Y-%m-%d")
+    metadata, _override = resolve_qfq_read_metadata(
+        scope=scope,
+        code=symbol,
+        trade_date=today if is_cn_a_trade_date(today) else None,
+    )
+    return metadata.effective_version
+
+
+def _qfq_data_not_ready_response(error):
+    return Response(
+        json.dumps(error.as_dict(), cls=FqJsonEncoder),
+        mimetype="application/json",
+        status=QFQ_DATA_NOT_READY_HTTP_STATUS,
+    )
 
 
 def _parse_bar_count(raw):
@@ -214,12 +252,15 @@ def stock_data():
         "true",
         "yes",
     }
-    result = None
-    if use_realtime_cache:
-        result = _get_realtime_stock_data_from_cache(symbol, period, end_date)
-        result = _tail_stock_data_payload(result, bar_count)
-    if result is None:
-        result = get_data_v2(symbol, period, end_date, bar_count=bar_count)
+    try:
+        result = None
+        if use_realtime_cache:
+            result = _get_realtime_stock_data_from_cache(symbol, period, end_date)
+            result = _tail_stock_data_payload(result, bar_count)
+        if result is None:
+            result = get_data_v2(symbol, period, end_date, bar_count=bar_count)
+    except QFQDataNotReadyError as error:
+        return _qfq_data_not_ready_response(error)
     return Response(json.dumps(result, cls=FqJsonEncoder), mimetype="application/json")
 
 
@@ -228,7 +269,10 @@ def stock_data_v2():
     period = request.args.get("period")
     symbol = request.args.get("symbol")
     end_date = request.args.get("endDate")
-    result = get_data_v2(symbol, period, end_date)
+    try:
+        result = get_data_v2(symbol, period, end_date)
+    except QFQDataNotReadyError as error:
+        return _qfq_data_not_ready_response(error)
     return Response(json.dumps(result, cls=FqJsonEncoder), mimetype="application/json")
 
 
@@ -237,7 +281,10 @@ def stock_data_chanlun_structure():
     period = request.args.get("period")
     symbol = request.args.get("symbol")
     end_date = request.args.get("endDate")
-    result = get_chanlun_structure(symbol, period, end_date)
+    try:
+        result = get_chanlun_structure(symbol, period, end_date)
+    except QFQDataNotReadyError as error:
+        return _qfq_data_not_ready_response(error)
     return Response(json.dumps(result, cls=FqJsonEncoder), mimetype="application/json")
 
 

--- a/freshquant/strategy/toolkit/threshold.py
+++ b/freshquant/strategy/toolkit/threshold.py
@@ -8,6 +8,7 @@ from QUANTAXIS.QAFetch.QAQuery_Advance import (
 from talib import ATR
 
 from freshquant.carnation.enum_instrument import InstrumentType
+from freshquant.data.qfq_reader import apply_qfq_to_bars
 from freshquant.database.cache import in_memory_cache
 from freshquant.instrument.general import query_instrument_type
 from freshquant.strategy.common import get_threshold_config
@@ -17,15 +18,19 @@ from freshquant.util.code import (
 )
 
 
-@in_memory_cache.memoize(expiration=900)
 def _compute_atr_last_stock(inst_code_base: str, period: int) -> float:
     """
-    计算 A 股个股在给定周期下的最新 ATR 值，并使用内存缓存避免重复计算。
+    计算 A 股个股在给定周期下的最新 ATR 值。
     """
     start_date = (datetime.now() - timedelta(days=60)).strftime("%Y-%m-%d")
     end_date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     data = QA_fetch_stock_day_adv(inst_code_base, start_date, end_date)
-    data = data.to_qfq().data
+    data, _metadata = apply_qfq_to_bars(
+        data.data,
+        scope="stock",
+        code=inst_code_base,
+        date_col="date",
+    )
     atr_value = ATR(data.high.values, data.low.values, data.close.values, period)
     return float(atr_value[-1])
 

--- a/freshquant/tests/test_adj_refresh_service.py
+++ b/freshquant/tests/test_adj_refresh_service.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, timezone
 
 import pytest
 
+from freshquant.data.qfq_reader import QFQDataNotReadyError
 from freshquant.market_data.xtdata.adj_refresh_service import AdjRefreshService
 from freshquant.market_data.xtdata.adj_refresh_worker import (
     main,
@@ -37,6 +38,14 @@ class FakeXtDataAdjClient:
         return self.close_pairs.get((code, trade_date))
 
 
+def _active_snapshot(kind):
+    return {
+        "collection": f"{kind}_adj_qfq_a",
+        "snapshot_id": f"{kind}-snapshot-v1",
+        "factor_asof": "2026-03-08",
+    }
+
+
 class FakeSyncService:
     def __init__(self, result=None):
         self.calls = 0
@@ -62,10 +71,24 @@ class SequencedRefreshService:
 
 def test_sync_adj_refresh_once_writes_stock_and_etf_intraday_overrides():
     repository = InMemoryAdjRefreshRepository(
-        {
+        base_adj_docs={
             ("stock", "sz000001", "2026-03-08"): {"date": "2026-03-08", "adj": 2.0},
             ("etf", "sh510050", "2026-03-08"): {"date": "2026-03-08", "adj": 1.5},
-        }
+        },
+        shadow_adj_docs={
+            (
+                "stock",
+                "sz000001",
+                "2026-03-08",
+                "stock_adj_qfq_a",
+            ): {"date": "2026-03-08", "adj": 2.0},
+            (
+                "etf",
+                "sh510050",
+                "2026-03-08",
+                "etf_adj_qfq_a",
+            ): {"date": "2026-03-08", "adj": 1.5},
+        },
     )
     market_client = FakeXtDataAdjClient(
         {
@@ -80,6 +103,7 @@ def test_sync_adj_refresh_once_writes_stock_and_etf_intraday_overrides():
         trade_date_provider=lambda: date(2026, 3, 9),
         prev_trade_date_provider=lambda: date(2026, 3, 8),
         now_provider=lambda: datetime(2026, 3, 9, 1, 20, tzinfo=timezone.utc),
+        snapshot_provider=_active_snapshot,
     )
 
     result = service.sync_once()
@@ -97,9 +121,17 @@ def test_sync_adj_refresh_once_writes_stock_and_etf_intraday_overrides():
 
 def test_sync_adj_refresh_once_uses_repository_anchor_date_for_xtdata_pair():
     repository = InMemoryAdjRefreshRepository(
-        {
+        base_adj_docs={
             ("stock", "sz000001", "2026-03-08"): {"date": "2026-03-07", "adj": 2.0},
-        }
+        },
+        shadow_adj_docs={
+            (
+                "stock",
+                "sz000001",
+                "2026-03-08",
+                "stock_adj_qfq_a",
+            ): {"date": "2026-03-07", "adj": 2.0},
+        },
     )
     market_client = FakeXtDataAdjClient(
         {
@@ -113,6 +145,7 @@ def test_sync_adj_refresh_once_uses_repository_anchor_date_for_xtdata_pair():
         trade_date_provider=lambda: date(2026, 3, 9),
         prev_trade_date_provider=lambda: date(2026, 3, 8),
         now_provider=lambda: datetime(2026, 3, 9, 1, 20, tzinfo=timezone.utc),
+        snapshot_provider=_active_snapshot,
     )
 
     result = service.sync_once()
@@ -166,6 +199,114 @@ def test_intraday_override_binds_to_active_shadow_snapshot():
     assert document["base_factor_asof"] == "2026-03-08"
     assert document["anchor_scale"] == pytest.approx(1.2)
     assert document["legacy_anchor_scale"] == pytest.approx(0.9)
+
+
+def test_snapshot_bound_override_does_not_require_legacy_anchor():
+    repository = InMemoryAdjRefreshRepository(
+        shadow_adj_docs={
+            (
+                "stock",
+                "sz000001",
+                "2026-03-08",
+                "stock_adj_qfq_a",
+            ): {"date": "2026-03-08", "adj": 1.5}
+        }
+    )
+    service = AdjRefreshService(
+        repository=repository,
+        market_client=FakeXtDataAdjClient(
+            {
+                ("sz000001", "2026-03-08"): {
+                    "front_close": 18.0,
+                    "raw_close": 10.0,
+                }
+            }
+        ),
+        code_loader=lambda: ["sz000001"],
+        trade_date_provider=lambda: date(2026, 3, 9),
+        prev_trade_date_provider=lambda: date(2026, 3, 8),
+        snapshot_provider=lambda kind: {
+            "collection": f"{kind}_adj_qfq_a",
+            "snapshot_id": f"{kind}-snapshot-v1",
+            "factor_asof": "2026-03-08",
+        },
+    )
+
+    result = service.sync_once()
+
+    assert result["count"] == 1
+    document = repository.saved_docs["stock"][0]
+    assert document["base_snapshot_id"] == "stock-snapshot-v1"
+    assert document["anchor_scale"] == pytest.approx(1.2)
+    assert "legacy_anchor_scale" not in document
+
+
+def test_snapshot_resolution_failure_keeps_existing_binding_unchanged():
+    existing = {
+        "code": "000001",
+        "trade_date": "2026-03-09",
+        "base_snapshot_id": "stock-snapshot-v0",
+        "base_factor_asof": "2026-03-07",
+        "anchor_scale": 0.8,
+    }
+    repository = InMemoryAdjRefreshRepository(
+        base_adj_docs={
+            ("stock", "sz000001", "2026-03-08"): {
+                "date": "2026-03-08",
+                "adj": 2.0,
+            }
+        }
+    )
+    repository.saved_docs["stock"] = [dict(existing)]
+
+    def fail_snapshot(_kind):
+        raise RuntimeError("marker unavailable")
+
+    service = AdjRefreshService(
+        repository=repository,
+        market_client=FakeXtDataAdjClient(),
+        code_loader=lambda: ["sz000001"],
+        trade_date_provider=lambda: date(2026, 3, 9),
+        prev_trade_date_provider=lambda: date(2026, 3, 8),
+        snapshot_provider=fail_snapshot,
+    )
+
+    with pytest.raises(QFQDataNotReadyError, match="snapshot resolution failed"):
+        service.sync_once()
+
+    assert repository.saved_docs["stock"] == [existing]
+
+
+def test_missing_snapshot_anchor_never_falls_back_to_legacy_binding():
+    existing = {
+        "code": "000001",
+        "trade_date": "2026-03-09",
+        "base_snapshot_id": "stock-snapshot-v0",
+        "base_factor_asof": "2026-03-07",
+        "anchor_scale": 0.8,
+    }
+    repository = InMemoryAdjRefreshRepository(
+        base_adj_docs={
+            ("stock", "sz000001", "2026-03-08"): {
+                "date": "2026-03-08",
+                "adj": 2.0,
+            }
+        }
+    )
+    repository.saved_docs["stock"] = [dict(existing)]
+    service = AdjRefreshService(
+        repository=repository,
+        market_client=FakeXtDataAdjClient(),
+        code_loader=lambda: ["sz000001"],
+        trade_date_provider=lambda: date(2026, 3, 9),
+        prev_trade_date_provider=lambda: date(2026, 3, 8),
+        snapshot_provider=_active_snapshot,
+    )
+
+    result = service.sync_once()
+
+    assert result["count"] == 0
+    assert repository.saved_docs["stock"] == [existing]
 
 
 def test_worker_run_once_calls_sync_service():

--- a/freshquant/tests/test_chanlun_structure_service.py
+++ b/freshquant/tests/test_chanlun_structure_service.py
@@ -1,16 +1,30 @@
+import json
 import sys
 import types
 
 import pandas as pd
 import pytest
 
+from freshquant.carnation.enum_instrument import InstrumentType
 from freshquant.chanlun_structure_service import (
     DEFAULT_BAR_LIMIT,
+    _get_realtime_cache_payload,
     _sanitize_kline_df,
     build_chanlun_structure_payload,
     build_dataframe_from_cache_payload,
     get_chanlun_structure,
 )
+from freshquant.util.period import get_redis_cache_key
+
+
+class _FakeRedis:
+    def __init__(self, payload):
+        self.payload = payload
+        self.keys = []
+
+    def get(self, key):
+        self.keys.append(key)
+        return self.payload
 
 
 def test_build_dataframe_from_cache_payload_keeps_ohlcv_alignment():
@@ -176,6 +190,38 @@ def test_sanitize_kline_df_handles_datetime_as_index_and_column():
         "2026-03-07 09:35",
     ]
     assert clean["open"].tolist() == [10.0, 20.0]
+
+
+def test_chanlun_index_cache_uses_bfq_adjustment_version(monkeypatch):
+    payload = {"symbol": "sh000001", "period": "5m"}
+    redis = _FakeRedis(json.dumps(payload))
+    redis_module = types.ModuleType("freshquant.database.redis")
+    redis_module.redis_db = redis
+    monkeypatch.setitem(sys.modules, "freshquant.database.redis", redis_module)
+    monkeypatch.setattr(
+        "freshquant.instrument.general.query_instrument_type",
+        lambda _symbol: InstrumentType.INDEX_CN,
+    )
+
+    result = _get_realtime_cache_payload("sh000001", "5m", None)
+
+    assert result == payload
+    assert redis.keys == [
+        get_redis_cache_key("sh000001", "5min", adjustment_version="bfq")
+    ]
+
+
+def test_chanlun_unknown_instrument_never_reads_unversioned_cache(monkeypatch):
+    redis = _FakeRedis(json.dumps({"source": "stale-unversioned"}))
+    redis_module = types.ModuleType("freshquant.database.redis")
+    redis_module.redis_db = redis
+    monkeypatch.setitem(sys.modules, "freshquant.database.redis", redis_module)
+    monkeypatch.setattr(
+        "freshquant.instrument.general.query_instrument_type", lambda _symbol: None
+    )
+
+    assert _get_realtime_cache_payload("unknown", "5m", None) is None
+    assert redis.keys == []
 
 
 def test_get_chanlun_structure_sanitizes_realtime_cache_before_fullcalc(monkeypatch):

--- a/freshquant/tests/test_etf_data_fetch.py
+++ b/freshquant/tests/test_etf_data_fetch.py
@@ -131,7 +131,11 @@ def _realtime_bar(dt, frequence, close):
 
 def _patch_common(monkeypatch, etf_module, collection):
     monkeypatch.setattr(etf_module, "DBfreshquant", _FakeDB(collection))
-    monkeypatch.setattr(etf_module, "_fetch_etf_adj", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        etf_module,
+        "apply_qfq_to_bars",
+        lambda bars, **_kwargs: (bars, None),
+    )
     monkeypatch.setattr(
         etf_module,
         "fq_util_code_append_market_code",

--- a/freshquant/tests/test_index_bfq_routing.py
+++ b/freshquant/tests/test_index_bfq_routing.py
@@ -202,8 +202,8 @@ def test_strategy_consumer_index_read_never_reads_factor(monkeypatch):
     monkeypatch.setattr(strategy_consumer, "DBfreshquant", _EmptyDatabase())
     monkeypatch.setattr(
         strategy_consumer,
-        "fetch_qfq_adj_df",
-        lambda **_kwargs: (_ for _ in ()).throw(
+        "apply_qfq_to_bars",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
             AssertionError("Index must not read adj")
         ),
     )

--- a/freshquant/tests/test_period_utils.py
+++ b/freshquant/tests/test_period_utils.py
@@ -14,3 +14,7 @@ def test_period_convert_roundtrip():
 
 def test_cache_key_format():
     assert get_redis_cache_key("sz000001", "5min") == "CACHE:KLINE:sz000001:5min"
+    assert (
+        get_redis_cache_key("sz000001", "5min", adjustment_version="snapshot-v2")
+        == "CACHE:KLINE:sz000001:5min:snapshot-v2"
+    )

--- a/freshquant/tests/test_qfq_reader.py
+++ b/freshquant/tests/test_qfq_reader.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import inspect
+
+import pandas as pd
+import pytest
+
+import freshquant.data.qfq_reader as qfq_reader
+from freshquant.data.qfq_reader import (
+    QFQDataNotReadyError,
+    apply_qfq_to_bars,
+    resolve_qfq_read_metadata,
+    resolve_qfq_scope_metadata,
+)
+
+
+class _Cursor:
+    def __init__(self, rows):
+        self.rows = list(rows)
+
+    def sort(self, key, direction):
+        self.rows.sort(key=lambda row: row.get(key), reverse=direction < 0)
+        return self
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+class _Collection:
+    def __init__(self, rows=None):
+        self.rows = list(rows or [])
+
+    def find_one(self, query=None, projection=None, **_kwargs):
+        rows = list(self.find(query, projection))
+        return rows[0] if rows else None
+
+    def find(self, query=None, projection=None):
+        rows = [row for row in self.rows if _matches(row, query or {})]
+        if projection:
+            included = {key for key, enabled in projection.items() if enabled}
+            if included:
+                rows = [
+                    {key: value for key, value in row.items() if key in included}
+                    for row in rows
+                ]
+            else:
+                excluded = {key for key, enabled in projection.items() if not enabled}
+                rows = [
+                    {key: value for key, value in row.items() if key not in excluded}
+                    for row in rows
+                ]
+        return _Cursor(rows)
+
+
+class _Database:
+    def __init__(self, **collections):
+        self.collections = {
+            name: _Collection(rows) for name, rows in collections.items()
+        }
+
+    def __getitem__(self, name):
+        return self.collections.setdefault(name, _Collection())
+
+
+def _matches(row, query):
+    for key, expected in query.items():
+        actual = row.get(key)
+        if isinstance(expected, dict):
+            if "$gte" in expected and actual < expected["$gte"]:
+                return False
+            if "$lte" in expected and actual > expected["$lte"]:
+                return False
+        elif actual != expected:
+            return False
+    return True
+
+
+def _slot(scope, slot, snapshot, *, factor_asof="2026-07-31", exclusions=None):
+    return {
+        "collection": f"{scope}_adj_qfq_{slot}",
+        "snapshot_id": snapshot,
+        "factor_asof": factor_asof,
+        "status": "ready",
+        "published_at": (
+            "2026-07-31T15:59:00+08:00" if slot == "a" else "2026-07-31T16:00:00+08:00"
+        ),
+        "source_exclusions": list(exclusions or []),
+    }
+
+
+def _marker(*, active="a", factor_asof="2026-07-31", exclusions=None):
+    return {
+        "scope": "stock",
+        "active_slot": active,
+        "slots": {
+            "a": _slot(
+                "stock",
+                "a",
+                "snapshot-a",
+                factor_asof=factor_asof,
+                exclusions=exclusions if active == "a" else None,
+            ),
+            "b": _slot(
+                "stock",
+                "b",
+                "snapshot-b",
+                factor_asof=factor_asof,
+                exclusions=exclusions if active == "b" else None,
+            ),
+        },
+        "source": "xtdata_preclose",
+        "schema_version": 1,
+    }
+
+
+def _bars(*dates):
+    return pd.DataFrame(
+        {
+            "datetime": [pd.Timestamp(f"{value} 10:00:00") for value in dates],
+            "open": [10.0] * len(dates),
+            "high": [11.0] * len(dates),
+            "low": [9.0] * len(dates),
+            "close": [10.5] * len(dates),
+        }
+    )
+
+
+def test_reader_uses_only_marker_selected_active_slot():
+    db = _Database(
+        qfq_ready=[
+            _marker(
+                active="b",
+                exclusions=[{"code": "999999", "reason": "source_empty_bars"}],
+            )
+        ],
+        stock_adj_qfq_a=[
+            {"code": "000001", "date": "2026-07-30", "adj": 0.1},
+            {"code": "000001", "date": "2026-07-31", "adj": 0.1},
+        ],
+        stock_adj_qfq_b=[
+            {"code": "000001", "date": "2026-07-30", "adj": 0.5},
+            {"code": "000001", "date": "2026-07-31", "adj": 1.0},
+        ],
+    )
+
+    result, metadata = apply_qfq_to_bars(
+        _bars("2026-07-30", "2026-07-31"),
+        scope="stock",
+        code="sz000001",
+        db=db,
+    )
+
+    assert result["open"].tolist() == [5.0, 10.0]
+    assert metadata.collection == "stock_adj_qfq_b"
+    assert metadata.snapshot_id == "snapshot-b"
+    assert metadata.effective_version == "snapshot-b"
+    assert metadata.active_slot == "b"
+    assert metadata.published_at == "2026-07-31T16:00:00+08:00"
+    assert metadata.source_exclusions == (
+        {"code": "999999", "reason": "source_empty_bars"},
+    )
+
+
+def test_reader_resolves_marker_again_after_active_slot_switch():
+    marker = _marker(active="a")
+    db = _Database(
+        qfq_ready=[marker],
+        stock_adj_qfq_a=[{"code": "000001", "date": "2026-07-31", "adj": 0.5}],
+        stock_adj_qfq_b=[{"code": "000001", "date": "2026-07-31", "adj": 0.8}],
+    )
+    first, _metadata = apply_qfq_to_bars(
+        _bars("2026-07-31"), scope="stock", code="000001", db=db
+    )
+    marker["active_slot"] = "b"
+    second, _metadata = apply_qfq_to_bars(
+        _bars("2026-07-31"), scope="stock", code="000001", db=db
+    )
+
+    assert first["open"].tolist() == [5.0]
+    assert second["open"].tolist() == [8.0]
+
+
+def test_scope_metadata_resolves_active_snapshot_on_every_call():
+    marker = _marker(
+        active="a",
+        exclusions=[{"code": "999999", "reason": "source_empty_bars"}],
+    )
+    db = _Database(qfq_ready=[marker])
+
+    first = resolve_qfq_scope_metadata(scope="stock", trade_date="2026-07-31", db=db)
+    marker["active_slot"] = "b"
+    second = resolve_qfq_scope_metadata(scope="stock", trade_date="2026-07-31", db=db)
+
+    assert first.snapshot_id == "snapshot-a"
+    assert first.collection == "stock_adj_qfq_a"
+    assert first.effective_version == "snapshot-a"
+    assert first.active_slot == "a"
+    assert first.published_at == "2026-07-31T15:59:00+08:00"
+    assert first.source_exclusions == (
+        {"code": "999999", "reason": "source_empty_bars"},
+    )
+    assert first.override_version is None
+    assert second.snapshot_id == "snapshot-b"
+    assert second.collection == "stock_adj_qfq_b"
+    assert second.effective_version == "snapshot-b"
+    assert second.active_slot == "b"
+    assert second.published_at == "2026-07-31T16:00:00+08:00"
+    assert second.source_exclusions == ()
+    assert second.override_version is None
+
+
+@pytest.mark.parametrize("resolver", ["scope", "code"])
+def test_reader_rejects_active_snapshot_without_published_at(resolver):
+    marker = _marker()
+    marker["slots"]["a"].pop("published_at")
+    db = _Database(qfq_ready=[marker])
+
+    with pytest.raises(QFQDataNotReadyError, match="metadata is incomplete"):
+        if resolver == "scope":
+            resolve_qfq_scope_metadata(scope="stock", db=db)
+        else:
+            resolve_qfq_read_metadata(scope="stock", code="000001", db=db)
+
+
+def test_read_metadata_rejects_invalid_nonempty_trade_date():
+    db = _Database(qfq_ready=[_marker()])
+
+    with pytest.raises(QFQDataNotReadyError, match="trade_date is invalid"):
+        resolve_qfq_read_metadata(
+            scope="stock", code="000001", trade_date="not-a-date", db=db
+        )
+
+
+def test_scope_metadata_normalizes_source_exclusion_codes(monkeypatch):
+    active = {
+        "scope": "stock",
+        "slot": "a",
+        **_slot("stock", "a", "snapshot-a"),
+        "source_exclusions": [
+            {"code": "SZ000001", "reason": "source_empty_bars", "rows": 0}
+        ],
+    }
+    monkeypatch.setattr(
+        "freshquant.market_data.xtdata.qfq.resolve_active_slot",
+        lambda **_kwargs: active,
+    )
+
+    metadata = resolve_qfq_scope_metadata(scope="stock", db=_Database())
+
+    assert metadata.source_exclusions == (
+        {"code": "000001", "reason": "source_empty_bars", "rows": 0},
+    )
+
+
+@pytest.mark.parametrize("resolver", ["scope", "code"])
+def test_reader_maps_malformed_source_exclusion_to_not_ready(monkeypatch, resolver):
+    active = {
+        "scope": "stock",
+        "slot": "a",
+        **_slot("stock", "a", "snapshot-a"),
+        "source_exclusions": [object()],
+    }
+    monkeypatch.setattr(
+        "freshquant.market_data.xtdata.qfq.resolve_active_slot",
+        lambda **_kwargs: active,
+    )
+
+    with pytest.raises(QFQDataNotReadyError, match="exclusions are malformed"):
+        if resolver == "scope":
+            resolve_qfq_scope_metadata(scope="stock", db=_Database())
+        else:
+            resolve_qfq_read_metadata(scope="stock", code="000001", db=_Database())
+
+
+def test_strict_factor_path_has_no_fillna_one_fallback():
+    assert "fillna(1.0)" not in inspect.getsource(qfq_reader._read_factor_series)
+
+
+def test_scope_metadata_rejects_trade_date_after_factor_asof_without_override():
+    db = _Database(
+        qfq_ready=[_marker()],
+        stock_adj_intraday=[
+            {
+                "code": "000001",
+                "trade_date": "2026-08-01",
+                "base_snapshot_id": "snapshot-a",
+                "anchor_scale": 1.0,
+                "updated_at": "override-v1",
+            }
+        ],
+    )
+
+    with pytest.raises(QFQDataNotReadyError, match="scope freeze") as exc_info:
+        resolve_qfq_scope_metadata(scope="stock", trade_date="2026-08-01", db=db)
+
+    assert exc_info.value.code == ""
+    assert exc_info.value.missing_dates == ("2026-08-01",)
+
+
+@pytest.mark.parametrize(
+    "database",
+    [
+        _Database(),
+        _Database(qfq_ready=[{**_marker(), "source": "legacy"}]),
+    ],
+)
+def test_reader_fails_closed_when_ready_marker_is_missing_or_invalid(database):
+    with pytest.raises(QFQDataNotReadyError, match="QFQ_DATA_NOT_READY"):
+        apply_qfq_to_bars(
+            _bars("2026-07-31"), scope="stock", code="000001", db=database
+        )
+
+
+def test_reader_fails_closed_on_factor_coverage_gap():
+    db = _Database(qfq_ready=[_marker()], stock_adj_qfq_a=[])
+
+    with pytest.raises(QFQDataNotReadyError) as exc_info:
+        apply_qfq_to_bars(
+            _bars("2026-07-30", "2026-07-31"),
+            scope="stock",
+            code="000001",
+            db=db,
+        )
+
+    assert exc_info.value.missing_dates == ("2026-07-30", "2026-07-31")
+
+
+def test_reader_fails_closed_for_active_source_exclusion():
+    db = _Database(
+        qfq_ready=[
+            _marker(exclusions=[{"code": "000001", "reason": "source_empty_bars"}])
+        ]
+    )
+
+    scope_metadata = resolve_qfq_scope_metadata(scope="stock", db=db)
+    assert scope_metadata.source_exclusions == (
+        {"code": "000001", "reason": "source_empty_bars"},
+    )
+
+    with pytest.raises(QFQDataNotReadyError, match="excluded"):
+        resolve_qfq_read_metadata(scope="stock", code="000001", db=db)
+
+
+def test_matching_override_is_snapshot_bound_and_versions_the_result():
+    db = _Database(
+        qfq_ready=[_marker()],
+        stock_adj_qfq_a=[{"code": "000001", "date": "2026-07-31", "adj": 1.0}],
+        stock_adj_intraday=[
+            {
+                "code": "000001",
+                "trade_date": "2026-08-01",
+                "base_snapshot_id": "snapshot-a",
+                "base_factor_asof": "2026-07-31",
+                "anchor_scale": 0.8,
+                "updated_at": "override-v2",
+            }
+        ],
+    )
+
+    result, metadata = apply_qfq_to_bars(
+        _bars("2026-07-31", "2026-08-01"),
+        scope="stock",
+        code="000001",
+        db=db,
+    )
+
+    assert result["open"].tolist() == [8.0, 10.0]
+    assert metadata.effective_version == "snapshot-a:override-v2"
+    assert metadata.active_slot == "a"
+    assert metadata.published_at == "2026-07-31T15:59:00+08:00"
+
+
+def test_stale_override_never_applies_to_a_new_snapshot():
+    db = _Database(
+        qfq_ready=[_marker(active="b")],
+        stock_adj_qfq_b=[{"code": "000001", "date": "2026-07-31", "adj": 1.0}],
+        stock_adj_intraday=[
+            {
+                "code": "000001",
+                "trade_date": "2026-08-01",
+                "base_snapshot_id": "snapshot-a",
+                "anchor_scale": 0.8,
+                "updated_at": "override-v1",
+            }
+        ],
+    )
+
+    with pytest.raises(QFQDataNotReadyError, match="snapshot mismatch"):
+        apply_qfq_to_bars(
+            _bars("2026-07-31", "2026-08-01"),
+            scope="stock",
+            code="000001",
+            db=db,
+        )
+
+
+def test_reader_requires_override_for_date_after_factor_asof():
+    db = _Database(
+        qfq_ready=[_marker()],
+        stock_adj_qfq_a=[{"code": "000001", "date": "2026-07-31", "adj": 1.0}],
+    )
+
+    with pytest.raises(QFQDataNotReadyError, match="override is missing") as exc_info:
+        apply_qfq_to_bars(
+            _bars("2026-07-31", "2026-08-01"),
+            scope="stock",
+            code="000001",
+            db=db,
+        )
+
+    assert exc_info.value.missing_dates == ("2026-08-01",)
+
+
+def test_reader_rejects_more_than_one_date_beyond_factor_asof():
+    db = _Database(
+        qfq_ready=[_marker()],
+        stock_adj_qfq_a=[{"code": "000001", "date": "2026-07-31", "adj": 1.0}],
+        stock_adj_intraday=[
+            {
+                "code": "000001",
+                "trade_date": "2026-08-03",
+                "base_snapshot_id": "snapshot-a",
+                "base_factor_asof": "2026-07-31",
+                "anchor_scale": 1.0,
+                "updated_at": "override-v3",
+            }
+        ],
+    )
+
+    with pytest.raises(QFQDataNotReadyError, match="behind"):
+        apply_qfq_to_bars(
+            _bars("2026-07-31", "2026-08-01", "2026-08-03"),
+            scope="stock",
+            code="000001",
+            db=db,
+        )

--- a/freshquant/tests/test_quantaxis_qfq_reader_routing.py
+++ b/freshquant/tests/test_quantaxis_qfq_reader_routing.py
@@ -1,0 +1,430 @@
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+import freshquant.quantaxis.qadata.qadatastruct as qadatastruct
+from freshquant.data.qfq_reader import QFQDataNotReadyError
+
+TEMPORARY_OFFLINE_QFACTOR_ALLOWLIST = {
+    (
+        "sunflower/QUANTAXIS/QUANTAXIS/QAAnalysis/QAAnalysis_block.py",
+        45,
+    ): (
+        "vendored offline QAAnalysis helper; it has no FreshQuant, CLX, or "
+        "QAWebServer deployed callsite"
+    ),
+    (
+        "sunflower/QUANTAXIS/QUANTAXIS/QAFetch/QAClickhouse.py",
+        255,
+    ): (
+        "vendored offline QAFactor ClickHouse helper; QACKClient is exported "
+        "but has no FreshQuant, CLX, or QAWebServer deployed callsite"
+    ),
+}
+
+CANONICAL_ADJUSTMENT_COLLECTION_NAMES = {
+    "stock_adj_qfq_a",
+    "stock_adj_qfq_b",
+    "etf_adj_qfq_a",
+    "etf_adj_qfq_b",
+    "stock_adj_intraday",
+    "etf_adj_intraday",
+    "stock_adj",
+    "etf_adj",
+}
+
+TEMPORARY_DIRECT_ADJUSTMENT_COLLECTION_ALLOWLIST = {
+    ("freshquant/data/etf_adj_sync.py", 115, "literal:etf_adj"): (
+        "PR2a transitional legacy ETF writer cleanup"
+    ),
+    ("freshquant/data/etf_adj_sync.py", 683, "attribute:etf_adj"): (
+        "PR2a transitional legacy ETF writer"
+    ),
+    ("freshquant/data/qfq_reader.py", 129, "fragment:_adj_intraday"): (
+        "shared strict QFQ reader"
+    ),
+    (
+        "freshquant/market_data/xtdata/adj_refresh_service.py",
+        73,
+        "literal:stock_adj",
+    ): "PR2a transitional legacy anchor evidence",
+    (
+        "freshquant/market_data/xtdata/adj_refresh_service.py",
+        73,
+        "literal:etf_adj",
+    ): "PR2a transitional legacy anchor evidence",
+    (
+        "freshquant/market_data/xtdata/adj_refresh_service.py",
+        105,
+        "literal:stock_adj_intraday",
+    ): "snapshot-bound intraday override writer",
+    (
+        "freshquant/market_data/xtdata/adj_refresh_service.py",
+        105,
+        "literal:etf_adj_intraday",
+    ): "snapshot-bound intraday override writer",
+    ("freshquant/market_data/xtdata/qfq.py", 32, "literal:stock_adj_qfq_a"): (
+        "shared QFQ writer"
+    ),
+    ("freshquant/market_data/xtdata/qfq.py", 33, "literal:stock_adj_qfq_b"): (
+        "shared QFQ writer"
+    ),
+    ("freshquant/market_data/xtdata/qfq.py", 36, "literal:etf_adj_qfq_a"): (
+        "shared QFQ writer"
+    ),
+    ("freshquant/market_data/xtdata/qfq.py", 37, "literal:etf_adj_qfq_b"): (
+        "shared QFQ writer"
+    ),
+    ("freshquant/market_data/xtdata/qfq.py", 40, "literal:stock_adj"): (
+        "shared QFQ writer legacy-copy input"
+    ),
+    ("freshquant/market_data/xtdata/qfq.py", 40, "literal:etf_adj"): (
+        "shared QFQ writer legacy-copy input"
+    ),
+    (
+        "freshquant/market_data/xtdata/qfq.py",
+        42,
+        "literal:stock_adj_intraday",
+    ): "shared QFQ writer override rebind",
+    (
+        "freshquant/market_data/xtdata/qfq.py",
+        43,
+        "literal:etf_adj_intraday",
+    ): "shared QFQ writer override rebind",
+    (
+        "sunflower/QUANTAXIS/QUANTAXIS/QAData/QADataStruct.py",
+        79,
+        "attribute:stock_adj",
+    ): "vendored transitional legacy path; PR2b closure",
+    (
+        "sunflower/QUANTAXIS/QUANTAXIS/QAFetch/QAClickhouse.py",
+        131,
+        "embedded:stock_adj",
+    ): "vendored transitional legacy path; PR2b closure",
+    (
+        "sunflower/QUANTAXIS/QUANTAXIS/QAFetch/QAQuery.py",
+        149,
+        "attribute:stock_adj",
+    ): "vendored transitional legacy path; PR2b closure",
+    (
+        "sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py",
+        632,
+        "attribute:stock_adj",
+    ): "vendored transitional legacy writer; PR2b closure",
+    (
+        "sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py",
+        650,
+        "literal:stock_adj",
+    ): "vendored transitional legacy writer; PR2b closure",
+    (
+        "sunflower/QUANTAXIS/QUANTAXIS/QASU/save_tdx.py",
+        651,
+        "attribute:stock_adj",
+    ): "vendored transitional legacy writer; PR2b closure",
+}
+
+TEMPORARY_FILL_ONE_ALLOWLIST = {
+    ("freshquant/data/adj_intraday.py", 117): (
+        "transitional legacy helper with no runtime callsite"
+    ),
+    ("freshquant/data/adj_intraday.py", 122): (
+        "transitional legacy helper with no runtime callsite"
+    ),
+    ("freshquant/data/astock/holding.py", 262): (
+        "trade amount_adjust default, not a QFQ factor fallback"
+    ),
+    ("freshquant/data/astock/holding.py", 282): (
+        "trade amount_adjust default, not a QFQ factor fallback"
+    ),
+    ("freshquant/data/astock/holding.py", 440): (
+        "trade amount_adjust default, not a QFQ factor fallback"
+    ),
+    ("freshquant/data/etf_adj.py", 95): (
+        "transitional legacy ETF factor implementation; PR2b closure"
+    ),
+    ("freshquant/data/etf_adj.py", 144): (
+        "transitional legacy ETF factor implementation; PR2b closure"
+    ),
+    ("sunflower/QUANTAXIS/config/data_init.py", 945): (
+        "vendored transitional legacy factor path; PR2b closure"
+    ),
+    ("sunflower/QUANTAXIS/config/data_init.py", 947): (
+        "vendored transitional legacy factor path; PR2b closure"
+    ),
+    ("sunflower/QUANTAXIS/QUANTAXIS/QAData/data_fq.py", 154): (
+        "vendored transitional legacy factor path; PR2b closure"
+    ),
+    ("sunflower/QUANTAXIS/QUANTAXIS/QAData/data_fq.py", 157): (
+        "vendored transitional legacy factor path; PR2b closure"
+    ),
+    ("sunflower/QUANTAXIS/QUANTAXIS/QAFetch/QAClickhouse.py", 47): (
+        "vendored transitional legacy factor path; PR2b closure"
+    ),
+    ("sunflower/QUANTAXIS/QUANTAXIS/QAFetch/QAClickhouse.py", 147): (
+        "vendored transitional legacy factor path; PR2b closure"
+    ),
+    ("sunflower/QUANTAXIS/QUANTAXIS/QAFetch/QAClickhouse.py", 189): (
+        "vendored transitional legacy factor path; PR2b closure"
+    ),
+    ("sunflower/QUANTAXIS/QUANTAXIS/QAFetch/QAClickhouse.py", 219): (
+        "vendored transitional legacy factor path; PR2b closure"
+    ),
+}
+
+
+def _runtime_python_files(repo_root):
+    for runtime_root in (
+        repo_root / "freshquant",
+        repo_root / "sunflower" / "QUANTAXIS",
+    ):
+        for path in runtime_root.rglob("*.py"):
+            relative_path = path.relative_to(repo_root)
+            lowered_parts = {part.lower() for part in relative_path.parts}
+            if lowered_parts & {
+                "tests",
+                "__pycache__",
+                "build",
+                "dist",
+                ".tox",
+                ".venv",
+            }:
+                continue
+            yield path, relative_path.as_posix()
+
+
+def _docstring_node_ids(tree):
+    result = set()
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if not body or not isinstance(body, list):
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            result.add(id(first.value))
+    return result
+
+
+def _direct_adjustment_collection_hits(repo_root):
+    hits = set()
+    search_terms = {*CANONICAL_ADJUSTMENT_COLLECTION_NAMES, "_adj_intraday"}
+    for path, relative_path in _runtime_python_files(repo_root):
+        source = path.read_text(encoding="utf-8-sig", errors="replace")
+        if not any(term in source for term in search_terms):
+            continue
+        tree = ast.parse(source)
+        docstrings = _docstring_node_ids(tree)
+        for node in ast.walk(tree):
+            kind = None
+            value = None
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and id(node) not in docstrings
+            ):
+                if node.value in CANONICAL_ADJUSTMENT_COLLECTION_NAMES:
+                    kind, value = "literal", node.value
+                elif "_adj_intraday" in node.value:
+                    kind, value = "fragment", "_adj_intraday"
+                elif "quantaxis.stock_adj" in node.value:
+                    kind, value = "embedded", "stock_adj"
+                elif "quantaxis.etf_adj" in node.value:
+                    kind, value = "embedded", "etf_adj"
+            elif isinstance(node, ast.Attribute) and node.attr in {
+                "stock_adj",
+                "etf_adj",
+            }:
+                kind, value = "attribute", node.attr
+            if kind:
+                hits.add((relative_path, node.lineno, f"{kind}:{value}"))
+    return hits
+
+
+def _fill_one_hits(repo_root):
+    hits = set()
+    for path, relative_path in _runtime_python_files(repo_root):
+        source = path.read_text(encoding="utf-8-sig", errors="replace")
+        if "fillna" not in source:
+            continue
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if (
+                not isinstance(node, ast.Call)
+                or not isinstance(node.func, ast.Attribute)
+                or node.func.attr != "fillna"
+            ):
+                continue
+            value = (
+                node.args[0]
+                if node.args
+                else next(
+                    (
+                        keyword.value
+                        for keyword in node.keywords
+                        if keyword.arg == "value"
+                    ),
+                    None,
+                )
+            )
+            if (
+                isinstance(value, ast.Constant)
+                and type(value.value) in {int, float}
+                and float(value.value) == 1.0
+            ):
+                hits.add((relative_path, node.lineno))
+    return hits
+
+
+def _fake_reader(calls):
+    def apply(data, *, scope, code, ohlc_cols):
+        calls.append((scope, code, tuple(ohlc_cols)))
+        result = data.copy()
+        factor = 0.5 if code == "000001" else 0.8
+        for column in ohlc_cols:
+            if column in result.columns:
+                result[column] = result[column] * factor
+        return result, SimpleNamespace(effective_version=f"snapshot-{code}")
+
+    return apply
+
+
+def test_custom_stock_day_to_qfq_routes_each_code_through_strict_reader(
+    monkeypatch,
+):
+    index = pd.MultiIndex.from_tuples(
+        [
+            (pd.Timestamp("2026-01-02"), "000001"),
+            (pd.Timestamp("2026-01-02"), "600000"),
+        ],
+        names=["date", "code"],
+    )
+    data = pd.DataFrame(
+        {
+            "open": [10.0, 20.0],
+            "high": [11.0, 21.0],
+            "low": [9.0, 19.0],
+            "close": [10.5, 20.5],
+            "volume": [100.0, 200.0],
+            "high_limit": [12.0, 22.0],
+            "low_limit": [8.0, 18.0],
+        },
+        index=index,
+    )
+    calls = []
+    monkeypatch.setattr(qadatastruct, "apply_qfq_to_bars", _fake_reader(calls))
+
+    result = qadatastruct.QA_DataStruct_Stock_day(data).to_qfq()
+
+    assert result.if_fq == "qfq"
+    assert result.data.loc[(pd.Timestamp("2026-01-02"), "000001"), "close"] == 5.25
+    assert result.data.loc[
+        (pd.Timestamp("2026-01-02"), "600000"), "close"
+    ] == pytest.approx(16.4)
+    assert [item[:2] for item in calls] == [
+        ("stock", "000001"),
+        ("stock", "600000"),
+    ]
+
+
+def test_custom_stock_min_to_qfq_propagates_strict_reader_failure(monkeypatch):
+    index = pd.MultiIndex.from_tuples(
+        [(pd.Timestamp("2026-01-02 09:35:00"), "000001")],
+        names=["datetime", "code"],
+    )
+    data = pd.DataFrame(
+        {
+            "open": [10.0],
+            "high": [11.0],
+            "low": [9.0],
+            "close": [10.5],
+            "volume": [100.0],
+            "amount": [1000.0],
+            "type": ["5min"],
+        },
+        index=index,
+    )
+
+    def fail(*_args, **_kwargs):
+        raise QFQDataNotReadyError("factor gap", scope="stock", code="000001")
+
+    monkeypatch.setattr(qadatastruct, "apply_qfq_to_bars", fail)
+
+    with pytest.raises(QFQDataNotReadyError, match="factor gap"):
+        qadatastruct.QA_DataStruct_Stock_min(data).to_qfq()
+
+
+def test_runtime_to_qfq_calls_are_strict_or_exactly_offline_allowlisted():
+    repo_root = Path(__file__).resolve().parents[2]
+    hits = set()
+    for path, relative_path in _runtime_python_files(repo_root):
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8-sig", errors="replace").splitlines(),
+            start=1,
+        ):
+            if ".to_qfq(" in line:
+                hits.add((relative_path, line_number))
+
+    assert hits == set(TEMPORARY_OFFLINE_QFACTOR_ALLOWLIST)
+    assert all(TEMPORARY_OFFLINE_QFACTOR_ALLOWLIST.values())
+    assert _direct_adjustment_collection_hits(repo_root) == set(
+        TEMPORARY_DIRECT_ADJUSTMENT_COLLECTION_ALLOWLIST
+    )
+    assert all(TEMPORARY_DIRECT_ADJUSTMENT_COLLECTION_ALLOWLIST.values())
+    assert _fill_one_hits(repo_root) == set(TEMPORARY_FILL_ONE_ALLOWLIST)
+    assert all(TEMPORARY_FILL_ONE_ALLOWLIST.values())
+
+    clickhouse_path = (
+        repo_root
+        / "sunflower"
+        / "QUANTAXIS"
+        / "QUANTAXIS"
+        / "QAFetch"
+        / "QAClickhouse.py"
+    )
+    clickhouse_lines = clickhouse_path.read_text(
+        encoding="utf-8", errors="replace"
+    ).splitlines()
+    assert {
+        line_number
+        for line_number, line in enumerate(clickhouse_lines, start=1)
+        if "quantaxis.stock_adj" in line
+    } == {131}
+    assert {
+        line_number
+        for line_number, line in enumerate(clickhouse_lines, start=1)
+        if ".fillna(1)" in line
+    } == {47, 148, 189, 220}
+
+
+def test_qfq_adjusted_outputs_are_not_memoized_without_snapshot_version():
+    repo_root = Path(__file__).resolve().parents[2]
+    adjusted_functions = {
+        "freshquant/KlineDataTool.py": {"get_stock_data"},
+        "freshquant/data/stock.py": {"fq_data_stock_fetch_atr"},
+        "freshquant/data/astock/holding.py": {
+            "_compute_atr_last_stock",
+            "_query_grid_interval",
+        },
+        "freshquant/strategy/toolkit/threshold.py": {"_compute_atr_last_stock"},
+        "freshquant/quote/etf.py": {"queryEtfCandleSticks"},
+        "freshquant/quote/stock.py": {"fq_quote_QA_fetch_stock_day_adv"},
+    }
+
+    for relative_path, expected_names in adjusted_functions.items():
+        tree = ast.parse((repo_root / relative_path).read_text(encoding="utf-8"))
+        functions = {
+            node.name: node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name in expected_names
+        }
+        assert set(functions) == expected_names
+        for function in functions.values():
+            decorators = [ast.unparse(item) for item in function.decorator_list]
+            assert not any("memoize" in item for item in decorators)

--- a/freshquant/tests/test_stock_data_chanlun_structure_route.py
+++ b/freshquant/tests/test_stock_data_chanlun_structure_route.py
@@ -53,6 +53,7 @@ def _install_route_stubs(monkeypatch):
 
     db = types.ModuleType("freshquant.db")
     db.DBfreshquant = {}
+    db.DBQuantAxis = {}
 
     instrument_general = types.ModuleType("freshquant.instrument.general")
     instrument_general.query_instrument_info = lambda *args, **kwargs: {}
@@ -76,6 +77,9 @@ def _install_route_stubs(monkeypatch):
 
     util_code = types.ModuleType("freshquant.util.code")
     util_code.fq_util_code_append_market_code_suffix = lambda code: code
+    util_code.normalize_to_base_code = (
+        lambda code: str(code or "").replace("sz", "").replace("sh", "")
+    )
 
     util_encoder = types.ModuleType("freshquant.util.encoder")
 
@@ -148,3 +152,20 @@ def test_stock_data_chanlun_structure_route_calls_service(monkeypatch, stock_rou
         "endDate": "2026-03-07",
     }
     assert called["args"] == ("sz000001", "5m", "2026-03-07")
+
+
+def test_stock_data_chanlun_structure_maps_qfq_not_ready_to_503(
+    monkeypatch, stock_routes
+):
+    def fail(*_args, **_kwargs):
+        raise stock_routes.QFQDataNotReadyError(
+            "factor gap", scope="stock", code="000001"
+        )
+
+    monkeypatch.setattr(stock_routes, "get_chanlun_structure", fail)
+    stock_routes.request.args = {"symbol": "sz000001", "period": "5m"}
+
+    response = stock_routes.stock_data_chanlun_structure()
+
+    assert response.status_code == 503
+    assert response.get_json()["error_code"] == "QFQ_DATA_NOT_READY"

--- a/freshquant/tests/test_stock_data_route_cache.py
+++ b/freshquant/tests/test_stock_data_route_cache.py
@@ -59,6 +59,7 @@ def _install_route_stubs(monkeypatch):
 
     db = types.ModuleType("freshquant.db")
     db.DBfreshquant = {}
+    db.DBQuantAxis = {}
 
     instrument_general = types.ModuleType("freshquant.instrument.general")
     instrument_general.query_instrument_info = lambda *args, **kwargs: {}
@@ -82,6 +83,9 @@ def _install_route_stubs(monkeypatch):
 
     util_code = types.ModuleType("freshquant.util.code")
     util_code.fq_util_code_append_market_code_suffix = lambda code: code
+    util_code.normalize_to_base_code = (
+        lambda code: str(code or "").replace("sz", "").replace("sh", "")
+    )
 
     util_encoder = types.ModuleType("freshquant.util.encoder")
 
@@ -165,11 +169,90 @@ def test_stock_data_uses_fallback_by_default(monkeypatch, stock_routes):
     assert fake_redis.keys == []
 
 
+def test_stock_data_maps_qfq_not_ready_to_503(monkeypatch, stock_routes):
+    def fail(*_args, **_kwargs):
+        raise stock_routes.QFQDataNotReadyError(
+            "active snapshot is missing", scope="stock", code="000001"
+        )
+
+    monkeypatch.setattr(stock_routes, "get_data_v2", fail)
+
+    response = call_stock_data(stock_routes, symbol="sz000001", period="5m")
+
+    assert response.status_code == 503
+    assert response.get_json()["error_code"] == "QFQ_DATA_NOT_READY"
+
+
+def test_stock_data_v2_maps_qfq_not_ready_to_503(monkeypatch, stock_routes):
+    def fail(*_args, **_kwargs):
+        raise stock_routes.QFQDataNotReadyError(
+            "active snapshot is missing", scope="stock", code="000001"
+        )
+
+    monkeypatch.setattr(stock_routes, "get_data_v2", fail)
+    stock_routes.request.args = {"symbol": "sz000001", "period": "5m"}
+
+    response = stock_routes.stock_data_v2()
+
+    assert response.status_code == 503
+    assert response.get_json()["error_code"] == "QFQ_DATA_NOT_READY"
+
+
+def test_stock_data_cache_key_is_bound_to_adjustment_version(monkeypatch, stock_routes):
+    payload = {"symbol": "sz000001", "period": "5m"}
+    fake_redis = FakeRedis(value=json.dumps(payload))
+    monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
+    monkeypatch.setattr(
+        stock_routes, "_resolve_qfq_cache_version", lambda _symbol: "snapshot-v2"
+    )
+
+    response = call_stock_data(
+        stock_routes,
+        symbol="sz000001",
+        period="5m",
+        realtimeCache="true",
+    )
+
+    assert response.status_code == 200
+    assert fake_redis.keys == [
+        get_redis_cache_key("sz000001", "5min", adjustment_version="snapshot-v2")
+    ]
+
+
+def test_index_cache_key_uses_bfq_version_written_by_strategy_consumer(
+    monkeypatch, stock_routes
+):
+    payload = {"symbol": "sh000001", "period": "5m"}
+    fake_redis = FakeRedis(value=json.dumps(payload))
+    monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
+    monkeypatch.setattr(
+        stock_routes,
+        "query_instrument_type",
+        lambda _symbol: stock_routes.InstrumentType.INDEX_CN,
+    )
+
+    response = call_stock_data(
+        stock_routes,
+        symbol="sh000001",
+        period="5m",
+        realtimeCache="true",
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == payload
+    assert fake_redis.keys == [
+        get_redis_cache_key("sh000001", "5min", adjustment_version="bfq")
+    ]
+
+
 def test_stock_data_reads_redis_for_opt_in_realtime_period(monkeypatch, stock_routes):
     cached_payload = {"symbol": "sz000001", "period": "5m", "close": [1, 2, 3]}
     fake_redis = FakeRedis(value=json.dumps(cached_payload))
 
     monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
+    monkeypatch.setattr(
+        stock_routes, "_resolve_qfq_cache_version", lambda _symbol: "snapshot-v1"
+    )
     monkeypatch.setattr(
         stock_routes,
         "get_data_v2",
@@ -182,7 +265,9 @@ def test_stock_data_reads_redis_for_opt_in_realtime_period(monkeypatch, stock_ro
 
     assert response.status_code == 200
     assert response.get_json() == cached_payload
-    assert fake_redis.keys == [get_redis_cache_key("sz000001", "5min")]
+    assert fake_redis.keys == [
+        get_redis_cache_key("sz000001", "5min", adjustment_version="snapshot-v1")
+    ]
 
 
 def test_stock_data_falls_back_when_opt_in_cache_missing(monkeypatch, stock_routes):
@@ -194,6 +279,9 @@ def test_stock_data_falls_back_when_opt_in_cache_missing(monkeypatch, stock_rout
         return {"source": "fallback", "symbol": symbol, "period": period}
 
     monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
+    monkeypatch.setattr(
+        stock_routes, "_resolve_qfq_cache_version", lambda _symbol: "snapshot-v1"
+    )
     monkeypatch.setattr(stock_routes, "get_data_v2", fake_get_data_v2)
 
     response = call_stock_data(
@@ -207,7 +295,9 @@ def test_stock_data_falls_back_when_opt_in_cache_missing(monkeypatch, stock_rout
         "period": "15m",
     }
     assert fallback_calls == [("sz000001", "15m", None, 0)]
-    assert fake_redis.keys == [get_redis_cache_key("sz000001", "15min")]
+    assert fake_redis.keys == [
+        get_redis_cache_key("sz000001", "15min", adjustment_version="snapshot-v1")
+    ]
 
 
 def test_stock_data_reads_redis_for_opt_in_1d_period(monkeypatch, stock_routes):
@@ -215,6 +305,9 @@ def test_stock_data_reads_redis_for_opt_in_1d_period(monkeypatch, stock_routes):
     fake_redis = FakeRedis(value=json.dumps(cached_payload))
 
     monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
+    monkeypatch.setattr(
+        stock_routes, "_resolve_qfq_cache_version", lambda _symbol: "snapshot-v1"
+    )
     monkeypatch.setattr(
         stock_routes,
         "get_data_v2",
@@ -227,7 +320,9 @@ def test_stock_data_reads_redis_for_opt_in_1d_period(monkeypatch, stock_routes):
 
     assert response.status_code == 200
     assert response.get_json() == cached_payload
-    assert fake_redis.keys == [get_redis_cache_key("sz000001", "1d")]
+    assert fake_redis.keys == [
+        get_redis_cache_key("sz000001", "1d", adjustment_version="snapshot-v1")
+    ]
 
 
 def test_stock_data_falls_back_when_opt_in_1d_cache_missing(monkeypatch, stock_routes):
@@ -239,6 +334,9 @@ def test_stock_data_falls_back_when_opt_in_1d_cache_missing(monkeypatch, stock_r
         return {"source": "fallback", "symbol": symbol, "period": period}
 
     monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
+    monkeypatch.setattr(
+        stock_routes, "_resolve_qfq_cache_version", lambda _symbol: "snapshot-v1"
+    )
     monkeypatch.setattr(stock_routes, "get_data_v2", fake_get_data_v2)
 
     response = call_stock_data(
@@ -252,7 +350,9 @@ def test_stock_data_falls_back_when_opt_in_1d_cache_missing(monkeypatch, stock_r
         "period": "1d",
     }
     assert fallback_calls == [("sz000001", "1d", None, 0)]
-    assert fake_redis.keys == [get_redis_cache_key("sz000001", "1d")]
+    assert fake_redis.keys == [
+        get_redis_cache_key("sz000001", "1d", adjustment_version="snapshot-v1")
+    ]
 
 
 def test_stock_data_skips_redis_when_end_date_present(monkeypatch, stock_routes):
@@ -264,6 +364,9 @@ def test_stock_data_skips_redis_when_end_date_present(monkeypatch, stock_routes)
         return {"source": "history", "endDate": end_date}
 
     monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
+    monkeypatch.setattr(
+        stock_routes, "_resolve_qfq_cache_version", lambda _symbol: "snapshot-v1"
+    )
     monkeypatch.setattr(stock_routes, "get_data_v2", fake_get_data_v2)
 
     response = call_stock_data(
@@ -298,6 +401,9 @@ def test_stock_data_tails_cache_payload_when_bar_count_is_provided(
 
     monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
     monkeypatch.setattr(
+        stock_routes, "_resolve_qfq_cache_version", lambda _symbol: "snapshot-v1"
+    )
+    monkeypatch.setattr(
         stock_routes,
         "get_data_v2",
         lambda *args, **kwargs: pytest.fail("cache hit should not call fallback"),
@@ -316,6 +422,27 @@ def test_stock_data_tails_cache_payload_when_bar_count_is_provided(
     assert response.get_json()["close"] == [3.5, 4.5, 5.5]
 
 
+def test_unknown_instrument_never_reads_unversioned_realtime_cache(
+    monkeypatch, stock_routes
+):
+    fake_redis = FakeRedis(value=json.dumps({"source": "stale-unversioned"}))
+    monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
+    monkeypatch.setattr(stock_routes, "query_instrument_type", lambda _symbol: None)
+    monkeypatch.setattr(
+        stock_routes,
+        "get_data_v2",
+        lambda symbol, period, end_date, bar_count=0: {"source": "fallback"},
+    )
+
+    response = call_stock_data(
+        stock_routes, symbol="unknown", period="5m", realtimeCache="1"
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"source": "fallback"}
+    assert fake_redis.keys == []
+
+
 def test_stock_data_forwards_bar_count_to_fallback(monkeypatch, stock_routes):
     fake_redis = FakeRedis(value=None)
     fallback_calls = []
@@ -325,6 +452,9 @@ def test_stock_data_forwards_bar_count_to_fallback(monkeypatch, stock_routes):
         return {"source": "fallback", "barCount": bar_count}
 
     monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
+    monkeypatch.setattr(
+        stock_routes, "_resolve_qfq_cache_version", lambda _symbol: "snapshot-v1"
+    )
     monkeypatch.setattr(stock_routes, "get_data_v2", fake_get_data_v2)
 
     response = call_stock_data(
@@ -351,6 +481,9 @@ def test_stock_data_clamps_oversized_bar_count_before_fallback(
         return {"source": "fallback", "barCount": bar_count}
 
     monkeypatch.setattr(stock_routes, "redis_db", fake_redis)
+    monkeypatch.setattr(
+        stock_routes, "_resolve_qfq_cache_version", lambda _symbol: "snapshot-v1"
+    )
     monkeypatch.setattr(stock_routes, "get_data_v2", fake_get_data_v2)
 
     response = call_stock_data(

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -2287,6 +2287,240 @@ def test_marker_cas_failure_keeps_old_active_visible():
     assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "a"
 
 
+def test_marker_switch_and_rollback_rebind_live_intraday_override():
+    target_date = "2026-01-02"
+    db = _stock_db([target_date])
+    loader = _loader_for({"000001": [(target_date, 10.0, 0.0)]})
+    qfq.sync_stock_adj_all(target_date=target_date, db=db, bars_loader=loader)
+    active_a = qfq.resolve_active_slot(scope="stock", db=db)
+    db["stock_adj_intraday"].rows.append(
+        {
+            "code": "000001",
+            "trade_date": "2026-01-05",
+            "base_anchor_date": target_date,
+            "base_snapshot_id": active_a["snapshot_id"],
+            "base_factor_asof": active_a["factor_asof"],
+            "anchor_scale": 0.8,
+            "updated_at": "override-v1",
+        }
+    )
+
+    updated = qfq.sync_stock_adj_all(
+        target_date=target_date,
+        db=db,
+        bars_loader=loader,
+        force_full_rebuild=True,
+        min_grace_seconds=0,
+    )
+
+    active_b = updated["by_scope"]["stock"]["marker"]["slots"]["b"]
+    override = db["stock_adj_intraday"].rows[0]
+    assert override["base_snapshot_id"] == active_b["snapshot_id"]
+    assert override["base_factor_asof"] == active_b["factor_asof"]
+    assert override["anchor_scale"] == pytest.approx(0.8)
+
+    rolled_back = qfq.rollback_active_slot(scope="stock", db=db)
+
+    override = db["stock_adj_intraday"].rows[0]
+    assert rolled_back["active_slot"] == "a"
+    assert override["base_snapshot_id"] == active_a["snapshot_id"]
+    assert override["base_factor_asof"] == active_a["factor_asof"]
+    assert override["anchor_scale"] == pytest.approx(0.8)
+
+
+def test_rollback_keeps_future_override_already_bound_to_target_snapshot():
+    dates = ["2026-01-02", "2026-01-05"]
+    db = _stock_db(dates[:1])
+    loader = _loader_for({"000001": [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]})
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    active_a = qfq.resolve_active_slot(scope="stock", db=db)
+    db["stock_adj_intraday"].rows.append(
+        {
+            "code": "000001",
+            "trade_date": dates[1],
+            "base_anchor_date": dates[0],
+            "base_snapshot_id": active_a["snapshot_id"],
+            "base_factor_asof": active_a["factor_asof"],
+            "anchor_scale": 0.8,
+            "updated_at": "override-v1",
+        }
+    )
+    db["stock_day"].rows.append({"code": "000001", "date": dates[1]})
+
+    updated = qfq.sync_stock_adj_all(
+        target_date=dates[1],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+    )
+
+    override_before = dict(db["stock_adj_intraday"].rows[0])
+    assert updated["by_scope"]["stock"]["marker"]["active_slot"] == "b"
+    assert override_before["base_snapshot_id"] == active_a["snapshot_id"]
+
+    rolled_back = qfq.rollback_active_slot(scope="stock", db=db)
+
+    assert rolled_back["active_slot"] == "a"
+    assert db["stock_adj_intraday"].rows[0] == override_before
+
+
+def test_marker_cas_failure_restores_intraday_override_binding():
+    target_date = "2026-01-02"
+    db = _stock_db([target_date])
+    loader = _loader_for({"000001": [(target_date, 10.0, 0.0)]})
+    qfq.sync_stock_adj_all(target_date=target_date, db=db, bars_loader=loader)
+    active = qfq.resolve_active_slot(scope="stock", db=db)
+    db["stock_adj_intraday"].rows.append(
+        {
+            "code": "000001",
+            "trade_date": "2026-01-05",
+            "base_anchor_date": target_date,
+            "base_snapshot_id": active["snapshot_id"],
+            "base_factor_asof": active["factor_asof"],
+            "anchor_scale": 0.8,
+            "updated_at": "override-v1",
+        }
+    )
+    original_update = db["qfq_ready"].update_one
+    calls = 0
+
+    def fail_publish(query, update, upsert=False):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            return _Result()
+        return original_update(query, update, upsert=upsert)
+
+    db["qfq_ready"].update_one = fail_publish
+
+    with pytest.raises(qfq.QFQSyncError, match="CAS publish lost"):
+        qfq.sync_stock_adj_all(
+            target_date=target_date,
+            db=db,
+            bars_loader=loader,
+            force_full_rebuild=True,
+            min_grace_seconds=0,
+        )
+
+    override = db["stock_adj_intraday"].rows[0]
+    assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "a"
+    assert override["base_snapshot_id"] == active["snapshot_id"]
+    assert override["base_factor_asof"] == active["factor_asof"]
+    assert override["anchor_scale"] == pytest.approx(0.8)
+
+
+def test_marker_publish_exception_after_commit_keeps_rebound_override():
+    target_date = "2026-01-02"
+    db = _stock_db([target_date])
+    loader = _loader_for({"000001": [(target_date, 10.0, 0.0)]})
+    qfq.sync_stock_adj_all(target_date=target_date, db=db, bars_loader=loader)
+    active = qfq.resolve_active_slot(scope="stock", db=db)
+    db["stock_adj_intraday"].rows.append(
+        {
+            "code": "000001",
+            "trade_date": "2026-01-05",
+            "base_anchor_date": target_date,
+            "base_snapshot_id": active["snapshot_id"],
+            "base_factor_asof": active["factor_asof"],
+            "anchor_scale": 0.8,
+            "updated_at": "override-v1",
+        }
+    )
+    original_update = db["qfq_ready"].update_one
+    calls = 0
+
+    def lose_publish_response(query, update, upsert=False):
+        nonlocal calls
+        calls += 1
+        result = original_update(query, update, upsert=upsert)
+        if calls == 2:
+            raise RuntimeError("publish response lost")
+        return result
+
+    db["qfq_ready"].update_one = lose_publish_response
+
+    updated = qfq.sync_stock_adj_all(
+        target_date=target_date,
+        db=db,
+        bars_loader=loader,
+        force_full_rebuild=True,
+        min_grace_seconds=0,
+    )
+
+    active_b = updated["by_scope"]["stock"]["marker"]["slots"]["b"]
+    override = db["stock_adj_intraday"].rows[0]
+    assert updated["by_scope"]["stock"]["marker"]["active_slot"] == "b"
+    assert override["base_snapshot_id"] == active_b["snapshot_id"]
+    assert override["base_factor_asof"] == active_b["factor_asof"]
+
+
+def test_rollback_marker_exception_restores_source_override_binding():
+    target_date = "2026-01-02"
+    db = _stock_db([target_date])
+    loader = _loader_for({"000001": [(target_date, 10.0, 0.0)]})
+    qfq.sync_stock_adj_all(target_date=target_date, db=db, bars_loader=loader)
+    active = qfq.resolve_active_slot(scope="stock", db=db)
+    db["stock_adj_intraday"].rows.append(
+        {
+            "code": "000001",
+            "trade_date": "2026-01-05",
+            "base_anchor_date": target_date,
+            "base_snapshot_id": active["snapshot_id"],
+            "base_factor_asof": active["factor_asof"],
+            "anchor_scale": 0.8,
+            "updated_at": "override-v1",
+        }
+    )
+
+    def fail_rollback_update(*_args, **_kwargs):
+        raise RuntimeError("rollback update failed")
+
+    db["qfq_ready"].update_one = fail_rollback_update
+
+    with pytest.raises(qfq.QFQSyncError, match="rollback marker failed"):
+        qfq.rollback_active_slot(scope="stock", db=db)
+
+    override = db["stock_adj_intraday"].rows[0]
+    assert qfq.resolve_active_slot(scope="stock", db=db)["slot"] == "a"
+    assert override["base_snapshot_id"] == active["snapshot_id"]
+    assert override["base_factor_asof"] == active["factor_asof"]
+    assert override["anchor_scale"] == pytest.approx(0.8)
+
+
+def test_rebind_ignores_inactive_intraday_override_statuses():
+    target_date = "2026-01-02"
+    db = _stock_db([target_date])
+    loader = _loader_for({"000001": [(target_date, 10.0, 0.0)]})
+    qfq.sync_stock_adj_all(target_date=target_date, db=db, bars_loader=loader)
+    inactive_overrides = [
+        {
+            "code": code,
+            "trade_date": "2026-01-05",
+            "base_anchor_date": target_date,
+            "base_snapshot_id": "stale-snapshot",
+            "anchor_scale": 0.8,
+            "status": status,
+        }
+        for code, status in zip(
+            ("000002", "000003", "000004"),
+            ("expired", "disabled", "failed"),
+            strict=True,
+        )
+    ]
+    db["stock_adj_intraday"].rows.extend(inactive_overrides)
+
+    updated = qfq.sync_stock_adj_all(
+        target_date=target_date,
+        db=db,
+        bars_loader=loader,
+        force_full_rebuild=True,
+        min_grace_seconds=0,
+    )
+
+    assert updated["by_scope"]["stock"]["marker"]["active_slot"] == "b"
+    assert db["stock_adj_intraday"].rows == inactive_overrides
+
+
 def test_rollback_swaps_only_between_ready_slots():
     dates = ["2026-01-02", "2026-01-05"]
     rows = [(dates[0], 10.0, 0.0), (dates[1], 10.0, 10.0)]

--- a/freshquant/tests/test_xtdata_qfq_worker.py
+++ b/freshquant/tests/test_xtdata_qfq_worker.py
@@ -125,9 +125,16 @@ def test_worker_consumes_latest_success_marker_for_each_scope():
         calls.append(kwargs)
         return {"ready": True}
 
+    factor_db = _DB(
+        qfq_ready=[
+            _marker(scope="stock", asof="2026-01-01"),
+            _marker(scope="etf", asof="2026-01-01"),
+        ]
+    )
+
     result = qfq_worker.run_pending_once(
         marker_db=marker_db,
-        factor_db=_DB(),
+        factor_db=factor_db,
         sync_fn=sync_fn,
     )
 
@@ -225,6 +232,32 @@ def test_worker_waits_when_bfq_marker_is_missing():
     assert result["by_scope"]["stock"]["status"] == "waiting_for_bfq"
 
 
+def test_worker_requires_manual_bootstrap_when_qfq_marker_is_missing():
+    marker_db = _DB(
+        dagster_pipeline_markers=[
+            {
+                "pipeline_key": "stock_postclose_ready",
+                "trade_date": "2026-01-05",
+                "status": "success",
+            }
+        ]
+    )
+    called = []
+
+    result = qfq_worker.run_pending_once(
+        scopes=["stock"],
+        marker_db=marker_db,
+        factor_db=_DB(),
+        sync_fn=lambda **kwargs: called.append(kwargs),
+    )
+
+    assert not called
+    assert result["by_scope"]["stock"] == {
+        "status": "bootstrap_required",
+        "target_date": "2026-01-05",
+    }
+
+
 def test_worker_scope_failure_does_not_block_other_scope():
     marker_db = _DB(
         dagster_pipeline_markers=[
@@ -248,9 +281,16 @@ def test_worker_scope_failure_does_not_block_other_scope():
             raise RuntimeError("stock sync failed")
         return {"ready": True}
 
+    factor_db = _DB(
+        qfq_ready=[
+            _marker(scope="stock", asof="2026-01-01"),
+            _marker(scope="etf", asof="2026-01-01"),
+        ]
+    )
+
     result = qfq_worker.run_pending_once(
         marker_db=marker_db,
-        factor_db=_DB(),
+        factor_db=factor_db,
         sync_fn=sync_fn,
     )
 

--- a/freshquant/tests/test_xtdata_strategy_consumer_history.py
+++ b/freshquant/tests/test_xtdata_strategy_consumer_history.py
@@ -10,6 +10,7 @@ import pytest
 
 import freshquant.market_data.xtdata.strategy_consumer as sc
 from freshquant.config import cfg
+from freshquant.data.qfq_reader import QFQDataNotReadyError
 from freshquant.market_data.xtdata.schema import BarCloseEvent
 
 
@@ -83,7 +84,35 @@ class FakeDatabase:
         self._collections = collections
 
     def __getitem__(self, name: str) -> FakeCollection:
+        if name == "qfq_ready":
+            return FakeCollection([_qfq_marker("stock"), _qfq_marker("etf")])
+        if name in {"stock_adj_qfq_a", "stock_adj_qfq_b"}:
+            return self._collections.get("stock_adj", FakeCollection([]))
+        if name in {"etf_adj_qfq_a", "etf_adj_qfq_b"}:
+            return self._collections.get("etf_adj", FakeCollection([]))
+        if name in {"stock_adj_intraday", "etf_adj_intraday"}:
+            return self._collections.get(name, FakeCollection([]))
         return self._collections[name]
+
+
+def _qfq_marker(scope: str) -> dict:
+    return {
+        "scope": scope,
+        "active_slot": "a",
+        "slots": {
+            slot: {
+                "collection": f"{scope}_adj_qfq_{slot}",
+                "snapshot_id": f"{scope}-snapshot-{slot}",
+                "factor_asof": "2099-12-31",
+                "status": "ready",
+                "published_at": "2026-07-31T16:00:00+08:00",
+                "source_exclusions": [],
+            }
+            for slot in ("a", "b")
+        },
+        "source": "xtdata_preclose",
+        "schema_version": 1,
+    }
 
 
 def _matches(doc: dict, query: dict) -> bool:
@@ -315,6 +344,82 @@ def test_handle_bar_close_stores_stock_realtime_as_raw_bar(monkeypatch):
     assert captured["records"][0]["close"] == 10.5
 
 
+def test_handle_bar_close_persists_raw_before_strict_qfq_failure(monkeypatch):
+    now_dt = cfg.TZ.localize(datetime(2026, 7, 6, 9, 35, 0))
+    calls = []
+    monkeypatch.setattr(
+        sc, "upsert_realtime_bars", lambda **kwargs: calls.append(kwargs) or 1
+    )
+    monkeypatch.setattr(
+        sc,
+        "read_qfq_factor",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            QFQDataNotReadyError("factor gap", scope="stock", code="000001")
+        ),
+    )
+
+    consumer = cast(Any, object.__new__(sc.StrategyConsumer))
+    consumer._is_real_index = lambda _code: False
+    consumer._is_index_like = lambda _code: False
+
+    with pytest.raises(QFQDataNotReadyError, match="factor gap"):
+        consumer.handle_bar_close(
+            BarCloseEvent(
+                code="sz000001",
+                period="5min",
+                data={
+                    "time": int(now_dt.timestamp()),
+                    "open": 10.0,
+                    "high": 11.0,
+                    "low": 9.5,
+                    "close": 10.5,
+                    "volume": 1000.0,
+                    "amount": 10000.0,
+                },
+            )
+        )
+
+    assert len(calls) == 1
+    assert calls[0]["records"][0]["close"] == 10.5
+
+
+def test_handle_bar_close_reloads_window_when_snapshot_version_changes(monkeypatch):
+    now_dt = cfg.TZ.localize(datetime(2026, 7, 6, 9, 35, 0))
+    monkeypatch.setattr(sc, "upsert_realtime_bars", lambda **_kwargs: 1)
+    monkeypatch.setattr(
+        sc,
+        "read_qfq_factor",
+        lambda **_kwargs: (
+            1.0,
+            type("Metadata", (), {"effective_version": "snapshot-v2"})(),
+        ),
+    )
+    warmed = []
+    consumer = cast(Any, object.__new__(sc.StrategyConsumer))
+    consumer._is_real_index = lambda _code: False
+    consumer._is_index_like = lambda _code: False
+    consumer._window_versions = {"sz000001": "snapshot-v1"}
+    consumer._warm_code_from_db = lambda **kwargs: warmed.append(kwargs["code"])
+
+    consumer.handle_bar_close(
+        BarCloseEvent(
+            code="sz000001",
+            period="5min",
+            data={
+                "time": int(now_dt.timestamp()),
+                "open": 10.0,
+                "high": 11.0,
+                "low": 9.5,
+                "close": 10.5,
+                "volume": 1000.0,
+                "amount": 10000.0,
+            },
+        )
+    )
+
+    assert warmed == ["sz000001"]
+
+
 def test_handle_bar_close_skips_non_trading_day(monkeypatch):
     weekend_dt = cfg.TZ.localize(datetime(2026, 7, 4, 9, 35, 0))
     calls: list[dict[str, Any]] = []
@@ -384,6 +489,14 @@ def test_handle_bar_close_does_not_refresh_symbol_position_snapshot_on_1min(
             return {"symbol": "000001"}
 
     monkeypatch.setattr(sc, "upsert_realtime_bars", lambda **_kwargs: 1)
+    monkeypatch.setattr(
+        sc,
+        "read_qfq_factor",
+        lambda **_kwargs: (
+            1.0,
+            type("Metadata", (), {"effective_version": "stock-snapshot-a"})(),
+        ),
+    )
 
     consumer = cast(Any, object.__new__(sc.StrategyConsumer))
     consumer.max_bars = 32
@@ -492,7 +605,15 @@ def test_load_window_from_db_handles_mixed_datetime_shapes_in_history_docs(
         FakeDatabase(
             {
                 "index_min": FakeCollection(mixed_docs),
-                "etf_adj": FakeCollection([]),
+                "etf_adj": FakeCollection(
+                    [
+                        {
+                            "code": "512000",
+                            "date": bar_1.strftime("%Y-%m-%d"),
+                            "adj": 1.0,
+                        }
+                    ]
+                ),
             }
         ),
     )
@@ -561,7 +682,16 @@ def test_load_window_from_db_ignores_completed_day_realtime_overlap(monkeypatch)
                         },
                     ]
                 ),
-                "etf_adj": FakeCollection([]),
+                "etf_adj": FakeCollection(
+                    [
+                        {
+                            "code": "512000",
+                            "date": value.strftime("%Y-%m-%d"),
+                            "adj": 1.0,
+                        }
+                        for value in (prev_day_bar, today_bar)
+                    ]
+                ),
             }
         ),
     )
@@ -635,7 +765,15 @@ def test_load_window_from_db_filters_non_trading_day_realtime(monkeypatch):
                 "stock_min": FakeCollection(
                     [_make_bar_doc(friday_bar, code="600104", period="5min", open_=9.8)]
                 ),
-                "stock_adj": FakeCollection([]),
+                "stock_adj": FakeCollection(
+                    [
+                        {
+                            "code": "600104",
+                            "date": friday_bar.strftime("%Y-%m-%d"),
+                            "adj": 1.0,
+                        }
+                    ]
+                ),
             }
         ),
     )

--- a/freshquant/util/period.py
+++ b/freshquant/util/period.py
@@ -48,8 +48,13 @@ def is_supported_realtime_period(period: str) -> bool:
     return p in {"1min", "5min", "15min", "30min", "1d"}
 
 
-def get_redis_cache_key(code: str, period_backend: str) -> str:
-    return f"{CACHE_KLINE_PREFIX}:{(code or '').lower()}:{to_backend_period(period_backend)}"
+def get_redis_cache_key(
+    code: str, period_backend: str, *, adjustment_version: str | None = None
+) -> str:
+    key = f"{CACHE_KLINE_PREFIX}:{(code or '').lower()}:{to_backend_period(period_backend)}"
+    if adjustment_version:
+        return f"{key}:{adjustment_version}"
+    return key
 
 
 def get_redis_queue_key(prefix: str, shard: int) -> str:


### PR DESCRIPTION
## 背景

Issue #467 的 PR1 已生成并审计 Stock/ETF XTData `preClose` QFQ A/B 快照。本 PR 是 PR2a reader 激活切片：将线上 Stock/ETF 调整读取统一切到 active marker/snapshot，并保留 PR2b 对旧 Dagster writer 的收口边界。

Related to #467.

## 目标与范围

- 新增唯一共享严格 reader：每次读取解析 `qfq_ready` active slot，校验 snapshot、日期覆盖、正因子、重复键、source exclusions 与 snapshot-bound intraday override。
- 将 Stock/ETF API、quote/data、StrategyConsumer、Chan、ATR/holding/threshold 与自定义 QUANTAXIS `.to_qfq()` 路径迁移到共享 reader。
- 三条 Stock Kline 路由统一映射 `QFQ_DATA_NOT_READY` 为 HTTP 503。
- Redis Kline 与 StrategyConsumer 常驻窗口绑定 effective adjustment version；Index 固定为 BFQ。
- 收紧 adj refresh 为 snapshot-only 写入，并完善 publish/rollback 的 exception outcome 判定与 override rebind。
- 增加全 FreshQuant + `sunflower/QUANTAXIS/**` 精确 static allowlist：新增 `.to_qfq()`、直接 canonical collection 读写或静默 `fillna(1)` 命中即失败。
- 同步 `docs/current/**` 到 PR2a 过渡事实。

## 非目标 / 后续边界

- PR2a 不移除旧 Stock/ETF Dagster factor writer；其 schedule 过渡期仍可能运行，但 legacy collection 已非 reader 真值。
- marker publish 的 hard-stop crash-resume publication intent 持久化列入 PR2b；当前 exception 三态恢复已覆盖 Python 异常路径。Issue #467 保持 open。
- 本 PR 不宣称 CLX 已完成同 SHA 集成，也不增加 feature flag、双 reader 或新框架。

## 验收与机器证据

- focused：`204 passed in 4.69s`
- staged diff：34 files；`git diff --cached --check` PASS；Black（`--skip-string-normalization`）27/27 PASS
- committed-state preflight（SHA `f674e2d6eab4c0084135dee8dac2497cafc508b1`）：
  - `docs-current-guard` PASS
  - 全部 pre-commit hooks PASS（Black/mypy/isort）
  - full pytest：`1579 passed`
  - 仅 2 个既有 runtime-memory subprocess 测试在 Windows `chcp=936` 下因 `git show` UTF-8 输出发生 cp936 decode 错误
  - 同一 clean worktree / 同一 SHA 设置 `PYTHONUTF8=1` 精确复跑：`2 passed in 6.69s`
- required GitHub CI 与 review discussions 仍作为 merge gate。

## 部署影响

合并前先验证 Stock/ETF marker ready、same-SHA full audit 与 strict-reader health。合并后按正式矩阵重部署 API、market_data、Guardian/StrategyConsumer 与受影响 QUANTAXIS surface，并验证 503、versioned cache/window reload、raw realtime 先落库。回退使用目标 ready slot 的 override rebind + marker CAS，再重启受影响 reader/consumer。