### PR TITLE
chore: retire legacy adjustment schedules

### DIFF
--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -202,7 +202,7 @@ powershell -ExecutionPolicy Bypass -File script/install_fqnext_supervisord_resta
 | `freshquant/strategy/**` 或 `freshquant/signal/**` | Guardian | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface guardian -BridgeIfServiceUnavailable` |
 | `sunflower/QUANTAXIS/**` | QAWebServer 与依赖 QUANTAXIS 的宿主机策略链路 | 重建 `fq_qawebserver`；同步重启受影响宿主机 Guardian / strategy 进程 |
 | `freshquant/data/gantt*` / `freshquant/shouban30_pool_service.py` | Gantt/Shouban30 读模型与 API | 重建 API；必要时重跑 Dagster 任务 |
-| `freshquant/data/etf_adj_sync.py` | ETF legacy xdxr/adj 过渡写入链（已非在线 reader 真值） | 重建 `fq_apiserver` 镜像并重启 `fq_dagster_webserver` / `fq_dagster_daemon` |
+| `freshquant/data/etf_adj_sync.py` | ETF legacy xdxr/adj 人工运维入口 | 重建 `fq_apiserver` 镜像并重启 `fq_dagster_webserver` / `fq_dagster_daemon` |
 | `freshquant/daily_screening/**` | 每日选股 API 与 `fqscreening` 读模型 | 重建 API；如改动影响自动任务语义，补跑 Dagster 每日筛选任务 |
 | `freshquant/clx_daily_selection/**` | CLX 日线计算服务、API 读链与 Dagster partition/finalizer 共用逻辑 | 重建 API；重启 `fq_dagster_webserver` / `fq_dagster_daemon` |
 | `freshquant/rear/clx_daily_selection/**` | CLX 日线 HTTP API | 重建 API |
@@ -262,7 +262,7 @@ powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mod
 
 部署 reader 前必须先确认 Stock / ETF active slot 均为 `ready` 且 full audit 通过。激活后 Stock / ETF API、StrategyConsumer、Chan、ATR/holding/threshold 统一读取 marker 指向的 A/B 快照；marker/coverage/override 证明失败返回 `QFQ_DATA_NOT_READY`，三条 Stock Kline API 返回 HTTP 503。StrategyConsumer 必须先成功写 raw realtime bar，再做 QFQ 派生；Redis key/payload 与常驻窗口绑定 effective adjustment version。Dagster ready asset 或 `dagster.yaml` 同时变更时，还必须按 `dagster` surface 重部署 webserver / daemon。`check_freshquant_runtime_post_deploy.ps1 -Mode Verify` 对 `market_data` surface 会自动执行 `status --strict`，marker 缺失或落后时 health gate 失败。
 
-PR2a reader 激活期间，旧 Stock / ETF factor writer 可能仍由现有 Dagster 依赖链执行，但其输出已不是在线读取真值；`stock_adj` / `etf_adj` 继续保留用于过渡观察。回退时先用 CAS 将 marker 切回上一 ready slot，清理或等待旧 adjustment-version Redis key 失效，再重启 API 与 StrategyConsumer 使常驻窗口按回切后的 snapshot reload。
+strict-reader health 通过后停止旧 Stock / ETF factor writers，但保留 `stock_adj` / `etf_adj` 至少 7 个交易日且不再写入。回退时先用 CAS 将 marker 切回上一 ready slot，清理或等待旧 adjustment-version Redis key 失效，再重启 API 与 StrategyConsumer 使常驻窗口按回切后的 snapshot reload。
 
 - `script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces` 当前会先做 surface reconcile；若首次重启失败且启用了 `-BridgeIfServiceUnavailable`，即使 `fqnext-supervisord` service 仍是 `Running`，也允许触发一次管理员桥接
 - 管理员桥接恢复后，脚本会先确认目标 programs 是否已经 settled 到 `RUNNING`；只有仍未恢复时，才继续补做第二次 `restart-surfaces`

--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -63,7 +63,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 
 ### QFQ A/B 链
 
-`Dagster Stock/ETF BFQ + 过渡期 legacy writer -> postclose ready marker -> fqnext_xtdata_qfq_worker -> XTData incremental -> inactive A/B slot -> full audit -> qfq_ready active_slot CAS`
+`Dagster Stock/ETF BFQ ready -> postclose ready marker -> fqnext_xtdata_qfq_worker -> XTData incremental -> inactive A/B slot -> full audit -> qfq_ready active_slot CAS`
 
 - Stock 数据集合为 `stock_adj_qfq_a` / `stock_adj_qfq_b`，ETF 数据集合为 `etf_adj_qfq_a` / `etf_adj_qfq_b`。
 - `quantaxis.qfq_ready` 对每个 scope 使用一个原子双槽 marker；构建 inactive slot 期间 active slot 保持只读，inactive slot 审计成功后才切换。
@@ -78,7 +78,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - XTData 长区间下载只返回近期后缀时，QFQ client 会以当前最早缓存日的前一日为边界继续向前分页，直至覆盖请求起点；任一页未把最早日期向前推进时立即报错，不发布不完整快照。
 - Stock / ETF 在线 reader 统一使用 `freshquant.data.qfq_reader`：每个请求重新解析 marker 指向的 active slot，严格验证 snapshot、请求日期覆盖、正因子、重复键、source exclusion 与 snapshot-bound override；失败统一为 `QFQ_DATA_NOT_READY`，Stock Kline API 映射 HTTP 503。
 - StrategyConsumer 先落 raw realtime bar，再执行严格 QFQ 派生；Redis Kline key/payload 和常驻窗口绑定 effective adjustment version，版本变化后旧缓存 miss、窗口 reload。
-- 旧 `stock_xdxr`、`etf_xdxr`、`etf_adj` asset 在 PR2a 过渡期仍可能由现有 schedule 执行，但 `stock_adj` / `etf_adj` 已不再作为在线读取真值。
+- 旧 `stock_xdxr`、`etf_xdxr`、`etf_adj` asset 不在正常 schedule，仅保留为人工 legacy 运维入口；`stock_adj` / `etf_adj` 至少保留 7 个交易日但不再作为在线读取真值。
 - 真实 Index 走 BFQ 日线/分钟线和 `index_realtime`，不读取 ETF/Stock 因子，也不进入 QFQ scope。
 
 ## 存储

--- a/docs/current/reference/etf-data.md
+++ b/docs/current/reference/etf-data.md
@@ -11,20 +11,20 @@ ETF 在 FreshQuant 中与 A 股共用大部分接口，但有几处语义不同�
 ## 当前入口
 
 - CLI
-  - `python -m freshquant.cli etf ...`
-  - `python -m freshquant.cli etf.xdxr save`
-  - `python -m freshquant.cli etf.adj save`
+  - `python -m freshquant.cli etf.day save`
+  - `python -m freshquant.cli etf.min save`
+  - `python -m freshquant.cli etf.xdxr save` / `etf.adj save` 仅保留为 legacy 人工诊断入口
 - HTTP
   - 与 A 股共用 `/api/stock_data` 等行情接口
 - 监控池
   - `must_pool` 中 `instrument_type=etf_cn` 的记录可进入监控范围
 
-当前标准 ETF 同步口径：
+当前标准 ETF 同步口径由工作日 Dagster `etf_data_job` 执行：
 
-- `python -m freshquant.cli etf save`
-  - 同步 `etf_list`
-  - 同步 `index_day/index_min` 口径的 ETF 历史数据
-  - 过渡期仍同步 `quantaxis.etf_xdxr` 并重算 `quantaxis.etf_adj`，但两者已不是在线 reader 真值
+- 同步 `etf_list`
+- 同步 `index_day/index_min` 口径的 ETF BFQ 历史数据并通过完整性门禁
+- 发布 `etf_postclose_ready` marker
+- Windows QFQ worker 读取 marker，以 XTData `preClose` 在 inactive slot 增量构建，full audit 通过后 CAS 切换 `quantaxis.qfq_ready`
 
 ## 与普通 A 股的差异
 
@@ -37,7 +37,7 @@ ETF 当前前复权链路：
 - `ETF BFQ ready -> XTData preClose -> etf_adj_qfq_a/b inactive slot -> full audit -> qfq_ready active_slot -> freshquant.data.qfq_reader`
 - 页面、策略与共享 QuantAxis 适配层每次读取 active marker，严格校验 snapshot、coverage、正因子、重复键、source exclusion 与 snapshot-bound intraday override
 - 合同不满足时返回 `QFQ_DATA_NOT_READY`；Stock/ETF Kline HTTP 路由映射为 503，不回退 `adj=1.0` 或 legacy 集合
-- `quantaxis.etf_xdxr` / `quantaxis.etf_adj` 在 PR2a 过渡期仍可能由现有 schedule 更新，但不再是在线 reader 真值
+- `quantaxis.etf_xdxr` / `quantaxis.etf_adj` 不在正常 schedule，也不是在线 reader 真值；相关 CLI/asset 仅用于 legacy 人工诊断
 
 ## 当前排查
 

--- a/docs/current/reference/market-data.md
+++ b/docs/current/reference/market-data.md
@@ -49,7 +49,7 @@ FreshQuant 当前同时使用三类行情来源：
 - CLX 日线选股按 Stock / ETF 各自 active marker 冻结 QFQ snapshot pair，并通过共享 strict reader 构造 effective universe；marker `source_exclusions` 与逐标的 `QFQ_DATA_NOT_READY` 会在 attempt 前通用隔离并记录，其他异常直接阻断规划，不回退为 `adj=1` 或 BFQ
 - Stock / ETF 在线读取统一使用 `freshquant.data.qfq_reader`，按 `quantaxis.qfq_ready` 指向的 active slot 读取 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`
 - XTData `preClose` QFQ writer 只在 inactive slot 构建并审计，审计成功且 writer lease owner 仍匹配后原子切换 marker；reader 每次请求重新解析 marker，并对 snapshot、coverage、source exclusion 与 override fail closed
-- Redis Kline 与 StrategyConsumer 常驻窗口绑定 effective adjustment version；旧 `stock_adj` / `etf_adj` 不再是 reader 真值，PR2a 过渡期旧 writer 仍可能运行且旧集合继续保留
+- Redis Kline 与 StrategyConsumer 常驻窗口绑定 effective adjustment version；旧 `stock_adj` / `etf_adj` 不再是 reader 真值，旧 writer 在切换健康检查后停止，旧集合保留至少 7 个交易日
 - 完整历史请求后仍无 source bars、有界内部 source gap 两端 adjustment proof 不一致，或 primary source 前缀分页稳定报告 `history_prefix_no_progress` 的 code，不写推断因子或 `1.0`，从当前 snapshot 隔离，并在对应 slot `source_exclusions[]` 分别记录 `source_empty_bars`、`source_adjustment_gap_unproven` 或 `source_prefix_unavailable`；A/B 与 rollback 各自保留该审计边界
 - `audit --mode structure` 检查 Mongo 结构合同，并读取 XTData instrument `OpenDate` / `IsTrading` 元数据以区分上市前 BFQ 覆盖与 `nontrading_terminal_history`，但不加载 source bars；`tail/full` 另会加载 XTData source bars 并验证 `preClose` 递推，正式发布门禁使用 `full`
 - 真实 Index 日线、分钟线与 realtime merge 固定为 BFQ，实时表使用 `freshquant.index_realtime`，不读取 ETF 或 Stock 复权因子
@@ -57,10 +57,10 @@ FreshQuant 当前同时使用三类行情来源：
 Dagster 盘后桥接口径当前新增两条 ready asset：
 
 - `stock_postclose_ready_asset`
-  - 依赖股票日线、分钟线、`quality_stock_universe` 快照刷新与过渡期旧 `stock_xdxr` writer
+  - 依赖股票日线、分钟线与 `quality_stock_universe` 快照刷新
   - 成功后写入 `freshquant.dagster_pipeline_markers` 中 `pipeline_key=stock_postclose_ready` 的文档
 - `etf_postclose_ready_asset`
-  - 依赖过渡期旧 `etf_xdxr -> etf_adj` writer 和通过日线/五周期完整性门禁的 `etf_min`
+  - 依赖 ETF 日线和通过五周期完整性门禁的 `etf_min`
   - 成功后写入 `freshquant.dagster_pipeline_markers` 中 `pipeline_key=etf_postclose_ready` 的文档
 
 其中：

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -60,11 +60,11 @@
 
 - Supervisor program 为 `fqnext_xtdata_qfq_worker`，并与 `fqnext_xtdata_adj_refresh_worker` 同属 `fqnext_reference_data` group；它运行在 Windows 宿主机，默认每 60 秒检查一次盘后就绪状态。
 - worker 从 `freshquant.dagster_pipeline_markers` 读取 `pipeline_key=stock_postclose_ready` / `etf_postclose_ready` 的最新成功文档，再把目标交易日传给 XTData QFQ writer。
-- `stock_postclose_ready` 在股票日线、分钟线、质量股票池快照和过渡期旧 `stock_xdxr` writer 完成后发布；`etf_postclose_ready` 在 ETF 日线/分钟线及过渡期旧 `etf_xdxr -> etf_adj` writer 完成后发布。
+- `stock_postclose_ready` 在股票日线、分钟线和质量股票池快照完成后发布；`etf_postclose_ready` 在 ETF 日线与分钟线完成后发布。正常 schedule 不再选择旧 `stock_xdxr`、`etf_xdxr`、`etf_adj` asset。
 - A/B 快照与发布 marker 写在 QuantAxis Mongo：数据集合为 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`，marker 集合为 `qfq_ready`；`qfq_writer_locks` 以 scope 唯一后台 heartbeat lease 强制 worker、人工 build 与 rollback 串行，单次 XTData 下载或 Mongo `$out` 阻塞期间也会持续续租，发布前再次核对 owner。
 - QFQ coverage 排除 `vol/amount` 同时命中 QASU 浮点哨兵的 BFQ 占位行；XTData 多出的真实交易日仍参与完整递推，之后才投影到有效 BFQ 日期。bootstrap、update 与 audit JSON 的 `coverage` 字段记录 sentinel 和无有效历史标的计数。
 - Stock / ETF 在线 reader 每次请求从 `qfq_ready` 解析 active slot；marker、coverage、factor 或 snapshot-bound override 不满足合同时 fail closed 为 `QFQ_DATA_NOT_READY`。Redis Kline 与 StrategyConsumer 常驻窗口按 effective adjustment version 隔离，marker/override 版本变化会 miss/reload。
-- 旧 `stock_xdxr`、`etf_xdxr`、`etf_adj` asset 在 PR2a 过渡期仍可能由现有 schedule 执行；`stock_adj` / `etf_adj` 集合继续保留但不再作为在线真值。
+- 旧 `stock_xdxr`、`etf_xdxr`、`etf_adj` asset 仅保留为人工 legacy 运维入口；`stock_adj` / `etf_adj` 集合至少保留 7 个交易日且不再作为在线真值。
 - 真实 Index 当前固定读取 BFQ 日线/分钟线与 `index_realtime`，不读取 `stock_adj`、`etf_adj` 或 QFQ A/B 集合。
 - 首次 bootstrap 与历史 backfill 只通过人工 `qfq_worker build --scope <stock|etf> --target-date YYYY-MM-DD [--full]` 执行；正常 worker 遇到缺失 `qfq_ready` marker 返回 `bootstrap_required`，不自动构建全历史。
 - 运维 CLI 入口为 `python -m freshquant.market_data.xtdata.qfq_worker`，子命令为 `worker`、`build`、`audit`、`status`、`rollback`；`status --strict` 检查 active 截止日是否追平盘后 ready marker，`audit --mode structure|tail|full` 分别执行结构、近期 XTData 递推和全历史 XTData 递推审计。

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -585,7 +585,7 @@ docker exec fqnext_20260223-fq_mongodb-1 mongosh --quiet --eval 'const c=db.getS
 
 - `etf_data_job` 在 `etf_day` 刚启动时失败，Mongo 返回 `codeName=IndexKeySpecsConflict`
 - 报错同时列出 `quantaxis.index_day` 的 `code_1_date_stamp_1` 已有唯一索引，以及 QASU 请求创建的同名非唯一索引
-- `etf_adj`、`etf_min` 与 `etf_postclose_ready_asset` 因依赖失败而跳过
+- `etf_min` 与 `etf_postclose_ready_asset` 因依赖失败而跳过
 
 处理：
 
@@ -617,12 +617,12 @@ docker exec fqnext_20260223-fq_mongodb-1 mongosh --quiet --eval 'const c=db.getS
 
 ## ETF 前复权未生效但 Dagster run 显示成功
 
-本节只排查 PR2a 过渡期仍可能由现有 schedule 执行的 `etf_xdxr -> etf_adj` 旧写入链。Stock / ETF 在线 reader 已改为读取 `qfq_ready` marker 指向的 A/B 快照；旧集合不再是在线读取真值。
+本节只排查保留期内的 `etf_xdxr -> etf_adj` 旧写入链。Stock / ETF 在线 reader 已改为读取 `qfq_ready` marker 指向的 A/B 快照；旧集合仅用于回退观察，不再是在线读取真值。
 
 现象：
 
 - KlineSlim / ETF 日线在拆分、扩缩股之后仍显示 bfq 价格
-- 过渡期 Dagster run 或人工执行 legacy `etf.xdxr` / `etf.adj` 后，`quantaxis.etf_xdxr` 仍缺少目标 ETF 的历史事件
+- 人工执行 legacy `etf.xdxr` / `etf.adj` 后，`quantaxis.etf_xdxr` 仍缺少目标 ETF 的历史事件
 - `quantaxis.etf_adj` 在事件日前后仍全部为 `1.0`
 
 先检查：
@@ -649,7 +649,7 @@ print(sync_etf_xdxr_all(codes=['512800']))
 - 当前实现会对 ETF xdxr 首次空结果做 fresh connection retry，并在全量同步时周期性重建 TDX 连接
 - 当前实现会在 batch host 连接失败时自动切到下一个可用 HQ host；fresh connection retry 的目标 host 若连不上，也会继续轮转其他 HQ host，而不是把 run 记成成功或打成 `bool` context manager 异常
 - retry 仍超时或为空时，优先核对该 code 在不同 TDX host 上是否一致为空；对确实为空但库里已有历史回填的 ETF，允许保留旧文档
-- Dagster `etf_xdxr` asset 会对本次同步中 `empty/preserved` 的可疑 code 追加一次近期覆盖审计；如果近窗口内源侧有事件但库里没有，或者所有 HQ host 都不可达，asset 会直接 fail
+- 人工执行 Dagster `etf_xdxr` asset 时会对本次同步中 `empty/preserved` 的可疑 code 追加一次近期覆盖审计；如果近窗口内源侧有事件但库里没有，或者所有 HQ host 都不可达，asset 会直接 fail
 - 如果 API / KlineSlim 在 `/api/stock_data` 上直接报 `redis.exceptions.ConnectionError: Error 111 connecting to 127.0.0.1:6379`，优先检查 Docker compose 是否把宿主机 `.env` 里的 Redis 地址误透传进容器；正式口径应由 `docker/compose.parallel.yaml` 显式覆盖为 `FRESHQUANT_REDIS__HOST=fq_redis`、`FRESHQUANT_REDIS__PORT=6379`
 - 如果 compose Redis 覆盖修复已经 merge，但 formal deploy 的 `plan.json` 仍显示 `deployment_required=false`，优先检查 changed paths 是否包含 `docker/compose.parallel.yaml`；当前正式口径要求这类 compose 运行时变更必须触发全量受管 Docker 并行环境容器重建/重启。
 - 对单券立即修复可执行：

--- a/freshquant/tests/test_market_data_assets.py
+++ b/freshquant/tests/test_market_data_assets.py
@@ -484,7 +484,6 @@ def test_stock_postclose_ready_asset_depends_on_quality_snapshot(monkeypatch):
         "refresh_quality_stock_universe_snapshot",
         "stock_day",
         "stock_min",
-        "stock_xdxr",
     ]
 
 
@@ -660,14 +659,12 @@ def test_stock_postclose_ready_asset_writes_marker(monkeypatch):
         },
         "2026-03-19 16:00:00",
         "2026-03-19 16:05:00",
-        "2026-03-19 16:10:00",
     )
 
     assert module.stock_postclose_ready_asset.dependency_names == [
         "refresh_quality_stock_universe_snapshot",
         "stock_day",
         "stock_min",
-        "stock_xdxr",
     ]
     assert calls == [
         {
@@ -678,7 +675,8 @@ def test_stock_postclose_ready_asset_writes_marker(monkeypatch):
                 "count": 18,
                 "source_version": "xgt_hot_blocks_v1",
                 "integrity_audited_dates": ["2026-03-19"],
-                "stock_xdxr_completed_at": "2026-03-19 16:10:00",
+                "stock_day_completed_at": "2026-03-19 16:00:00",
+                "stock_min_completed_at": "2026-03-19 16:05:00",
             },
         }
     ]
@@ -719,14 +717,14 @@ def test_etf_postclose_ready_asset_writes_marker(monkeypatch):
         "2026-03-19 16:10:00",
     )
 
-    assert module.etf_postclose_ready_asset.dependency_names == ["etf_adj", "etf_min"]
+    assert module.etf_postclose_ready_asset.dependency_names == ["etf_day", "etf_min"]
     assert calls == [
         {
             "pipeline_key": "etf_postclose_ready",
             "trade_date": "2026-03-19",
             "run_id": "run-etf-1",
             "payload": {
-                "etf_adj_completed_at": "2026-03-19 16:05:00",
+                "etf_day_completed_at": "2026-03-19 16:05:00",
                 "etf_min_completed_at": "2026-03-19 16:10:00",
             },
         }

--- a/freshquant/tests/test_market_data_schedules.py
+++ b/freshquant/tests/test_market_data_schedules.py
@@ -84,7 +84,6 @@ def test_stock_and_etf_jobs_bound_runtime_and_failed_run_retries(monkeypatch):
         "stock_block",
         "stock_day",
         "stock_min",
-        "stock_xdxr",
         "refresh_quality_stock_universe_snapshot",
         "stock_postclose_ready_asset",
     }
@@ -92,8 +91,6 @@ def test_stock_and_etf_jobs_bound_runtime_and_failed_run_retries(monkeypatch):
         "etf_list",
         "etf_day",
         "etf_min",
-        "etf_xdxr",
-        "etf_adj",
         "etf_postclose_ready_asset",
     }
     assert set(module.index_data_job.selection.asset_names) == {

--- a/morningglory/fqdagster/src/fqdagster/defs/assets/market_data.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/assets/market_data.py
@@ -504,7 +504,7 @@ def stock_min(context: AssetExecutionContext, stock_list: str) -> str:
 
 @asset(deps=[stock_day], group_name="stock_data")
 def stock_xdxr(context: AssetExecutionContext, stock_day: str) -> str:
-    """Download and save stock dividend/adjustment data. Depends on stock_day."""
+    """Manual legacy operation; not selected by the normal Stock schedule."""
     context.log.info(
         f"Saving stock dividend data, triggered after stock_day at {stock_day}"
     )
@@ -525,7 +525,6 @@ def stock_postclose_ready_asset(
     refresh_quality_stock_universe_snapshot: dict,
     stock_day: str,
     stock_min: str,
-    stock_xdxr: str,
 ) -> dict:
     trade_date = (
         str(refresh_quality_stock_universe_snapshot.get("trade_date") or "")
@@ -539,7 +538,8 @@ def stock_postclose_ready_asset(
             refresh_quality_stock_universe_snapshot.get("source_version") or ""
         ).strip(),
         "integrity_audited_dates": list(integrity.get("audited_dates") or []),
-        "stock_xdxr_completed_at": stock_xdxr,
+        "stock_day_completed_at": stock_day,
+        "stock_min_completed_at": stock_min,
     }
     upsert_postclose_marker(
         "stock_postclose_ready",
@@ -656,7 +656,7 @@ def etf_min(context: AssetExecutionContext, etf_day: str) -> str:
 
 @asset(deps=[etf_list], group_name="etf_data")
 def etf_xdxr(context: AssetExecutionContext, etf_list: str) -> str:
-    """Download and save ETF xdxr(adjustment events) data. Depends on etf_list."""
+    """Manual legacy operation; not selected by the normal ETF schedule."""
     context.log.info(f"Saving ETF xdxr data, triggered after etf_list at {etf_list}")
     stats = sync_etf_xdxr_all()
     context.log.info(f"ETF xdxr sync stats: {stats}")
@@ -694,7 +694,7 @@ def etf_xdxr(context: AssetExecutionContext, etf_list: str) -> str:
 
 @asset(deps=[etf_day, etf_xdxr], group_name="etf_data")
 def etf_adj(context: AssetExecutionContext, etf_day: str, etf_xdxr: str) -> str:
-    """Compute and save ETF qfq adjustment factors. Depends on etf_day + etf_xdxr."""
+    """Manual legacy operation; not selected by the normal ETF schedule."""
     context.log.info(
         f"Saving ETF adj(qfq) data, triggered after etf_day at {etf_day} and etf_xdxr at {etf_xdxr}"
     )
@@ -712,10 +712,13 @@ def etf_adj(context: AssetExecutionContext, etf_day: str, etf_xdxr: str) -> str:
 
 @asset(group_name="etf_data")
 def etf_postclose_ready_asset(
-    context: AssetExecutionContext, etf_adj: str, etf_min: str
+    context: AssetExecutionContext, etf_day: str, etf_min: str
 ) -> dict:
     trade_date = resolve_latest_completed_trade_date()
-    payload = {"etf_adj_completed_at": etf_adj, "etf_min_completed_at": etf_min}
+    payload = {
+        "etf_day_completed_at": etf_day,
+        "etf_min_completed_at": etf_min,
+    }
     upsert_postclose_marker(
         "etf_postclose_ready",
         trade_date,

--- a/morningglory/fqdagster/src/fqdagster/defs/schedules/market_data.py
+++ b/morningglory/fqdagster/src/fqdagster/defs/schedules/market_data.py
@@ -15,12 +15,10 @@ from dagster import (
 )
 from fqdagster.defs.assets.market_data import (
     bond_list,
-    etf_adj,
     etf_day,
     etf_list,
     etf_min,
     etf_postclose_ready_asset,
-    etf_xdxr,
     future_list,
     index_day,
     index_list,
@@ -30,7 +28,6 @@ from fqdagster.defs.assets.market_data import (
     stock_list,
     stock_min,
     stock_postclose_ready_asset,
-    stock_xdxr,
 )
 from fqdagster.defs.assets.postclose_ready import (
     refresh_quality_stock_universe_snapshot,
@@ -56,7 +53,6 @@ stock_data_job = define_asset_job(
         stock_block,
         stock_day,
         stock_min,
-        stock_xdxr,
         refresh_quality_stock_universe_snapshot,
         stock_postclose_ready_asset,
     ),
@@ -77,8 +73,6 @@ etf_data_job = define_asset_job(
         etf_list,
         etf_day,
         etf_min,
-        etf_xdxr,
-        etf_adj,
         etf_postclose_ready_asset,
     ),
     tags=BOUNDED_MARKET_JOB_TAGS,


### PR DESCRIPTION
## 背景

Issue #467 已完成 Stock/ETF strict QFQ reader 与正式 QFQ A/B snapshot 部署。本 PR 收口正常 Dagster 调度中的旧 adjustment writer，维持单一 XTData QFQ writer 合同。

## 改动

- Stock 正常 schedule 仅保留 BFQ `stock_day` / `stock_min`、质量股票池刷新，再发布 `stock_postclose_ready` marker。
- ETF 正常 schedule 仅保留 BFQ `etf_day` / `etf_min`，再发布 `etf_postclose_ready` marker。
- `stock_xdxr`、`etf_xdxr`、`etf_adj` asset 与相关 CLI 继续保留为人工 legacy 运维/诊断入口，不进入正常 schedule。
- 同步更新 `docs/current/**` 当前运行、部署与排障真值。

## 非目标

- 不删除 legacy collection 或人工运维入口。
- 不修改 QFQ reader/writer、snapshot identity 或 CLX 业务逻辑。
- 本 PR 不触发业务运行或数据回填。

## 验收

- `python -m pytest -q freshquant/tests/test_market_data_assets.py freshquant/tests/test_market_data_schedules.py`：19 passed。
- `dagster definitions validate -m fqdagster.definitions`：PASS。
- `docs-current-guard`：PASS。
- modified-files pre-commit（Black/mypy/isort/all hooks）：PASS。
- `git diff --check`：PASS。

## 部署影响

仅需重部署 `fq_dagster_webserver` / `fq_dagster_daemon`。正式 deploy 必须等待当前 CLX active runs 全部完成，避免重启 Dagster 中断运行；合并与部署由 Issue #467 单写者按 formal 入口执行。

Refs #467