### PR TITLE
feat: append CLX 15/30 monitor hits to TDX clx_15_30 group

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -100,6 +100,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 当前模块会在启用 CLX 能力时把命中的多周期 CLX 信号写入 `realtime_screen_multi_period`。
 实时 CLX 只在 15/30 分钟 bar 上运行，生产模型为 `S0000-S0017`，对应 `model_opt=10000..10017`。
 正信号写库后会复用现有 DingTalk 私聊发送链做聚合通知；webhook 配置入口已存在，只有启用 CLX 实时模式且出现正信号时才发送，不在文档或日志中输出真实 webhook/token。
+consumer 还会把本批命中标的（带前缀代码，如 `sh600000`）去重追加到通达信自选股分组 `clx_15_30`（文件 `T0002/blocknew/CLX_15_30.blk`），复用 `freshquant/clx_daily_selection/tdx_export.py` 的编码与原子写实现；写入为 best-effort，失败只记 warning，不影响信号主链，无新增标的时不触碰旧文件。
 
 ## 配置
 

--- a/docs/current/reference/stock-pools-and-positions.md
+++ b/docs/current/reference/stock-pools-and-positions.md
@@ -80,6 +80,9 @@
   - `realtime_screen_multi_period`
   - 当前展示 `datetime`、`created_at`、`code`、`name`、`period`、`source` 与单行价格摘要
   - 实时 CLX 生产模型为 `S0000-S0017 / 10000..10017`
+- CLX 15/30 实时监控命中标的通达信分组
+  - consumer 正信号写库后会把本批命中标的去重追加到通达信自选股分组 `clx_15_30`（`T0002/blocknew/CLX_15_30.blk`）
+  - 复用 `freshquant/clx_daily_selection/tdx_export.py` 的编码与原子写实现，best-effort 失败不阻塞信号链
 
 ## 当前高频操作
 

--- a/docs/plans/2026-08-05-clx-15-30-monitor-tdx-group-plan.md
+++ b/docs/plans/2026-08-05-clx-15-30-monitor-tdx-group-plan.md
@@ -1,0 +1,70 @@
+# CLX 15/30 监控结果自动去重追加到通达信新自选股分组
+
+日期：2026-08-05
+状态：待与 Devin 评审后定稿
+关联需求：clx_15_30 监控结果自动去重追加到通达信新增自选股分组
+
+## 目标
+
+- 通达信中新增一个自选股分组 `clx_15_30`（文件 `T0002/blocknew/CLX_15_30.blk`）。
+- `strategy_consumer` 的 CLX 15/30 监控命中（写 `realtime_screen_multi_period` 的正信号）自动去重追加到该分组。
+- 复用现有通达信实现：`freshquant/clx_daily_selection/tdx_export.py` 的编码与原子写模式。
+
+## 现状事实（本机核实）
+
+- 监控命中写入点：`freshquant/market_data/xtdata/strategy_consumer.py::_process_clx_signals`
+  - 正信号 docs 写入 `realtime_screen_multi_period`，随后 DingTalk 聚合通知。
+  - `meta["code"]` 为带前缀代码（如 `sh600000`），`_base_code()` 可还原 6 位代码。
+- 可复用实现：`freshquant/clx_daily_selection/tdx_export.py`
+  - `encode_tdx_blk_code()`：6 位/带前缀代码 → TDX `.blk` 行（`1/0/2` + 6 位）。
+  - `write_clx_tdx_group()`：全量覆盖 `CLX_18.blk`，GBK + CRLF + temp/fsync/os.replace 原子写。
+- 消费进程可写 TDX：supervisord `[program-default] envFiles=D:/fqpack/config/envs.conf` 已含
+  `TDX_HOME=D:/new_tdx` 与 `FRESHQUANT_TDX__HOME=D:/new_tdx`，`bootstrap_config.tdx.home` 在 consumer 进程可解析。
+
+## 方案（最小化，复用现有实现）
+
+1. `freshquant/clx_daily_selection/tdx_export.py`
+   - 新增常量：`CLX_15_30_TDX_GROUP_DISPLAY_NAME="clx_15_30"`、`CLX_15_30_TDX_BLOCK_KEY="CLX_15_30"`、`CLX_15_30_TDX_BLK_FILENAME="CLX_15_30.blk"`。
+   - `write_clx_tdx_group` 增加可选参数 `block_key/display_name`（默认保持 `CLX_18`，向后兼容）。
+   - 新增 `read_tdx_blk_codes(tdx_home=None, filename=...)`：读回现有分组行并解码为 6 位代码（顺序保留、去重）。
+   - 新增 `append_clx_15_30_tdx_group(codes, *, tdx_home=None)`：
+     - 现有行 + 新命中代码合并，按首见顺序去重；
+     - 无新代码时不写文件，返回 `appended_count=0`；
+     - 有新增时复用原子写（GBK、CRLF、temp+fsync+replace），失败保留旧分组并抛错。
+2. `freshquant/market_data/xtdata/strategy_consumer.py::_process_clx_signals`
+   - `insert_many` 成功后，收集 docs 的 `_base_code(code)` 去重集合，best-effort 调用
+     `append_clx_15_30_tdx_group(codes)`；异常仅记 warning，不影响信号主链。
+3. 测试
+   - `freshquant/tests/test_clx_daily_selection_tdx_export.py`：append 去重/顺序/无新增不写/原子失败保留旧文件/泛化参数兼容。
+   - consumer 侧：新增对 docs→base codes 去重的纯函数测试。
+4. 文档：`docs/current/modules/market-data-xtdata.md` 补充“正信号写库后去重追加通达信 `CLX_15_30.blk` 分组”。
+
+## 非目标
+
+- 不改变 `CLX_18.blk` 每日选股导出行为。
+- 不改变 `stock_pools` / `must_pool` 语义。
+- 不触发下单、不写 `must_pool`。
+
+## 部署面
+
+- `freshquant/market_data/**` → 重启 consumer（`fqnext_realtime_xtdata_consumer`）。
+- `freshquant/clx_daily_selection/**` → 重部署 API（`fq_apiserver`），因 clx_daily_selection 路由由 API 提供。
+
+## 验收
+
+- pytest：`test_clx_daily_selection_tdx_export.py` 新增用例全绿；相关既有用例全绿。
+- consumer 进程重启后运行验证通过；TDX 分组文件在无命中时不创建、有命中时去重追加。
+
+## Devin 评审结论（2026-08-05，已达成一致）
+
+Devin 单轮评审（只读，基于 GitHub main 克隆核对）方向同意，3 个必改点：
+
+1. 不泛化 `write_clx_tdx_group`（保持其签名与 CLX_18 行为不变），新增独立 `append_tdx_group_members`，并抽取共用原子写 `_atomic_write_blk`。
+2. 去重按“编码后 7 字符行”直接比对，禁止解码回 6 位再编码（LOF 如 160512 裸 6 位会 fail-closed）；consumer 侧直接传带前缀的 `meta["code"]`（如 sh600000）给编码函数。
+3. `_process_clx_signals` 挂载点正确；但回调来自线程池并发，读-合并-重写需模块级 `threading.Lock`；空追加（无新成员）应为 no-op，不抛错、不触碰旧文件。
+
+最终文件级改动清单：
+- `freshquant/clx_daily_selection/tdx_export.py`：新增 `CLX_15_30_*` 常量、`_TDX_BLK_WRITE_LOCK`、`_atomic_write_blk`、`read_tdx_blk_lines`、`append_tdx_group_members`；`write_clx_tdx_group` 改为复用 `_atomic_write_blk`（行为与错误文案不变）。
+- `freshquant/market_data/xtdata/strategy_consumer.py::_process_clx_signals`：insert_many 之后 best-effort 调用 `append_tdx_group_members([d.get("code") for d in docs])`，异常仅 warning。
+- 测试：`freshquant/tests/test_clx_daily_selection_tdx_export.py` 新增 append/read 用例；新增 `freshquant/tests/test_xtdata_consumer_clx_tdx_group.py` 验证挂载与 best-effort。
+- 文档：`docs/current/modules/market-data-xtdata.md` 补充分组写入说明。

--- a/freshquant/clx_daily_selection/tdx_export.py
+++ b/freshquant/clx_daily_selection/tdx_export.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping
+import threading
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from uuid import uuid4
 
 CLX_TDX_GROUP_DISPLAY_NAME = "clx_18"
 CLX_TDX_BLOCK_KEY = "CLX_18"
 CLX_TDX_BLK_FILENAME = f"{CLX_TDX_BLOCK_KEY}.blk"
+
+CLX_15_30_TDX_GROUP_DISPLAY_NAME = "clx_15_30"
+CLX_15_30_TDX_BLOCK_KEY = "CLX_15_30"
+CLX_15_30_TDX_BLK_FILENAME = f"{CLX_15_30_TDX_BLOCK_KEY}.blk"
+
+# consumer 的 fullcalc 回调来自线程池，读-合并-重写必须串行化
+_TDX_BLK_WRITE_LOCK = threading.Lock()
 
 
 def encode_tdx_blk_code(value: object) -> str:
@@ -94,6 +102,80 @@ def write_clx_tdx_group(
 
     root = Path(tdx_home) if tdx_home is not None else _require_tdx_home()
     target = root / "T0002" / "blocknew" / CLX_TDX_BLK_FILENAME
+    with _TDX_BLK_WRITE_LOCK:
+        _atomic_write_blk(lines, target)
+
+    return {
+        "group_name": CLX_TDX_GROUP_DISPLAY_NAME,
+        "file_name": CLX_TDX_BLK_FILENAME,
+        "written_count": len(lines),
+    }
+
+
+def read_tdx_blk_lines(
+    tdx_home: str | Path | None = None,
+    filename: str = CLX_15_30_TDX_BLK_FILENAME,
+) -> list[str]:
+    """Read an existing TDX .blk group as normalized 7-char lines (order preserved, dedup)."""
+    root = Path(tdx_home) if tdx_home is not None else _require_tdx_home()
+    target = root / "T0002" / "blocknew" / filename
+    if not target.exists():
+        return []
+
+    text = target.read_bytes().decode("gbk", errors="ignore")
+    lines = []
+    seen = set()
+    for raw in text.splitlines():
+        line = str(raw).strip().upper()
+        if not line or line in seen:
+            continue
+        seen.add(line)
+        lines.append(line)
+    return lines
+
+
+def append_tdx_group_members(
+    symbols: Sequence[object],
+    *,
+    tdx_home: str | Path | None = None,
+    block_key: str = CLX_15_30_TDX_BLOCK_KEY,
+    display_name: str = CLX_15_30_TDX_GROUP_DISPLAY_NAME,
+) -> dict[str, object]:
+    """去重追加成员到通达信分组，复用编码与原子写实现。
+
+    - 以编码后的 7 字符行直接去重（不解码回 6 位，避免 LOF 等裸 6 位歧义）。
+    - 无新增成员时为 no-op，不抛错、不触碰旧文件。
+    """
+    filename = f"{block_key}.blk"
+    lines = list(read_tdx_blk_lines(tdx_home=tdx_home, filename=filename))
+    seen = set(lines)
+
+    appended_count = 0
+    for symbol in symbols or []:
+        line = encode_tdx_blk_code(symbol)
+        if line in seen:
+            continue
+        seen.add(line)
+        lines.append(line)
+        appended_count += 1
+
+    result = {
+        "group_name": display_name,
+        "file_name": filename,
+        "appended_count": appended_count,
+        "written_count": len(lines),
+    }
+    if appended_count == 0:
+        return result
+
+    root = Path(tdx_home) if tdx_home is not None else _require_tdx_home()
+    target = root / "T0002" / "blocknew" / filename
+    with _TDX_BLK_WRITE_LOCK:
+        _atomic_write_blk(lines, target)
+    return result
+
+
+def _atomic_write_blk(lines: list[str], target: Path) -> None:
     temp_path = target.with_name(f".{target.name}.{uuid4().hex}.tmp")
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -105,12 +187,6 @@ def write_clx_tdx_group(
     except Exception as exc:
         temp_path.unlink(missing_ok=True)
         raise RuntimeError(f"导入通达信失败，旧分组已保留：{exc}") from exc
-
-    return {
-        "group_name": CLX_TDX_GROUP_DISPLAY_NAME,
-        "file_name": CLX_TDX_BLK_FILENAME,
-        "written_count": len(lines),
-    }
 
 
 def _require_tdx_home() -> Path:

--- a/freshquant/market_data/xtdata/strategy_consumer.py
+++ b/freshquant/market_data/xtdata/strategy_consumer.py
@@ -780,6 +780,31 @@ class StrategyConsumer:
         except Exception as e:
             logger.error(f"[Consumer] insert clx docs failed: {e}")
 
+        # 通达信 clx_15_30 分组：去重追加（best-effort，不影响信号主链）
+        try:
+            from freshquant.clx_daily_selection.tdx_export import (
+                append_tdx_group_members,
+            )
+
+            result = append_tdx_group_members(
+                sorted(
+                    {
+                        str(d.get("code") or "").strip()
+                        for d in docs
+                        if str(d.get("code") or "").strip()
+                    }
+                )
+            )
+            appended_count = int(str(result.get("appended_count") or 0))
+            if appended_count > 0:
+                logger.info(
+                    f"[Consumer] clx_15_30 tdx group appended "
+                    f"{appended_count} new member(s), "
+                    f"total {result.get('written_count')}"
+                )
+        except Exception as e:
+            logger.warning(f"[Consumer] append clx_15_30 tdx group failed: {e}")
+
         # DingTalk: minimal aggregation
         try:
             from freshquant.message.dingtalk import send_private_message

--- a/freshquant/tests/test_clx_daily_selection_tdx_export.py
+++ b/freshquant/tests/test_clx_daily_selection_tdx_export.py
@@ -5,7 +5,10 @@ import os
 import pytest
 
 from freshquant.clx_daily_selection.tdx_export import (
+    CLX_15_30_TDX_BLK_FILENAME,
+    append_tdx_group_members,
     encode_tdx_blk_code,
+    read_tdx_blk_lines,
     write_clx_tdx_group,
 )
 
@@ -85,3 +88,85 @@ def test_write_clx_tdx_group_rejects_empty_without_touching_old_file(tmp_path):
         write_clx_tdx_group([], tdx_home=tmp_path)
 
     assert target.read_bytes() == b"old-group\r\n"
+
+
+def test_read_tdx_blk_lines_returns_normalized_dedup_lines(tmp_path):
+    target = tmp_path / "T0002" / "blocknew" / CLX_15_30_TDX_BLK_FILENAME
+    target.parent.mkdir(parents=True)
+    target.write_bytes("1510050\r\n0000001\r\n1510050\r\n0000001\r\n".encode("gbk"))
+
+    assert read_tdx_blk_lines(tdx_home=tmp_path) == ["1510050", "0000001"]
+
+
+def test_read_tdx_blk_lines_missing_file_returns_empty(tmp_path):
+    assert read_tdx_blk_lines(tdx_home=tmp_path) == []
+
+
+def test_append_tdx_group_members_appends_dedup_preserves_order(tmp_path):
+    target = tmp_path / "T0002" / "blocknew" / CLX_15_30_TDX_BLK_FILENAME
+    target.parent.mkdir(parents=True)
+    target.write_bytes("1510050\r\n".encode("gbk"))
+
+    result = append_tdx_group_members(
+        ["sh600000", "000001", "sh600000", {"symbol": "160512", "asset_type": "etf"}],
+        tdx_home=tmp_path,
+    )
+
+    assert result == {
+        "group_name": "clx_15_30",
+        "file_name": "CLX_15_30.blk",
+        "appended_count": 3,
+        "written_count": 4,
+    }
+    assert target.read_bytes() == b"1510050\r\n1600000\r\n0000001\r\n0160512\r\n"
+
+
+def test_append_tdx_group_members_no_new_members_is_noop(tmp_path):
+    target = tmp_path / "T0002" / "blocknew" / CLX_15_30_TDX_BLK_FILENAME
+    target.parent.mkdir(parents=True)
+    target.write_bytes("1510050\r\n".encode("gbk"))
+
+    result = append_tdx_group_members(["sh510050"], tdx_home=tmp_path)
+
+    assert result == {
+        "group_name": "clx_15_30",
+        "file_name": "CLX_15_30.blk",
+        "appended_count": 0,
+        "written_count": 1,
+    }
+    assert target.read_bytes() == b"1510050\r\n"
+
+
+def test_append_tdx_group_members_atomic_failure_preserves_old(monkeypatch, tmp_path):
+    target = tmp_path / "T0002" / "blocknew" / CLX_15_30_TDX_BLK_FILENAME
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"old-group\r\n")
+
+    def fail_replace(_source, _target):
+        raise OSError("replace denied")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(RuntimeError, match="旧分组已保留"):
+        append_tdx_group_members(["sh600000"], tdx_home=tmp_path)
+
+    assert target.read_bytes() == b"old-group\r\n"
+    assert list(target.parent.glob(".CLX_15_30.blk.*.tmp")) == []
+
+
+def test_append_tdx_group_members_supports_custom_block_key(tmp_path):
+    result = append_tdx_group_members(
+        ["sh510050"],
+        tdx_home=tmp_path,
+        block_key="CUSTOM",
+        display_name="custom",
+    )
+
+    target = tmp_path / "T0002" / "blocknew" / "CUSTOM.blk"
+    assert target.read_bytes() == b"1510050\r\n"
+    assert result == {
+        "group_name": "custom",
+        "file_name": "CUSTOM.blk",
+        "appended_count": 1,
+        "written_count": 1,
+    }

--- a/freshquant/tests/test_xtdata_consumer_clx_tdx_group.py
+++ b/freshquant/tests/test_xtdata_consumer_clx_tdx_group.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from freshquant.market_data.xtdata import strategy_consumer as consumer_module
+from freshquant.market_data.xtdata.strategy_consumer import StrategyConsumer
+
+
+class FakeRedis:
+    def __init__(self):
+        self.lock_keys = []
+
+    def set(self, key, value, ex=None, nx=False):
+        self.lock_keys.append(key)
+        return True
+
+
+class FakeRealtimeCollection:
+    def __init__(self):
+        self.inserted = []
+
+    def insert_many(self, docs, ordered=False):
+        self.inserted.extend(list(docs))
+
+
+class FakeDB:
+    def __init__(self, realtime_collection):
+        self._collections = {"realtime_screen_multi_period": realtime_collection}
+
+    def __getitem__(self, name):
+        return self._collections[name]
+
+
+def _make_consumer(monkeypatch, append_impl, *, query_inst=None):
+    fake_redis = FakeRedis()
+    realtime_collection = FakeRealtimeCollection()
+    monkeypatch.setattr(consumer_module, "redis_db", fake_redis)
+    monkeypatch.setattr(consumer_module, "DBfreshquant", FakeDB(realtime_collection))
+    monkeypatch.setattr(
+        "freshquant.instrument.general.query_instrument_info",
+        query_inst or (lambda code: None),
+    )
+    monkeypatch.setattr(
+        "freshquant.message.dingtalk.send_private_message",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "freshquant.clx_daily_selection.tdx_export.append_tdx_group_members",
+        append_impl,
+    )
+    consumer = object.__new__(StrategyConsumer)
+    return consumer, fake_redis, realtime_collection
+
+
+def _meta_and_result(code="sh600000", period="15min"):
+    meta = {
+        "code": code,
+        "period": period,
+        "bar_time": 1780000000,
+        "model_ids": [10000, 10001],
+    }
+    fc_res = {
+        "signals": [
+            {"signal": 1, "model": 10000, "close": 10.5, "stop_loss": 9.8},
+            {"signal": 0, "model": 10001, "close": 10.5, "stop_loss": 9.8},
+            {"signal": 1, "model": 10001, "close": 10.6, "stop_loss": 9.9},
+        ]
+    }
+    return meta, fc_res
+
+
+def test_process_clx_signals_appends_docs_codes_to_tdx_group(monkeypatch):
+    calls = []
+
+    def append_impl(
+        symbols, *, tdx_home=None, block_key="CLX_15_30", display_name="clx_15_30"
+    ):
+        calls.append((symbols, block_key))
+        return {
+            "group_name": display_name,
+            "file_name": f"{block_key}.blk",
+            "appended_count": 1,
+            "written_count": 1,
+        }
+
+    consumer, fake_redis, realtime_collection = _make_consumer(monkeypatch, append_impl)
+    meta, fc_res = _meta_and_result()
+
+    consumer._process_clx_signals(meta, fc_res)
+
+    assert calls == [(["sh600000"], "CLX_15_30")]
+    assert len(realtime_collection.inserted) == 2
+    assert {doc["code"] for doc in realtime_collection.inserted} == {"sh600000"}
+    assert len(fake_redis.lock_keys) == 2
+
+
+def test_process_clx_signals_tdx_append_failure_is_best_effort(monkeypatch):
+    def append_impl(
+        symbols, *, tdx_home=None, block_key="CLX_15_30", display_name="clx_15_30"
+    ):
+        raise RuntimeError("TDX group write denied")
+
+    consumer, fake_redis, realtime_collection = _make_consumer(monkeypatch, append_impl)
+    meta, fc_res = _meta_and_result()
+
+    # 必须不抛出异常，且信号仍正常入库
+    consumer._process_clx_signals(meta, fc_res)
+
+    assert len(realtime_collection.inserted) == 2
+
+
+def test_process_clx_signals_skips_tdx_append_without_models(monkeypatch):
+    calls = []
+
+    def append_impl(
+        symbols, *, tdx_home=None, block_key="CLX_15_30", display_name="clx_15_30"
+    ):
+        calls.append(symbols)
+        return {"appended_count": 0, "written_count": 0}
+
+    consumer, _fake_redis, realtime_collection = _make_consumer(
+        monkeypatch, append_impl
+    )
+    meta = {
+        "code": "sh600000",
+        "period": "15min",
+        "bar_time": 1780000000,
+        "model_ids": [],
+    }
+
+    consumer._process_clx_signals(meta, {"signals": []})
+
+    assert calls == []
+    assert realtime_collection.inserted == []


### PR DESCRIPTION
背景：clx_15_30 实时监控命中结果目前只写 realtime_screen_multi_period 与钉钉通知，通达信中缺少对应自选股分组，人工无法直接在通达信里查看监控命中标的。

目标：通达信新增自选股分组 clx_15_30（T0002/blocknew/CLX_15_30.blk），consumer 在正信号写库后把本批命中标的（带前缀代码）去重追加到该分组，复用现有 tdx_export.py 编码与原子写实现。

范围：
- freshquant/clx_daily_selection/tdx_export.py：新增 CLX_15_30 常量、_atomic_write_blk、read_tdx_blk_lines、append_tdx_group_members；write_clx_tdx_group 行为不变。
- freshquant/market_data/xtdata/strategy_consumer.py：_process_clx_signals 在 insert_many 后 best-effort 追加通达信分组，失败仅 warning。
- 测试：tdx_export 追加/去重/顺序/no-op/原子失败用例；consumer 挂载与 best-effort 用例。
- 文档：docs/current/modules/market-data-xtdata.md、docs/current/reference/stock-pools-and-positions.md、docs/plans/2026-08-05-clx-15-30-monitor-tdx-group-plan.md。

非目标：不改 CLX_18.blk 每日选股导出；不改 stock_pools/must_pool 语义；不触发下单。

验收标准：
- pytest：test_clx_daily_selection_tdx_export.py、test_xtdata_consumer_clx_tdx_group.py 及相关套件全绿。
- 部署后 consumer 正信号写入 CLX_15_30.blk（去重、保留顺序、无新增不触碰旧文件）。

部署影响：api（fq_apiserver）+ dagster（fq_dagster_webserver/daemon）+ market_data（host consumer 等重启）；已本地部署并通过 health/runtime verify。