### PR TITLE
fix: harden order ledger identity and targeted repair

### DIFF
--- a/docs/current/architecture.md
+++ b/docs/current/architecture.md
@@ -10,10 +10,9 @@
 - Guardian 新买单提交前复用订单管理撤单链处理同标的内部活动买单；存在
   等待态、外部单或撤单请求时，本 Tick 不提交新单。
 - 当前 Guardian 与 `om_broker_orders` 运行面按单一已配置 XT 账户部署；
-  `om_broker_orders` 只有 `account_type`、没有可用于撤单隔离的 `account_id`，
-  因此活动买单查询在该单账户边界内按标的过滤。若未来同一运行实例承载多个
-  券商账户，必须先把 `account_id` 持久化到订单读模型并加入查询条件，不能直接
-  复用当前撤单编排。
+  `om_broker_orders` 已持久化 `account_id / trading_day / order_sysid / broker_order_key`。
+  活动买单查询仍在当前单账户运行边界内按标的过滤；若未来同一运行实例承载多个
+  券商账户，撤单编排必须显式加入 `account_id` 条件，不能依赖单账户部署假设。
 - 三档止盈按触发时券商总仓位分别计算 1/3、1/2、全部，并受 open ledger
   与 `can_use_volume` 截断；来源分配先使用达价 Slice，不足部分从剩余数量
   最大的 Slice 补足。
@@ -168,7 +167,9 @@ finalizer 只在两侧 completed 后运行。sensor 先持久化 `finalization_a
   - 定义内部订单执行事实，并用于交叉核对 `xt_trades`
 - `om_broker_orders`
   - 定义券商订单聚合视图，不单独作为历史成交数量真值
-  - XT 回报进入订单账本时，`broker_order_id` 只作为候选检索键；重复券商订单号需要结合 `symbol`、`side/order_type` 与回报时间确定内部订单
+  - 规范身份首选 `account_id + trading_day + order_sysid`，缺少 `order_sysid` 时回退到
+    `account_id + trading_day + symbol + side + broker_order_id`
+  - `broker_order_id / order_sysid` 只可用于候选检索，不能单独作为全局唯一键；身份不完整、冲突或歧义时 fail closed，不按回报时间或唯一候选猜测归属
 - `om_position_entries`
   - 定义系统可消费的持仓入口
 - `om_reconciliation_*`

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -47,6 +47,7 @@ docker compose -f docker/compose.parallel.yaml up -d --build
 - `script/ci/run_formal_deploy.py` 会读取 `production-state.json` 中的上一次成功部署 SHA，计算 `last_success_sha -> current main HEAD` 的 changed paths，再调用 `script/freshquant_deploy_plan.py` 得到本轮 deploy plan。
 - `script/ci/run_formal_deploy.py` 命中宿主机 deployment surface 时，会把当前 canonical repo root repo root 追加给 `script/fqnext_host_runtime_ctl.ps1`，由后者用 `script/fqnext_supervisor_config.py` 收敛 `D:\fqpack\config\supervisord.fqnext.conf`。
 - `script/fqnext_host_runtime_ctl.ps1` 或 `script/fqnext_supervisor_config.py` 自身发生变更时，`script/freshquant_deploy_plan.py` 现在会强制命中全部宿主机 deployment surface（`market_data`、`guardian`、`position_management`、`tpsl`、`order_management`）；这类 host-runtime infra 变更不允许再被判成 no-op deploy。
+- `freshquant/order_management/repository.py` 或 `entry_adapter.py` 是 Guardian、Position Management、TPSL 与 Order Management 共享账本边界；部署计划会在 API 之外强制命中这四个宿主机 surface，不能只重启 broker/ingest。
 - `script/ci/run_production_deploy.ps1` 会显式把 canonical repo root、local main sync root 与本机 canonical repo root 加入 git `safe.directory`，避免 runner 在多 worktree 场景下拒绝执行 git。
 - 正式 deploy 要求 production runner 至少存在一个可用的 Python 3.12；若 `py -3.12` 因旧注册失效，入口脚本会回退到已注册的 per-user / system Python 3.12，并回补 `HKCU\Software\Python\PythonCore\3.12\InstallPath`。
 - 若 runner Python 3.12 缺少 `uv` 模块，入口脚本会先执行 `python -m pip install uv --break-system-packages` 再继续部署。
@@ -106,7 +107,7 @@ powershell -ExecutionPolicy Bypass -File script/ci/run_production_deploy.ps1 -Ca
 ```powershell
 $preview = .venv\Scripts\python.exe script/maintenance/backfill_position_review_history.py |
     ConvertFrom-Json
-if ($preview.executions.discovered -lt 366) {
+if ($preview.executions.discovered -lt 596) {
     throw "position-review execution preview is below the verified floor"
 }
 
@@ -125,11 +126,15 @@ $enhua.data_quality.account_partitions
 - 已验证环境中，恩华药业 `002262` 的
   `data_quality.canonical_trade_count` 必须为 `55`；2026-04-29 两次卖出复盘仍应分别为
   `2300 / 2300 / PASS` 与 `4500 / 0 / FAIL`。
-- 当前正式数据 preview 的 canonical execution 下限是 `366`；若
+- 2026-08-05 已验证正式 archive 基线为 `596` 条 canonical execution、`2766`
+  条 position-review evidence；标的 `688772` 对应 `10` 条 execution、`47` 条
+  evidence。后续 backfill preview 不能低于该基线。
+- 若
   `conflicting_evidence` 非零，表示 OM 与 XT 在五元成交身份一致但方向冲突，
   这些记录只作质量告警，不能增加 canonical execution 数。
 - `account_partition` 只能是不可逆摘要或 `unknown`；接口和部署日志不得输出原始账户号。
 - positions-only initialize 与正式 order-ledger rebuild 都会在清理前自动归档，并在归档失败时中止清理；人工 backfill 是既有数据上线前的安全补齐，不替代自动钩子。
+- archive 只保存 append-only 复盘证据，不包含可恢复的完整可写账本闭包，不能替代 repair/rebuild 的 preimage backup 或 restore manifest。
 
 ### 正式部署最佳实践
 
@@ -198,6 +203,7 @@ powershell -ExecutionPolicy Bypass -File script/install_fqnext_supervisord_resta
 | `freshquant/rear/**` | API Server | 重建 `fq_apiserver` 容器或重启 API 进程 |
 | `freshquant/runtime_observability/**` | Runtime Observability API / ClickHouse / indexer | 重建 `fq_apiserver`，并确认 `fq_runtime_clickhouse`、`fq_runtime_indexer` 已恢复 |
 | `freshquant/order_management/**` | 订单管理、API、broker/ingest、XT 自动还款相关宿主机进程 | 重建 API；执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface order_management -BridgeIfServiceUnavailable` |
+| `freshquant/order_management/repository.py` / `freshquant/order_management/entry_adapter.py` | API 与共享订单账本消费者 | 重建 API；同时重启 `guardian`、`position_management`、`tpsl`、`order_management` 四个宿主机 surface |
 | `freshquant/position_management/**` | 仓位管理（宿主机实际由统一 `xt_account_sync.worker` 承担） | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface position_management -BridgeIfServiceUnavailable` |
 | `freshquant/xt_account_sync/**` | XT 主动查询统一 worker（仓位管理 + 订单管理） | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface position_management -DeploymentSurface order_management -BridgeIfServiceUnavailable` |
 | `freshquant/xt_auto_repay/**` | XT 自动还款 worker | 执行 `powershell -ExecutionPolicy Bypass -File script/fqnext_host_runtime_ctl.ps1 -Mode EnsureServiceAndRestartSurfaces -DeploymentSurface order_management -BridgeIfServiceUnavailable` |
@@ -294,7 +300,50 @@ strict-reader health 通过后停止旧 Stock / ETF factor writers，但保留 `
 
 - destructive rebuild 前必须先备份目标订单账本数据库
 - 若重建后验证失败，先停写入面，再清理新 `om_*` 集合，并用备份库整库恢复
-- 不做局部回滚；当前正式口径只接受整库恢复
+- destructive rebuild 不做局部回滚；当前正式口径只接受整库恢复
+
+## 定向 Order Ledger Repair / Restore 执行口径
+
+单账户、单标的或同一 broker identity 闭包的数据污染不使用全库 rebuild。正式顺序固定为：
+
+1. 最新代码先经 PR 合并到远程 `main`，完成 API 与命中的宿主机 surface formal deploy
+2. 停止相关 API order-write、Guardian、Position Management、TPSL 与 Order Management 写入面
+3. 先执行持仓复盘 archive backfill，保全 append-only 证据；archive 不作为 rollback backup
+4. repair plan 显式声明 `account_id`、全部受影响 `symbols`、`broker_order_ids/order_sysids` 与 request/order/fill/entry/slice/allocation/gap/resolution/rejection 引用闭包
+5. 不修改但必须进入并发门槛的 XT/OM 文档使用 `mode=snapshot`；真实改写拆成单文档原子 `mode=replace` change，并列出精确 `allowed_diff`；每个 selector 分支必须包含账户锚点（或计划内精确 `_id`）与稳定闭包键
+6. 先 dry-run，人工核对所有 selector、diff 和 `preimage_hash`
+7. execute 必须提交相同 `preimage_hash`，并在数据库写入前落完整 BSON preimage manifest
+8. 核对 `om_targeted_repair_runs`、postimage hash、成交/分摊守恒、allocation 引用完整性、gap/resolution 和 compat 视图
+9. 验收通过后恢复写入面并执行 runtime health/ops verify
+
+```powershell
+$preview = .venv\Scripts\python.exe script/maintenance/targeted_order_ledger_repair.py `
+  --plan-path <repair-plan.json> --dry-run | ConvertFrom-Json
+
+.venv\Scripts\python.exe script/maintenance/targeted_order_ledger_repair.py `
+  --plan-path <repair-plan.json> `
+  --execute `
+  --expected-preimage-hash $preview.preimage_hash `
+  --manifest-path <immutable-preimage-manifest.json>
+```
+
+正式 restore 只使用上述 manifest：
+
+```powershell
+$restore = .venv\Scripts\python.exe script/maintenance/targeted_order_ledger_repair.py `
+  --restore-manifest <immutable-preimage-manifest.json> --dry-run | ConvertFrom-Json
+
+.venv\Scripts\python.exe script/maintenance/targeted_order_ledger_repair.py `
+  --restore-manifest <immutable-preimage-manifest.json> `
+  --execute `
+  --expected-current-hash $restore.current_hash
+```
+
+- restore 只有在当前完整闭包仍等于 repair postimage hash 时才允许；出现后续业务写入后不得强制覆盖
+- 多集合之间中断时，每个原子 change 必须仍精确处于 preimage/postimage/unchanged；满足该条件可幂等续跑，任何 change 漂移到第三种状态都 fail closed
+- 同一 `repair_id` 永久绑定同一 plan；修复范围或期望文档改变时使用新 `repair_id`
+- repair/restore 期间禁止运行 `python -m freshquant.initialize` 和 `rebuild_order_ledger_v2.py --execute`
+- manifest 含原始可恢复业务文档，必须保存在受控 artifact 目录，不写入 Git，不在日志或 PR 中公开账户号
 
 ## 健康检查
 

--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -58,10 +58,15 @@
   `account_id + trading_day + symbol + side + broker_order_id`
 - `broker_order_id` 和 `order_sysid` 都不能脱离账户、交易日单独作为全局唯一键；历史数据中已确认存在 `6` 组 `order_sysid` 跨日复用
 - 回报已知的 `account_id / trading_day / symbol / side / broker_order_id / order_sysid` 都是硬约束；唯一候选也必须逐维校验，冲突或歧义时 fail closed，不按时间最近或“只有一条候选”猜测归属
+- 每张新内部订单固定生成一个 `24` 字符 `broker_correlation_token`，格式为 `FQOM` 加 `20` 位小写十六进制字符，仅包含字母和数字；broker 执行桥把它独占写入 XT `order_remark`，原始用户备注只保留在内部 request/queue 事实中，不与 token 拼接
+- 券商单号尚未绑定时，XT order/trade 回报只有携带并命中该 token 才能认领内部订单；`account_id + trading_day + symbol + side` 只用于发现潜在歧义，不能作为首回报绑定依据
+- token 缺失、截断、未知、与显式 internal order 冲突、订单类型冲突，或同一 broker identity 已被另一 internal order 占用时，回报进入 `om_ingest_rejections` 并 fail closed；bound 与 unbound 候选并存时也不允许先返回任一候选
 - XT 原始 `side` 是 canonical 执行方向；内部订单方向不能覆盖与其冲突的回报，未知方向不再默认成 `sell`
 - 无法关联到内部请求但身份完整的 XT 回报使用规范 broker identity 派生稳定 broker-only `internal_order_id`，不再把裸 `broker_order_id` 冒充内部订单 ID
 - execution fill 的幂等身份固定包含
   `account_id + trading_day + symbol + side + broker_trade_id`，避免不同账户、交易日或标的复用成交号时互相覆盖
+- 规范 execution 重放遇到尚无 `execution_identity` 的历史数据时，必须分别在 `om_execution_fills` 与 `om_trade_facts` 中按 `broker_trade_id` 找到唯一候选并组成一对；任一侧缺失、任一集合出现多候选、或一侧已经规范化而另一侧仍是不可证明的 legacy/unversioned 记录时都会 fail closed
+- 成对候选还必须完整校验账户归属、交易日、标的、方向、数量、价格、成交时间与订单归属；全部一致后才原位补齐两侧规范身份，并把历史 execution fill 标记为已应用，不新增第二份成交事实，也不重复执行历史持仓投影。broker-only order 只在这组 replay preflight 全部通过后持久化
 
 ### 破坏性 rebuild 治理
 
@@ -100,6 +105,8 @@
 - `om_targeted_repair_runs`
   - 定向修账的 `repair_id / plan_hash / preimage_hash / postimage_hash / manifest_hash / status` 审计收据
 
+`OrderManagementRepository` 构造期只保存数据库句柄，不主动联网建索引。`internal_order_id / broker_correlation_token / broker_order_key / execution_identity / entry_id / entry_slice_id / allocation_id` 等 canonical partial unique indexes 会在首次相关写入前确保存在，并在同一 repository 实例内复用已完成状态；缺少规范字符串身份的历史文档不进入这些 partial unique index。
+
 ### legacy / 兼容集合
 
 - `om_buy_lots`
@@ -117,6 +124,10 @@
 ### 下单
 
 `submit_order -> credit mode resolve -> position gate -> om_order_requests / om_orders / om_broker_orders / om_order_events -> STOCK_ORDER_QUEUE -> broker`
+
+- submit 在意图规范化阶段固定一次规范 `account_id` 与 `trading_day`：`account_id` 取显式请求值或当前 `xtquant.account` 配置，缺失时拒单；`trading_day` 取请求已声明交易日，缺失时按当前北京时间解析。相同值会写入 request/order 并透传到 `STOCK_ORDER_QUEUE`，后续 tracking、broker 与回报关联不得另行猜测或覆盖
+- tracking 同时固定 `broker_correlation_token` 并透传到队列；broker 真正调用 `order_stock()` 时只把该 token 写入 XT `order_remark`，确保同步返回券商单号之前到达的首笔 callback 仍能证明所属 internal order
+- 真实账户值属于敏感运行配置，只能进入受控账本、内部队列和必要的受限排障面；公开日志、PR、正式文档与测试/命令示例不得写入真实值，必须省略或使用明显的脱敏占位符
 
 当前信用账户买单的运行期语义已经固定为：
 
@@ -154,9 +165,15 @@ Guardian 卖出请求当前会把本次卖量对应的来源入口计划一起�
 当前写链规则：
 
 - XT order/trade callback 进入 tracking 前先建立账户、交易日、标的、方向和券商订单身份；已绑定内部订单仍要做同一套硬校验
+- 尚未绑定 broker order id 的内部订单必须先通过 `order_remark -> broker_correlation_token` 精确关联；没有 token 的回报即使只有一个四维相同的在途单也不能猜测绑定
+- token 精确关联后仍要校验 `account_id / trading_day / symbol / side / broker_order_type`，并确认该 broker identity 没有另一 internal order owner
 - 若规范身份冲突、候选歧义或聚合成员出现 mixed-account / mixed-symbol / mixed-side，回报不进入该订单聚合和持仓账本
 - 若券商订单已在 submit 成功阶段绑定到内部订单，trade callback 当前仍会继续进入 `ingest_trade_report()`；`ExternalOrderReconcileService` 只负责补齐 trace/request/internal order 上下文与 reconcile 侧 runtime event，不再把这类回报提前短路
 - `om_broker_orders` 的 `filled_quantity / avg_filled_price / fill_count` 从该规范 broker identity 下已接受的 canonical fills 确定性重算，不在旧聚合数值上盲目累加
+- 新写入的 execution fill 先落为 `projection_status=PENDING`；ingest 会先生成并持久化版本化的确定性 `projection_plan`，再按计划写入 buy lot、entry、slice 与 allocation，全部投影完成后才把状态推进为 `APPLIED`
+- `PENDING` execution 尚无计划时会先生成并持久化一次 `projection_plan`，已有计划时重放必须复用同一份计划；单文档目标只允许精确处于计划 preimage 或 postimage，发生第三种并发漂移时 fail closed
+- lot slice / entry slice 组只能处于计划定义的确定性步骤前缀，包括完整 before、逐步完成的合法前缀和完整 after；缺失或多出切片、重复身份、任意 before/after 混合都不能作为恢复点
+- 计划中的 sell/exit allocation 必须全部具有计划内唯一 `allocation_id`；同 ID 已存在时只有完整文档一致才视为已应用，重复 ID、内容冲突或执行后仍缺少计划 allocation 都会 fail closed。已到 `APPLIED` 的 execution 重放只返回现有规范结果，不重复扣减或重复生成 allocation；原位迁移的历史 execution 直接标记为已应用，不重新执行历史账本副作用
 - buy fill 先按 `broker_order_key` 收口成 buy execution group，再按保守规则归并进 `buy_cluster` entry
 - `buy_cluster` 归并规则当前固定为：
   - 同一 `symbol`
@@ -228,15 +245,15 @@ py -3.12 script/maintenance/repair_guardian_sell_entry_allocations.py --execute 
 `AUTO_OPENED` 当前已经拆成“真值确认优先、切片排布随后”的两阶段行为：
 
 - entry truth 会先落 `om_position_entries`
-- Guardian 切片排布随后尝试生成
+- Guardian 切片排布随后统一调用 canonical `guardian.arranger.arrange_entry()` 生成；每一档都按新的 Guardian 价格重新计算剩余市值，不再维护 reconcile 私有切片算法
 - 若 `grid_interval / lot_amount / arrange_entry_slices` 任一环节异常，entry 仍保持 `OPEN`
 - 降级状态通过 `arrange_status / arrange_degraded / arrange_error_* / arrange_runtime_errors` 落在 entry 上
 - 降级时仍会写 compat mirror 与 holdings cache，避免真值已确认但视图长期滞后
 
-当前 external reconcile 对 XT 外部回报也支持部分匹配：
+当前 external reconcile 对 XT 部分成交仍支持回挂，但订单归属必须先由 `broker_correlation_token` 或已经绑定且无歧义的 broker identity 证明：
 
-- 若内部在途单的请求数量大于 XT 回报数量，但 symbol / side / 价格匹配，当前允许挂回同一 internal order
-- 这样 `intent=600`、`external_reported=300` 这类场景不会再一律 externalize
+- 归属已证明后，内部请求数量大于 XT 回报数量仍允许挂回同一 internal order，例如 `intent=600`、`external_reported=300`
+- `symbol / side / 价格 / 数量` 只能用于一致性校验，不能单独认领尚未绑定的内部订单
 自动平账与 XT 回报补录路径里，凡是由 `trade_time / confirmed_at` 回填 `date/time` 的订单域记录，当前统一按北京时间（`Asia/Shanghai`）落地，避免同一笔成交在不同读模型里出现跨日漂移。
 
 排障查看口径也保持同一套时间语义：`xt-order list`、`xt-trade list` 以及依赖成交 epoch 时间的 fill 查看命令，当前统一按北京时间展示；其中 `--date` 过滤使用北京时间自然日边界，而不是宿主机本地时区。
@@ -342,6 +359,7 @@ repair plan 当前固定包含：
 - request、internal order、execution、entry、slice、allocation、gap、resolution、rejection 等显式闭包身份
 - 每个逻辑 selector 分支都必须同时具有 `account_id`（账户字段缺失时使用已声明的精确 `_id`）和稳定 order/execution/document 闭包键；symbol-only selector 会被拒绝
 - 每个 `mode=replace` change 只允许一个原子 insert/update/delete；同集合多文档修复拆成多个互不重叠 change，restore 按相反顺序执行
+- `mode=replace` 的 insert 必须在 postimage 中携带固定 `_id`，selector 必须精确锚定同一个 `_id`；执行期不得让 Mongo 临时生成新 `_id`，`insert_one` 依赖 `_id` 唯一键提供“目标仍不存在”的原子门槛
 - `mode=snapshot`：只纳入完整 preimage/postimage hash 门槛，不执行写入
 - `mode=replace`：声明该稳定 selector 下最多一个修复后文档
 - 每个 replace 集合精确到文档身份的 `allowed_diff.inserted / updated / deleted`
@@ -353,9 +371,26 @@ fail closed。
 
 `repair_id` 的运行收据写入 `om_targeted_repair_runs`。每个原子 change 会单独判定为
 preimage/postimage/unchanged；进程在多集合之间中断时，只要没有 change 漂移到第三种状态，
-后续相同 repair 可以继续尚未应用的 change，restore 也可按反向顺序继续。同一 plan 和同一已应用状态重复
-执行会返回 `already_applied`；同一 `repair_id` 绑定不同 plan 会拒绝。中断时只有当前闭包
-仍精确等于 preimage 或 postimage 才允许确定性续跑/收口。
+后续合法 attempt 可以继续尚未应用的 change，restore 也可按反向顺序继续。
+
+apply/restore 的写权限都由 receipt attempt lease 隔离：收据保存单调递增的 `receipt_version`，以及
+`apply_attempt_id / apply_lease_expires_at` 或 `restore_attempt_id / restore_lease_expires_at`。
+lease 当前为 `300` 秒，每个 change 写入前续租；claim、续租、失败和完成转换都必须同时匹配
+`repair_id + status + attempt_id + receipt_version`，且只接受 `matched_count=1`。每次 claim 与终态
+转换都会把 `receipt_version` 加一，单纯续租不改变 version。lease 超时会打开 CAS 接管窗口；新 owner
+一旦完成 claim，旧 attempt 下一次续租会因 attempt/version 不匹配而 fail closed，不能继续写账本或
+改写新 owner 的状态。
+
+apply 的合法状态边固定为：首次执行原子创建 `applying` 收据并成为 owner；只有 `failed` 或 lease
+已经过期的 `applying` 才能被新 attempt CAS 接管，仍在有效 lease 内的 `applying` 会拒绝第二执行者；
+`applied` 是幂等终态并返回 `already_applied`，`restoring / restore_failed / restored` 都不能重新进入
+apply。同一 `repair_id` 绑定不同 plan 仍会拒绝。
+
+每个 replace 写入都使用 preimage/postimage compare-and-swap：更新与删除必须匹配刚读取的完整
+BSON 文档；插入只允许带固定 `_id` 的 `insert_one`，不得通过 upsert 覆盖并发出现的文档。CAS
+失败会保留并发业务值。apply 异常时只反向 rollback 当前仍精确等于 postimage 的 change，第三种
+漂移值不会被覆盖；全部回到 preimage 时 `rollback_succeeded=true`，存在未回滚或 CAS 冲突时为
+`false` 并保留 `rollback_error`，仍由当前 owner 把 attempt 收口为 `failed`。
 
 restore 使用同一 manifest：
 
@@ -369,8 +404,15 @@ $restore = .venv\Scripts\python.exe script/maintenance/targeted_order_ledger_rep
   --expected-current-hash $restore.current_hash
 ```
 
-只有当前闭包仍精确等于 repair postimage 时 restore 才会恢复 preimage；后续任何业务写入
-导致 hash 漂移都会阻断回滚。执行定向 repair/restore 前必须停止相关 API order-write、
+restore dry-run 与 execute 都必须先找到 `om_targeted_repair_runs` 中既有收据，并逐项匹配 `repair_id / plan_hash / preimage_hash / postimage_hash / manifest_hash`；外部提供的 manifest 会重新执行 scope、selector scope、固定 `_id` insert 与 preimage/postimage document scope 校验，不能单靠自算 hash 获得恢复权限。
+
+restore 的合法状态边固定为：首次 restore 只能从 `applied` claim，且所有 change 都仍精确等于
+repair postimage；只有 lease 已过期的 `restoring`，或 lease 已清除/失效的 `restore_failed`，才能由新 restore attempt 接管，
+有效 lease 内的 `restoring` 会拒绝第二执行者。续跑时每个 change 只能分别处于 preimage、postimage
+或 unchanged，出现第三种漂移值即阻断；`restored` 仅在全部 change 已回到 preimage 时幂等返回。
+restore 成功由当前 owner CAS 收口为 `restored`，异常由当前 owner 收口为 `restore_failed`；所有
+转换与续租同样受 `restore_attempt_id + receipt_version + lease` fencing，旧 attempt 不能覆盖新状态。
+执行定向 repair/restore 前必须停止相关 API order-write、
 Guardian、Position Management、TPSL 与 Order Management 写入面。定向事故修复期间不得
 运行 `python -m freshquant.initialize` 或全库 `rebuild_order_ledger_v2.py --execute`。
 

--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -29,6 +29,8 @@
   - `python -m freshquant.cli stock.fill rebuild --code <symbol>`
   - `python -m freshquant.cli stock.fill rebuild --all`
   - `python -m freshquant.cli stock.fill compare --code <symbol>`
+  - `py -3.12 script/maintenance/targeted_order_ledger_repair.py --plan-path <plan.json>`
+  - `py -3.12 script/maintenance/targeted_order_ledger_repair.py --restore-manifest <manifest.json>`
 - 核心服务
   - `freshquant.order_management.submit.service.OrderSubmitService`
   - `freshquant.order_management.read_service.OrderManagementReadService`
@@ -48,12 +50,25 @@
 - `xt_account_sync.worker` 遇到 quarantine 的 `positions` 快照会显式打 warning，便于运行面第一时间发现真值冻结
 - 当前委托/成交回报真值只认 XT callback 与 `xt_account_sync.worker` 增量刷新
 
+### 券商订单与成交身份
+
+- 券商订单规范主键首选
+  `account_id + trading_day + order_sysid`
+- XT 未提供 `order_sysid` 时，回退主键固定为
+  `account_id + trading_day + symbol + side + broker_order_id`
+- `broker_order_id` 和 `order_sysid` 都不能脱离账户、交易日单独作为全局唯一键；历史数据中已确认存在 `6` 组 `order_sysid` 跨日复用
+- 回报已知的 `account_id / trading_day / symbol / side / broker_order_id / order_sysid` 都是硬约束；唯一候选也必须逐维校验，冲突或歧义时 fail closed，不按时间最近或“只有一条候选”猜测归属
+- XT 原始 `side` 是 canonical 执行方向；内部订单方向不能覆盖与其冲突的回报，未知方向不再默认成 `sell`
+- 无法关联到内部请求但身份完整的 XT 回报使用规范 broker identity 派生稳定 broker-only `internal_order_id`，不再把裸 `broker_order_id` 冒充内部订单 ID
+- execution fill 的幂等身份固定包含
+  `account_id + trading_day + symbol + side + broker_trade_id`，避免不同账户、交易日或标的复用成交号时互相覆盖
+
 ### 破坏性 rebuild 治理
 
 - 破坏性 `order-ledger rebuild` 只能由 broker truth 驱动，primary truth 只允许 `xt_orders`、`xt_trades`、`xt_positions`
 - `om_*`、`stock_fills`、`stock_fills_compat` 只能作为迁移期兼容投影或排障线索，不能作为 rebuild 主输入
 - rebuild 默认拒绝用空 `xt_positions` 快照去 flatten 非空账本；只有显式允许空快照 flatten 时，才会把空 `xt_positions` 视为券商已清仓
-- 初始化向导的 runtime bootstrap 当前走 `xt_positions`-only destructive rebuild 变体：先 purge order-ledger rebuild 边界内的旧账本集合，再按券商当前持仓快照重建 V2 账本，并刷新 `stock_fills_compat`
+- 初始化向导的 runtime bootstrap 当前走 `xt_positions`-only destructive rebuild 变体：先归档将被替换的执行与持仓解释证据，归档成功后才 purge order-ledger rebuild 边界内的旧账本集合，再按券商当前持仓快照重建 V2 账本，并刷新 `stock_fills_compat`
 - 这类破坏性 rebuild 在编码前必须先建立 GitHub Issue，写清影响面、验收标准与部署影响
 
 ### OM 主账本
@@ -63,9 +78,9 @@
 - `om_orders`
   - 兼容期内部订单壳
 - `om_broker_orders`
-  - 券商订单聚合，维护 `requested_quantity / filled_quantity / avg_filled_price / fill_count`
+  - 券商订单聚合，保存 `account_id / trading_day / order_sysid / broker_order_key`，并维护 `requested_quantity / filled_quantity / avg_filled_price / fill_count`
 - `om_execution_fills`
-  - 真实券商成交 fill，`broker_trade_id` 去重
+  - 真实券商成交 fill，按规范 execution identity 去重
 - `om_trade_facts`
   - 兼容期成交事实镜像，仍保留给旧读链和部分排障
 - `om_position_entries`
@@ -82,6 +97,8 @@
   - entry 级止损绑定
 - `om_ingest_rejections`
   - 进入 XT ingest 但不允许进入主账本的拒绝记录
+- `om_targeted_repair_runs`
+  - 定向修账的 `repair_id / plan_hash / preimage_hash / postimage_hash / manifest_hash / status` 审计收据
 
 ### legacy / 兼容集合
 
@@ -136,7 +153,10 @@ Guardian 卖出请求当前会把本次卖量对应的来源入口计划一起�
 
 当前写链规则：
 
-- 若 `broker_order_id` 已在 submit 成功阶段绑定到内部订单，trade callback 当前仍会继续进入 `ingest_trade_report()`；`ExternalOrderReconcileService` 只负责补齐 trace/request/internal order 上下文与 reconcile 侧 runtime event，不再把这类回报提前短路
+- XT order/trade callback 进入 tracking 前先建立账户、交易日、标的、方向和券商订单身份；已绑定内部订单仍要做同一套硬校验
+- 若规范身份冲突、候选歧义或聚合成员出现 mixed-account / mixed-symbol / mixed-side，回报不进入该订单聚合和持仓账本
+- 若券商订单已在 submit 成功阶段绑定到内部订单，trade callback 当前仍会继续进入 `ingest_trade_report()`；`ExternalOrderReconcileService` 只负责补齐 trace/request/internal order 上下文与 reconcile 侧 runtime event，不再把这类回报提前短路
+- `om_broker_orders` 的 `filled_quantity / avg_filled_price / fill_count` 从该规范 broker identity 下已接受的 canonical fills 确定性重算，不在旧聚合数值上盲目累加
 - buy fill 先按 `broker_order_key` 收口成 buy execution group，再按保守规则归并进 `buy_cluster` entry
 - `buy_cluster` 归并规则当前固定为：
   - 同一 `symbol`
@@ -147,6 +167,9 @@ Guardian 卖出请求当前会把本次卖量对应的来源入口计划一起�
   - 已发生卖出扣减的 entry 不再接受新的 buy order 合并
 - 同一 broker order 的多笔 fill 会更新同一个聚合成员，而不是继续生成多条 entry
 - sell fill 先尝试按 `om_order_requests.strategy_context.guardian_sell_sources.entries` 对齐来源入口，再回退默认 `entry_slice` 顺序扣减，最后写 `exit_allocations`
+- XT 成交碎片只要求 `quantity` 为正整数；单笔 execution 可以不是 `100` 股整数倍，所有碎片按规范 execution identity 分别入账后再汇总
+- entry slice 以 `entry_slice_id` 做定向更新；运行期和 reconcile 都不得用 open slice 子集覆盖某个 entry 的完整历史切片
+- 每条 `exit_allocation.entry_id / entry_slice_id` 都必须引用现存且归属一致的 V2 entry/slice；entry 与 slice 的已扣减数量必须分别与 allocation 合计守恒
 - legacy `buy_lot / lot_slice / sell_allocation` 仍同步写入，供迁移期兼容链使用
 - 若 sell fill 已成功写入 V2 `om_position_entries / om_entry_slices / om_exit_allocations`，但 legacy `buy_lot / lot_slice` 镜像缺失或数量落后，trade callback 当前会跳过 legacy sell allocation，并依赖后续 `stock_fills_compat` 镜像刷新，不再把整笔成交回报记为失败
 
@@ -186,6 +209,7 @@ py -3.12 script/maintenance/repair_guardian_sell_entry_allocations.py --execute 
 当前内部仓位累计规则：
 
 - 若某个 symbol 已存在 open `om_position_entries`，对账只以 V2 entry remaining quantity 作为内部仓位真值
+- 某 symbol 只要存在过 V2 position entry，包括全部 entry 已 `CLOSED`，读侧和 reconcile 就不再回退 legacy remaining；CLOSED V2 同样是 authoritative history
 - 同 symbol 的 legacy `om_buy_lots` 仅保留给兼容读链与排障，不再额外叠加进对账 internal remaining，避免 mixed-state 双计数后误生成 `sell gap`
 自动平账在检测到“同一轮快照对账户内多只持仓同时形成大比例 sell-gap、且近期缺少足够卖出成交证据”时，当前会熔断该轮 sell reconcile，不新建 sell gap，也不推进 sell-side gap 自动确认。
 
@@ -285,6 +309,10 @@ py -3.12 -m uv run script/maintenance/rebuild_order_ledger_v2.py --execute --bac
 之前自动写入这两个档案；同一 `execution_key` 下的请求、订单、fill、trade fact
 冲突关联以候选数组保留，不用后到单值覆盖先到证据。
 
+这两个 archive 是 append-only 复盘证据，不是 rollback backup：它们不包含 broker
+order、event、gap、resolution、rejection、compat 与 legacy 全闭包，不能用于恢复一次
+定向修账或 destructive rebuild 的完整 preimage。
+
 重建后的运行期读侧：
 
 - `holding.py` / `/api/stock_fills` 把 OM 主链返回的空列表视为 authoritative，不再因此掉回 compat/raw legacy
@@ -292,14 +320,69 @@ py -3.12 -m uv run script/maintenance/rebuild_order_ledger_v2.py --execute --bac
 - `SubjectManagement`、`TPSL` 现在可以在没有 legacy `buy_lots` 的情况下直接读取 v2 `position_entries`
 - 当前 rebuild 生成的 buy-side `position_entries` 已切到 `buy_cluster / broker_execution_cluster` 语义
 
+## 定向 Repair / Restore
+
+跨标的、跨账户或跨交易日串单的正式修复入口是：
+
+```powershell
+$preview = .venv\Scripts\python.exe script/maintenance/targeted_order_ledger_repair.py `
+  --plan-path <repair-plan.json> --dry-run | ConvertFrom-Json
+
+.venv\Scripts\python.exe script/maintenance/targeted_order_ledger_repair.py `
+  --plan-path <repair-plan.json> `
+  --execute `
+  --expected-preimage-hash $preview.preimage_hash `
+  --manifest-path <immutable-preimage-manifest.json>
+```
+
+repair plan 当前固定包含：
+
+- 唯一且不可复用到其他计划的 `repair_id`
+- `account_id + symbols[] + broker_order_ids[]/order_sysids[]` 目标边界
+- request、internal order、execution、entry、slice、allocation、gap、resolution、rejection 等显式闭包身份
+- 每个逻辑 selector 分支都必须同时具有 `account_id`（账户字段缺失时使用已声明的精确 `_id`）和稳定 order/execution/document 闭包键；symbol-only selector 会被拒绝
+- 每个 `mode=replace` change 只允许一个原子 insert/update/delete；同集合多文档修复拆成多个互不重叠 change，restore 按相反顺序执行
+- `mode=snapshot`：只纳入完整 preimage/postimage hash 门槛，不执行写入
+- `mode=replace`：声明该稳定 selector 下最多一个修复后文档
+- 每个 replace 集合精确到文档身份的 `allowed_diff.inserted / updated / deleted`
+
+dry-run 不连接额外数据源、不写账本，只计算完整闭包的 preimage、postimage、diff
+和 hash。execute 必须提交同一次 dry-run 的 `preimage_hash`，并在任何数据库写入前先把
+完整 BSON preimage manifest 落盘；当前闭包发生漂移、allowed diff 多一条或少一条都会
+fail closed。
+
+`repair_id` 的运行收据写入 `om_targeted_repair_runs`。每个原子 change 会单独判定为
+preimage/postimage/unchanged；进程在多集合之间中断时，只要没有 change 漂移到第三种状态，
+后续相同 repair 可以继续尚未应用的 change，restore 也可按反向顺序继续。同一 plan 和同一已应用状态重复
+执行会返回 `already_applied`；同一 `repair_id` 绑定不同 plan 会拒绝。中断时只有当前闭包
+仍精确等于 preimage 或 postimage 才允许确定性续跑/收口。
+
+restore 使用同一 manifest：
+
+```powershell
+$restore = .venv\Scripts\python.exe script/maintenance/targeted_order_ledger_repair.py `
+  --restore-manifest <immutable-preimage-manifest.json> --dry-run | ConvertFrom-Json
+
+.venv\Scripts\python.exe script/maintenance/targeted_order_ledger_repair.py `
+  --restore-manifest <immutable-preimage-manifest.json> `
+  --execute `
+  --expected-current-hash $restore.current_hash
+```
+
+只有当前闭包仍精确等于 repair postimage 时 restore 才会恢复 preimage；后续任何业务写入
+导致 hash 漂移都会阻断回滚。执行定向 repair/restore 前必须停止相关 API order-write、
+Guardian、Position Management、TPSL 与 Order Management 写入面。定向事故修复期间不得
+运行 `python -m freshquant.initialize` 或全库 `rebuild_order_ledger_v2.py --execute`。
+
 ## Board Lot 规则
 
-系统当前把普通 A 股 `100` 股整数倍视为硬约束：
+系统当前把下单意图与外部成交事实分开校验：
 
-- odd-lot XT 回报会写 `om_execution_fills / om_trade_facts` 审计事实
-- odd-lot 不会生成 `position_entry / entry_slice / exit_allocation`
-- odd-lot 会写入 `om_ingest_rejections.reason_code=non_board_lot_quantity`
-- 手工导入与手工 reset 直接拒绝 odd-lot 数量
+- 普通 A 股策略/API 下单意图仍要求 `100` 股整数倍
+- 手工 import/reset 仍要求 `100` 股整数倍
+- XT order/trade callback 是已经发生的外部事实，任何正整数 execution quantity 都必须入账
+- 同一订单由多个非整百 execution fragment 组成时，按 fragment 幂等保存，再从 accepted fills 重算订单聚合与 entry/allocation
+- `om_ingest_rejections.reason_code=non_board_lot_quantity` 不再用于拒绝 XT 已成交碎片；历史这类 rejection 只作为待修复证据
 
 ## 读模型口径
 
@@ -353,10 +436,19 @@ py -3.12 -m uv run script/maintenance/rebuild_order_ledger_v2.py --execute --bac
 
 ## 部署
 
-- 改动 `freshquant/order_management/**` 后：
+- 一般改动 `freshquant/order_management/**` 后：
   - 重建 API Server
+  - 重启 `order_management` surface（broker、`xt_account_sync.worker`、`xt_auto_repay.worker`）
+- 改动共享 `freshquant/order_management/repository.py` 或 `entry_adapter.py` 后：
+  - 重建 API Server
+  - 同时重启 Guardian、Position Management、TPSL、Order Management 四个宿主机 surface
+- 涉及账本修复正式上线后：
+  - 先完成最新远程 `main` formal deploy 与 runtime health check
+  - 再停相关写入面执行定向 repair
+  - repair 验收完成后恢复并验证全部命中 surface
+- 改动 `freshquant/xt_account_sync/**` 后：
   - 重启 `xt_account_sync.worker`
-  - 重启 `xt_auto_repay.worker`
+- 改动 `freshquant/tpsl/**` 后：
   - 重启 `tpsl.tick_listener`
 - 改动 `freshquant/xt_auto_repay/**` 后：
   - 重启 `xt_auto_repay.worker`

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -31,7 +31,9 @@
 
 - `ExternalOrderReconcileService` 对 buy gap 会同时记录 `initial/latest/chosen` 三组价格快照；运行面和排障口径里若看到 `chosen_price_policy=freeze_initial`，表示最终确认价按首次发现快照冻结，而不是跟随长时间观测漂移。
 - Guardian 遇到“持仓 entry 已确认但 arranged fills 不可用”的场景时，当前会显式区分 `arrangement_degraded` 与 `entry_without_slices`；这两种情况默认保守跳过，不再误记成“无持仓”。
-- XT 委托/成交回报匹配内部订单时，`broker_order_id` 不视为全局唯一键；同一 `broker_order_id` 命中多条 `om_orders` 时，会继续按 `symbol`、`side/order_type` 与回报时间选择候选。
+- XT 委托/成交回报匹配内部订单时，`broker_order_id / order_sysid` 都不视为全局唯一键；只接受完整的
+  `account_id + trading_day + order_sysid` 主身份，或
+  `account_id + trading_day + symbol + side + broker_order_id` fallback。身份不完整、冲突或歧义时 fail closed，不按回报时间或唯一候选猜测归属。
 
 ### Docker 并行环境承担
 

--- a/docs/current/storage.md
+++ b/docs/current/storage.md
@@ -44,6 +44,8 @@
 - `om_takeprofit_states`
 - `om_exit_trigger_events`
 - `om_credit_subjects`
+- `om_targeted_repair_runs`
+  - 定向修账审计收据；`repair_id` 唯一，保存 plan/manifest/preimage/postimage hash、状态与 restore 结果
 - `om_execution_history_archive`
   - 持仓复盘的规范化成交档案；`execution_key` 使用
     `broker_trade_id + symbol + side + trade_time + quantity + price`
@@ -59,6 +61,21 @@
   - 使用 `evidence_type + account_partition + 稳定业务身份` 幂等写入
   - 顶层、候选快照和 payload 均不持久化原始 `account_id`；只保留不可逆
     `account_partition`
+
+订单与成交身份当前固定为：
+
+- broker order 首选：`account_id + trading_day + order_sysid`
+- broker order fallback：`account_id + trading_day + symbol + side + broker_order_id`
+- execution fill：`account_id + trading_day + symbol + side + broker_trade_id`
+
+裸 `broker_order_id / order_sysid / broker_trade_id` 都不是跨账户、跨交易日的全局
+唯一键。`om_broker_orders / om_execution_fills / om_trade_facts` 持久化已知身份维度，
+聚合与幂等写入必须使用规范复合身份。
+
+Mongo 当前使用 partial unique index 约束字符串形态的 `broker_order_key`、两类
+`execution_identity`、`entry_id`、`entry_slice_id` 与 `allocation_id`。历史
+execution 文档在补齐 `execution_identity` 前不进入该唯一索引，避免上线索引时把
+缺失字段的旧记录误判为重复。
 
 当前仍保留的 legacy 集合：
 
@@ -129,6 +146,7 @@
 - 当前执行事实真值
   - `om_broker_orders`
   - `om_execution_fills`
+  - 订单聚合从同一规范 broker identity 下已接受的 canonical fills 确定性重算
 - 当前持仓解释真值
   - `om_position_entries`
   - `om_entry_slices`
@@ -143,6 +161,11 @@
     提供不随 positions-only initialize 或 destructive rebuild 消失的历史只读证据
   - 历史档案不参与当前仓位重建，也不反向改写 `xt_positions`
   - `account_partition` 是账户号的不可逆摘要；API 不返回原始账户号
+  - 两个历史档案不包含完整可写账本闭包，不能作为 repair/rebuild rollback backup
+- 定向修账恢复真值
+  - 写前完整 BSON preimage manifest
+  - `om_targeted_repair_runs` 中与 manifest 一致的 hash/status 收据
+  - manifest 同时覆盖 `mode=replace` 写集合和 `mode=snapshot` 只读闭包；restore 只在当前完整闭包仍等于 postimage hash 时允许
 - CLX partition 计算真值
   - `freshquant_clx_daily_selection.partitions`
   - `memberships / snapshots / model_stats` 只通过 `partition_id` 归属不可变输出
@@ -185,6 +208,7 @@
   - 写 `om_position_entries / om_entry_slices / om_exit_allocations`
   - 写 `om_ingest_rejections`
   - 同步 legacy `buy_lot` 链与 `stock_fills_compat`
+  - XT execution fragment 只要求正整数数量；订单聚合从 accepted fills 重算
 - `ExternalOrderReconcileService`
   - 写 `om_reconciliation_gaps / om_reconciliation_resolutions`
   - 必要时自动写 `position_entries / exit_allocations`
@@ -194,6 +218,12 @@
 - initialize / order-ledger rebuild
   - 替换 `xt_trades` 或 purge OM 账本前，先幂等写入两个持仓复盘档案
   - 归档失败时中止清理；两个档案集合不在 order-ledger purge 边界内
+- targeted order-ledger repair
+  - 从 `business/order` 两个 store 读取计划声明的账户、标的、broker identity 与引用闭包
+  - `snapshot` 项只进入一致性 hash；每个 `replace` 项只做一个原子文档 insert/update/delete，并由精确 allowed diff 限制身份
+  - selector 每个逻辑分支要求账户锚点（或计划内精确 `_id`）与稳定闭包键，禁止 symbol-only 批量 selector；同集合 change 不得重叠
+  - 逻辑 diff/preimage/postimage hash 在 `_id` 不是业务 identity field 时忽略 Mongo 自动 `_id`，但 manifest 保留原始 preimage `_id` 用于精确 restore
+  - 写前落完整 preimage manifest，写后记录 `om_targeted_repair_runs`；restore 从 manifest 恢复，不从历史 archive 反推
 - `PositionReviewRepository`
   - 合并当前 `xt_trades / om_*` 与两个历史档案
   - 同一账户内按成交六元身份去重，不同已知账户分区保留为不同成交
@@ -219,7 +249,7 @@
 - 查当前仓位先看 `xt_positions`
 - 查账本解释先看 `om_position_entries`
 - 查执行事实先看 `om_broker_orders / om_execution_fills`
-- 查 odd-lot 或拒绝写入先看 `om_ingest_rejections`
+- 查 XT execution fragment 是否完整先看 `om_execution_fills` 与 broker aggregate；外部已成交 odd-lot 不应再出现 `non_board_lot_quantity` rejection
 - 查 legacy 镜像问题最后再看 `stock_fills_compat / om_buy_lots`
 - 查全历史持仓复盘缺失先看
   `om_execution_history_archive / position_review_evidence_archive`

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -138,14 +138,45 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
 - `@'
 from freshquant.order_management.db import DBOrderManagement
 broker_order_id = "<broker_order_id>"
-print(list(DBOrderManagement["om_orders"].find({"broker_order_id": str(broker_order_id)}, {"_id": 0, "internal_order_id": 1, "trace_id": 1, "symbol": 1, "side": 1, "broker_order_type": 1, "state": 1, "submitted_at": 1})))
+print(list(DBOrderManagement["om_orders"].find({"broker_order_id": str(broker_order_id)}, {"_id": 0, "internal_order_id": 1, "trace_id": 1, "account_id": 1, "trading_day": 1, "order_sysid": 1, "symbol": 1, "side": 1, "broker_order_type": 1, "state": 1, "submitted_at": 1})))
 '@ | py -3.12 -m uv run -`
 
 处理：
 
-- 当前 `broker_order_id` 不能单独当作全局唯一键；如果同号命中多条 `om_orders`，以 `symbol`、`side/order_type` 与回报时间确认真实内部订单。
+- 当前 `broker_order_id` 与 `order_sysid` 都不能单独当作全局唯一键；规范 broker identity 首选 `account_id + trading_day + order_sysid`，fallback 为 `account_id + trading_day + symbol + side + broker_order_id`。
+- 同号命中多条时不要以“唯一旧候选”或时间最近猜测；核对账户、交易日、标的、方向和 XT 原始字段，任一已知维度冲突都应 fail closed。
 - 若重复券商订单号曾把回报挂到旧内部订单，需要同步核对 `om_execution_fills`、`om_trade_facts` 与 `om_position_entries` 是否已有错归属事实；必要时按券商真值 `xt_orders/xt_trades/xt_positions` 做账本修复。
-- 修复代码后需要重新部署 `order_management` host surface，并确认 broker / XT report ingest runtime event 已回到新内部订单对应的 trace。
+- 修复身份代码后需要重新部署 `order_management` host surface；若变更命中共享 `repository.py / entry_adapter.py`，还要同步重启 Guardian、Position Management 与 TPSL，并确认 broker / XT report ingest runtime event 已回到新内部订单对应的 trace。
+
+## 定向 order-ledger repair 被 hash 或 allowed-diff 阻断
+
+现象：
+
+- dry-run 报 `allowed diff mismatch`
+- execute 报 `preimage hash mismatch`
+- restore 返回 `restorable=false` 或报 postimage state mismatch
+- 相同 `repair_id` 报已绑定到另一 plan
+
+先检查：
+
+```powershell
+$preview = .venv\Scripts\python.exe script/maintenance/targeted_order_ledger_repair.py `
+  --plan-path <repair-plan.json> --dry-run | ConvertFrom-Json
+$preview | ConvertTo-Json -Depth 20
+
+$restore = .venv\Scripts\python.exe script/maintenance/targeted_order_ledger_repair.py `
+  --restore-manifest <manifest.json> --dry-run | ConvertFrom-Json
+$restore | ConvertTo-Json -Depth 20
+```
+
+处理：
+
+- `allowed diff mismatch` 表示 selector 实际命中的 inserted/updated/deleted 身份与计划不完全一致；停止执行，补查账户、标的、broker identity 与 request/order/fill/entry/slice/allocation/gap/resolution/rejection 闭包，不扩大 selector 猜修
+- `preimage hash mismatch` 表示 dry-run 后闭包已变化；保持写入面停止，重新 dry-run 并人工复核新 diff，不能复用旧 hash
+- restore 只在当前闭包仍等于 manifest 的 postimage 时允许；有后续业务写入时先保全新证据并制定新的 repair，不强行覆盖
+- `repair_id` 永久绑定同一 plan；计划内容变化必须换新 `repair_id`
+- `om_execution_history_archive / position_review_evidence_archive` 只用于证据复盘，不是 rollback backup；restore 只能使用本次 execute 写前落盘且 hash 校验通过的完整 preimage manifest
+- repair/restore 期间禁止运行 `python -m freshquant.initialize` 与全库 `rebuild_order_ledger_v2.py --execute`
 
 ## broker_gateway 健康摘要停留在旧 warning
 
@@ -482,17 +513,18 @@ print('resolutions', repo.list_reconciliation_resolutions(symbol=symbol))
 
 处理：
 
-- 先确认当前代码已包含“有 open V2 entry 时不再把 legacy buy_lot 叠加进 internal remaining”的修复
-- 再停止订单写入面，执行 `script/maintenance/rebuild_order_ledger_v2.py --execute --backup-db <backup>`
-- 重建后复查 `xt_positions`、`om_position_entries`、`om_reconciliation_resolutions` 与页面读模是否一致
+- 先确认当前代码已包含“symbol 只要存在过 V2 entry（包括全部 CLOSED）就不再回退 legacy remaining”的修复
+- 停止相关写入面，以 broker truth 和完整引用闭包创建 targeted repair plan；先 dry-run，再用相同 `preimage_hash` execute
+- 修复后复查 `xt_positions`、`om_position_entries`、完整历史 `om_entry_slices`、`om_exit_allocations`、`om_reconciliation_resolutions` 与页面读模是否一致
+- 只有明确需要全库重建且已完成独立治理、备份和验收计划时，才执行 destructive rebuild；单标的串单不使用全库 rebuild
 
-## Order Ledger V2 rebuild 后出现 odd-lot 拒绝
+## XT 成交碎片被标成 `non_board_lot_quantity`
 
 现象：
 
-- 某 symbol 在页面中没有生成 `position_entry`
-- `PositionManagement` 或 `TPSL` 显示对账异常
+- XT 已回报真实成交，但某些 execution fragment 不是 `100` 股整数倍
 - `om_ingest_rejections` 出现 `reason_code=non_board_lot_quantity`
+- broker order aggregate、position entry 或 exit allocation 数量小于 XT 成交合计
 
 先检查：
 
@@ -506,9 +538,10 @@ print(repo.list_reconciliation_resolutions())
 
 处理：
 
-- odd-lot 当前只保留在 `execution_fill / ingest_rejection` 审计层，不会进入 `position_entry / entry_slice`
-- 若券商当前仓位仍存在合法 board-lot 差额，系统会通过 `auto_open_entry / auto_close_allocation` 收敛
-- 若差额本身仍不是 `100` 股整数倍，当前口径是继续保留 `REJECTED gap`，不要手工伪造 entry
+- XT order/trade callback 是外部已发生事实，任何正整数 execution quantity 都必须进入 canonical fill；`100` 股整数倍只在下单意图和手工 import/reset 边界校验
+- 若当前 runtime 仍新增 `non_board_lot_quantity` rejection，先确认 API/order-management 宿主机已运行最新远程 `main`，再查是否有旧进程或旧 ingest 路径
+- 对历史 rejection 使用 targeted repair：完整保留 XT fragment，按规范 execution identity 重建 aggregate，并校验 sell allocations 合计与 accepted fills 守恒
+- 不用 `auto_close_allocation` 或伪造整百成交补齐被错误拒绝的真实 execution fragment
 
 ## Dagster 容器持续重启
 

--- a/freshquant/order_management/allocation_integrity.py
+++ b/freshquant/order_management/allocation_integrity.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Mapping, Sequence
+
+
+def find_exit_allocation_integrity_errors(
+    *,
+    position_entries: Sequence[Mapping[str, Any]],
+    entry_slices: Sequence[Mapping[str, Any]],
+    exit_allocations: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    entries = [dict(item) for item in list(position_entries or [])]
+    slices = [dict(item) for item in list(entry_slices or [])]
+    allocations = [dict(item) for item in list(exit_allocations or [])]
+    errors: list[dict[str, Any]] = []
+
+    entry_by_id = _unique_documents(
+        entries,
+        identity_field="entry_id",
+        duplicate_reference_type="duplicate_entry_id",
+        errors=errors,
+    )
+    slice_by_id = _unique_documents(
+        slices,
+        identity_field="entry_slice_id",
+        duplicate_reference_type="duplicate_entry_slice_id",
+        errors=errors,
+    )
+    _unique_documents(
+        allocations,
+        identity_field="allocation_id",
+        duplicate_reference_type="duplicate_allocation_id",
+        errors=errors,
+    )
+
+    allocated_by_entry: Counter[str] = Counter()
+    allocated_by_slice: Counter[str] = Counter()
+    for allocation in allocations:
+        allocation_id = _normalize_text(allocation.get("allocation_id"))
+        entry_id = _normalize_text(allocation.get("entry_id"))
+        slice_id = _normalize_text(allocation.get("entry_slice_id"))
+        entry = entry_by_id.get(entry_id)
+        slice_document = slice_by_id.get(slice_id)
+
+        if entry is None:
+            errors.append(
+                _reference_error(
+                    allocation_id=allocation_id,
+                    reference_type="entry_id",
+                    reference_id=entry_id,
+                )
+            )
+        if slice_document is None:
+            errors.append(
+                _reference_error(
+                    allocation_id=allocation_id,
+                    reference_type="entry_slice_id",
+                    reference_id=slice_id,
+                )
+            )
+        if entry is not None and slice_document is not None:
+            slice_entry_id = _normalize_text(slice_document.get("entry_id"))
+            if slice_entry_id != entry_id:
+                errors.append(
+                    {
+                        **_reference_error(
+                            allocation_id=allocation_id,
+                            reference_type="entry_slice_owner",
+                            reference_id=slice_id,
+                        ),
+                        "expected_entry_id": entry_id,
+                        "actual_entry_id": slice_entry_id,
+                    }
+                )
+            entry_symbol = _normalize_text(entry.get("symbol"))
+            slice_symbol = _normalize_text(slice_document.get("symbol"))
+            if entry_symbol and slice_symbol and entry_symbol != slice_symbol:
+                errors.append(
+                    {
+                        **_reference_error(
+                            allocation_id=allocation_id,
+                            reference_type="entry_slice_symbol",
+                            reference_id=slice_id,
+                        ),
+                        "expected_symbol": entry_symbol,
+                        "actual_symbol": slice_symbol,
+                    }
+                )
+
+        allocation_symbol = _normalize_text(allocation.get("symbol"))
+        for reference_type, document in (
+            ("allocation_entry_symbol", entry),
+            ("allocation_entry_slice_symbol", slice_document),
+        ):
+            document_symbol = _normalize_text((document or {}).get("symbol"))
+            if (
+                allocation_symbol
+                and document_symbol
+                and allocation_symbol != document_symbol
+            ):
+                errors.append(
+                    {
+                        **_reference_error(
+                            allocation_id=allocation_id,
+                            reference_type=reference_type,
+                            reference_id=entry_id if document is entry else slice_id,
+                        ),
+                        "expected_symbol": document_symbol,
+                        "actual_symbol": allocation_symbol,
+                    }
+                )
+
+        allocated_quantity = _positive_int(allocation.get("allocated_quantity"))
+        if allocated_quantity is None:
+            errors.append(
+                {
+                    **_reference_error(
+                        allocation_id=allocation_id,
+                        reference_type="allocated_quantity",
+                        reference_id=allocation_id,
+                    ),
+                    "actual_quantity": allocation.get("allocated_quantity"),
+                }
+            )
+            continue
+        if entry_id:
+            allocated_by_entry[entry_id] += allocated_quantity
+        if slice_id:
+            allocated_by_slice[slice_id] += allocated_quantity
+
+    errors.extend(
+        _quantity_conservation_errors(
+            documents=entries,
+            identity_field="entry_id",
+            actual_by_identity=allocated_by_entry,
+            reference_type="entry_allocation_quantity",
+        )
+    )
+    errors.extend(
+        _quantity_conservation_errors(
+            documents=slices,
+            identity_field="entry_slice_id",
+            actual_by_identity=allocated_by_slice,
+            reference_type="entry_slice_allocation_quantity",
+        )
+    )
+    return sorted(errors, key=_error_sort_key)
+
+
+def _unique_documents(
+    documents,
+    *,
+    identity_field,
+    duplicate_reference_type,
+    errors,
+):
+    result = {}
+    for document in documents:
+        identity = _normalize_text(document.get(identity_field))
+        if not identity:
+            errors.append(
+                _reference_error(
+                    allocation_id=(
+                        _normalize_text(document.get("allocation_id"))
+                        if identity_field != "allocation_id"
+                        else None
+                    ),
+                    reference_type=identity_field,
+                    reference_id=None,
+                )
+            )
+            continue
+        if identity in result:
+            errors.append(
+                _reference_error(
+                    allocation_id=(
+                        identity if identity_field == "allocation_id" else None
+                    ),
+                    reference_type=duplicate_reference_type,
+                    reference_id=identity,
+                )
+            )
+            continue
+        result[identity] = document
+    return result
+
+
+def _quantity_conservation_errors(
+    *,
+    documents,
+    identity_field,
+    actual_by_identity,
+    reference_type,
+):
+    errors = []
+    for document in documents:
+        identity = _normalize_text(document.get(identity_field))
+        original = _nonnegative_int(document.get("original_quantity"))
+        remaining = _nonnegative_int(document.get("remaining_quantity"))
+        if not identity or original is None or remaining is None:
+            continue
+        if remaining > original:
+            errors.append(
+                {
+                    **_reference_error(
+                        allocation_id=None,
+                        reference_type=f"{identity_field}_quantity_bounds",
+                        reference_id=identity,
+                    ),
+                    "original_quantity": original,
+                    "remaining_quantity": remaining,
+                }
+            )
+            continue
+        expected = original - remaining
+        actual = int(actual_by_identity.get(identity, 0))
+        if expected != actual:
+            errors.append(
+                {
+                    **_reference_error(
+                        allocation_id=None,
+                        reference_type=reference_type,
+                        reference_id=identity,
+                    ),
+                    "expected_quantity": expected,
+                    "actual_quantity": actual,
+                }
+            )
+    return errors
+
+
+def _reference_error(*, allocation_id, reference_type, reference_id):
+    return {
+        "allocation_id": allocation_id,
+        "reference_type": reference_type,
+        "reference_id": reference_id,
+    }
+
+
+def _positive_int(value):
+    normalized = _exact_int(value)
+    return normalized if normalized is not None and normalized > 0 else None
+
+
+def _nonnegative_int(value):
+    normalized = _exact_int(value)
+    return normalized if normalized is not None and normalized >= 0 else None
+
+
+def _exact_int(value):
+    try:
+        normalized = int(value)
+        numeric = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if normalized != numeric:
+        return None
+    return normalized
+
+
+def _normalize_text(value):
+    if value in (None, "", "None"):
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _error_sort_key(error):
+    return (
+        error.get("allocation_id") is None,
+        str(error.get("allocation_id") or ""),
+        str(error.get("reference_type") or ""),
+        str(error.get("reference_id") or ""),
+    )
+
+
+__all__ = ["find_exit_allocation_integrity_errors"]

--- a/freshquant/order_management/broker_correlation.py
+++ b/freshquant/order_management/broker_correlation.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+import re
+from hashlib import sha256
+
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityError,
+    normalize_identifier,
+)
+
+_TOKEN_PREFIX = "FQOM"
+_TOKEN_PATTERN = re.compile(r"^FQOM[0-9a-f]{20}$")
+
+
+def build_broker_correlation_token(internal_order_id):
+    normalized = normalize_identifier(internal_order_id)
+    if normalized is None:
+        raise BrokerIdentityError(
+            "internal_order_id is required for broker correlation"
+        )
+    payload = sha256(normalized.encode("utf-8")).hexdigest()[:20]
+    token = f"{_TOKEN_PREFIX}{payload}"
+    if len(token) != 24:  # pragma: no cover - 20 hex chars are fixed-width
+        raise BrokerIdentityError("broker correlation token length is invalid")
+    return token
+
+
+def normalize_broker_correlation_token(value):
+    normalized = normalize_identifier(value)
+    if normalized is None or _TOKEN_PATTERN.fullmatch(normalized) is None:
+        return None
+    return normalized
+
+
+def looks_like_broker_correlation_token(value):
+    normalized = normalize_identifier(value)
+    return bool(normalized and normalized.startswith(_TOKEN_PREFIX))

--- a/freshquant/order_management/broker_identity.py
+++ b/freshquant/order_management/broker_identity.py
@@ -1,0 +1,231 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+from typing import Any, Mapping
+
+_BEIJING_TZ = timezone(timedelta(hours=8))
+
+
+class BrokerIdentityError(ValueError):
+    """Base error for broker identity normalization and validation failures."""
+
+
+class BrokerIdentityConflict(BrokerIdentityError):
+    """Raised when a broker report conflicts with a pinned internal order."""
+
+
+def normalize_identifier(value: Any) -> str | None:
+    if value in (None, "", "None"):
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def normalize_account_id(value: Any) -> str | None:
+    return normalize_identifier(value)
+
+
+def normalize_symbol(value: Any) -> str | None:
+    normalized = normalize_identifier(value)
+    if normalized is None:
+        return None
+    normalized = normalized.upper()
+    return normalized[:6] if len(normalized) >= 6 else normalized
+
+
+def normalize_side(value: Any) -> str | None:
+    normalized = normalize_identifier(value)
+    if normalized is None:
+        return None
+    normalized = normalized.lower()
+    return normalized if normalized in {"buy", "sell"} else None
+
+
+def normalize_trading_day(value: Any) -> int | None:
+    if value in (None, "", 0, "0"):
+        return None
+    if isinstance(value, datetime):
+        return int(_as_beijing(value).strftime("%Y%m%d"))
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError, OverflowError):
+        numeric = None
+    if numeric is not None and 19000101 <= numeric <= 29991231:
+        return numeric
+    parsed = _parse_datetime(value)
+    if parsed is None:
+        return None
+    return int(_as_beijing(parsed).strftime("%Y%m%d"))
+
+
+def resolve_trading_day(
+    payload: Mapping[str, Any] | None = None,
+    *,
+    trading_day: Any = None,
+    report_time: Any = None,
+) -> int | None:
+    payload = payload or {}
+    for value in (
+        trading_day,
+        payload.get("trading_day"),
+        payload.get("date"),
+    ):
+        normalized = normalize_trading_day(value)
+        if normalized is not None:
+            return normalized
+    for value in (
+        report_time,
+        payload.get("traded_time"),
+        payload.get("trade_time"),
+        payload.get("order_time"),
+        payload.get("submitted_at"),
+        payload.get("created_at"),
+    ):
+        normalized = normalize_trading_day(value)
+        if normalized is not None:
+            return normalized
+    return None
+
+
+def build_broker_order_key(
+    *,
+    account_id: Any = None,
+    order_sysid: Any = None,
+    trading_day: Any = None,
+    symbol: Any = None,
+    side: Any = None,
+    broker_order_id: Any = None,
+    strict: bool = True,
+) -> str | None:
+    """Return the canonical external broker-order identity when it is complete."""
+
+    account_id = normalize_account_id(account_id)
+    order_sysid = normalize_identifier(order_sysid)
+    trading_day = normalize_trading_day(trading_day)
+    if account_id and trading_day and order_sysid:
+        return f"account:{account_id}:day:{trading_day}:sysid:{order_sysid}"
+
+    symbol = normalize_symbol(symbol)
+    side = normalize_side(side)
+    broker_order_id = normalize_identifier(broker_order_id)
+    if all((account_id, trading_day, symbol, side, broker_order_id)):
+        return (
+            f"account:{account_id}:day:{trading_day}:symbol:{symbol}:"
+            f"side:{side}:order:{broker_order_id}"
+        )
+    if strict:
+        raise BrokerIdentityError(
+            "broker order identity requires account_id + trading_day + order_sysid, or "
+            "account_id + trading_day + symbol + side + broker_order_id"
+        )
+    return None
+
+
+def build_broker_order_key_from_payload(
+    payload: Mapping[str, Any], *, strict: bool = True
+) -> str | None:
+    return build_broker_order_key(
+        account_id=payload.get("account_id"),
+        order_sysid=payload.get("order_sysid"),
+        trading_day=resolve_trading_day(payload),
+        symbol=payload.get("symbol") or payload.get("stock_code"),
+        side=payload.get("side"),
+        broker_order_id=payload.get("broker_order_id") or payload.get("order_id"),
+        strict=strict,
+    )
+
+
+def build_broker_only_internal_order_id(
+    *,
+    account_id: Any = None,
+    order_sysid: Any = None,
+    trading_day: Any = None,
+    symbol: Any = None,
+    side: Any = None,
+    broker_order_id: Any = None,
+) -> str:
+    broker_order_key = build_broker_order_key(
+        account_id=account_id,
+        order_sysid=order_sysid,
+        trading_day=trading_day,
+        symbol=symbol,
+        side=side,
+        broker_order_id=broker_order_id,
+        strict=True,
+    )
+    if broker_order_key is None:  # pragma: no cover - strict mode guarantees this
+        raise BrokerIdentityError("canonical broker order identity is required")
+    assert isinstance(broker_order_key, str)
+    digest = sha256(broker_order_key.encode("utf-8")).hexdigest()[:24]
+    return f"ord_broker_{digest}"
+
+
+def build_execution_identity(payload: Mapping[str, Any]) -> str:
+    broker_trade_id = normalize_identifier(
+        payload.get("broker_trade_id") or payload.get("traded_id")
+    )
+    symbol = normalize_symbol(payload.get("symbol") or payload.get("stock_code"))
+    side = normalize_side(payload.get("side"))
+    trading_day = resolve_trading_day(payload)
+    if broker_trade_id is None or symbol is None or side is None or trading_day is None:
+        raise BrokerIdentityError(
+            "execution identity requires broker_trade_id, trading_day, symbol and side"
+        )
+    account_id = normalize_account_id(payload.get("account_id"))
+    if account_id is None:
+        raise BrokerIdentityError("execution identity requires account_id")
+    assert isinstance(broker_trade_id, str)
+    assert isinstance(symbol, str)
+    assert isinstance(side, str)
+    assert isinstance(trading_day, int)
+    identity = "|".join((account_id, str(trading_day), symbol, side, broker_trade_id))
+    return f"execution:{sha256(identity.encode('utf-8')).hexdigest()}"
+
+
+def identity_conflicts(
+    candidate: Mapping[str, Any], report_identity: Mapping[str, Any]
+) -> dict[str, tuple[Any, Any]]:
+    """Return all dimensions that are known on both sides and disagree."""
+
+    normalizers = {
+        "account_id": normalize_account_id,
+        "order_sysid": normalize_identifier,
+        "trading_day": normalize_trading_day,
+        "symbol": normalize_symbol,
+        "side": normalize_side,
+        "broker_order_id": normalize_identifier,
+    }
+    conflicts: dict[str, tuple[Any, Any]] = {}
+    for field, normalizer in normalizers.items():
+        left = normalizer(candidate.get(field))
+        right = normalizer(report_identity.get(field))
+        if left is not None and right is not None and left != right:
+            conflicts[field] = (left, right)
+    return conflicts
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    except (TypeError, ValueError, OverflowError, OSError):
+        pass
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _as_beijing(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=_BEIJING_TZ)
+    return value.astimezone(_BEIJING_TZ)

--- a/freshquant/order_management/broker_match.py
+++ b/freshquant/order_management/broker_match.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityConflict,
+    identity_conflicts,
+    normalize_account_id,
+    normalize_identifier,
+    normalize_side,
+    normalize_symbol,
+    resolve_trading_day,
+)
 
-_BEIJING_TZ = ZoneInfo("Asia/Shanghai")
 _BUY_ORDER_TYPES = {23, 27, 28, "23", "27", "28", "buy", "BUY"}
 _SELL_ORDER_TYPES = {24, 31, 32, "24", "31", "32", "sell", "SELL"}
 _NONTERMINAL_STATES = {
@@ -27,61 +33,107 @@ def find_order_for_broker_report(
     side=None,
     order_type=None,
     report_time=None,
+    account_id=None,
+    order_sysid=None,
+    trading_day=None,
+    pinned_internal_order_id=None,
 ):
-    if repository is None or broker_order_id in (None, "", "None"):
+    if repository is None:
         return None
-
-    candidates = _list_order_candidates(repository, broker_order_id)
-    if not candidates:
-        return None
-    if len(candidates) == 1:
-        return candidates[0]
 
     report = report or {}
-    symbol = _normalize_symbol(
-        symbol or report.get("symbol") or report.get("stock_code")
-    )
+    report_identity = {
+        "account_id": normalize_account_id(
+            account_id if account_id is not None else report.get("account_id")
+        ),
+        "order_sysid": normalize_identifier(
+            order_sysid if order_sysid is not None else report.get("order_sysid")
+        ),
+        "trading_day": resolve_trading_day(
+            report,
+            trading_day=trading_day,
+            report_time=report_time,
+        ),
+        "symbol": normalize_symbol(
+            symbol or report.get("symbol") or report.get("stock_code")
+        ),
+        "broker_order_id": normalize_identifier(
+            broker_order_id
+            if broker_order_id is not None
+            else report.get("broker_order_id") or report.get("order_id")
+        ),
+    }
     order_type = order_type if order_type is not None else report.get("order_type")
-    side = _normalize_side(side) or side_from_order_type(order_type)
-    report_time = _coalesce_report_time(report_time, report)
+    report_identity["side"] = normalize_side(side) or side_from_order_type(order_type)
 
-    filtered = candidates
-    if symbol:
-        by_symbol = [
-            item for item in filtered if _normalize_symbol(item.get("symbol")) == symbol
+    if pinned_internal_order_id not in (None, "", "None"):
+        candidate = repository.find_order(str(pinned_internal_order_id))
+        if candidate is None:
+            raise BrokerIdentityConflict(
+                f"pinned internal order does not exist: {pinned_internal_order_id}"
+            )
+        conflicts = identity_conflicts(_candidate_identity(candidate), report_identity)
+        if conflicts:
+            dimensions = ", ".join(sorted(conflicts))
+            raise BrokerIdentityConflict(
+                f"pinned internal order conflicts with broker report: {dimensions}"
+            )
+        return candidate
+
+    candidates = _list_order_candidates(
+        repository,
+        broker_order_id=report_identity["broker_order_id"],
+        order_sysid=report_identity["order_sysid"],
+    )
+    compatible = [
+        candidate
+        for candidate in candidates
+        if not identity_conflicts(_candidate_identity(candidate), report_identity)
+    ]
+    if not compatible:
+        return None
+
+    if (
+        report_identity["account_id"]
+        and report_identity["trading_day"]
+        and report_identity["order_sysid"]
+    ):
+        primary = [
+            candidate
+            for candidate in compatible
+            if normalize_account_id(candidate.get("account_id"))
+            == report_identity["account_id"]
+            and resolve_trading_day(candidate) == report_identity["trading_day"]
+            and normalize_identifier(candidate.get("order_sysid"))
+            == report_identity["order_sysid"]
         ]
-        if by_symbol:
-            filtered = by_symbol
+        if len(primary) == 1:
+            return primary[0]
+        if len(primary) > 1:
+            return None
 
-    if side:
-        by_side = [item for item in filtered if _candidate_side(item) in (None, side)]
-        if by_side:
-            filtered = by_side
-
-    if order_type is not None and len(filtered) > 1:
-        report_side = side_from_order_type(order_type)
-        by_order_type = [
-            item
-            for item in filtered
-            if _order_type_equivalent(item.get("broker_order_type"), order_type)
-            or (
-                report_side is not None
-                and side_from_order_type(item.get("broker_order_type")) == report_side
+    fallback_fields = (
+        "account_id",
+        "trading_day",
+        "symbol",
+        "side",
+        "broker_order_id",
+    )
+    if all(report_identity.get(field) is not None for field in fallback_fields):
+        exact_fallback = [
+            candidate
+            for candidate in compatible
+            if all(
+                _candidate_identity(candidate).get(field) == report_identity[field]
+                for field in fallback_fields
             )
         ]
-        if by_order_type:
-            filtered = by_order_type
+        if len(exact_fallback) == 1:
+            return exact_fallback[0]
+        if len(exact_fallback) > 1:
+            return None
 
-    scored = sorted(
-        ((_candidate_score(item, report_time), item) for item in filtered),
-        key=lambda pair: pair[0],
-        reverse=True,
-    )
-    if not scored:
-        return None
-    if len(scored) > 1 and scored[0][0] == scored[1][0]:
-        return None
-    return scored[0][1]
+    return None
 
 
 def side_from_order_type(order_type):
@@ -100,93 +152,48 @@ def side_from_order_type(order_type):
     return None
 
 
-def _list_order_candidates(repository, broker_order_id):
-    if hasattr(repository, "list_orders_by_broker_order_id"):
-        return list(repository.list_orders_by_broker_order_id(broker_order_id))
+def _list_order_candidates(repository, *, broker_order_id, order_sysid):
+    candidates = []
+    if broker_order_id is not None and hasattr(
+        repository, "list_orders_by_broker_order_id"
+    ):
+        candidates.extend(repository.list_orders_by_broker_order_id(broker_order_id))
+    elif broker_order_id is not None and hasattr(
+        repository, "find_order_by_broker_order_id"
+    ):
+        order = repository.find_order_by_broker_order_id(broker_order_id)
+        if order is not None:
+            candidates.append(order)
 
-    order = repository.find_order_by_broker_order_id(broker_order_id)
-    return [order] if order is not None else []
+    if order_sysid is not None and hasattr(repository, "list_orders"):
+        candidates.extend(
+            order
+            for order in repository.list_orders()
+            if normalize_identifier(order.get("order_sysid")) == order_sysid
+        )
+
+    deduplicated = {}
+    for candidate in candidates:
+        key = normalize_identifier(candidate.get("internal_order_id")) or id(candidate)
+        deduplicated[key] = candidate
+    return list(deduplicated.values())
 
 
 def _candidate_side(order):
-    return _normalize_side(order.get("side")) or side_from_order_type(
+    return normalize_side(order.get("side")) or side_from_order_type(
         order.get("broker_order_type")
     )
 
 
-def _candidate_score(order, report_time):
-    state_score = 1 if order.get("state") in _NONTERMINAL_STATES else 0
-    submitted_at = _parse_order_datetime(
-        order.get("submitted_at") or order.get("updated_at") or order.get("created_at")
-    )
-    if report_time is None or submitted_at is None:
-        time_score = 0
-        distance_score = 0
-    else:
-        distance = abs((report_time - submitted_at).total_seconds())
-        time_score = 1
-        distance_score = -distance
-    recency = submitted_at.timestamp() if submitted_at is not None else 0
-    return (time_score, state_score, distance_score, recency)
-
-
-def _coalesce_report_time(report_time, report):
-    if report_time is not None:
-        return _parse_report_datetime(report_time)
-    for key in ("traded_time", "trade_time", "order_time"):
-        if report.get(key) is not None:
-            return _parse_report_datetime(report.get(key))
-    return None
-
-
-def _parse_report_datetime(value):
-    if value in (None, ""):
-        return None
-    if isinstance(value, datetime):
-        return _as_aware(value)
-    try:
-        return datetime.fromtimestamp(float(value), tz=timezone.utc)
-    except (TypeError, ValueError, OSError):
-        return _parse_order_datetime(value)
-
-
-def _parse_order_datetime(value):
-    if value in (None, ""):
-        return None
-    if isinstance(value, datetime):
-        return _as_aware(value)
-    text = str(value).strip()
-    if not text:
-        return None
-    if text.endswith("Z"):
-        text = f"{text[:-1]}+00:00"
-    try:
-        parsed = datetime.fromisoformat(text)
-    except ValueError:
-        return None
-    return _as_aware(parsed)
-
-
-def _as_aware(value):
-    if value.tzinfo is None:
-        return value.replace(tzinfo=_BEIJING_TZ).astimezone(timezone.utc)
-    return value.astimezone(timezone.utc)
-
-
-def _normalize_symbol(value):
-    if value in (None, ""):
-        return None
-    text = str(value).strip().upper()
-    return text[:6] if len(text) >= 6 else text
-
-
-def _normalize_side(value):
-    if value in (None, ""):
-        return None
-    text = str(value).strip().lower()
-    if text in {"buy", "sell"}:
-        return text
-    return None
+def _candidate_identity(order):
+    return {
+        "account_id": order.get("account_id"),
+        "order_sysid": order.get("order_sysid"),
+        "trading_day": resolve_trading_day(order),
+        "symbol": order.get("symbol"),
+        "side": _candidate_side(order),
+        "broker_order_id": order.get("broker_order_id"),
+    }
 
 
 def _order_type_equivalent(left, right):

--- a/freshquant/order_management/broker_match.py
+++ b/freshquant/order_management/broker_match.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from freshquant.order_management.broker_correlation import (
+    looks_like_broker_correlation_token,
+    normalize_broker_correlation_token,
+)
 from freshquant.order_management.broker_identity import (
     BrokerIdentityConflict,
     identity_conflicts,
@@ -37,6 +41,7 @@ def find_order_for_broker_report(
     order_sysid=None,
     trading_day=None,
     pinned_internal_order_id=None,
+    broker_correlation_token=None,
 ):
     if repository is None:
         return None
@@ -65,6 +70,41 @@ def find_order_for_broker_report(
     }
     order_type = order_type if order_type is not None else report.get("order_type")
     report_identity["side"] = normalize_side(side) or side_from_order_type(order_type)
+    report_identity["broker_order_type"] = order_type
+
+    raw_correlation_token = (
+        broker_correlation_token
+        if broker_correlation_token is not None
+        else report.get("broker_correlation_token") or report.get("order_remark")
+    )
+    correlation_token = normalize_broker_correlation_token(raw_correlation_token)
+    if correlation_token is None and looks_like_broker_correlation_token(
+        raw_correlation_token
+    ):
+        raise BrokerIdentityConflict("broker correlation token is malformed")
+    if correlation_token is not None:
+        correlated_order = _find_order_by_broker_correlation_token(
+            repository,
+            correlation_token,
+        )
+        if correlated_order is None:
+            raise BrokerIdentityConflict("broker correlation token is unknown")
+        correlated_internal_order_id = normalize_identifier(
+            correlated_order.get("internal_order_id")
+        )
+        if correlated_internal_order_id is None:
+            raise BrokerIdentityConflict(
+                "broker correlation token has no internal order owner"
+            )
+        if (
+            pinned_internal_order_id not in (None, "", "None")
+            and normalize_identifier(pinned_internal_order_id)
+            != correlated_internal_order_id
+        ):
+            raise BrokerIdentityConflict(
+                "pinned internal order conflicts with broker correlation token"
+            )
+        pinned_internal_order_id = correlated_internal_order_id
 
     if pinned_internal_order_id not in (None, "", "None"):
         candidate = repository.find_order(str(pinned_internal_order_id))
@@ -72,12 +112,17 @@ def find_order_for_broker_report(
             raise BrokerIdentityConflict(
                 f"pinned internal order does not exist: {pinned_internal_order_id}"
             )
-        conflicts = identity_conflicts(_candidate_identity(candidate), report_identity)
+        conflicts = _identity_conflicts(_candidate_identity(candidate), report_identity)
         if conflicts:
             dimensions = ", ".join(sorted(conflicts))
             raise BrokerIdentityConflict(
                 f"pinned internal order conflicts with broker report: {dimensions}"
             )
+        _assert_no_competing_broker_identity(
+            repository,
+            candidate=candidate,
+            report_identity=report_identity,
+        )
         return candidate
 
     candidates = _list_order_candidates(
@@ -88,10 +133,22 @@ def find_order_for_broker_report(
     compatible = [
         candidate
         for candidate in candidates
-        if not identity_conflicts(_candidate_identity(candidate), report_identity)
+        if not _identity_conflicts(_candidate_identity(candidate), report_identity)
     ]
+    matching_unbound_orders = _list_matching_unbound_orders(
+        repository,
+        report_identity=report_identity,
+    )
     if not compatible:
+        if matching_unbound_orders:
+            raise BrokerIdentityConflict(
+                "broker report lacks correlation token for unbound internal order candidates"
+            )
         return None
+    if matching_unbound_orders:
+        raise BrokerIdentityConflict(
+            "broker report has bound and unbound internal order candidates without a correlation token"
+        )
 
     if (
         report_identity["account_id"]
@@ -110,7 +167,9 @@ def find_order_for_broker_report(
         if len(primary) == 1:
             return primary[0]
         if len(primary) > 1:
-            return None
+            raise BrokerIdentityConflict(
+                "broker report matches multiple primary internal orders"
+            )
 
     fallback_fields = (
         "account_id",
@@ -131,7 +190,9 @@ def find_order_for_broker_report(
         if len(exact_fallback) == 1:
             return exact_fallback[0]
         if len(exact_fallback) > 1:
-            return None
+            raise BrokerIdentityConflict(
+                "broker report matches multiple fallback internal orders"
+            )
 
     return None
 
@@ -193,7 +254,95 @@ def _candidate_identity(order):
         "symbol": order.get("symbol"),
         "side": _candidate_side(order),
         "broker_order_id": order.get("broker_order_id"),
+        "broker_order_type": order.get("broker_order_type"),
     }
+
+
+def _identity_conflicts(candidate_identity, report_identity):
+    conflicts = identity_conflicts(candidate_identity, report_identity)
+    candidate_order_type = candidate_identity.get("broker_order_type")
+    report_order_type = report_identity.get("broker_order_type")
+    if (
+        candidate_order_type not in (None, "")
+        and report_order_type not in (None, "")
+        and not _order_type_equivalent(candidate_order_type, report_order_type)
+    ):
+        conflicts["broker_order_type"] = (
+            candidate_order_type,
+            report_order_type,
+        )
+    return conflicts
+
+
+def _find_order_by_broker_correlation_token(repository, token):
+    finder = getattr(repository, "find_order_by_broker_correlation_token", None)
+    if callable(finder):
+        return finder(token)
+    if not hasattr(repository, "list_orders"):
+        return None
+    matches = [
+        order
+        for order in repository.list_orders()
+        if normalize_broker_correlation_token(order.get("broker_correlation_token"))
+        == token
+    ]
+    if len(matches) > 1:
+        raise BrokerIdentityConflict(
+            "broker correlation token has multiple internal order owners"
+        )
+    return matches[0] if matches else None
+
+
+def _list_matching_unbound_orders(repository, *, report_identity):
+    required_fields = ("account_id", "trading_day", "symbol", "side")
+    if not hasattr(repository, "list_orders") or not all(
+        report_identity.get(field) is not None for field in required_fields
+    ):
+        return []
+    try:
+        candidates = repository.list_orders(
+            symbol=report_identity["symbol"],
+            states=_NONTERMINAL_STATES,
+            missing_broker_only=True,
+        )
+    except TypeError:
+        candidates = repository.list_orders()
+    return [
+        candidate
+        for candidate in candidates
+        if normalize_identifier(candidate.get("broker_order_id")) is None
+        and str(candidate.get("state") or "").upper() in _NONTERMINAL_STATES
+        and all(
+            _candidate_identity(candidate).get(field) == report_identity[field]
+            for field in required_fields
+        )
+    ]
+
+
+def _assert_no_competing_broker_identity(
+    repository,
+    *,
+    candidate,
+    report_identity,
+):
+    candidate_internal_order_id = normalize_identifier(
+        candidate.get("internal_order_id")
+    )
+    for other in _list_order_candidates(
+        repository,
+        broker_order_id=report_identity.get("broker_order_id"),
+        order_sysid=report_identity.get("order_sysid"),
+    ):
+        other_internal_order_id = normalize_identifier(other.get("internal_order_id"))
+        if (
+            candidate_internal_order_id is not None
+            and other_internal_order_id == candidate_internal_order_id
+        ):
+            continue
+        if not identity_conflicts(_candidate_identity(other), report_identity):
+            raise BrokerIdentityConflict(
+                "broker identity is already owned by another internal order"
+            )
 
 
 def _order_type_equivalent(left, right):

--- a/freshquant/order_management/ingest/xt_reports.py
+++ b/freshquant/order_management/ingest/xt_reports.py
@@ -6,6 +6,17 @@ from uuid import uuid4
 from loguru import logger
 
 from freshquant.carnation import xtconstant
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityConflict,
+    BrokerIdentityError,
+    build_broker_only_internal_order_id,
+    build_broker_order_key,
+    normalize_account_id,
+    normalize_identifier,
+    normalize_side,
+    normalize_symbol,
+    resolve_trading_day,
+)
 from freshquant.order_management.broker_match import find_order_for_broker_report
 from freshquant.order_management.entry_adapter import (
     list_open_entry_slices_compat,
@@ -153,143 +164,137 @@ class OrderManagementXtIngestService:
                 }
 
             if trade_fact["side"] == "buy":
-                if not _is_board_lot_quantity(trade_fact.get("quantity")):
-                    _record_ingest_rejection(
-                        self.repository,
-                        trade_fact=trade_fact,
-                        reason_code="non_board_lot_quantity",
+                if hasattr(self.repository, "find_buy_lot_by_origin_trade_fact_id"):
+                    buy_lot = self.repository.find_buy_lot_by_origin_trade_fact_id(
+                        trade_fact["trade_fact_id"]
                     )
-                else:
-                    if hasattr(self.repository, "find_buy_lot_by_origin_trade_fact_id"):
-                        buy_lot = self.repository.find_buy_lot_by_origin_trade_fact_id(
-                            trade_fact["trade_fact_id"]
-                        )
-                    if buy_lot is None and hasattr(self.repository, "insert_buy_lot"):
-                        buy_lot = build_buy_lot_from_trade_fact(trade_fact)
-                        self.repository.insert_buy_lot(buy_lot)
-                        lot_slices = arrange_buy_lot(
-                            buy_lot,
-                            lot_amount=lot_amount,
-                            grid_interval=grid_interval_lookup(symbol, trade_fact),
-                        )
-                        self.repository.replace_lot_slices_for_lot(
-                            buy_lot["buy_lot_id"],
-                            lot_slices,
-                        )
-                    if hasattr(self.repository, "replace_position_entry") and hasattr(
+                if buy_lot is None and hasattr(self.repository, "insert_buy_lot"):
+                    buy_lot = build_buy_lot_from_trade_fact(trade_fact)
+                    self.repository.insert_buy_lot(buy_lot)
+                    lot_slices = arrange_buy_lot(
+                        buy_lot,
+                        lot_amount=lot_amount,
+                        grid_interval=grid_interval_lookup(symbol, trade_fact),
+                    )
+                    self.repository.replace_lot_slices_for_lot(
+                        buy_lot["buy_lot_id"],
+                        lot_slices,
+                    )
+                if hasattr(self.repository, "replace_position_entry"):
+                    (
+                        position_entry,
+                        entry_slices,
+                        rebuilt_entry_slices,
+                    ) = _upsert_broker_position_entry(
+                        repository=self.repository,
+                        trade_fact=trade_fact,
+                        lot_amount=lot_amount,
+                        grid_interval=grid_interval_lookup(symbol, trade_fact),
+                        include_rebuild_status=True,
+                    )
+                    if rebuilt_entry_slices and hasattr(
                         self.repository, "replace_entry_slices_for_entry"
                     ):
-                        position_entry, entry_slices = _upsert_broker_position_entry(
-                            repository=self.repository,
-                            trade_fact=trade_fact,
-                            lot_amount=lot_amount,
-                            grid_interval=grid_interval_lookup(symbol, trade_fact),
-                        )
                         self.repository.replace_entry_slices_for_entry(
-                            position_entry["entry_id"],
-                            entry_slices,
+                            position_entry["entry_id"], entry_slices
                         )
-                    holdings_changed = True
-                    self._notify_new_buy_trade(
-                        symbol=symbol,
-                        price=trade_fact["price"],
-                    )
-                if not holdings_changed and hasattr(
-                    self.repository, "list_open_slices"
-                ):
-                    lot_slices = self.repository.list_open_slices(symbol)
+                    else:
+                        _persist_entry_slices_preserving_history(
+                            self.repository,
+                            entry_id=position_entry["entry_id"],
+                            slices=entry_slices,
+                        )
+                holdings_changed = True
+                self._notify_new_buy_trade(
+                    symbol=symbol,
+                    price=trade_fact["price"],
+                )
             elif trade_fact["side"] == "sell":
-                if not _is_board_lot_quantity(trade_fact.get("quantity")):
-                    _record_ingest_rejection(
-                        self.repository,
-                        trade_fact=trade_fact,
-                        reason_code="non_board_lot_quantity",
+                has_v2_entries = False
+                entries = []
+                if hasattr(self.repository, "list_position_entries"):
+                    entries = self.repository.list_position_entries(symbol=symbol)
+                    has_v2_entries = bool(entries)
+                if entries and hasattr(self.repository, "list_open_entry_slices"):
+                    open_entry_slices = self.repository.list_open_entry_slices(
+                        symbol=symbol
                     )
-                else:
-                    if hasattr(self.repository, "list_position_entries") and hasattr(
-                        self.repository, "list_open_entry_slices"
-                    ):
-                        entries = self.repository.list_position_entries(symbol=symbol)
-                        open_entry_slices = self.repository.list_open_entry_slices(
-                            symbol=symbol
-                        )
-                        if entries and open_entry_slices:
-                            preferred_entry_quantities = (
-                                _resolve_trade_preferred_entry_quantities(
-                                    repository=self.repository,
-                                    report=report,
-                                    execution_fill=execution_fill,
-                                    trade_fact=trade_fact,
-                                )
+                    if open_entry_slices:
+                        preferred_entry_quantities = (
+                            _resolve_trade_preferred_entry_quantities(
+                                repository=self.repository,
+                                report=report,
+                                execution_fill=execution_fill,
+                                trade_fact=trade_fact,
                             )
-                            exit_allocations = allocate_sell_to_entry_slices(
-                                entries=entries,
-                                open_slices=open_entry_slices,
+                        )
+                        exit_allocations = allocate_sell_to_entry_slices(
+                            entries=entries,
+                            open_slices=open_entry_slices,
+                            sell_trade_fact=trade_fact,
+                            preferred_entry_quantities=preferred_entry_quantities,
+                        )
+                        for item in entries:
+                            self.repository.replace_position_entry(item)
+                        touched_entry_ids = {
+                            item.get("entry_id")
+                            for item in open_entry_slices
+                            if item.get("entry_id")
+                        }
+                        for entry_id in touched_entry_ids:
+                            _persist_entry_slices_preserving_history(
+                                self.repository,
+                                entry_id=entry_id,
+                                slices=[
+                                    item
+                                    for item in open_entry_slices
+                                    if item.get("entry_id") == entry_id
+                                ],
+                            )
+                        self.repository.insert_exit_allocations(exit_allocations)
+                        entry_slices = open_entry_slices
+                        holdings_changed = holdings_changed or bool(exit_allocations)
+                if (
+                    not has_v2_entries
+                    and hasattr(self.repository, "list_buy_lots")
+                    and hasattr(self.repository, "list_open_slices")
+                ):
+                    buy_lots = self.repository.list_buy_lots(symbol)
+                    open_slices = self.repository.list_open_slices(symbol)
+                    should_attempt_legacy_allocation = (
+                        bool(buy_lots and open_slices) or not exit_allocations
+                    )
+                    if should_attempt_legacy_allocation:
+                        try:
+                            sell_allocations = allocate_sell_to_slices(
+                                buy_lots=buy_lots,
+                                open_slices=open_slices,
                                 sell_trade_fact=trade_fact,
-                                preferred_entry_quantities=preferred_entry_quantities,
                             )
-                            for item in entries:
-                                self.repository.replace_position_entry(item)
-                            touched_entry_ids = {
-                                item.get("entry_id")
-                                for item in open_entry_slices
-                                if item.get("entry_id")
-                            }
-                            for entry_id in touched_entry_ids:
-                                self.repository.replace_entry_slices_for_entry(
-                                    entry_id,
-                                    [
-                                        item
-                                        for item in open_entry_slices
-                                        if item.get("entry_id") == entry_id
-                                    ],
-                                )
-                            self.repository.insert_exit_allocations(exit_allocations)
-                            entry_slices = open_entry_slices
-                            holdings_changed = holdings_changed or bool(
+                        except ValueError as exc:
+                            if (
                                 exit_allocations
-                            )
-                    if hasattr(self.repository, "list_buy_lots") and hasattr(
-                        self.repository, "list_open_slices"
-                    ):
-                        buy_lots = self.repository.list_buy_lots(symbol)
-                        open_slices = self.repository.list_open_slices(symbol)
-                        should_attempt_legacy_allocation = (
-                            bool(buy_lots and open_slices) or not exit_allocations
-                        )
-                        if should_attempt_legacy_allocation:
-                            try:
-                                sell_allocations = allocate_sell_to_slices(
-                                    buy_lots=buy_lots,
-                                    open_slices=open_slices,
-                                    sell_trade_fact=trade_fact,
+                                and str(exc)
+                                == "sell quantity exceeds open guardian slices"
+                            ):
+                                logger.info(
+                                    "skip legacy sell allocation after authoritative V2 exit allocation: symbol={} internal_order_id={} broker_trade_id={}",
+                                    symbol,
+                                    trade_fact.get("internal_order_id"),
+                                    trade_fact.get("broker_trade_id"),
                                 )
-                            except ValueError as exc:
-                                if (
-                                    exit_allocations
-                                    and str(exc)
-                                    == "sell quantity exceeds open guardian slices"
-                                ):
-                                    logger.info(
-                                        "skip legacy sell allocation after authoritative V2 exit allocation: symbol={} internal_order_id={} broker_trade_id={}",
-                                        symbol,
-                                        trade_fact.get("internal_order_id"),
-                                        trade_fact.get("broker_trade_id"),
-                                    )
-                                else:
-                                    raise
                             else:
-                                for item in buy_lots:
-                                    self.repository.replace_buy_lot(item)
-                                self.repository.replace_open_slices(open_slices)
-                                self.repository.insert_sell_allocations(
-                                    sell_allocations
-                                )
-                                holdings_changed = holdings_changed or bool(
-                                    sell_allocations
-                                )
-                    if holdings_changed:
-                        self._reset_guardian_buy_grid_after_sell(symbol)
+                                raise
+                        else:
+                            for item in buy_lots:
+                                self.repository.replace_buy_lot(item)
+                            self.repository.replace_open_slices(open_slices)
+                            self.repository.insert_sell_allocations(sell_allocations)
+                            holdings_changed = holdings_changed or bool(
+                                sell_allocations
+                            )
+                if holdings_changed:
+                    self._reset_guardian_buy_grid_after_sell(symbol)
 
             projections = _build_entry_projections(symbol, repository=self.repository)
             if holdings_changed:
@@ -421,43 +426,132 @@ class OrderManagementXtIngestService:
 
 
 def normalize_xt_trade_report(report, repository=None):
-    if "side" in report and "broker_trade_id" in report:
-        return report
-
-    traded_time = report["traded_time"]
+    is_normalized = "side" in report and "broker_trade_id" in report
+    traded_time = report.get("trade_time") or report.get("traded_time")
+    if traded_time is None:
+        raise BrokerIdentityError("trade_time is required")
     traded_datetime = _xt_timestamp_to_datetime(traded_time)
     stock_code = report.get("stock_code", "")
-    symbol = report.get("symbol") or stock_code[:6]
-    order_id = report.get("order_id")
-    internal_order_id = report.get("internal_order_id")
+    symbol = normalize_symbol(report.get("symbol") or stock_code)
+    order_id = normalize_identifier(
+        report.get("broker_order_id") or report.get("order_id")
+    )
+    internal_order_id = normalize_identifier(report.get("internal_order_id"))
     order = None
     order_type = report.get("order_type")
-    if internal_order_id is not None and repository is not None:
-        order = repository.find_order(internal_order_id)
-    if internal_order_id is None and repository is not None and order_id is not None:
-        order = find_order_for_broker_report(
-            repository,
-            broker_order_id=order_id,
-            report=report,
-            symbol=symbol,
-            order_type=order_type,
-            report_time=traded_time,
+    side = normalize_side(report.get("side")) or _map_xt_order_type_to_side(order_type)
+    if side is None:
+        _record_identity_quarantine(
+            repository, report=report, reason_code="unknown_order_side"
         )
-        if order is not None:
-            internal_order_id = order["internal_order_id"]
-    if order is not None and order.get("broker_order_type") is not None:
-        order_type = order.get("broker_order_type")
+        raise BrokerIdentityError(
+            "unknown XT order_type; trade side cannot be resolved"
+        )
+    trading_day = resolve_trading_day(report, report_time=traded_time) or int(
+        traded_datetime.strftime("%Y%m%d")
+    )
+    account_id = normalize_account_id(report.get("account_id"))
+    if account_id is None:
+        _record_identity_quarantine(
+            repository, report=report, reason_code="missing_account_id"
+        )
+        raise BrokerIdentityError("XT trade report requires account_id")
+    order_sysid = normalize_identifier(report.get("order_sysid"))
+    try:
+        if repository is not None and internal_order_id is not None:
+            order = find_order_for_broker_report(
+                repository,
+                broker_order_id=order_id,
+                report=report,
+                symbol=symbol,
+                side=side,
+                order_type=order_type,
+                report_time=traded_time,
+                account_id=account_id,
+                order_sysid=order_sysid,
+                trading_day=trading_day,
+                pinned_internal_order_id=internal_order_id,
+            )
+        elif repository is not None:
+            order = find_order_for_broker_report(
+                repository,
+                broker_order_id=order_id,
+                report=report,
+                symbol=symbol,
+                side=side,
+                order_type=order_type,
+                report_time=traded_time,
+                account_id=account_id,
+                order_sysid=order_sysid,
+                trading_day=trading_day,
+            )
+            if order is not None:
+                internal_order_id = order["internal_order_id"]
+    except BrokerIdentityConflict:
+        _record_identity_quarantine(
+            repository, report=report, reason_code="broker_identity_conflict"
+        )
+        raise
+    account_id = account_id or normalize_account_id((order or {}).get("account_id"))
+    order_sysid = order_sysid or normalize_identifier((order or {}).get("order_sysid"))
+    if internal_order_id is None:
+        broker_order_key = build_broker_order_key(
+            account_id=account_id,
+            order_sysid=order_sysid,
+            trading_day=trading_day,
+            symbol=symbol,
+            side=side,
+            broker_order_id=order_id,
+            strict=False,
+        )
+        if broker_order_key is None:
+            _record_identity_quarantine(
+                repository,
+                report=report,
+                reason_code="incomplete_broker_order_identity",
+            )
+            raise BrokerIdentityError(
+                "unmatched XT trade report requires a complete broker order identity"
+            )
+        internal_order_id = build_broker_only_internal_order_id(
+            account_id=account_id,
+            order_sysid=order_sysid,
+            trading_day=trading_day,
+            symbol=symbol,
+            side=side,
+            broker_order_id=order_id,
+        )
+    broker_order_key = build_broker_order_key(
+        account_id=account_id,
+        order_sysid=order_sysid,
+        trading_day=trading_day,
+        symbol=symbol,
+        side=side,
+        broker_order_id=order_id,
+        strict=False,
+    )
     return {
-        "internal_order_id": internal_order_id or str(order_id),
-        "broker_order_id": str(order_id) if order_id is not None else None,
-        "broker_trade_id": str(report["traded_id"]),
+        **report,
+        "internal_order_id": internal_order_id,
+        "broker_order_key": broker_order_key
+        or (order or {}).get("broker_order_key")
+        or internal_order_id,
+        "broker_order_id": order_id,
+        "broker_trade_id": normalize_identifier(
+            report.get("broker_trade_id") or report.get("traded_id")
+        ),
+        "account_id": account_id,
+        "order_sysid": order_sysid,
+        "trading_day": trading_day,
         "symbol": symbol,
-        "side": _map_xt_order_type_to_side(order_type),
-        "quantity": report["traded_volume"],
-        "price": report["traded_price"],
+        "side": side,
+        "quantity": (
+            report.get("quantity") if is_normalized else report.get("traded_volume")
+        ),
+        "price": (report.get("price") if is_normalized else report.get("traded_price")),
         "trade_time": traded_time,
-        "date": int(traded_datetime.strftime("%Y%m%d")),
-        "time": traded_datetime.strftime("%H:%M:%S"),
+        "date": report.get("date") or trading_day,
+        "time": report.get("time") or traded_datetime.strftime("%H:%M:%S"),
         "source": report.get("source", "xt_trade_callback"),
         "strategy_name": report.get("strategy_name"),
         "request_id": report.get("request_id") or (order or {}).get("request_id"),
@@ -467,39 +561,121 @@ def normalize_xt_trade_report(report, repository=None):
 
 
 def normalize_xt_order_report(report, repository=None):
-    if "state" in report and "internal_order_id" in report:
-        return report
-
-    broker_order_id = report.get("broker_order_id") or report.get("order_id")
+    is_normalized = "state" in report and "internal_order_id" in report
+    broker_order_id = normalize_identifier(
+        report.get("broker_order_id") or report.get("order_id")
+    )
     if broker_order_id is None:
         return None
-    internal_order_id = report.get("internal_order_id")
+    internal_order_id = normalize_identifier(report.get("internal_order_id"))
+    symbol = normalize_symbol(report.get("symbol") or report.get("stock_code"))
+    side = normalize_side(report.get("side")) or _map_xt_order_type_to_side(
+        report.get("order_type")
+    )
+    account_id = normalize_account_id(report.get("account_id"))
+    if account_id is None:
+        _record_identity_quarantine(
+            repository, report=report, reason_code="missing_account_id"
+        )
+        raise BrokerIdentityError("XT order report requires account_id")
+    order_sysid = normalize_identifier(report.get("order_sysid"))
+    trading_day = resolve_trading_day(
+        report, report_time=report.get("order_time") or report.get("submitted_at")
+    )
     order = None
-    if internal_order_id is None and repository is not None:
-        order = find_order_for_broker_report(
-            repository,
-            broker_order_id=broker_order_id,
-            report=report,
-            symbol=report.get("symbol") or report.get("stock_code"),
-            order_type=report.get("order_type"),
-            report_time=report.get("order_time"),
+    try:
+        if internal_order_id is not None and repository is not None:
+            order = find_order_for_broker_report(
+                repository,
+                broker_order_id=broker_order_id,
+                report=report,
+                symbol=symbol,
+                side=side,
+                order_type=report.get("order_type"),
+                report_time=report.get("order_time") or report.get("submitted_at"),
+                account_id=account_id,
+                order_sysid=order_sysid,
+                trading_day=trading_day,
+                pinned_internal_order_id=internal_order_id,
+            )
+        elif repository is not None:
+            order = find_order_for_broker_report(
+                repository,
+                broker_order_id=broker_order_id,
+                report=report,
+                symbol=symbol,
+                side=side,
+                order_type=report.get("order_type"),
+                report_time=report.get("order_time"),
+                account_id=account_id,
+                order_sysid=order_sysid,
+                trading_day=trading_day,
+            )
+            if order is not None:
+                internal_order_id = order["internal_order_id"]
+    except BrokerIdentityConflict:
+        _record_identity_quarantine(
+            repository, report=report, reason_code="broker_identity_conflict"
         )
-        if order is not None:
-            internal_order_id = order["internal_order_id"]
-    else:
-        order = (
-            repository.find_order(internal_order_id) if repository is not None else None
-        )
+        raise
+    account_id = account_id or normalize_account_id((order or {}).get("account_id"))
+    order_sysid = order_sysid or normalize_identifier((order or {}).get("order_sysid"))
+    symbol = symbol or normalize_symbol((order or {}).get("symbol"))
+    side = side or normalize_side((order or {}).get("side"))
+    trading_day = trading_day or resolve_trading_day(order or {})
     if internal_order_id is None:
-        if repository is not None:
+        broker_order_key = build_broker_order_key(
+            account_id=account_id,
+            order_sysid=order_sysid,
+            trading_day=trading_day,
+            symbol=symbol,
+            side=side,
+            broker_order_id=broker_order_id,
+            strict=False,
+        )
+        if broker_order_key is None:
+            _record_identity_quarantine(
+                repository,
+                report=report,
+                reason_code="incomplete_broker_order_identity",
+            )
             return None
-        internal_order_id = str(broker_order_id)
-        order = None
+        internal_order_id = build_broker_only_internal_order_id(
+            account_id=account_id,
+            order_sysid=order_sysid,
+            trading_day=trading_day,
+            symbol=symbol,
+            side=side,
+            broker_order_id=broker_order_id,
+        )
+    broker_order_key = build_broker_order_key(
+        account_id=account_id,
+        order_sysid=order_sysid,
+        trading_day=trading_day,
+        symbol=symbol,
+        side=side,
+        broker_order_id=broker_order_id,
+        strict=False,
+    )
 
     return {
+        **report,
         "internal_order_id": internal_order_id,
-        "broker_order_id": str(broker_order_id),
-        "state": _map_xt_order_status_to_state(report.get("order_status")),
+        "broker_order_key": broker_order_key
+        or (order or {}).get("broker_order_key")
+        or internal_order_id,
+        "broker_order_id": broker_order_id,
+        "account_id": account_id,
+        "order_sysid": order_sysid,
+        "trading_day": trading_day,
+        "symbol": symbol,
+        "side": side,
+        "broker_order_type": report.get("order_type"),
+        "state": (
+            report.get("state")
+            if is_normalized
+            else _map_xt_order_status_to_state(report.get("order_status"))
+        ),
         "event_type": "xt_order_reported",
         "request_id": report.get("request_id") or (order or {}).get("request_id"),
         "trace_id": report.get("trace_id") or (order or {}).get("trace_id"),
@@ -596,6 +772,67 @@ def _record_ingest_rejection(repository, *, trade_fact, reason_code):
     return document
 
 
+def _record_identity_quarantine(repository, *, report, reason_code):
+    if repository is None or not hasattr(repository, "insert_ingest_rejection"):
+        return None
+    traded_time = report.get("traded_time") or report.get("trade_time")
+    document = {
+        "rejection_id": f"reject_{uuid4().hex}",
+        "account_id": normalize_account_id(report.get("account_id")),
+        "order_sysid": normalize_identifier(report.get("order_sysid")),
+        "trading_day": resolve_trading_day(report, report_time=traded_time),
+        "symbol": normalize_symbol(report.get("symbol") or report.get("stock_code")),
+        "broker_order_id": normalize_identifier(
+            report.get("broker_order_id") or report.get("order_id")
+        ),
+        "broker_trade_id": normalize_identifier(
+            report.get("broker_trade_id") or report.get("traded_id")
+        ),
+        "internal_order_id": normalize_identifier(report.get("internal_order_id")),
+        "reason_code": reason_code,
+        "quantity": int(report.get("quantity") or report.get("traded_volume") or 0),
+        "trade_time": traded_time,
+        "source": report.get("source") or "xt_report",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    repository.insert_ingest_rejection(document)
+    return document
+
+
+def _persist_entry_slices_preserving_history(repository, *, entry_id, slices):
+    slices = [dict(item) for item in slices]
+    if hasattr(repository, "upsert_entry_slices"):
+        return repository.upsert_entry_slices(slices)
+
+    existing = []
+    if hasattr(repository, "list_entry_slices"):
+        existing = repository.list_entry_slices(entry_ids=[entry_id])
+    else:
+        collection = getattr(repository, "entry_slices", None)
+        if isinstance(collection, list):
+            existing = [item for item in collection if item.get("entry_id") == entry_id]
+        elif hasattr(collection, "find"):
+            existing = list(collection.find({"entry_id": entry_id}))
+
+    by_slice_id = {
+        item.get("entry_slice_id"): dict(item)
+        for item in existing
+        if item.get("entry_slice_id")
+    }
+    for item in slices:
+        slice_id = item.get("entry_slice_id")
+        if not slice_id:
+            raise ValueError("entry_slice_id is required")
+        by_slice_id[slice_id] = item
+
+    if hasattr(repository, "replace_entry_slices_for_entry"):
+        return repository.replace_entry_slices_for_entry(
+            entry_id,
+            list(by_slice_id.values()),
+        )
+    raise RuntimeError("repository cannot safely persist entry slices")
+
+
 def _build_entry_projections(symbol, *, repository):
     if hasattr(repository, "list_trade_facts"):
         trade_facts = repository.list_trade_facts(symbol)
@@ -684,9 +921,12 @@ def _upsert_broker_position_entry(
     trade_fact,
     lot_amount,
     grid_interval,
+    include_rebuild_status=False,
 ):
     symbol = trade_fact["symbol"]
-    broker_order_key = str(trade_fact.get("internal_order_id") or "").strip()
+    broker_order_key = str(
+        trade_fact.get("broker_order_key") or trade_fact.get("internal_order_id") or ""
+    ).strip()
     broker_order = (
         repository.find_broker_order(broker_order_key)
         if hasattr(repository, "find_broker_order")
@@ -730,13 +970,15 @@ def _upsert_broker_position_entry(
             symbol=symbol,
             entry_ids=[entry["entry_id"]],
         )
-        return entry, entry_slices
+        result = (entry, entry_slices, False)
+        return result if include_rebuild_status else result[:2]
     entry_slices = arrange_entry(
         entry,
         lot_amount=lot_amount,
         grid_interval=grid_interval,
     )
-    return entry, entry_slices
+    result = (entry, entry_slices, True)
+    return result if include_rebuild_status else result[:2]
 
 
 def _map_xt_order_status_to_state(order_status):
@@ -773,7 +1015,7 @@ def _map_xt_order_type_to_side(order_type):
         return "buy"
     if order_type in _SELL_ORDER_TYPES:
         return "sell"
-    return "sell"
+    return None
 
 
 def _xt_timestamp_to_datetime(timestamp):

--- a/freshquant/order_management/ingest/xt_reports.py
+++ b/freshquant/order_management/ingest/xt_reports.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 
+from copy import deepcopy
 from datetime import datetime, timezone
 from uuid import uuid4
 
 from loguru import logger
 
 from freshquant.carnation import xtconstant
+from freshquant.order_management.broker_correlation import (
+    normalize_broker_correlation_token,
+)
 from freshquant.order_management.broker_identity import (
     BrokerIdentityConflict,
     BrokerIdentityError,
@@ -36,7 +40,6 @@ from freshquant.order_management.guardian.arranger import (
     arrange_buy_lot,
     arrange_entry,
     build_buy_lot_from_trade_fact,
-    build_position_entry_from_trade_fact,
 )
 from freshquant.order_management.projection.cache_invalidator import (
     mark_stock_holdings_projection_updated,
@@ -82,20 +85,22 @@ _SELL_ORDER_TYPES = {
     "SELL",
 }
 
+_DEFAULT_TPSL_SERVICE = object()
+
 
 class OrderManagementXtIngestService:
     def __init__(
         self,
         repository=None,
         tracking_service=None,
-        tpsl_service=None,
+        tpsl_service=_DEFAULT_TPSL_SERVICE,
         runtime_logger=None,
     ):
         self.repository = repository or OrderManagementRepository()
         self.tracking_service = tracking_service or OrderTrackingService(
             repository=self.repository
         )
-        self.tpsl_service = tpsl_service or _get_tpsl_service()
+        self.tpsl_service = tpsl_service
         self.runtime_logger = runtime_logger or _get_runtime_logger()
 
     def ingest_trade_report(self, report, lot_amount, grid_interval_lookup):
@@ -122,184 +127,75 @@ class OrderManagementXtIngestService:
             exit_allocations = []
             holdings_changed = False
 
-            if not created:
-                if trade_fact["side"] == "buy":
-                    position_entry = _find_position_entry_for_broker_order(
-                        self.repository,
-                        symbol=symbol,
-                        broker_order_key=(
-                            (execution_fill or {}).get("broker_order_key")
-                            or trade_fact.get("internal_order_id")
-                        ),
-                    )
-                    if position_entry is not None and hasattr(
-                        self.repository, "list_open_entry_slices"
-                    ):
-                        entry_slices = self.repository.list_open_entry_slices(
-                            symbol=symbol,
-                            entry_ids=[position_entry["entry_id"]],
-                        )
-                if trade_fact["side"] == "buy" and hasattr(
-                    self.repository, "find_buy_lot_by_origin_trade_fact_id"
-                ):
-                    buy_lot = self.repository.find_buy_lot_by_origin_trade_fact_id(
-                        trade_fact["trade_fact_id"]
-                    )
-                if hasattr(self.repository, "list_open_slices"):
-                    lot_slices = self.repository.list_open_slices(symbol)
-                projections = _build_entry_projections(
-                    symbol, repository=self.repository
+            projection_status = str(
+                (execution_fill or {}).get("projection_status") or ""
+            ).upper()
+            if not projection_status and created:
+                projection_status = "PENDING"
+            if projection_status != "PENDING":
+                return _build_replayed_trade_result(
+                    repository=self.repository,
+                    trade_fact=trade_fact,
+                    execution_fill=execution_fill,
                 )
-                return {
-                    "trade_fact": trade_fact,
-                    "execution_fill": execution_fill,
-                    "buy_lot": buy_lot,
-                    "position_entry": position_entry,
-                    "lot_slices": lot_slices,
-                    "entry_slices": entry_slices,
-                    "sell_allocations": [],
-                    "exit_allocations": [],
-                    "created": False,
-                    "projections": projections,
-                }
 
-            if trade_fact["side"] == "buy":
-                if hasattr(self.repository, "find_buy_lot_by_origin_trade_fact_id"):
-                    buy_lot = self.repository.find_buy_lot_by_origin_trade_fact_id(
-                        trade_fact["trade_fact_id"]
-                    )
-                if buy_lot is None and hasattr(self.repository, "insert_buy_lot"):
-                    buy_lot = build_buy_lot_from_trade_fact(trade_fact)
-                    self.repository.insert_buy_lot(buy_lot)
-                    lot_slices = arrange_buy_lot(
-                        buy_lot,
-                        lot_amount=lot_amount,
-                        grid_interval=grid_interval_lookup(symbol, trade_fact),
-                    )
-                    self.repository.replace_lot_slices_for_lot(
-                        buy_lot["buy_lot_id"],
-                        lot_slices,
-                    )
-                if hasattr(self.repository, "replace_position_entry"):
-                    (
-                        position_entry,
-                        entry_slices,
-                        rebuilt_entry_slices,
-                    ) = _upsert_broker_position_entry(
+            projection_plan = (execution_fill or {}).get("projection_plan")
+            if projection_plan is None:
+                projection_plan = _build_execution_projection_plan(
+                    repository=self.repository,
+                    report=report,
+                    execution_fill=execution_fill,
+                    trade_fact=trade_fact,
+                    lot_amount=lot_amount,
+                    grid_interval=grid_interval_lookup(symbol, trade_fact),
+                )
+                execution_fill = _prepare_execution_projection(
+                    repository=self.repository,
+                    execution_fill=execution_fill,
+                    projection_plan=projection_plan,
+                )
+                if str(execution_fill.get("projection_status") or "").upper() == (
+                    "APPLIED"
+                ):
+                    return _build_replayed_trade_result(
                         repository=self.repository,
                         trade_fact=trade_fact,
-                        lot_amount=lot_amount,
-                        grid_interval=grid_interval_lookup(symbol, trade_fact),
-                        include_rebuild_status=True,
+                        execution_fill=execution_fill,
                     )
-                    if rebuilt_entry_slices and hasattr(
-                        self.repository, "replace_entry_slices_for_entry"
-                    ):
-                        self.repository.replace_entry_slices_for_entry(
-                            position_entry["entry_id"], entry_slices
-                        )
-                    else:
-                        _persist_entry_slices_preserving_history(
-                            self.repository,
-                            entry_id=position_entry["entry_id"],
-                            slices=entry_slices,
-                        )
-                holdings_changed = True
+                projection_plan = execution_fill.get("projection_plan")
+
+            applied = _apply_execution_projection_plan(
+                repository=self.repository,
+                projection_plan=projection_plan,
+            )
+            buy_lot = applied.get("buy_lot")
+            lot_slices = applied.get("lot_slices", [])
+            position_entry = applied.get("position_entry")
+            entry_slices = applied.get("entry_slices", [])
+            sell_allocations = applied.get("sell_allocations", [])
+            exit_allocations = applied.get("exit_allocations", [])
+            holdings_changed = bool(applied.get("holdings_changed"))
+
+            if trade_fact["side"] == "buy":
                 self._notify_new_buy_trade(
                     symbol=symbol,
                     price=trade_fact["price"],
                 )
-            elif trade_fact["side"] == "sell":
-                has_v2_entries = False
-                entries = []
-                if hasattr(self.repository, "list_position_entries"):
-                    entries = self.repository.list_position_entries(symbol=symbol)
-                    has_v2_entries = bool(entries)
-                if entries and hasattr(self.repository, "list_open_entry_slices"):
-                    open_entry_slices = self.repository.list_open_entry_slices(
-                        symbol=symbol
-                    )
-                    if open_entry_slices:
-                        preferred_entry_quantities = (
-                            _resolve_trade_preferred_entry_quantities(
-                                repository=self.repository,
-                                report=report,
-                                execution_fill=execution_fill,
-                                trade_fact=trade_fact,
-                            )
-                        )
-                        exit_allocations = allocate_sell_to_entry_slices(
-                            entries=entries,
-                            open_slices=open_entry_slices,
-                            sell_trade_fact=trade_fact,
-                            preferred_entry_quantities=preferred_entry_quantities,
-                        )
-                        for item in entries:
-                            self.repository.replace_position_entry(item)
-                        touched_entry_ids = {
-                            item.get("entry_id")
-                            for item in open_entry_slices
-                            if item.get("entry_id")
-                        }
-                        for entry_id in touched_entry_ids:
-                            _persist_entry_slices_preserving_history(
-                                self.repository,
-                                entry_id=entry_id,
-                                slices=[
-                                    item
-                                    for item in open_entry_slices
-                                    if item.get("entry_id") == entry_id
-                                ],
-                            )
-                        self.repository.insert_exit_allocations(exit_allocations)
-                        entry_slices = open_entry_slices
-                        holdings_changed = holdings_changed or bool(exit_allocations)
-                if (
-                    not has_v2_entries
-                    and hasattr(self.repository, "list_buy_lots")
-                    and hasattr(self.repository, "list_open_slices")
-                ):
-                    buy_lots = self.repository.list_buy_lots(symbol)
-                    open_slices = self.repository.list_open_slices(symbol)
-                    should_attempt_legacy_allocation = (
-                        bool(buy_lots and open_slices) or not exit_allocations
-                    )
-                    if should_attempt_legacy_allocation:
-                        try:
-                            sell_allocations = allocate_sell_to_slices(
-                                buy_lots=buy_lots,
-                                open_slices=open_slices,
-                                sell_trade_fact=trade_fact,
-                            )
-                        except ValueError as exc:
-                            if (
-                                exit_allocations
-                                and str(exc)
-                                == "sell quantity exceeds open guardian slices"
-                            ):
-                                logger.info(
-                                    "skip legacy sell allocation after authoritative V2 exit allocation: symbol={} internal_order_id={} broker_trade_id={}",
-                                    symbol,
-                                    trade_fact.get("internal_order_id"),
-                                    trade_fact.get("broker_trade_id"),
-                                )
-                            else:
-                                raise
-                        else:
-                            for item in buy_lots:
-                                self.repository.replace_buy_lot(item)
-                            self.repository.replace_open_slices(open_slices)
-                            self.repository.insert_sell_allocations(sell_allocations)
-                            holdings_changed = holdings_changed or bool(
-                                sell_allocations
-                            )
-                if holdings_changed:
-                    self._reset_guardian_buy_grid_after_sell(symbol)
+            elif trade_fact["side"] == "sell" and holdings_changed:
+                self._reset_guardian_buy_grid_after_sell(symbol)
 
             projections = _build_entry_projections(symbol, repository=self.repository)
             if holdings_changed:
                 mark_stock_holdings_projection_updated()
                 _sync_stock_fills_compat(symbol, repository=self.repository)
+            _assert_execution_projection_plan_applied(
+                repository=self.repository,
+                projection_plan=projection_plan,
+            )
+            execution_fill = _mark_execution_projection_applied(
+                repository=self.repository,
+                execution_fill=execution_fill,
+            )
             self._emit_runtime(
                 "report_receive", report, extra_payload={"report_type": "trade"}
             )
@@ -311,8 +207,8 @@ class OrderManagementXtIngestService:
                     "side": trade_fact["side"],
                     "quantity": trade_fact["quantity"],
                     "holdings_changed": holdings_changed,
-                    "created": True,
-                    "dedup_hit": False,
+                    "created": created,
+                    "dedup_hit": not created,
                 },
             )
 
@@ -341,6 +237,8 @@ class OrderManagementXtIngestService:
             raise
 
     def _notify_new_buy_trade(self, *, symbol, price):
+        if self.tpsl_service is _DEFAULT_TPSL_SERVICE:
+            self.tpsl_service = _get_tpsl_service()
         if self.tpsl_service is None:
             return
         try:
@@ -554,6 +452,9 @@ def normalize_xt_trade_report(report, repository=None):
         "time": report.get("time") or traded_datetime.strftime("%H:%M:%S"),
         "source": report.get("source", "xt_trade_callback"),
         "strategy_name": report.get("strategy_name"),
+        "broker_correlation_token": normalize_broker_correlation_token(
+            report.get("broker_correlation_token") or report.get("order_remark")
+        ),
         "request_id": report.get("request_id") or (order or {}).get("request_id"),
         "trace_id": report.get("trace_id") or (order or {}).get("trace_id"),
         "intent_id": report.get("intent_id") or (order or {}).get("intent_id"),
@@ -671,6 +572,9 @@ def normalize_xt_order_report(report, repository=None):
         "symbol": symbol,
         "side": side,
         "broker_order_type": report.get("order_type"),
+        "broker_correlation_token": normalize_broker_correlation_token(
+            report.get("broker_correlation_token") or report.get("order_remark")
+        ),
         "state": (
             report.get("state")
             if is_normalized
@@ -833,6 +737,1005 @@ def _persist_entry_slices_preserving_history(repository, *, entry_id, slices):
     raise RuntimeError("repository cannot safely persist entry slices")
 
 
+def _build_replayed_trade_result(*, repository, trade_fact, execution_fill):
+    symbol = trade_fact["symbol"]
+    position_entry = None
+    entry_slices = []
+    buy_lot = None
+    if trade_fact["side"] == "buy":
+        position_entry = _find_position_entry_for_broker_order(
+            repository,
+            symbol=symbol,
+            broker_order_key=(
+                (execution_fill or {}).get("broker_order_key")
+                or trade_fact.get("broker_order_key")
+                or trade_fact.get("internal_order_id")
+            ),
+        )
+        if position_entry is not None and hasattr(repository, "list_open_entry_slices"):
+            entry_slices = repository.list_open_entry_slices(
+                symbol=symbol,
+                entry_ids=[position_entry["entry_id"]],
+            )
+        if hasattr(repository, "find_buy_lot_by_origin_trade_fact_id"):
+            buy_lot = repository.find_buy_lot_by_origin_trade_fact_id(
+                trade_fact["trade_fact_id"]
+            )
+    lot_slices = (
+        repository.list_open_slices(symbol)
+        if hasattr(repository, "list_open_slices")
+        else []
+    )
+    return {
+        "trade_fact": trade_fact,
+        "execution_fill": execution_fill,
+        "buy_lot": buy_lot,
+        "position_entry": position_entry,
+        "lot_slices": lot_slices,
+        "entry_slices": entry_slices,
+        "sell_allocations": [],
+        "exit_allocations": [],
+        "created": False,
+        "projections": _build_entry_projections(symbol, repository=repository),
+    }
+
+
+def _build_execution_projection_plan(
+    *,
+    repository,
+    report,
+    execution_fill,
+    trade_fact,
+    lot_amount,
+    grid_interval,
+):
+    if trade_fact["side"] == "buy":
+        return _build_buy_execution_projection_plan(
+            repository=repository,
+            trade_fact=trade_fact,
+            lot_amount=lot_amount,
+            grid_interval=grid_interval,
+        )
+    if trade_fact["side"] == "sell":
+        return _build_sell_execution_projection_plan(
+            repository=repository,
+            report=report,
+            execution_fill=execution_fill,
+            trade_fact=trade_fact,
+        )
+    raise BrokerIdentityConflict("execution projection side is unsupported")
+
+
+def _build_buy_execution_projection_plan(
+    *, repository, trade_fact, lot_amount, grid_interval
+):
+    plan = _new_projection_plan(trade_fact)
+    buy_lot = None
+    if hasattr(repository, "find_buy_lot_by_origin_trade_fact_id"):
+        buy_lot = repository.find_buy_lot_by_origin_trade_fact_id(
+            trade_fact["trade_fact_id"]
+        )
+    before_buy_lot = _projection_document(buy_lot)
+    if buy_lot is None and hasattr(repository, "insert_buy_lot"):
+        buy_lot = build_buy_lot_from_trade_fact(trade_fact)
+    after_buy_lot = _projection_document(buy_lot)
+    if after_buy_lot is not None:
+        plan["buy_lots"].append({"before": before_buy_lot, "after": after_buy_lot})
+        before_lot_slices = _list_lot_slices_for_lot(
+            repository,
+            after_buy_lot["buy_lot_id"],
+        )
+        after_lot_slices = before_lot_slices
+        if before_buy_lot is None:
+            after_lot_slices = arrange_buy_lot(
+                deepcopy(after_buy_lot),
+                lot_amount=lot_amount,
+                grid_interval=grid_interval,
+            )
+        plan["lot_slice_groups"].append(
+            {
+                "operation_id": _new_projection_group_operation_id(),
+                "buy_lot_id": after_buy_lot["buy_lot_id"],
+                "before": _projection_documents(before_lot_slices),
+                "after": _projection_documents(after_lot_slices),
+            }
+        )
+
+    if hasattr(repository, "replace_position_entry"):
+        position_entry, entry_slices, rebuilt_entry_slices = (
+            _upsert_broker_position_entry(
+                repository=repository,
+                trade_fact=trade_fact,
+                lot_amount=lot_amount,
+                grid_interval=grid_interval,
+                include_rebuild_status=True,
+                persist=False,
+            )
+        )
+        before_entry = _find_position_entry(
+            repository,
+            position_entry["entry_id"],
+        )
+        plan["position_entries"].append(
+            {
+                "before": _projection_document(before_entry),
+                "after": _projection_document(position_entry),
+            }
+        )
+        before_entry_slices = _list_entry_slices_for_entry(
+            repository,
+            position_entry["entry_id"],
+        )
+        if rebuilt_entry_slices:
+            after_entry_slices = entry_slices
+        else:
+            after_entry_slices = _merge_projection_documents(
+                before_entry_slices,
+                entry_slices,
+                identity_field="entry_slice_id",
+            )
+        plan["entry_slice_groups"].append(
+            {
+                "operation_id": _new_projection_group_operation_id(),
+                "entry_id": position_entry["entry_id"],
+                "before": _projection_documents(before_entry_slices),
+                "after": _projection_documents(after_entry_slices),
+            }
+        )
+    return plan
+
+
+def _build_sell_execution_projection_plan(
+    *, repository, report, execution_fill, trade_fact
+):
+    plan = _new_projection_plan(trade_fact)
+    entries_before = (
+        repository.list_position_entries(symbol=trade_fact["symbol"])
+        if hasattr(repository, "list_position_entries")
+        else []
+    )
+    has_v2_entries = bool(entries_before)
+    if entries_before:
+        if not hasattr(repository, "list_open_entry_slices"):
+            raise BrokerIdentityConflict(
+                "sell execution projection requires V2 entry slices"
+            )
+        open_entry_slices_before = repository.list_open_entry_slices(
+            symbol=trade_fact["symbol"]
+        )
+        _assert_open_entry_inventory_consistent(
+            entries=entries_before,
+            open_slices=open_entry_slices_before,
+            symbol=trade_fact["symbol"],
+        )
+        entries_after = deepcopy(entries_before)
+        open_entry_slices_after = deepcopy(open_entry_slices_before)
+        exit_allocations = allocate_sell_to_entry_slices(
+            entries=entries_after,
+            open_slices=open_entry_slices_after,
+            sell_trade_fact=trade_fact,
+            preferred_entry_quantities=_resolve_trade_preferred_entry_quantities(
+                repository=repository,
+                report=report,
+                execution_fill=execution_fill,
+                trade_fact=trade_fact,
+            ),
+        )
+        before_entries_by_id = {item["entry_id"]: item for item in entries_before}
+        for item in entries_after:
+            plan["position_entries"].append(
+                {
+                    "before": _projection_document(
+                        before_entries_by_id.get(item["entry_id"])
+                    ),
+                    "after": _projection_document(item),
+                }
+            )
+        touched_entry_ids = {
+            item.get("entry_id")
+            for item in open_entry_slices_after
+            if item.get("entry_id")
+        }
+        for entry_id in touched_entry_ids:
+            before_group = _list_entry_slices_for_entry(repository, entry_id)
+            changed = [
+                item
+                for item in open_entry_slices_after
+                if item.get("entry_id") == entry_id
+            ]
+            after_group = _merge_projection_documents(
+                before_group,
+                changed,
+                identity_field="entry_slice_id",
+            )
+            plan["entry_slice_groups"].append(
+                {
+                    "operation_id": _new_projection_group_operation_id(),
+                    "entry_id": entry_id,
+                    "before": _projection_documents(before_group),
+                    "after": _projection_documents(after_group),
+                }
+            )
+        plan["exit_allocations"] = _projection_documents(exit_allocations)
+
+    if (
+        not has_v2_entries
+        and hasattr(repository, "list_buy_lots")
+        and hasattr(repository, "list_open_slices")
+    ):
+        buy_lots_before = repository.list_buy_lots(trade_fact["symbol"])
+        open_slices_before = repository.list_open_slices(trade_fact["symbol"])
+        _assert_open_buy_lot_inventory_consistent(
+            buy_lots=buy_lots_before,
+            open_slices=open_slices_before,
+            symbol=trade_fact["symbol"],
+        )
+        buy_lots_after = deepcopy(buy_lots_before)
+        open_slices_after = deepcopy(open_slices_before)
+        sell_allocations = allocate_sell_to_slices(
+            buy_lots=buy_lots_after,
+            open_slices=open_slices_after,
+            sell_trade_fact=trade_fact,
+        )
+        before_lots_by_id = {item["buy_lot_id"]: item for item in buy_lots_before}
+        for item in buy_lots_after:
+            plan["buy_lots"].append(
+                {
+                    "before": _projection_document(
+                        before_lots_by_id.get(item["buy_lot_id"])
+                    ),
+                    "after": _projection_document(item),
+                }
+            )
+        touched_lot_ids = {
+            item.get("buy_lot_id")
+            for item in open_slices_after
+            if item.get("buy_lot_id")
+        }
+        for buy_lot_id in touched_lot_ids:
+            before_group = _list_lot_slices_for_lot(repository, buy_lot_id)
+            changed = [
+                item
+                for item in open_slices_after
+                if item.get("buy_lot_id") == buy_lot_id
+            ]
+            after_group = _merge_projection_documents(
+                before_group,
+                changed,
+                identity_field="lot_slice_id",
+            )
+            plan["lot_slice_groups"].append(
+                {
+                    "operation_id": _new_projection_group_operation_id(),
+                    "buy_lot_id": buy_lot_id,
+                    "before": _projection_documents(before_group),
+                    "after": _projection_documents(after_group),
+                }
+            )
+        plan["sell_allocations"] = _projection_documents(sell_allocations)
+    if not plan["exit_allocations"] and not plan["sell_allocations"]:
+        raise BrokerIdentityConflict(
+            "sell execution projection requires allocatable canonical inventory"
+        )
+    return plan
+
+
+def _new_projection_plan(trade_fact):
+    return {
+        "version": 1,
+        "execution_identity": trade_fact.get("execution_identity"),
+        "trade_fact_id": trade_fact.get("trade_fact_id"),
+        "symbol": trade_fact.get("symbol"),
+        "side": trade_fact.get("side"),
+        "buy_lots": [],
+        "lot_slice_groups": [],
+        "position_entries": [],
+        "entry_slice_groups": [],
+        "sell_allocations": [],
+        "exit_allocations": [],
+    }
+
+
+def _new_projection_group_operation_id():
+    return f"projection_group_{uuid4().hex}"
+
+
+def _prepare_execution_projection(*, repository, execution_fill, projection_plan):
+    execution_identity = (execution_fill or {}).get("execution_identity") or (
+        projection_plan.get("execution_identity")
+    )
+    if hasattr(repository, "prepare_execution_projection"):
+        return repository.prepare_execution_projection(
+            execution_identity,
+            projection_plan,
+        )
+    saved = dict(execution_fill or {})
+    saved["projection_status"] = "PENDING"
+    saved["projection_plan"] = deepcopy(projection_plan)
+    if isinstance(execution_fill, dict):
+        execution_fill.update(saved)
+        return execution_fill
+    return saved
+
+
+def _mark_execution_projection_applied(*, repository, execution_fill):
+    execution_identity = (execution_fill or {}).get("execution_identity")
+    applied_at = datetime.now(timezone.utc).isoformat()
+    if hasattr(repository, "mark_execution_projection_applied"):
+        return repository.mark_execution_projection_applied(
+            execution_identity,
+            applied_at=applied_at,
+        )
+    saved = dict(execution_fill or {})
+    saved["projection_status"] = "APPLIED"
+    saved["projection_applied_at"] = applied_at
+    if isinstance(execution_fill, dict):
+        execution_fill.update(saved)
+        return execution_fill
+    return saved
+
+
+def _apply_execution_projection_plan(*, repository, projection_plan):
+    if int((projection_plan or {}).get("version") or 0) != 1:
+        raise BrokerIdentityConflict("execution projection plan version is unsupported")
+    _assert_execution_projection_plan_recoverable(
+        repository=repository,
+        projection_plan=projection_plan,
+    )
+
+    for operation in projection_plan.get("buy_lots") or []:
+        _apply_projection_document_operation(
+            repository,
+            projection_type="buy_lot",
+            before=operation.get("before"),
+            after=operation.get("after"),
+            current_lookup=lambda document: _find_buy_lot(
+                repository, document["buy_lot_id"]
+            ),
+            label=f"buy_lot:{operation['after']['buy_lot_id']}",
+        )
+
+    for group in projection_plan.get("lot_slice_groups") or []:
+        _apply_projection_group(
+            repository,
+            projection_type="lot_slice",
+            current=_list_lot_slices_for_lot(repository, group["buy_lot_id"]),
+            before=group.get("before") or [],
+            after=group.get("after") or [],
+            identity_field="lot_slice_id",
+            label=f"lot_slices:{group['buy_lot_id']}",
+        )
+
+    for operation in projection_plan.get("position_entries") or []:
+        _apply_projection_document_operation(
+            repository,
+            projection_type="position_entry",
+            before=operation.get("before"),
+            after=operation.get("after"),
+            current_lookup=lambda document: _find_position_entry(
+                repository, document["entry_id"]
+            ),
+            label=f"position_entry:{operation['after']['entry_id']}",
+        )
+
+    for group in projection_plan.get("entry_slice_groups") or []:
+        _apply_projection_group(
+            repository,
+            projection_type="entry_slice",
+            current=_list_entry_slices_for_entry(repository, group["entry_id"]),
+            before=group.get("before") or [],
+            after=group.get("after") or [],
+            identity_field="entry_slice_id",
+            label=f"entry_slices:{group['entry_id']}",
+        )
+
+    _persist_projection_allocations(
+        repository,
+        allocation_type="sell",
+        documents=projection_plan.get("sell_allocations") or [],
+    )
+    _persist_projection_allocations(
+        repository,
+        allocation_type="exit",
+        documents=projection_plan.get("exit_allocations") or [],
+    )
+    _assert_execution_projection_plan_applied(
+        repository=repository,
+        projection_plan=projection_plan,
+    )
+
+    position_entries = [
+        deepcopy(item["after"])
+        for item in projection_plan.get("position_entries") or []
+    ]
+    buy_lots = [
+        deepcopy(item["after"]) for item in projection_plan.get("buy_lots") or []
+    ]
+    lot_slices = [
+        deepcopy(item)
+        for group in projection_plan.get("lot_slice_groups") or []
+        for item in group.get("after") or []
+    ]
+    entry_slices = [
+        deepcopy(item)
+        for group in projection_plan.get("entry_slice_groups") or []
+        for item in group.get("after") or []
+    ]
+    sell_allocations = deepcopy(projection_plan.get("sell_allocations") or [])
+    exit_allocations = deepcopy(projection_plan.get("exit_allocations") or [])
+    return {
+        "buy_lot": buy_lots[0] if buy_lots else None,
+        "lot_slices": lot_slices,
+        "position_entry": position_entries[0] if position_entries else None,
+        "entry_slices": entry_slices,
+        "sell_allocations": sell_allocations,
+        "exit_allocations": exit_allocations,
+        "holdings_changed": bool(
+            projection_plan.get("side") == "buy" or sell_allocations or exit_allocations
+        ),
+    }
+
+
+def _assert_execution_projection_plan_recoverable(*, repository, projection_plan):
+    for operation in projection_plan.get("buy_lots") or []:
+        after = operation["after"]
+        current = _find_buy_lot(repository, after["buy_lot_id"])
+        _assert_projection_document_recoverable(
+            current,
+            before=operation.get("before"),
+            after=after,
+            label=f"buy_lot:{after['buy_lot_id']}",
+        )
+    for operation in projection_plan.get("position_entries") or []:
+        after = operation["after"]
+        current = _find_position_entry(repository, after["entry_id"])
+        _assert_projection_document_recoverable(
+            current,
+            before=operation.get("before"),
+            after=after,
+            label=f"position_entry:{after['entry_id']}",
+        )
+    for group in projection_plan.get("lot_slice_groups") or []:
+        _assert_projection_group_recoverable(
+            _list_lot_slices_for_lot(repository, group["buy_lot_id"]),
+            before=group.get("before") or [],
+            after=group.get("after") or [],
+            identity_field="lot_slice_id",
+            label=f"lot_slices:{group['buy_lot_id']}",
+        )
+    for group in projection_plan.get("entry_slice_groups") or []:
+        _assert_projection_group_recoverable(
+            _list_entry_slices_for_entry(repository, group["entry_id"]),
+            before=group.get("before") or [],
+            after=group.get("after") or [],
+            identity_field="entry_slice_id",
+            label=f"entry_slices:{group['entry_id']}",
+        )
+    for allocation_type, documents in (
+        ("sell", projection_plan.get("sell_allocations") or []),
+        ("exit", projection_plan.get("exit_allocations") or []),
+    ):
+        _assert_projection_allocations_recoverable(
+            repository,
+            allocation_type=allocation_type,
+            documents=documents,
+        )
+
+
+def _assert_execution_projection_plan_applied(*, repository, projection_plan):
+    for operation in projection_plan.get("buy_lots") or []:
+        after = operation["after"]
+        current = _find_buy_lot(repository, after["buy_lot_id"])
+        if not _projection_documents_equal(current, after):
+            raise BrokerIdentityConflict(
+                f"execution projection postimage diverged at buy_lot:{after['buy_lot_id']}"
+            )
+    for operation in projection_plan.get("position_entries") or []:
+        after = operation["after"]
+        current = _find_position_entry(repository, after["entry_id"])
+        if not _projection_documents_equal(current, after):
+            raise BrokerIdentityConflict(
+                "execution projection postimage diverged at "
+                f"position_entry:{after['entry_id']}"
+            )
+    for group in projection_plan.get("lot_slice_groups") or []:
+        current = _list_lot_slices_for_lot(repository, group["buy_lot_id"])
+        if not _projection_document_groups_equal(current, group.get("after") or []):
+            raise BrokerIdentityConflict(
+                "execution projection postimage diverged at "
+                f"lot_slices:{group['buy_lot_id']}"
+            )
+    for group in projection_plan.get("entry_slice_groups") or []:
+        current = _list_entry_slices_for_entry(repository, group["entry_id"])
+        if not _projection_document_groups_equal(current, group.get("after") or []):
+            raise BrokerIdentityConflict(
+                "execution projection postimage diverged at "
+                f"entry_slices:{group['entry_id']}"
+            )
+    for allocation_type, documents in (
+        ("sell", projection_plan.get("sell_allocations") or []),
+        ("exit", projection_plan.get("exit_allocations") or []),
+    ):
+        _assert_projection_allocations_recoverable(
+            repository,
+            allocation_type=allocation_type,
+            documents=documents,
+            require_present=True,
+        )
+
+
+def _assert_projection_document_recoverable(current, *, before, after, label):
+    if _projection_documents_equal(current, before) or _projection_documents_equal(
+        current, after
+    ):
+        return
+    raise BrokerIdentityConflict(f"execution projection diverged at {label}")
+
+
+def _assert_projection_group_recoverable(
+    current, *, before, after, identity_field, label
+):
+    states, _steps = _projection_group_transition(
+        before=before,
+        after=after,
+        identity_field=identity_field,
+        label=label,
+    )
+    for index, state in enumerate(states):
+        if _projection_document_groups_equal(current, state):
+            return index
+    raise BrokerIdentityConflict(f"execution projection diverged at {label}")
+
+
+def _apply_projection_document_operation(
+    repository,
+    *,
+    projection_type,
+    before,
+    after,
+    current_lookup,
+    label,
+):
+    if after is None:
+        raise BrokerIdentityConflict(
+            f"execution projection requires postimage at {label}"
+        )
+    current = current_lookup(after)
+    if _projection_documents_equal(current, after):
+        return
+    _assert_projection_document_recoverable(
+        current,
+        before=before,
+        after=after,
+        label=label,
+    )
+    _compare_and_set_projection_document(
+        repository,
+        projection_type=projection_type,
+        before=before,
+        after=after,
+    )
+
+
+def _apply_projection_group(
+    repository,
+    *,
+    projection_type,
+    current,
+    before,
+    after,
+    identity_field,
+    label,
+):
+    states, steps = _projection_group_transition(
+        before=before,
+        after=after,
+        identity_field=identity_field,
+        label=label,
+    )
+    completed_steps = None
+    for index, state in enumerate(states):
+        if _projection_document_groups_equal(current, state):
+            completed_steps = index
+            break
+    if completed_steps is None:
+        raise BrokerIdentityConflict(f"execution projection diverged at {label}")
+    for step in steps[completed_steps:]:
+        _compare_and_set_projection_document(
+            repository,
+            projection_type=projection_type,
+            before=step.get("before"),
+            after=step.get("after"),
+        )
+
+
+def _compare_and_set_projection_document(
+    repository,
+    *,
+    projection_type,
+    before,
+    after,
+):
+    compare_and_set = getattr(repository, "compare_and_set_projection_document", None)
+    if callable(compare_and_set):
+        return compare_and_set(
+            projection_type,
+            before=deepcopy(before),
+            after=deepcopy(after),
+        )
+    return _compare_and_set_in_memory_projection_document(
+        repository,
+        projection_type=projection_type,
+        before=before,
+        after=after,
+    )
+
+
+def _compare_and_set_in_memory_projection_document(
+    repository,
+    *,
+    projection_type,
+    before,
+    after,
+):
+    targets = {
+        "buy_lot": ("buy_lots", "buy_lot_id"),
+        "lot_slice": ("lot_slices", "lot_slice_id"),
+        "position_entry": ("position_entries", "entry_id"),
+        "entry_slice": ("entry_slices", "entry_slice_id"),
+    }
+    attribute_name, identity_field = targets.get(projection_type, (None, None))
+    collection = getattr(repository, attribute_name, None) if attribute_name else None
+    if not isinstance(collection, list):
+        raise BrokerIdentityConflict(
+            "repository cannot atomically apply execution projection"
+        )
+    identity = normalize_identifier((after or before or {}).get(identity_field))
+    if identity is None:
+        raise BrokerIdentityConflict(f"execution projection requires {identity_field}")
+    matches = [
+        (index, document)
+        for index, document in enumerate(collection)
+        if normalize_identifier(document.get(identity_field)) == identity
+    ]
+    if len(matches) > 1:
+        raise BrokerIdentityConflict(
+            f"execution projection compare-and-set conflict at {projection_type}:{identity}"
+        )
+    current = matches[0][1] if matches else None
+    if _projection_documents_equal(current, after):
+        return current
+    if not _projection_documents_equal(current, before):
+        raise BrokerIdentityConflict(
+            f"execution projection compare-and-set conflict at {projection_type}:{identity}"
+        )
+    if after is None:
+        if matches:
+            del collection[matches[0][0]]
+        return None
+    saved = deepcopy(after)
+    if matches:
+        collection[matches[0][0]] = saved
+    else:
+        collection.append(saved)
+    return saved
+
+
+def _projection_group_transition(*, before, after, identity_field, label):
+    before_by_id, before_order = _projection_group_documents_by_identity(
+        before,
+        identity_field=identity_field,
+        label=label,
+    )
+    after_by_id, after_order = _projection_group_documents_by_identity(
+        after,
+        identity_field=identity_field,
+        label=label,
+    )
+    state = {
+        identity: deepcopy(document) for identity, document in before_by_id.items()
+    }
+    states = [list(state.values())]
+    steps = []
+
+    for identity in before_order:
+        before_document = before_by_id[identity]
+        after_document = after_by_id.get(identity)
+        if _projection_documents_equal(before_document, after_document):
+            continue
+        steps.append(
+            {
+                "before": deepcopy(before_document),
+                "after": deepcopy(after_document),
+            }
+        )
+        if after_document is None:
+            state.pop(identity, None)
+        else:
+            state[identity] = deepcopy(after_document)
+        states.append(list(state.values()))
+
+    for identity in after_order:
+        if identity in before_by_id:
+            continue
+        after_document = after_by_id[identity]
+        steps.append({"before": None, "after": deepcopy(after_document)})
+        state[identity] = deepcopy(after_document)
+        states.append(list(state.values()))
+    return states, steps
+
+
+def _projection_group_documents_by_identity(documents, *, identity_field, label):
+    by_identity = {}
+    order = []
+    for raw_document in list(documents or []):
+        document = _projection_document(raw_document)
+        identity = normalize_identifier(document.get(identity_field))
+        if identity is None:
+            raise BrokerIdentityConflict(
+                f"execution projection requires {identity_field} at {label}"
+            )
+        if identity in by_identity:
+            raise BrokerIdentityConflict(
+                f"execution projection contains duplicate {identity_field} at {label}"
+            )
+        document[identity_field] = identity
+        by_identity[identity] = document
+        order.append(identity)
+    return by_identity, order
+
+
+def _assert_projection_allocations_recoverable(
+    repository,
+    *,
+    allocation_type,
+    documents,
+    require_present=False,
+):
+    expected_by_id = _projection_allocations_by_identity(
+        documents,
+        allocation_type=allocation_type,
+    )
+    existing_by_id = {allocation_id: [] for allocation_id in expected_by_id}
+    for document in _list_projection_allocations(
+        repository,
+        allocation_type=allocation_type,
+    ):
+        allocation_id = normalize_identifier(document.get("allocation_id"))
+        if allocation_id in existing_by_id:
+            existing_by_id[allocation_id].append(document)
+    for allocation_id, existing in existing_by_id.items():
+        if len(existing) > 1:
+            raise BrokerIdentityConflict(
+                f"execution projection has duplicate allocation:{allocation_id}"
+            )
+        if require_present and not existing:
+            raise BrokerIdentityConflict(
+                f"execution projection allocation is missing:{allocation_id}"
+            )
+        if existing and not _projection_documents_equal(
+            existing[0], expected_by_id[allocation_id]
+        ):
+            raise BrokerIdentityConflict(
+                f"execution projection diverged at allocation:{allocation_id}"
+            )
+
+
+def _projection_allocations_by_identity(documents, *, allocation_type):
+    by_identity = {}
+    for raw_document in list(documents or []):
+        document = _projection_document(raw_document)
+        allocation_id = normalize_identifier(document.get("allocation_id"))
+        if allocation_id is None:
+            raise BrokerIdentityConflict(
+                f"execution projection {allocation_type} allocation_id is required"
+            )
+        if allocation_id in by_identity:
+            raise BrokerIdentityConflict(
+                f"execution projection contains duplicate allocation_id:{allocation_id}"
+            )
+        document["allocation_id"] = allocation_id
+        by_identity[allocation_id] = document
+    return by_identity
+
+
+def _persist_projection_allocations(repository, *, allocation_type, documents):
+    expected_by_id = _projection_allocations_by_identity(
+        documents,
+        allocation_type=allocation_type,
+    )
+    _assert_projection_allocations_recoverable(
+        repository,
+        allocation_type=allocation_type,
+        documents=list(expected_by_id.values()),
+        require_present=False,
+    )
+    existing_ids = {
+        normalize_identifier(item.get("allocation_id"))
+        for item in _list_projection_allocations(
+            repository,
+            allocation_type=allocation_type,
+        )
+    }
+    missing = [
+        deepcopy(document)
+        for allocation_id, document in expected_by_id.items()
+        if allocation_id not in existing_ids
+    ]
+    if not missing:
+        return
+    if allocation_type == "exit":
+        repository.insert_exit_allocations(missing)
+    else:
+        repository.insert_sell_allocations(missing)
+    _assert_projection_allocations_recoverable(
+        repository,
+        allocation_type=allocation_type,
+        documents=list(expected_by_id.values()),
+        require_present=True,
+    )
+
+
+def _list_projection_allocations(repository, *, allocation_type):
+    method_name = (
+        "list_exit_allocations"
+        if allocation_type == "exit"
+        else "list_sell_allocations"
+    )
+    method = getattr(repository, method_name, None)
+    if callable(method):
+        return list(method())
+    attribute_name = (
+        "exit_allocations" if allocation_type == "exit" else "sell_allocations"
+    )
+    collection = getattr(repository, attribute_name, None)
+    if isinstance(collection, list):
+        return list(collection)
+    if hasattr(collection, "find"):
+        return list(collection.find({}))
+    return []
+
+
+def _find_buy_lot(repository, buy_lot_id):
+    if hasattr(repository, "find_buy_lot"):
+        return repository.find_buy_lot(buy_lot_id)
+    for item in getattr(repository, "buy_lots", []) or []:
+        if item.get("buy_lot_id") == buy_lot_id:
+            return item
+    return None
+
+
+def _find_position_entry(repository, entry_id):
+    if hasattr(repository, "find_position_entry"):
+        return repository.find_position_entry(entry_id)
+    for item in getattr(repository, "position_entries", []) or []:
+        if item.get("entry_id") == entry_id:
+            return item
+    return None
+
+
+def _list_lot_slices_for_lot(repository, buy_lot_id):
+    if hasattr(repository, "list_lot_slices"):
+        return repository.list_lot_slices(buy_lot_ids=[buy_lot_id])
+    collection = getattr(repository, "lot_slices", None)
+    if isinstance(collection, list):
+        return [item for item in collection if item.get("buy_lot_id") == buy_lot_id]
+    if hasattr(collection, "find"):
+        return list(collection.find({"buy_lot_id": buy_lot_id}))
+    return []
+
+
+def _list_entry_slices_for_entry(repository, entry_id):
+    if hasattr(repository, "list_entry_slices"):
+        return repository.list_entry_slices(entry_ids=[entry_id])
+    collection = getattr(repository, "entry_slices", None)
+    if isinstance(collection, list):
+        return [item for item in collection if item.get("entry_id") == entry_id]
+    if hasattr(collection, "find"):
+        return list(collection.find({"entry_id": entry_id}))
+    return []
+
+
+def _assert_open_entry_inventory_consistent(*, entries, open_slices, symbol):
+    expected_by_entry = {
+        str(item.get("entry_id") or "").strip(): int(
+            item.get("remaining_quantity") or 0
+        )
+        for item in list(entries or [])
+        if int(item.get("remaining_quantity") or 0) > 0
+    }
+    if not expected_by_entry:
+        raise BrokerIdentityConflict(
+            f"sell execution has no open V2 inventory for {symbol}"
+        )
+    actual_by_entry = {entry_id: 0 for entry_id in expected_by_entry}
+    for item in list(open_slices or []):
+        entry_id = str(item.get("entry_id") or "").strip()
+        remaining_quantity = int(item.get("remaining_quantity") or 0)
+        if remaining_quantity <= 0:
+            continue
+        if entry_id not in expected_by_entry:
+            raise BrokerIdentityConflict(
+                f"sell execution V2 slice references unknown open entry for {symbol}"
+            )
+        actual_by_entry[entry_id] += remaining_quantity
+    if actual_by_entry != expected_by_entry:
+        raise BrokerIdentityConflict(
+            f"sell execution V2 entry slices do not match open inventory for {symbol}"
+        )
+
+
+def _assert_open_buy_lot_inventory_consistent(*, buy_lots, open_slices, symbol):
+    expected_by_lot = {
+        str(item.get("buy_lot_id") or "").strip(): int(
+            item.get("remaining_quantity") or 0
+        )
+        for item in list(buy_lots or [])
+        if int(item.get("remaining_quantity") or 0) > 0
+    }
+    if not expected_by_lot:
+        raise BrokerIdentityConflict(
+            f"sell execution has no open legacy inventory for {symbol}"
+        )
+    actual_by_lot = {buy_lot_id: 0 for buy_lot_id in expected_by_lot}
+    for item in list(open_slices or []):
+        buy_lot_id = str(item.get("buy_lot_id") or "").strip()
+        remaining_quantity = int(item.get("remaining_quantity") or 0)
+        if remaining_quantity <= 0:
+            continue
+        if buy_lot_id not in expected_by_lot:
+            raise BrokerIdentityConflict(
+                f"sell execution legacy slice references unknown buy lot for {symbol}"
+            )
+        actual_by_lot[buy_lot_id] += remaining_quantity
+    if actual_by_lot != expected_by_lot:
+        raise BrokerIdentityConflict(
+            f"sell execution legacy slices do not match open inventory for {symbol}"
+        )
+
+
+def _merge_projection_documents(existing, updates, *, identity_field):
+    by_identity = {
+        item.get(identity_field): _projection_document(item)
+        for item in existing
+        if item.get(identity_field) is not None
+    }
+    for item in updates:
+        identity = item.get(identity_field)
+        if identity is None:
+            raise BrokerIdentityConflict(
+                f"execution projection requires {identity_field}"
+            )
+        by_identity[identity] = _projection_document(item)
+    return list(by_identity.values())
+
+
+def _projection_document(document):
+    if document is None:
+        return None
+    return {
+        key: deepcopy(value) for key, value in dict(document).items() if key != "_id"
+    }
+
+
+def _projection_documents(documents):
+    return [_projection_document(item) for item in list(documents or [])]
+
+
+def _projection_documents_equal(left, right):
+    return _projection_document(left) == _projection_document(right)
+
+
+def _projection_document_groups_equal(left, right):
+    return sorted(
+        _projection_documents(left),
+        key=lambda item: repr(sorted(item.items())),
+    ) == sorted(
+        _projection_documents(right),
+        key=lambda item: repr(sorted(item.items())),
+    )
+
+
 def _build_entry_projections(symbol, *, repository):
     if hasattr(repository, "list_trade_facts"):
         trade_facts = repository.list_trade_facts(symbol)
@@ -922,6 +1825,7 @@ def _upsert_broker_position_entry(
     lot_amount,
     grid_interval,
     include_rebuild_status=False,
+    persist=True,
 ):
     symbol = trade_fact["symbol"]
     broker_order_key = str(
@@ -962,14 +1866,62 @@ def _upsert_broker_position_entry(
         broker_order_key=broker_order_key,
         existing_entry=existing_entry,
     )
-    repository.replace_position_entry(entry)
+    if persist:
+        repository.replace_position_entry(entry)
     if not entry_requires_slice_rebuild(existing_entry) and hasattr(
         repository, "list_open_entry_slices"
     ):
-        entry_slices = repository.list_open_entry_slices(
+        existing_open_slices = repository.list_open_entry_slices(
             symbol=symbol,
             entry_ids=[entry["entry_id"]],
         )
+        existing_remaining_quantity = int(
+            (existing_entry or {}).get("remaining_quantity") or 0
+        )
+        sliced_remaining_quantity = sum(
+            int(item.get("remaining_quantity") or 0) for item in existing_open_slices
+        )
+        if sliced_remaining_quantity != existing_remaining_quantity:
+            raise BrokerIdentityConflict(
+                "late buy fill cannot extend an entry whose open slices diverge"
+            )
+        added_remaining_quantity = (
+            int(entry.get("remaining_quantity") or 0) - existing_remaining_quantity
+        )
+        if added_remaining_quantity < 0:
+            raise BrokerIdentityConflict(
+                "late buy fill reduced canonical entry remaining quantity"
+            )
+        incremental_slices = []
+        if added_remaining_quantity > 0:
+            incremental_entry = {
+                **entry,
+                "original_quantity": added_remaining_quantity,
+                "remaining_quantity": added_remaining_quantity,
+                "amount": round(
+                    float(entry.get("entry_price") or 0.0) * added_remaining_quantity,
+                    2,
+                ),
+            }
+            incremental_slices = arrange_entry(
+                incremental_entry,
+                lot_amount=lot_amount,
+                grid_interval=grid_interval,
+            )
+            existing_all_slices = _list_entry_slices_for_entry(
+                repository,
+                entry["entry_id"],
+            )
+            next_slice_seq = (
+                max(
+                    [int(item.get("slice_seq") or 0) for item in existing_all_slices]
+                    or [-1]
+                )
+                + 1
+            )
+            for offset, item in enumerate(incremental_slices):
+                item["slice_seq"] = next_slice_seq + offset
+        entry_slices = [*existing_open_slices, *incremental_slices]
         result = (entry, entry_slices, False)
         return result if include_rebuild_status else result[:2]
     entry_slices = arrange_entry(

--- a/freshquant/order_management/rebuild/service.py
+++ b/freshquant/order_management/rebuild/service.py
@@ -1,7 +1,20 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 
+from freshquant.order_management.allocation_integrity import (
+    find_exit_allocation_integrity_errors,
+)
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityConflict,
+    BrokerIdentityError,
+    build_broker_order_key,
+    build_execution_identity,
+    identity_conflicts,
+    normalize_account_id,
+    resolve_trading_day,
+)
 from freshquant.order_management.entry_aggregation import (
     build_clustered_position_entry,
     build_reconciliation_resolution_member_key,
@@ -19,6 +32,7 @@ from freshquant.order_management.guardian.arranger import (
     build_position_entry_from_trade_fact,
 )
 from freshquant.order_management.ids import (
+    new_execution_fill_id,
     new_reconciliation_gap_id,
     new_reconciliation_resolution_id,
     new_trade_fact_id,
@@ -63,74 +77,74 @@ class OrderLedgerV2RebuildService:
 
         broker_orders_by_key = {}
         broker_order_keys = []
-        order_match_to_broker_order_key = {}
-        cross_day_reused_order_ids = _collect_cross_day_reused_order_ids(
-            xt_orders=xt_orders,
-        )
-        cross_day_reused_trade_only_ids = _collect_cross_day_reused_order_ids(
-            xt_orders=xt_trades,
-        )
-        cross_day_reused_trade_match_ids = (
-            cross_day_reused_order_ids | cross_day_reused_trade_only_ids
-        )
+        order_alias_to_broker_order_keys = {}
 
         for raw_order in xt_orders:
-            order_identity = _build_broker_order_identity(raw_order)
             trading_day = _resolve_rebuild_trading_day(raw_order)
+            symbol = _normalize_symbol(raw_order)
+            side = _normalize_side(raw_order.get("order_type") or raw_order.get("side"))
+            broker_order_key = _build_canonical_broker_order_key(
+                raw_order,
+                trading_day=trading_day,
+                symbol=symbol,
+                side=side,
+            )
             broker_order = _normalize_broker_order(
                 raw_order,
-                disambiguate_order_id=order_identity in cross_day_reused_order_ids,
+                broker_order_key=broker_order_key,
                 trading_day=trading_day,
             )
-            broker_order_key = broker_order["broker_order_key"]
             if broker_order_key not in broker_orders_by_key:
                 broker_order_keys.append(broker_order_key)
             broker_orders_by_key[broker_order_key] = broker_order
-            match_key = _build_broker_order_match_key(
-                symbol=broker_order.get("symbol"),
-                side=broker_order.get("side"),
-                order_id=raw_order.get("order_id"),
-                trading_day=(
-                    trading_day
-                    if order_identity in cross_day_reused_order_ids
-                    else None
-                ),
+            fallback_key = _build_fallback_broker_order_key(
+                raw_order,
+                trading_day=trading_day,
+                symbol=symbol,
+                side=side,
             )
-            if match_key:
-                order_match_to_broker_order_key[match_key] = broker_order_key
+            for alias in {broker_order_key, fallback_key} - {None}:
+                order_alias_to_broker_order_keys.setdefault(alias, set()).add(
+                    broker_order_key
+                )
 
         execution_fill_documents = []
+        execution_fills_by_identity = {}
         for raw_trade in xt_trades:
-            order_id = _normalize_identifier(raw_trade.get("order_id"))
             trade_symbol = _normalize_symbol(raw_trade)
             trade_side = _normalize_side(
                 raw_trade.get("order_type") or raw_trade.get("side")
             )
-            trade_identity = _build_broker_order_identity(raw_trade)
             trading_day = _resolve_rebuild_trading_day(raw_trade)
-            match_key = _build_broker_order_match_key(
+            trade_broker_order_key = _build_canonical_broker_order_key(
+                raw_trade,
+                trading_day=trading_day,
                 symbol=trade_symbol,
                 side=trade_side,
-                order_id=order_id,
-                trading_day=(
-                    trading_day
-                    if trade_identity in cross_day_reused_trade_match_ids
-                    else None
-                ),
             )
-            broker_order_key = order_match_to_broker_order_key.get(match_key)
-            if not broker_order_key:
-                broker_order_key = _build_trade_only_broker_order_key(
+            broker_order_key = (
+                trade_broker_order_key
+                if trade_broker_order_key in broker_orders_by_key
+                else None
+            )
+            if broker_order_key is None and not _normalize_identifier(
+                raw_trade.get("order_sysid")
+            ):
+                fallback_key = _build_fallback_broker_order_key(
+                    raw_trade,
+                    trading_day=trading_day,
                     symbol=trade_symbol,
                     side=trade_side,
-                    order_id=order_id,
-                    traded_id=raw_trade.get("traded_id"),
-                    trading_day=(
-                        trading_day
-                        if trade_identity in cross_day_reused_trade_only_ids
-                        else None
-                    ),
                 )
+                candidates = order_alias_to_broker_order_keys.get(fallback_key, set())
+                if len(candidates) > 1:
+                    raise BrokerIdentityError(
+                        f"ambiguous broker order fallback identity: {fallback_key}"
+                    )
+                if candidates:
+                    broker_order_key = next(iter(candidates))
+            if broker_order_key is None:
+                broker_order_key = trade_broker_order_key
 
             broker_order = broker_orders_by_key.get(broker_order_key)
             if broker_order is None:
@@ -139,12 +153,36 @@ class OrderLedgerV2RebuildService:
                 )
                 broker_orders_by_key[broker_order_key] = broker_order
                 broker_order_keys.append(broker_order_key)
-                if match_key:
-                    order_match_to_broker_order_key[match_key] = broker_order_key
+            else:
+                _assert_rebuild_join_compatible(
+                    broker_order,
+                    raw_trade,
+                    trading_day=trading_day,
+                    symbol=trade_symbol,
+                    side=trade_side,
+                )
 
             execution_fill = _normalize_execution_fill(raw_trade, broker_order)
+            execution_identity = execution_fill["execution_identity"]
+            existing_fill = execution_fills_by_identity.get(execution_identity)
+            if existing_fill is not None:
+                _assert_execution_replay_consistent(existing_fill, execution_fill)
+                continue
+            execution_fills_by_identity[execution_identity] = execution_fill
             execution_fill_documents.append(execution_fill)
-            _apply_execution_fill_to_broker_order(broker_order, execution_fill)
+
+        fills_by_broker_order_key = {}
+        for execution_fill in execution_fill_documents:
+            if not _is_positive_execution_quantity(execution_fill.get("quantity")):
+                continue
+            fills_by_broker_order_key.setdefault(
+                execution_fill["broker_order_key"], []
+            ).append(execution_fill)
+        for broker_order_key in broker_order_keys:
+            _recompute_broker_order_from_fills(
+                broker_orders_by_key[broker_order_key],
+                fills_by_broker_order_key.get(broker_order_key, []),
+            )
 
         broker_order_documents = [
             broker_orders_by_key[broker_order_key]
@@ -180,6 +218,19 @@ class OrderLedgerV2RebuildService:
             allow_empty_xt_positions_flatten=allow_empty_xt_positions_flatten,
         )
         ingest_rejection_documents.extend(reconciliation_ingest_rejections)
+        allocation_reference_errors = _find_exit_allocation_reference_errors(
+            position_entry_documents=position_entry_documents,
+            entry_slice_documents=entry_slice_documents,
+            exit_allocation_documents=exit_allocation_documents,
+        )
+        if allocation_reference_errors:
+            raise ValueError(
+                "exit allocation reference integrity failed: "
+                + "; ".join(
+                    json.dumps(item, ensure_ascii=False, sort_keys=True)
+                    for item in allocation_reference_errors
+                )
+            )
         return {
             "broker_orders": len(broker_order_documents),
             "execution_fills": len(execution_fill_documents),
@@ -201,6 +252,7 @@ class OrderLedgerV2RebuildService:
             "ingest_rejection_documents": ingest_rejection_documents,
             "unmatched_sell_trade_facts": unmatched_sell_trade_facts,
             "replay_warnings": replay_warnings,
+            "allocation_reference_errors": allocation_reference_errors,
             "clustered_entries": count_clustered_entries(position_entry_documents),
             "mergeable_entry_gap": summarize_mergeable_gap(position_entry_documents),
             "non_default_lot_slices": _count_non_default_lot_slices_with_lookup(
@@ -238,7 +290,7 @@ def _rebuild_position_entries(
         broker_order_key = broker_order.get("broker_order_key")
         accepted_buy_fills = []
         for execution_fill in fills_by_broker_order_key.get(broker_order_key) or []:
-            if not _is_board_lot_quantity(execution_fill.get("quantity")):
+            if not _is_positive_execution_quantity(execution_fill.get("quantity")):
                 ingest_rejection_documents.append(
                     _build_ingest_rejection_from_execution_fill(execution_fill)
                 )
@@ -269,7 +321,7 @@ def _rebuild_position_entries(
     for execution_fill in execution_fills:
         if execution_fill.get("side") != "sell":
             continue
-        if not _is_board_lot_quantity(execution_fill.get("quantity")):
+        if not _is_positive_execution_quantity(execution_fill.get("quantity")):
             ingest_rejection_documents.append(
                 _build_ingest_rejection_from_execution_fill(execution_fill)
             )
@@ -413,7 +465,7 @@ def _rebuild_position_entries(
 def _normalize_broker_order(
     raw_order,
     *,
-    disambiguate_order_id=False,
+    broker_order_key,
     trading_day=None,
 ):
     broker_order_id = _normalize_identifier(raw_order.get("order_id"))
@@ -421,14 +473,11 @@ def _normalize_broker_order(
         raw_order.get("order_volume") or raw_order.get("quantity")
     )
     return {
-        "broker_order_key": _build_rebuild_broker_order_key(
-            symbol=_normalize_symbol(raw_order),
-            side=_normalize_side(raw_order.get("order_type") or raw_order.get("side")),
-            order_id=broker_order_id,
-            trading_day=trading_day,
-            disambiguate=disambiguate_order_id,
-        ),
+        "broker_order_key": broker_order_key,
         "broker_order_id": broker_order_id,
+        "order_sysid": _normalize_identifier(raw_order.get("order_sysid")),
+        "account_id": normalize_account_id(raw_order.get("account_id")),
+        "trading_day": trading_day,
         "broker_order_type": raw_order.get("order_type"),
         "symbol": _normalize_symbol(raw_order),
         "side": _normalize_side(raw_order.get("order_type") or raw_order.get("side")),
@@ -450,6 +499,9 @@ def _build_trade_only_broker_order(raw_trade, broker_order_key):
     return {
         "broker_order_key": broker_order_key,
         "broker_order_id": broker_order_id,
+        "order_sysid": _normalize_identifier(raw_trade.get("order_sysid")),
+        "account_id": normalize_account_id(raw_trade.get("account_id")),
+        "trading_day": _resolve_rebuild_trading_day(raw_trade),
         "broker_order_type": raw_trade.get("order_type"),
         "symbol": _normalize_symbol(raw_trade),
         "side": _normalize_side(raw_trade.get("order_type") or raw_trade.get("side")),
@@ -481,9 +533,7 @@ def _build_grouped_trade_fact(*, broker_order, fills):
         trade_time,
     )
     return {
-        "trade_fact_id": first_fill.get("execution_fill_id")
-        or first_fill.get("broker_trade_id")
-        or f"rebuild-buy:{broker_order.get('broker_order_key')}",
+        "trade_fact_id": new_trade_fact_id(),
         "symbol": broker_order.get("symbol") or first_fill.get("symbol"),
         "side": "buy",
         "quantity": quantity or 0,
@@ -504,14 +554,23 @@ def _normalize_execution_fill(raw_trade, broker_order):
         raw_trade.get("time"),
         trade_time,
     )
-    return {
-        "execution_fill_id": _normalize_identifier(raw_trade.get("traded_id")),
+    symbol = _normalize_symbol(raw_trade) or broker_order.get("symbol")
+    side = _normalize_side(
+        raw_trade.get("order_type") or raw_trade.get("side")
+    ) or broker_order.get("side")
+    account_id = normalize_account_id(raw_trade.get("account_id")) or broker_order.get(
+        "account_id"
+    )
+    trading_day = _resolve_rebuild_trading_day(raw_trade)
+    document = {
         "broker_trade_id": _normalize_identifier(raw_trade.get("traded_id")),
         "broker_order_key": broker_order["broker_order_key"],
-        "broker_order_id": broker_order.get("broker_order_id"),
-        "symbol": broker_order.get("symbol") or _normalize_symbol(raw_trade),
-        "side": broker_order.get("side")
-        or _normalize_side(raw_trade.get("order_type") or raw_trade.get("side")),
+        "broker_order_id": _normalize_identifier(raw_trade.get("order_id")),
+        "order_sysid": _normalize_identifier(raw_trade.get("order_sysid")),
+        "account_id": account_id,
+        "trading_day": trading_day,
+        "symbol": symbol,
+        "side": side,
         "quantity": _coerce_int(
             raw_trade.get("traded_volume") or raw_trade.get("quantity")
         ),
@@ -521,6 +580,9 @@ def _normalize_execution_fill(raw_trade, broker_order):
         "time": time_value,
         "source": "broker_rebuild",
     }
+    document["execution_fill_id"] = new_execution_fill_id()
+    document["execution_identity"] = build_execution_identity(document)
+    return document
 
 
 def _build_trade_fact_from_execution_fill(execution_fill):
@@ -531,9 +593,7 @@ def _build_trade_fact_from_execution_fill(execution_fill):
         trade_time,
     )
     return {
-        "trade_fact_id": execution_fill.get("execution_fill_id")
-        or execution_fill.get("broker_trade_id")
-        or execution_fill.get("broker_order_key"),
+        "trade_fact_id": new_trade_fact_id(),
         "symbol": execution_fill.get("symbol"),
         "side": execution_fill.get("side"),
         "quantity": _coerce_int(execution_fill.get("quantity")) or 0,
@@ -545,38 +605,40 @@ def _build_trade_fact_from_execution_fill(execution_fill):
     }
 
 
-def _apply_execution_fill_to_broker_order(broker_order, execution_fill):
-    previous_quantity = _coerce_int(broker_order.get("filled_quantity")) or 0
-    previous_fill_count = _coerce_int(broker_order.get("fill_count")) or 0
-    previous_avg_price = _coerce_float(broker_order.get("avg_filled_price")) or 0.0
-    fill_quantity = _coerce_int(execution_fill.get("quantity")) or 0
-    fill_price = _coerce_float(execution_fill.get("price")) or 0.0
-
-    next_quantity = previous_quantity + fill_quantity
-    next_fill_count = previous_fill_count + 1
-    previous_notional = previous_quantity * previous_avg_price
-    next_avg_price = None
-    if next_quantity > 0:
-        next_avg_price = round(
-            (previous_notional + fill_quantity * fill_price) / next_quantity,
-            6,
-        )
-
-    broker_order["filled_quantity"] = next_quantity
-    broker_order["avg_filled_price"] = next_avg_price
-    broker_order["fill_count"] = next_fill_count
-    broker_order["first_fill_time"] = _pick_first_time(
-        broker_order.get("first_fill_time"),
-        execution_fill.get("trade_time"),
+def _recompute_broker_order_from_fills(broker_order, execution_fills):
+    fills = list(execution_fills or [])
+    if not fills:
+        broker_order["filled_quantity"] = 0
+        broker_order["avg_filled_price"] = None
+        broker_order["fill_count"] = 0
+        broker_order["first_fill_time"] = None
+        broker_order["last_fill_time"] = None
+        return broker_order
+    filled_quantity = sum(_coerce_int(item.get("quantity")) or 0 for item in fills)
+    broker_order["filled_quantity"] = filled_quantity
+    broker_order["avg_filled_price"] = _weighted_average_fill_price(fills)
+    broker_order["fill_count"] = len(fills)
+    broker_order["first_fill_time"] = min(
+        (
+            _coerce_int(item.get("trade_time"))
+            for item in fills
+            if _coerce_int(item.get("trade_time")) is not None
+        ),
+        default=None,
     )
-    broker_order["last_fill_time"] = _pick_last_time(
-        broker_order.get("last_fill_time"),
-        execution_fill.get("trade_time"),
+    broker_order["last_fill_time"] = max(
+        (
+            _coerce_int(item.get("trade_time"))
+            for item in fills
+            if _coerce_int(item.get("trade_time")) is not None
+        ),
+        default=None,
     )
     broker_order["state"] = _resolve_fill_state(
         requested_quantity=broker_order.get("requested_quantity"),
-        filled_quantity=next_quantity,
+        filled_quantity=filled_quantity,
     )
+    return broker_order
 
 
 def _normalize_symbol(payload):
@@ -597,105 +659,77 @@ def _normalize_side(order_type):
     return str(order_type or "").strip().lower() or None
 
 
-def _build_rebuild_broker_order_key(
-    *,
-    symbol,
-    side,
-    order_id,
-    trading_day=None,
-    disambiguate=False,
-):
-    normalized_order_id = _normalize_identifier(order_id)
-    if not normalized_order_id:
-        return None
-    if not disambiguate:
-        return normalized_order_id
-    normalized_symbol = str(symbol or "").strip()
-    normalized_side = str(side or "").strip().lower()
-    normalized_trading_day = _coerce_int(trading_day)
-    if normalized_symbol and normalized_side and normalized_trading_day:
-        return (
-            f"{normalized_symbol}:{normalized_side}:"
-            f"{normalized_order_id}:{normalized_trading_day}"
-        )
-    return normalized_order_id
-
-
-def _build_broker_order_match_key(*, symbol, side, order_id, trading_day=None):
-    normalized_symbol = str(symbol or "").strip()
-    normalized_side = str(side or "").strip().lower()
-    normalized_order_id = _normalize_identifier(order_id)
-    if not normalized_symbol or not normalized_side or not normalized_order_id:
-        return None
-    normalized_trading_day = _coerce_int(trading_day)
-    if normalized_trading_day:
-        return (
-            f"{normalized_symbol}:{normalized_side}:"
-            f"{normalized_order_id}:{normalized_trading_day}"
-        )
-    return f"{normalized_symbol}:{normalized_side}:{normalized_order_id}"
-
-
-def _build_trade_only_broker_order_key(
-    *,
-    symbol,
-    side,
-    order_id,
-    traded_id,
-    trading_day=None,
-):
-    match_key = _build_broker_order_match_key(
+def _build_canonical_broker_order_key(payload, *, trading_day, symbol, side):
+    return build_broker_order_key(
+        account_id=payload.get("account_id"),
+        order_sysid=payload.get("order_sysid"),
+        trading_day=trading_day,
         symbol=symbol,
         side=side,
-        order_id=order_id,
-        trading_day=trading_day,
+        broker_order_id=payload.get("broker_order_id") or payload.get("order_id"),
     )
-    if match_key:
-        return f"trade_only:{match_key}"
-    normalized_traded_id = _normalize_identifier(traded_id)
-    if normalized_traded_id:
-        return f"trade_only:{normalized_traded_id}"
-    return "trade_only:unknown"
 
 
-def _build_broker_order_identity(payload):
-    normalized_symbol = _normalize_symbol(payload)
-    normalized_side = _normalize_side(payload.get("order_type") or payload.get("side"))
-    normalized_order_id = _normalize_identifier(payload.get("order_id"))
-    if not normalized_symbol or not normalized_side or not normalized_order_id:
-        return None
-    return normalized_symbol, normalized_side, normalized_order_id
+def _build_fallback_broker_order_key(payload, *, trading_day, symbol, side):
+    return build_broker_order_key(
+        account_id=payload.get("account_id"),
+        trading_day=trading_day,
+        symbol=symbol,
+        side=side,
+        broker_order_id=payload.get("broker_order_id") or payload.get("order_id"),
+        strict=False,
+    )
+
+
+def _assert_rebuild_join_compatible(
+    broker_order,
+    raw_trade,
+    *,
+    trading_day,
+    symbol,
+    side,
+):
+    trade_identity = {
+        "account_id": normalize_account_id(raw_trade.get("account_id")),
+        "order_sysid": _normalize_identifier(raw_trade.get("order_sysid")),
+        "trading_day": trading_day,
+        "symbol": symbol,
+        "side": side,
+        "broker_order_id": _normalize_identifier(
+            raw_trade.get("broker_order_id") or raw_trade.get("order_id")
+        ),
+    }
+    conflicts = identity_conflicts(broker_order, trade_identity)
+    if conflicts:
+        raise BrokerIdentityError(
+            "broker order/trade identity conflict during rebuild: "
+            + ", ".join(sorted(conflicts))
+        )
+
+
+def _assert_execution_replay_consistent(existing, incoming):
+    conflicts = identity_conflicts(existing, incoming)
+    for field in (
+        "execution_identity",
+        "broker_trade_id",
+        "broker_order_key",
+        "quantity",
+        "price",
+        "trade_time",
+    ):
+        left = existing.get(field)
+        right = incoming.get(field)
+        if left is not None and right is not None and left != right:
+            conflicts[field] = (left, right)
+    if conflicts:
+        raise BrokerIdentityConflict(
+            "execution replay conflicts with canonical rebuild fill: "
+            + ", ".join(sorted(conflicts))
+        )
 
 
 def _resolve_rebuild_trading_day(payload):
-    date_value = _coerce_int(payload.get("date"))
-    if date_value:
-        return date_value
-    timestamp = _coerce_int(
-        payload.get("order_time")
-        or payload.get("traded_time")
-        or payload.get("trade_time")
-    )
-    if not timestamp:
-        return None
-    return int(
-        datetime.fromtimestamp(timestamp, tz=_BEIJING_TIMEZONE).strftime("%Y%m%d")
-    )
-
-
-def _collect_cross_day_reused_order_ids(*, xt_orders):
-    trading_days_by_identity = {}
-    for payload in list(xt_orders or []):
-        identity = _build_broker_order_identity(payload)
-        trading_day = _resolve_rebuild_trading_day(payload)
-        if identity is None or trading_day is None:
-            continue
-        trading_days_by_identity.setdefault(identity, set()).add(trading_day)
-    return {
-        identity
-        for identity, trading_days in trading_days_by_identity.items()
-        if len(trading_days) > 1
-    }
+    return resolve_trading_day(payload)
 
 
 def _normalize_broker_order_state(order_status):
@@ -814,6 +848,10 @@ def _is_board_lot_quantity(quantity):
     return normalized > 0 and normalized % 100 == 0
 
 
+def _is_positive_execution_quantity(quantity):
+    return (_coerce_int(quantity) or 0) > 0
+
+
 def _build_entry_broker_order(*, broker_order, fills):
     filled_quantity = sum(_coerce_int(item.get("quantity")) or 0 for item in fills)
     return {
@@ -845,7 +883,7 @@ def _build_ingest_rejection_from_execution_fill(execution_fill):
         "symbol": execution_fill.get("symbol"),
         "broker_trade_id": execution_fill.get("broker_trade_id"),
         "internal_order_id": None,
-        "reason_code": "non_board_lot_quantity",
+        "reason_code": "non_positive_quantity",
         "quantity": _coerce_int(execution_fill.get("quantity")) or 0,
         "trade_time": execution_fill.get("trade_time"),
         "date": execution_fill.get("date"),
@@ -869,6 +907,16 @@ def _build_ingest_rejection_from_gap(gap):
         "source": "rebuild_reconciliation",
         "created_at": datetime.now(tz=timezone.utc).isoformat(),
     }
+
+
+def _find_exit_allocation_reference_errors(
+    *, position_entry_documents, entry_slice_documents, exit_allocation_documents
+):
+    return find_exit_allocation_integrity_errors(
+        position_entries=position_entry_documents,
+        entry_slices=entry_slice_documents,
+        exit_allocations=exit_allocation_documents,
+    )
 
 
 def _normalize_xt_positions(xt_positions):

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -5,6 +5,12 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from freshquant.order_management.broker_identity import (
+    normalize_account_id,
+    normalize_side,
+    normalize_symbol,
+    normalize_trading_day,
+)
 from freshquant.order_management.broker_match import find_order_for_broker_report
 from freshquant.order_management.entry_aggregation import (
     build_clustered_position_entry,
@@ -14,6 +20,7 @@ from freshquant.order_management.entry_aggregation import (
 from freshquant.order_management.guardian.allocation_policy import (
     allocate_sell_to_slices,
 )
+from freshquant.order_management.guardian.arranger import arrange_entry
 from freshquant.order_management.guardian.sell_semantics import (
     normalize_preferred_entry_quantities as normalize_guardian_preferred_entry_quantities,
 )
@@ -22,7 +29,6 @@ from freshquant.order_management.guardian.sell_semantics import (
 )
 from freshquant.order_management.ids import (
     new_allocation_id,
-    new_entry_slice_id,
     new_event_id,
     new_internal_order_id,
     new_position_entry_id,
@@ -63,6 +69,46 @@ class TradeReportReconcileOutcome:
     result: dict | None = None
     normalized: dict | None = None
     ingested: bool = False
+
+
+def _normalize_inflight_trade_identity(normalized_trade):
+    identity = {
+        "account_id": normalize_account_id(normalized_trade.get("account_id")),
+        "trading_day": normalize_trading_day(normalized_trade.get("trading_day")),
+        "symbol": normalize_symbol(normalized_trade.get("symbol")),
+        "side": normalize_side(normalized_trade.get("side")),
+    }
+    if any(value is None for value in identity.values()):
+        return None
+    return identity
+
+
+def _inflight_candidate_identity_matches(*, order, request, trade_identity):
+    order_identity = {
+        "account_id": normalize_account_id(order.get("account_id")),
+        "trading_day": normalize_trading_day(order.get("trading_day")),
+        "symbol": normalize_symbol(order.get("symbol")),
+        "side": normalize_side(order.get("side")),
+    }
+    if any(value is None for value in order_identity.values()):
+        return False
+    if any(order_identity[field] != trade_identity[field] for field in order_identity):
+        return False
+
+    known_request_identity = (
+        (normalize_account_id(request.get("account_id")), trade_identity["account_id"]),
+        (
+            normalize_trading_day(request.get("trading_day")),
+            trade_identity["trading_day"],
+        ),
+        (normalize_symbol(request.get("symbol")), trade_identity["symbol"]),
+        (normalize_side(request.get("side")), trade_identity["side"]),
+        (normalize_side(request.get("action")), trade_identity["side"]),
+    )
+    return all(
+        candidate_value is None or candidate_value == trade_value
+        for candidate_value, trade_value in known_request_identity
+    )
 
 
 class ExternalOrderReconcileService:
@@ -469,19 +515,27 @@ class ExternalOrderReconcileService:
             raise
 
     def _match_inflight_internal_order(self, normalized_trade):
+        trade_identity = _normalize_inflight_trade_identity(normalized_trade)
+        if trade_identity is None:
+            return "missing", None
+
         exact_candidates = []
         partial_candidates = []
         for order in self.repository.list_orders(
-            symbol=normalized_trade["symbol"],
+            symbol=trade_identity["symbol"],
             states={"ACCEPTED", "QUEUED", "SUBMITTING"},
             missing_broker_only=True,
         ):
-            if order.get("side") != normalized_trade["side"]:
-                continue
             if order.get("source_type") in {"external_reported", "external_inferred"}:
                 continue
             request = self.repository.find_order_request(order["request_id"])
             if request is None:
+                continue
+            if not _inflight_candidate_identity_matches(
+                order=order,
+                request=request,
+                trade_identity=trade_identity,
+            ):
                 continue
             request_quantity = int(request.get("quantity") or 0)
             trade_quantity = int(normalized_trade["quantity"] or 0)
@@ -645,7 +699,7 @@ class ExternalOrderReconcileService:
             )
         entry_slices = []
         try:
-            entry_slices = _arrange_entry_slices(
+            entry_slices = arrange_entry(
                 entry,
                 lot_amount=arrange_runtime["lot_amount"],
                 grid_interval=arrange_runtime["grid_interval"],
@@ -1766,81 +1820,6 @@ def _mark_entry_arrangement_failure(entry, exc, *, existing_errors=None):
 
 _ORIGINAL_SAFE_RESOLVE_LOT_AMOUNT = _safe_resolve_lot_amount
 _ORIGINAL_SAFE_GRID_INTERVAL_LOOKUP = _safe_grid_interval_lookup
-
-
-def _arrange_entry_slices(entry, *, lot_amount, grid_interval):
-    slices = []
-    _arrange_entry_remaining(
-        slices=slices,
-        entry=entry,
-        remaining_quantity=int(entry["original_quantity"]),
-        remaining_amount=float(entry["original_quantity"])
-        * float(entry["entry_price"]),
-        current_price=float(entry["entry_price"]),
-        lot_amount=lot_amount,
-        grid_interval=grid_interval,
-        slice_seq=0,
-    )
-    return slices
-
-
-def _arrange_entry_remaining(
-    *,
-    slices,
-    entry,
-    remaining_quantity,
-    remaining_amount,
-    current_price,
-    lot_amount,
-    grid_interval,
-    slice_seq,
-):
-    if remaining_quantity <= 0:
-        return
-
-    if remaining_amount > lot_amount:
-        quantity = int(lot_amount / current_price / 100) * 100
-        if quantity == 0:
-            quantity = 100
-        quantity = min(quantity, remaining_quantity)
-    else:
-        quantity = remaining_quantity
-
-    rounded_price = float(f"{current_price:.2f}")
-    slices.append(
-        {
-            "entry_slice_id": new_entry_slice_id(),
-            "entry_id": entry["entry_id"],
-            "slice_seq": slice_seq,
-            "guardian_price": rounded_price,
-            "original_quantity": quantity,
-            "remaining_quantity": quantity,
-            "remaining_amount": round(rounded_price * quantity, 2),
-            "sort_key": rounded_price,
-            "date": entry.get("date"),
-            "time": entry.get("time"),
-            "trade_time": entry.get("trade_time"),
-            "symbol": entry["symbol"],
-            "status": "OPEN",
-        }
-    )
-
-    next_quantity = remaining_quantity - quantity
-    if next_quantity <= 0:
-        return
-
-    next_amount = remaining_amount - quantity * rounded_price
-    next_price = float(f"{(current_price * grid_interval):.2f}")
-    _arrange_entry_remaining(
-        slices=slices,
-        entry=entry,
-        remaining_quantity=next_quantity,
-        remaining_amount=next_amount,
-        current_price=next_price,
-        lot_amount=lot_amount,
-        grid_interval=grid_interval,
-        slice_seq=slice_seq + 1,
-    )
 
 
 def _allocate_gap_to_entry_slices(

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -397,6 +397,10 @@ class ExternalOrderReconcileService:
                 source_type="external_reported",
                 state="FILLED",
                 broker_order_id=normalized.get("broker_order_id"),
+                broker_order_key=normalized.get("broker_order_key"),
+                account_id=normalized.get("account_id"),
+                order_sysid=normalized.get("order_sysid"),
+                trading_day=normalized.get("trading_day"),
             )
             ids = {
                 "request_id": order["request_id"],
@@ -703,6 +707,10 @@ class ExternalOrderReconcileService:
                     "resolution_type": resolution["resolution_type"],
                 },
             )
+        v2_authoritative = _symbol_has_v2_entries(
+            self.repository,
+            gap["symbol"],
+        )
         entry_allocations = []
         if remaining > 0:
             remaining, entry_allocations = _allocate_gap_to_entry_slices(
@@ -714,7 +722,7 @@ class ExternalOrderReconcileService:
             )
 
         legacy_allocations = []
-        if remaining > 0:
+        if remaining > 0 and not v2_authoritative:
             legacy_allocations = _allocate_gap_to_legacy_buy_lots(
                 repository=self.repository,
                 symbol=gap["symbol"],
@@ -724,6 +732,34 @@ class ExternalOrderReconcileService:
                 trade_time=int(now),
             )
             remaining = 0
+
+        if remaining > 0:
+            resolution = {
+                "resolution_id": resolution_id,
+                "gap_id": gap["gap_id"],
+                "resolution_type": "v2_inventory_insufficient",
+                "resolved_quantity": int(gap.get("quantity_delta") or 0) - remaining,
+                "unresolved_quantity": remaining,
+                "resolved_price": float(gap.get("price_estimate") or 0.0),
+                "resolved_at": int(now),
+                "source_ref_type": "reconciliation_gap",
+                "source_ref_id": gap["gap_id"],
+                "entry_allocation_ids": [
+                    item["allocation_id"] for item in entry_allocations
+                ],
+                "legacy_allocation_ids": [],
+            }
+            self.repository.insert_reconciliation_resolution(resolution)
+            return self.repository.update_reconciliation_gap(
+                gap["gap_id"],
+                {
+                    "state": "REJECTED",
+                    "confirmed_at": int(now),
+                    "resolution_id": resolution_id,
+                    "resolution_type": resolution["resolution_type"],
+                    "unresolved_quantity": remaining,
+                },
+            )
 
         resolution = {
             "resolution_id": resolution_id,
@@ -764,6 +800,10 @@ class ExternalOrderReconcileService:
         source_type,
         state,
         broker_order_id,
+        broker_order_key,
+        account_id,
+        order_sysid,
+        trading_day,
     ):
         request_id = new_request_id()
         internal_order_id = new_internal_order_id()
@@ -773,6 +813,7 @@ class ExternalOrderReconcileService:
                 "request_id": request_id,
                 "action": side,
                 "source": source_type,
+                "account_id": account_id,
                 "symbol": symbol,
                 "price": price,
                 "quantity": quantity,
@@ -791,6 +832,10 @@ class ExternalOrderReconcileService:
             "broker_order_id": (
                 str(broker_order_id) if broker_order_id is not None else None
             ),
+            "broker_order_key": broker_order_key,
+            "account_id": account_id,
+            "order_sysid": order_sysid,
+            "trading_day": trading_day,
             "symbol": symbol,
             "side": side,
             "state": state,
@@ -843,23 +888,30 @@ def _build_positions_by_symbol(positions):
 
 def _build_internal_remaining_by_symbol(repository):
     result = {}
-    symbols_with_open_v2_entries = set()
+    symbols_with_v2_entries = set()
     position_entries = []
     if hasattr(repository, "list_position_entries"):
         position_entries = list(repository.list_position_entries() or [])
     for item in position_entries:
+        symbol = item["symbol"]
+        symbols_with_v2_entries.add(symbol)
+        result.setdefault(symbol, 0)
         remaining_quantity = int(item.get("remaining_quantity", 0) or 0)
         if remaining_quantity <= 0:
             continue
-        symbol = item["symbol"]
-        symbols_with_open_v2_entries.add(symbol)
         result[symbol] = result.get(symbol, 0) + remaining_quantity
     for item in repository.list_buy_lots():
         symbol = item["symbol"]
-        if symbol in symbols_with_open_v2_entries:
+        if symbol in symbols_with_v2_entries:
             continue
         result[symbol] = result.get(symbol, 0) + int(item.get("remaining_quantity", 0))
     return result
+
+
+def _symbol_has_v2_entries(repository, symbol):
+    if not hasattr(repository, "list_position_entries"):
+        return False
+    return bool(repository.list_position_entries(symbol=symbol))
 
 
 def _detect_sell_gap_blast(
@@ -1860,9 +1912,7 @@ def _allocate_gap_to_entry_slices(
 
     for entry_id in touched_entry_ids:
         repository.replace_position_entry(entries[entry_id])
-        repository.replace_entry_slices_for_entry(
-            entry_id, slices_by_entry.get(entry_id, [])
-        )
+        repository.upsert_entry_slices(slices_by_entry.get(entry_id, []))
     if allocations:
         repository.insert_exit_allocations(allocations)
     return remaining, allocations

--- a/freshquant/order_management/repair/targeted_ledger.py
+++ b/freshquant/order_management/repair/targeted_ledger.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import re
+import uuid
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Mapping, Sequence, cast
+from typing import Any, Callable, Mapping, Sequence, cast
 
 from bson import json_util
 from pymongo.errors import DuplicateKeyError
@@ -24,6 +25,13 @@ _PROTECTED_COLLECTIONS = {
 }
 _SAFE_QUERY_OPERATORS = {"$and", "$or", "$eq", "$in"}
 _REPAIR_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$")
+_REPAIR_ATTEMPT_LEASE_SECONDS = 300
+_RESTORABLE_RECEIPT_STATUSES = {
+    "applied",
+    "restoring",
+    "restore_failed",
+    "restored",
+}
 
 _SCOPE_FIELDS: dict[str, tuple[str, ...]] = {
     "account_id": ("account_id",),
@@ -129,18 +137,18 @@ def stage_targeted_repair(
                 f"replace change for {change['store']}.{change['collection']} "
                 "must express one atomic insert, update or delete; split identity moves"
             )
-        staged_changes.append(
-            {
-                "mode": change["mode"],
-                "store": change["store"],
-                "collection": change["collection"],
-                "selector": deepcopy(change["selector"]),
-                "identity_fields": list(change["identity_fields"]),
-                "preimage_documents": preimage_documents,
-                "postimage_documents": postimage_documents,
-                "diff": diff,
-            }
-        )
+        staged_change = {
+            "mode": change["mode"],
+            "store": change["store"],
+            "collection": change["collection"],
+            "selector": deepcopy(change["selector"]),
+            "identity_fields": list(change["identity_fields"]),
+            "preimage_documents": preimage_documents,
+            "postimage_documents": postimage_documents,
+            "diff": diff,
+        }
+        _require_fixed_id_for_insert(staged_change)
+        staged_changes.append(staged_change)
 
     _assert_staged_changes_do_not_overlap(staged_changes)
     if not any(_diff_count(item["diff"]) for item in staged_changes):
@@ -197,10 +205,15 @@ def execute_targeted_repair(
         label="preimage",
     )
     persisted_manifest_path = _persist_manifest(manifest, manifest_path)
+    apply_attempt_id = _new_attempt_id("apply", repair_id)
+    apply_lease_expires_at = _new_attempt_lease_expiry()
     receipt = {
         "repair_id": repair_id,
         "schema_version": TARGETED_REPAIR_SCHEMA_VERSION,
+        "receipt_version": 1,
         "status": "applying",
+        "apply_attempt_id": apply_attempt_id,
+        "apply_lease_expires_at": apply_lease_expires_at,
         "reason": normalized_plan["reason"],
         "scope": deepcopy(normalized_plan["scope"]),
         "plan_hash": manifest["plan_hash"],
@@ -229,6 +242,8 @@ def execute_targeted_repair(
         databases=databases,
         journal=journal,
         resumed=False,
+        attempt_id=apply_attempt_id,
+        receipt_version=1,
     )
 
 
@@ -239,16 +254,24 @@ def preview_targeted_restore(
 ) -> dict[str, Any]:
     normalized_manifest = _validate_manifest(manifest)
     _validate_manifest_databases(normalized_manifest, databases)
+    receipt = _require_restore_receipt(
+        manifest=normalized_manifest,
+        databases=databases,
+    )
     current_hash = _current_snapshot_hash(normalized_manifest, databases)
     change_states = _manifest_change_states(normalized_manifest, databases)
+    receipt_status = str(receipt.get("status") or "")
     return {
         "repair_id": normalized_manifest["repair_id"],
+        "receipt_status": receipt_status,
         "execute": False,
         "current_hash": current_hash,
         "expected_postimage_hash": normalized_manifest["postimage_hash"],
         "target_preimage_hash": normalized_manifest["preimage_hash"],
-        "restorable": not any(item["state"] == "diverged" for item in change_states)
-        and any(item["state"] == "postimage" for item in change_states),
+        "restorable": _restore_state_is_executable(
+            receipt_status=receipt_status,
+            change_states=change_states,
+        ),
         "change_states": change_states,
         "changes": [
             {
@@ -280,17 +303,23 @@ def restore_targeted_repair(
         raise InvalidRepairPlan("restore_id must not be empty")
     journal = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION]
     _ensure_journal_index(journal)
-    receipt = journal.find_one({"repair_id": repair_id})
-    if receipt is not None:
-        _assert_receipt_matches_manifest(receipt, normalized_manifest)
+    receipt = _require_restore_receipt(
+        manifest=normalized_manifest,
+        databases=databases,
+    )
+    receipt_status = str(receipt.get("status") or "")
+    prior_restore_id = str(receipt.get("restore_id") or "").strip()
+    if receipt_status in {"restoring", "restore_failed", "restored"} and (
+        prior_restore_id and prior_restore_id != normalized_restore_id
+    ):
+        raise RepairIdConflict(
+            f"repair_id {repair_id!r} is already bound to restore_id "
+            f"{prior_restore_id!r}"
+        )
 
     current_hash = _current_snapshot_hash(normalized_manifest, databases)
     change_states = _manifest_change_states(normalized_manifest, databases)
-    if receipt is not None and receipt.get("status") == "restored":
-        if str(receipt.get("restore_id") or "") != normalized_restore_id:
-            raise RepairIdConflict(
-                f"repair_id {repair_id!r} was restored by another restore_id"
-            )
+    if receipt_status == "restored":
         if not _all_changes_at(change_states, "preimage"):
             raise RestoreStateMismatch(
                 "restored receipt exists but current scoped state no longer matches preimage"
@@ -311,7 +340,6 @@ def restore_targeted_repair(
         raise RestoreStateMismatch(
             "restore is blocked because one or more changes match neither preimage nor postimage"
         )
-    receipt_status = str((receipt or {}).get("status") or "")
     if not _all_changes_at(change_states, "postimage") and receipt_status not in {
         "restoring",
         "restore_failed",
@@ -320,32 +348,44 @@ def restore_targeted_repair(
             "partial restore state is resumable only from a restoring receipt"
         )
 
-    journal.update_one(
-        {"repair_id": repair_id},
-        {
-            "$set": {
-                "status": "restoring",
-                "restore_id": normalized_restore_id,
-                "restore_started_at": _utc_now(),
-            },
-            "$setOnInsert": {
-                "repair_id": repair_id,
-                "schema_version": TARGETED_REPAIR_SCHEMA_VERSION,
-                "reason": normalized_manifest.get("reason"),
-                "scope": deepcopy(normalized_manifest.get("scope") or {}),
-                "plan_hash": normalized_manifest["plan_hash"],
-                "manifest_hash": normalized_manifest["manifest_hash"],
-                "preimage_hash": normalized_manifest["preimage_hash"],
-                "postimage_hash": normalized_manifest["postimage_hash"],
-            },
-        },
-        upsert=True,
+    attempt_id, receipt_version = _claim_attempt(
+        journal,
+        receipt=receipt,
+        operation="restore",
+        allowed_statuses={"applied", "restoring", "restore_failed"},
+        restore_id=normalized_restore_id,
     )
 
     try:
+        _renew_owned_attempt_lease(
+            journal,
+            repair_id=repair_id,
+            operation="restore",
+            attempt_id=attempt_id,
+            receipt_version=receipt_version,
+        )
+        current_hash = _current_snapshot_hash(normalized_manifest, databases)
+        _assert_expected_hash(
+            expected=expected_current_hash,
+            actual=current_hash,
+            label="restore current state",
+        )
+        change_states = _manifest_change_states(normalized_manifest, databases)
+        if any(item["state"] == "diverged" for item in change_states):
+            raise RestoreStateMismatch(
+                "restore is blocked because one or more changes match neither "
+                "preimage nor postimage"
+            )
         for index in range(len(normalized_manifest["changes"]) - 1, -1, -1):
             if change_states[index]["state"] != "postimage":
                 continue
+            _renew_owned_attempt_lease(
+                journal,
+                repair_id=repair_id,
+                operation="restore",
+                attempt_id=attempt_id,
+                receipt_version=receipt_version,
+            )
             _write_change_documents(
                 normalized_manifest["changes"][index],
                 databases=databases,
@@ -356,42 +396,39 @@ def restore_targeted_repair(
             raise RestoreStateMismatch(
                 "restore write completed but scoped state does not match preimage hash"
             )
+    except RepairIdConflict:
+        raise
     except Exception as exc:
-        journal.update_one(
-            {"repair_id": repair_id},
-            {
-                "$set": {
-                    "status": "restore_failed",
+        try:
+            _finish_owned_attempt(
+                journal,
+                repair_id=repair_id,
+                operation="restore",
+                attempt_id=attempt_id,
+                receipt_version=receipt_version,
+                status="restore_failed",
+                values={
                     "restore_id": normalized_restore_id,
                     "restore_failed_at": _utc_now(),
                     "restore_error": f"{type(exc).__name__}: {exc}",
-                }
-            },
-        )
+                },
+            )
+        except RepairIdConflict as receipt_exc:
+            raise receipt_exc from exc
         raise
 
-    receipt_update = {
-        "$set": {
-            "status": "restored",
+    _finish_owned_attempt(
+        journal,
+        repair_id=repair_id,
+        operation="restore",
+        attempt_id=attempt_id,
+        receipt_version=receipt_version,
+        status="restored",
+        values={
             "restore_id": normalized_restore_id,
             "restored_at": _utc_now(),
             "restored_hash": normalized_manifest["preimage_hash"],
         },
-        "$setOnInsert": {
-            "repair_id": repair_id,
-            "schema_version": TARGETED_REPAIR_SCHEMA_VERSION,
-            "reason": normalized_manifest.get("reason"),
-            "scope": deepcopy(normalized_manifest.get("scope") or {}),
-            "plan_hash": normalized_manifest["plan_hash"],
-            "manifest_hash": normalized_manifest["manifest_hash"],
-            "preimage_hash": normalized_manifest["preimage_hash"],
-            "postimage_hash": normalized_manifest["postimage_hash"],
-        },
-    }
-    journal.update_one(
-        {"repair_id": repair_id},
-        receipt_update,
-        upsert=True,
     )
     return _repair_summary(
         normalized_manifest,
@@ -416,95 +453,112 @@ def _apply_manifest(
     databases: Mapping[str, Any],
     journal,
     resumed: bool,
+    attempt_id: str,
+    receipt_version: int,
 ) -> dict[str, Any]:
     repair_id = str(manifest["repair_id"])
-    journal.update_one(
-        {"repair_id": repair_id},
-        {"$set": {"status": "applying", "last_attempt_at": _utc_now()}},
-    )
+    already_applied = False
+    observed_postimage_hash = ""
+
     try:
+        _renew_owned_attempt_lease(
+            journal,
+            repair_id=repair_id,
+            operation="apply",
+            attempt_id=attempt_id,
+            receipt_version=receipt_version,
+        )
         change_states = _manifest_change_states(manifest, databases)
         if any(item["state"] == "diverged" for item in change_states):
             raise PreimageHashMismatch(
                 "one or more scoped changes match neither preimage nor postimage"
             )
         if _all_changes_at(change_states, "postimage"):
-            current_hash = _current_snapshot_hash(manifest, databases)
-            if current_hash == manifest["postimage_hash"]:
-                journal.update_one(
-                    {"repair_id": repair_id},
-                    {
-                        "$set": {
-                            "status": "applied",
-                            "applied_at": _utc_now(),
-                            "observed_postimage_hash": current_hash,
-                        }
-                    },
+            observed_postimage_hash = _current_snapshot_hash(manifest, databases)
+            already_applied = observed_postimage_hash == manifest["postimage_hash"]
+        if not already_applied:
+            for index, change in enumerate(manifest["changes"]):
+                if change_states[index]["state"] != "preimage":
+                    continue
+                _renew_owned_attempt_lease(
+                    journal,
+                    repair_id=repair_id,
+                    operation="apply",
+                    attempt_id=attempt_id,
+                    receipt_version=receipt_version,
                 )
-                return _repair_summary(
-                    manifest,
-                    execute=True,
-                    status="already_applied",
-                    idempotent=True,
+                _write_change_documents(
+                    change,
+                    databases=databases,
+                    document_field="postimage_documents",
                 )
-        for index, change in enumerate(manifest["changes"]):
-            if change_states[index]["state"] != "preimage":
-                continue
-            _write_change_documents(
-                change,
-                databases=databases,
-                document_field="postimage_documents",
-            )
-        observed_postimage_hash = _current_snapshot_hash(manifest, databases)
-        if observed_postimage_hash != manifest["postimage_hash"]:
-            raise TargetedRepairError(
-                "repair write completed but scoped state does not match postimage hash"
-            )
+            observed_postimage_hash = _current_snapshot_hash(manifest, databases)
+            if observed_postimage_hash != manifest["postimage_hash"]:
+                raise TargetedRepairError(
+                    "repair write completed but scoped state does not match postimage hash"
+                )
+    except RepairIdConflict:
+        # Ownership has already moved to another attempt. Never rollback data that
+        # the new owner may currently be reconciling.
+        raise
     except Exception as exc:
         rollback_succeeded = False
         rollback_error = None
         try:
-            _replace_manifest_documents(
+            _rollback_manifest_postimages(
                 manifest,
                 databases=databases,
-                document_field="preimage_documents",
-                reverse=True,
+                before_write=lambda: _renew_owned_attempt_lease(
+                    journal,
+                    repair_id=repair_id,
+                    operation="apply",
+                    attempt_id=attempt_id,
+                    receipt_version=receipt_version,
+                ),
             )
-            rollback_succeeded = (
-                _current_snapshot_hash(manifest, databases) == manifest["preimage_hash"]
+            rollback_succeeded = _all_changes_at(
+                _manifest_change_states(manifest, databases),
+                "preimage",
             )
         except Exception as rollback_exc:  # pragma: no cover - runtime safeguard
             rollback_error = f"{type(rollback_exc).__name__}: {rollback_exc}"
-        journal.update_one(
-            {"repair_id": repair_id},
-            {
-                "$set": {
-                    "status": "failed",
+        try:
+            _finish_owned_attempt(
+                journal,
+                repair_id=repair_id,
+                operation="apply",
+                attempt_id=attempt_id,
+                receipt_version=receipt_version,
+                status="failed",
+                values={
                     "failed_at": _utc_now(),
                     "error": f"{type(exc).__name__}: {exc}",
                     "rollback_succeeded": rollback_succeeded,
                     "rollback_error": rollback_error,
-                }
-            },
-        )
+                },
+            )
+        except RepairIdConflict as receipt_exc:
+            raise receipt_exc from exc
         raise
 
-    journal.update_one(
-        {"repair_id": repair_id},
-        {
-            "$set": {
-                "status": "applied",
-                "applied_at": _utc_now(),
-                "observed_postimage_hash": observed_postimage_hash,
-                "resumed": bool(resumed),
-            }
+    _finish_owned_attempt(
+        journal,
+        repair_id=repair_id,
+        operation="apply",
+        attempt_id=attempt_id,
+        receipt_version=receipt_version,
+        status="applied",
+        values={
+            "applied_at": _utc_now(),
+            "observed_postimage_hash": observed_postimage_hash,
+            "resumed": bool(resumed),
         },
     )
     return _repair_summary(
         manifest,
         execute=True,
-        status="applied",
-        idempotent=False,
+        status="already_applied" if already_applied else "applied",
+        idempotent=already_applied,
     )
 
 
@@ -533,24 +587,17 @@ def _resume_or_report_existing_repair(
         actual=manifest["preimage_hash"],
         label="preimage",
     )
-    current_hash = _current_snapshot_hash(manifest, databases)
-    change_states = _manifest_change_states(manifest, databases)
     status = str(existing.get("status") or "")
-    if status == "restored":
+    if status in {"restoring", "restore_failed", "restored"}:
         raise RepairIdConflict(
-            f"repair_id {repair_id!r} has been restored and cannot be reused"
+            f"repair_id {repair_id!r} is in restore lifecycle state {status!r} "
+            "and cannot be applied"
         )
-    if current_hash == manifest["postimage_hash"]:
-        if status != "applied":
-            journal.update_one(
-                {"repair_id": repair_id},
-                {
-                    "$set": {
-                        "status": "applied",
-                        "applied_at": _utc_now(),
-                        "observed_postimage_hash": current_hash,
-                    }
-                },
+    if status == "applied":
+        current_hash = _current_snapshot_hash(manifest, databases)
+        if current_hash != manifest["postimage_hash"]:
+            raise RepairIdConflict(
+                f"repair_id {repair_id!r} is marked applied but its postimage drifted"
             )
         return _repair_summary(
             manifest,
@@ -558,35 +605,43 @@ def _resume_or_report_existing_repair(
             status="already_applied",
             idempotent=True,
         )
-    if status in {"applying", "failed"} and not any(
-        item["state"] == "diverged" for item in change_states
-    ):
-        return _apply_manifest(
-            manifest=manifest,
-            databases=databases,
-            journal=journal,
-            resumed=True,
+    if status not in {"applying", "failed"}:
+        raise RepairIdConflict(
+            f"repair_id {repair_id!r} has unsupported apply state {status!r}"
         )
-    raise RepairIdConflict(
-        f"repair_id {repair_id!r} exists but scoped state matches neither preimage nor postimage"
+    attempt_id, receipt_version = _claim_attempt(
+        journal,
+        receipt=existing,
+        operation="apply",
+        allowed_statuses={"applying", "failed"},
+    )
+    return _apply_manifest(
+        manifest=manifest,
+        databases=databases,
+        journal=journal,
+        resumed=True,
+        attempt_id=attempt_id,
+        receipt_version=receipt_version,
     )
 
 
-def _replace_manifest_documents(
+def _rollback_manifest_postimages(
     manifest: Mapping[str, Any],
     *,
     databases: Mapping[str, Any],
-    document_field: str,
-    reverse: bool = False,
+    before_write: Callable[[], None] | None = None,
 ) -> None:
     changes = list(manifest["changes"])
-    if reverse:
-        changes.reverse()
-    for change in changes:
+    for index in range(len(changes) - 1, -1, -1):
+        current_state = _manifest_change_states(manifest, databases)[index]["state"]
+        if current_state != "postimage":
+            continue
+        if before_write is not None:
+            before_write()
         _write_change_documents(
-            change,
+            changes[index],
             databases=databases,
-            document_field=document_field,
+            document_field="preimage_documents",
         )
 
 
@@ -599,17 +654,129 @@ def _write_change_documents(
     if change.get("mode", "replace") != "replace":
         return
     collection = databases[change["store"]][change["collection"]]
-    documents = deepcopy(list(change[document_field]))
-    if len(documents) > 1:
+    target_documents = deepcopy(list(change[document_field]))
+    expected_field = (
+        "preimage_documents"
+        if document_field == "postimage_documents"
+        else "postimage_documents"
+    )
+    expected_documents = deepcopy(list(change[expected_field]))
+    if len(target_documents) > 1 or len(expected_documents) > 1:
         raise InvalidRepairPlan("atomic replace change contains multiple documents")
-    if documents:
-        collection.replace_one(
-            deepcopy(change["selector"]),
-            documents[0],
-            upsert=True,
+
+    selector = deepcopy(change["selector"])
+    current_documents = list(collection.find(selector))
+    current_sorted = _sorted_documents(
+        current_documents,
+        identity_fields=change["identity_fields"],
+    )
+    expected_sorted = _sorted_documents(
+        expected_documents,
+        identity_fields=change["identity_fields"],
+    )
+    if _single_change_hash(change, current_sorted) != _single_change_hash(
+        change,
+        expected_sorted,
+    ):
+        raise TargetedRepairError(
+            "repair compare-and-swap failed because current documents no longer "
+            f"match {expected_field} for {change['store']}.{change['collection']}"
         )
-    else:
-        collection.delete_one(deepcopy(change["selector"]))
+
+    if target_documents and not expected_documents:
+        target_id = _require_fixed_id_for_insert(change)
+        try:
+            collection.insert_one(target_documents[0])
+        except DuplicateKeyError as exc:
+            current_by_id = _sorted_documents(
+                list(collection.find({"_id": deepcopy(target_id)})),
+                identity_fields=change["identity_fields"],
+            )
+            if _single_change_hash(change, current_by_id) == _single_change_hash(
+                change,
+                target_documents,
+            ):
+                return
+            raise TargetedRepairError(
+                "repair compare-and-swap insert failed because the fixed _id "
+                f"already contains a different document for "
+                f"{change['store']}.{change['collection']}"
+            ) from exc
+        return
+
+    if not expected_documents:
+        return
+
+    exact_selector = _exact_document_cas_selector(
+        selector,
+        current_document=current_documents[0],
+    )
+    if target_documents:
+        result = collection.replace_one(
+            exact_selector,
+            target_documents[0],
+            upsert=False,
+        )
+        matched_count = int(getattr(result, "matched_count", 0) or 0)
+        if matched_count != 1:
+            raise TargetedRepairError(
+                "repair compare-and-swap replace failed because the source document "
+                f"changed concurrently for {change['store']}.{change['collection']}"
+            )
+        return
+
+    result = collection.delete_one(exact_selector)
+    deleted_count = int(getattr(result, "deleted_count", 0) or 0)
+    if deleted_count != 1:
+        raise TargetedRepairError(
+            "repair compare-and-swap delete failed because the source document "
+            f"changed concurrently for {change['store']}.{change['collection']}"
+        )
+
+
+def _exact_document_cas_selector(
+    selector: Mapping[str, Any],
+    *,
+    current_document: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "$and": [
+            deepcopy(dict(selector)),
+            {
+                "$expr": {
+                    "$eq": [
+                        "$$ROOT",
+                        {"$literal": deepcopy(dict(current_document))},
+                    ]
+                }
+            },
+        ]
+    }
+
+
+def _require_fixed_id_for_insert(change: Mapping[str, Any]) -> Any | None:
+    if change.get("mode", "replace") != "replace":
+        return None
+    preimage_documents = list(change.get("preimage_documents") or [])
+    postimage_documents = list(change.get("postimage_documents") or [])
+    if preimage_documents or not postimage_documents:
+        return None
+    if len(postimage_documents) != 1:
+        raise InvalidRepairPlan("atomic insert must contain exactly one postimage")
+    target_document = postimage_documents[0]
+    if "_id" not in target_document or target_document.get("_id") in (None, ""):
+        raise InvalidRepairPlan("repair manifest insert requires a fixed non-empty _id")
+    target_id = deepcopy(target_document["_id"])
+    branches = _selector_branches(cast(Mapping[str, Any], change["selector"]))
+    if not branches or any(
+        len(branch.get("_id") or []) != 1
+        or not _values_equal(branch["_id"][0], target_id)
+        for branch in branches
+    ):
+        raise InvalidRepairPlan(
+            "repair manifest insert selector must require the same fixed _id"
+        )
+    return target_id
 
 
 def _current_snapshot_hash(
@@ -677,6 +844,21 @@ def _manifest_change_states(
 def _all_changes_at(states, target):
     accepted = {target, "unchanged"}
     return all(item["state"] in accepted for item in states)
+
+
+def _restore_state_is_executable(*, receipt_status, change_states):
+    if any(item["state"] == "diverged" for item in change_states):
+        return False
+    if receipt_status == "applied":
+        return _all_changes_at(change_states, "postimage")
+    if receipt_status in {"restoring", "restore_failed"}:
+        return all(
+            item["state"] in {"preimage", "postimage", "unchanged"}
+            for item in change_states
+        )
+    if receipt_status == "restored":
+        return _all_changes_at(change_states, "preimage")
+    return False
 
 
 def _single_change_hash(change, documents):
@@ -1353,6 +1535,8 @@ def _validate_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
         raise InvalidRepairPlan("unsupported repair manifest schema_version")
     required = {
         "repair_id",
+        "reason",
+        "scope",
         "plan_hash",
         "preimage_hash",
         "postimage_hash",
@@ -1364,26 +1548,122 @@ def _validate_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
         raise InvalidRepairPlan(f"repair manifest is missing fields: {missing}")
     if _manifest_hash(normalized) != str(normalized["manifest_hash"]):
         raise InvalidRepairPlan("repair manifest hash verification failed")
-    for change in normalized["changes"]:
-        mode = str(change.get("mode") or "replace")
+
+    repair_id = str(normalized.get("repair_id") or "").strip()
+    if not _REPAIR_ID_PATTERN.fullmatch(repair_id):
+        raise InvalidRepairPlan("repair manifest contains an invalid repair_id")
+    reason = str(normalized.get("reason") or "").strip()
+    if not reason:
+        raise InvalidRepairPlan("repair manifest reason must not be empty")
+    scope = _normalize_scope(normalized.get("scope"))
+    raw_changes = normalized.get("changes")
+    if not isinstance(raw_changes, Sequence) or isinstance(raw_changes, (str, bytes)):
+        raise InvalidRepairPlan("repair manifest changes must be a non-empty array")
+    if not raw_changes:
+        raise InvalidRepairPlan("repair manifest changes must be a non-empty array")
+
+    normalized_changes = []
+    for raw_change in raw_changes:
+        if not isinstance(raw_change, Mapping):
+            raise InvalidRepairPlan("repair manifest contains a non-object change")
+        change = deepcopy(dict(raw_change))
+        mode = str(change.get("mode") or "replace").strip().lower()
         if mode not in {"replace", "snapshot"}:
             raise InvalidRepairPlan(
                 "repair manifest contains an unsupported change mode"
             )
         change["mode"] = mode
-        if change.get("store") not in _SUPPORTED_STORES:
+        store = str(change.get("store") or "").strip()
+        collection = str(change.get("collection") or "").strip()
+        if store not in _SUPPORTED_STORES:
             raise InvalidRepairPlan("repair manifest contains an unsupported store")
-        if change.get("collection") in _PROTECTED_COLLECTIONS:
+        if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_]{1,127}", collection):
+            raise InvalidRepairPlan("repair manifest contains an invalid collection")
+        if collection in _PROTECTED_COLLECTIONS:
             raise InvalidRepairPlan("repair manifest targets a protected collection")
-        _validate_selector(change.get("selector"))
-        identity_fields = list(change.get("identity_fields") or [])
-        if not identity_fields:
+        change["store"] = store
+        change["collection"] = collection
+
+        selector_value = deepcopy(change.get("selector"))
+        _validate_selector(selector_value)
+        selector = cast(Mapping[str, Any], selector_value)
+        _validate_selector_scope(
+            selector,
+            scope=scope,
+            label=f"{store}.{collection}",
+        )
+        change["selector"] = selector
+
+        identity_fields = [
+            str(item or "").strip()
+            for item in list(change.get("identity_fields") or [])
+        ]
+        if not identity_fields or any(not item for item in identity_fields):
             raise InvalidRepairPlan("repair manifest change has no identity_fields")
+        if len(identity_fields) != len(set(identity_fields)):
+            raise InvalidRepairPlan(
+                "repair manifest change contains duplicate identity_fields"
+            )
+        change["identity_fields"] = identity_fields
+
         for field in ("preimage_documents", "postimage_documents"):
-            _sorted_documents(
-                list(change.get(field) or []),
+            documents_value = change.get(field)
+            if not isinstance(documents_value, list) or any(
+                not isinstance(item, Mapping) for item in documents_value
+            ):
+                raise InvalidRepairPlan(
+                    f"repair manifest {field} must be an array of objects"
+                )
+            documents = _sorted_documents(
+                [dict(cast(Mapping[str, Any], item)) for item in documents_value],
                 identity_fields=identity_fields,
             )
+            if mode == "replace" and len(documents) > 1:
+                raise InvalidRepairPlan(
+                    "repair manifest atomic replace contains multiple documents"
+                )
+            for document in documents:
+                if not _document_matches(document, selector):
+                    raise InvalidRepairPlan(
+                        f"repair manifest {field} for {store}.{collection} "
+                        "escapes its stable selector"
+                    )
+            _assert_documents_within_scope(
+                documents,
+                scope=scope,
+                label=f"{store}.{collection} {field}",
+            )
+            change[field] = documents
+
+        if mode == "snapshot" and _single_change_hash(
+            change,
+            change["preimage_documents"],
+        ) != _single_change_hash(change, change["postimage_documents"]):
+            raise InvalidRepairPlan(
+                "repair manifest snapshot change must preserve its preimage"
+            )
+        _require_fixed_id_for_insert(change)
+        if (
+            mode == "replace"
+            and _diff_count(
+                _build_document_diff(
+                    change["preimage_documents"],
+                    change["postimage_documents"],
+                    identity_fields=identity_fields,
+                )
+            )
+            > 1
+        ):
+            raise InvalidRepairPlan(
+                "repair manifest replace change is not one atomic mutation"
+            )
+        normalized_changes.append(change)
+
+    normalized["repair_id"] = repair_id
+    normalized["reason"] = reason
+    normalized["scope"] = scope
+    normalized["changes"] = normalized_changes
+    _assert_staged_changes_do_not_overlap(normalized_changes)
     if _snapshot_hash(normalized["changes"], "preimage_documents") != str(
         normalized["preimage_hash"]
     ):
@@ -1425,6 +1705,221 @@ def _persist_manifest(manifest: Mapping[str, Any], path: str | Path) -> Path:
         return target
 
 
+def _new_attempt_id(operation: str, repair_id: str) -> str:
+    return f"{operation}:{repair_id}:{uuid.uuid4().hex}"
+
+
+def _new_attempt_lease_expiry() -> str:
+    return (
+        datetime.now(timezone.utc) + timedelta(seconds=_REPAIR_ATTEMPT_LEASE_SECONDS)
+    ).isoformat()
+
+
+def _lease_is_active(value: Any) -> bool:
+    normalized = str(value or "").strip()
+    if not normalized:
+        return False
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        # A malformed non-empty lease must fail closed rather than authorizing a
+        # competing repair attempt.
+        return True
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc) > datetime.now(timezone.utc)
+
+
+def _receipt_version(receipt: Mapping[str, Any]) -> int:
+    try:
+        return int(receipt.get("receipt_version") or 0)
+    except (TypeError, ValueError) as exc:
+        raise RepairIdConflict("repair receipt has an invalid receipt_version") from exc
+
+
+def _add_existing_receipt_field(
+    selector: dict[str, Any],
+    receipt: Mapping[str, Any],
+    field: str,
+) -> None:
+    if field in receipt:
+        selector[field] = deepcopy(receipt.get(field))
+    else:
+        selector[field] = {"$exists": False}
+
+
+def _claim_attempt(
+    journal,
+    *,
+    receipt: Mapping[str, Any],
+    operation: str,
+    allowed_statuses: set[str],
+    restore_id: str | None = None,
+) -> tuple[str, int]:
+    repair_id = str(receipt.get("repair_id") or "")
+    status = str(receipt.get("status") or "")
+    if operation not in {"apply", "restore"}:
+        raise ValueError(f"unsupported repair operation: {operation}")
+    if status not in allowed_statuses:
+        raise RepairIdConflict(
+            f"repair_id {repair_id!r} cannot start {operation} from status {status!r}"
+        )
+
+    active_status = "applying" if operation == "apply" else "restoring"
+    attempt_field = f"{operation}_attempt_id"
+    lease_field = f"{operation}_lease_expires_at"
+    if status == active_status and _lease_is_active(receipt.get(lease_field)):
+        raise RepairIdConflict(
+            f"repair_id {repair_id!r} already has an active {operation} attempt"
+        )
+
+    normalized_restore_id = None
+    if operation == "restore":
+        normalized_restore_id = str(restore_id or "").strip()
+        if not normalized_restore_id:
+            raise InvalidRepairPlan("restore_id must not be empty")
+        prior_restore_id = str(receipt.get("restore_id") or "").strip()
+        if status in {"restoring", "restore_failed"} and (
+            prior_restore_id and prior_restore_id != normalized_restore_id
+        ):
+            raise RepairIdConflict(
+                f"repair_id {repair_id!r} is already bound to restore_id "
+                f"{prior_restore_id!r}"
+            )
+
+    previous_version = _receipt_version(receipt)
+    next_version = previous_version + 1
+    attempt_id = _new_attempt_id(operation, repair_id)
+    selector: dict[str, Any] = {
+        "repair_id": repair_id,
+        "status": status,
+    }
+    _add_existing_receipt_field(selector, receipt, "receipt_version")
+    _add_existing_receipt_field(selector, receipt, attempt_field)
+    _add_existing_receipt_field(selector, receipt, lease_field)
+    if operation == "restore":
+        _add_existing_receipt_field(selector, receipt, "restore_id")
+
+    now = _utc_now()
+    values: dict[str, Any] = {
+        "status": active_status,
+        "receipt_version": next_version,
+        attempt_field: attempt_id,
+        lease_field: _new_attempt_lease_expiry(),
+        f"{operation}_last_attempt_at": now,
+    }
+    if operation == "apply":
+        values["last_attempt_at"] = now
+    else:
+        values["restore_id"] = normalized_restore_id
+        values["restore_started_at"] = now
+
+    _checked_receipt_update(
+        journal,
+        selector=selector,
+        update={"$set": values},
+        message=(
+            f"repair_id {repair_id!r} {operation} receipt changed while claiming "
+            "attempt ownership"
+        ),
+    )
+    return attempt_id, next_version
+
+
+def _renew_owned_attempt_lease(
+    journal,
+    *,
+    repair_id: str,
+    operation: str,
+    attempt_id: str,
+    receipt_version: int,
+) -> None:
+    status = "applying" if operation == "apply" else "restoring"
+    attempt_field = f"{operation}_attempt_id"
+    lease_field = f"{operation}_lease_expires_at"
+    _checked_receipt_update(
+        journal,
+        selector={
+            "repair_id": repair_id,
+            "status": status,
+            "receipt_version": int(receipt_version),
+            attempt_field: attempt_id,
+        },
+        update={
+            "$set": {
+                lease_field: _new_attempt_lease_expiry(),
+                f"{operation}_last_attempt_at": _utc_now(),
+            }
+        },
+        message=(
+            f"repair_id {repair_id!r} lost {operation} attempt ownership while "
+            "renewing its lease"
+        ),
+    )
+
+
+def _finish_owned_attempt(
+    journal,
+    *,
+    repair_id: str,
+    operation: str,
+    attempt_id: str,
+    receipt_version: int,
+    status: str,
+    values: Mapping[str, Any],
+) -> None:
+    active_status = "applying" if operation == "apply" else "restoring"
+    allowed_terminal_statuses = (
+        {"applied", "failed"}
+        if operation == "apply"
+        else {"restored", "restore_failed"}
+    )
+    if status not in allowed_terminal_statuses:
+        raise ValueError(
+            f"unsupported terminal status {status!r} for repair operation {operation!r}"
+        )
+    attempt_field = f"{operation}_attempt_id"
+    lease_field = f"{operation}_lease_expires_at"
+    update_values = deepcopy(dict(values))
+    update_values.update(
+        {
+            "status": status,
+            "receipt_version": int(receipt_version) + 1,
+            lease_field: None,
+        }
+    )
+    _checked_receipt_update(
+        journal,
+        selector={
+            "repair_id": repair_id,
+            "status": active_status,
+            "receipt_version": int(receipt_version),
+            attempt_field: attempt_id,
+        },
+        update={"$set": update_values},
+        message=(
+            f"repair_id {repair_id!r} lost {operation} attempt ownership before "
+            f"transitioning to {status!r}"
+        ),
+    )
+
+
+def _checked_receipt_update(
+    journal,
+    *,
+    selector: Mapping[str, Any],
+    update: Mapping[str, Any],
+    message: str,
+) -> None:
+    result = journal.update_one(
+        deepcopy(dict(selector)),
+        deepcopy(dict(update)),
+        upsert=False,
+    )
+    if int(getattr(result, "matched_count", 0) or 0) != 1:
+        raise RepairIdConflict(message)
+
+
 def _assert_receipt_matches_manifest(
     receipt: Mapping[str, Any],
     manifest: Mapping[str, Any],
@@ -1438,6 +1933,27 @@ def _assert_receipt_matches_manifest(
     ):
         if str(receipt.get(key) or "") != str(manifest.get(key) or ""):
             raise RepairIdConflict(f"repair journal and manifest disagree on {key}")
+
+
+def _require_restore_receipt(
+    *,
+    manifest: Mapping[str, Any],
+    databases: Mapping[str, Any],
+) -> dict[str, Any]:
+    repair_id = str(manifest.get("repair_id") or "")
+    journal = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION]
+    receipt = journal.find_one({"repair_id": repair_id})
+    if receipt is None:
+        raise RepairIdConflict(
+            f"repair_id {repair_id!r} has no matching applied repair receipt"
+        )
+    _assert_receipt_matches_manifest(receipt, manifest)
+    status = str(receipt.get("status") or "")
+    if status not in _RESTORABLE_RECEIPT_STATUSES:
+        raise RestoreStateMismatch(
+            f"repair_id {repair_id!r} receipt status {status!r} is not restorable"
+        )
+    return dict(receipt)
 
 
 def _assert_expected_hash(*, expected: str, actual: str, label: str) -> None:

--- a/freshquant/order_management/repair/targeted_ledger.py
+++ b/freshquant/order_management/repair/targeted_ledger.py
@@ -1,0 +1,1583 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import hashlib
+import re
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence, cast
+
+from bson import json_util
+from pymongo.errors import DuplicateKeyError
+
+TARGETED_REPAIR_SCHEMA_VERSION = 1
+TARGETED_REPAIR_MANIFEST_SCHEMA_VERSION = 1
+TARGETED_REPAIR_JOURNAL_COLLECTION = "om_targeted_repair_runs"
+
+_SUPPORTED_STORES = {"business", "order"}
+_PROTECTED_COLLECTIONS = {
+    "om_execution_history_archive",
+    "position_review_evidence_archive",
+    TARGETED_REPAIR_JOURNAL_COLLECTION,
+}
+_SAFE_QUERY_OPERATORS = {"$and", "$or", "$eq", "$in"}
+_REPAIR_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$")
+
+_SCOPE_FIELDS: dict[str, tuple[str, ...]] = {
+    "account_id": ("account_id",),
+    "symbols": ("symbol", "stock_code"),
+    "broker_order_ids": ("broker_order_id", "order_id"),
+    "order_sysids": ("order_sysid", "order_sys_id"),
+    "broker_trade_ids": ("broker_trade_id", "traded_id"),
+    "trading_days": ("trading_day", "date"),
+    "request_ids": ("request_id",),
+    "internal_order_ids": ("internal_order_id",),
+    "execution_fill_ids": ("execution_fill_id",),
+    "trade_fact_ids": ("trade_fact_id", "exit_trade_fact_id"),
+    "entry_ids": ("entry_id",),
+    "entry_slice_ids": ("entry_slice_id",),
+    "allocation_ids": ("allocation_id",),
+    "gap_ids": ("gap_id",),
+    "resolution_ids": ("resolution_id",),
+    "rejection_ids": ("rejection_id",),
+    "document_ids": ("_id",),
+}
+
+
+class TargetedRepairError(RuntimeError):
+    pass
+
+
+class InvalidRepairPlan(TargetedRepairError):
+    pass
+
+
+class AllowedDiffMismatch(TargetedRepairError):
+    pass
+
+
+class PreimageHashMismatch(TargetedRepairError):
+    pass
+
+
+class RepairIdConflict(TargetedRepairError):
+    pass
+
+
+class RestoreStateMismatch(TargetedRepairError):
+    pass
+
+
+def stage_targeted_repair(
+    *,
+    plan: Mapping[str, Any],
+    databases: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build an immutable repair manifest without mutating any database."""
+
+    normalized_plan = _normalize_plan(plan)
+    _validate_databases(normalized_plan, databases)
+    staged_changes: list[dict[str, Any]] = []
+
+    for change in normalized_plan["changes"]:
+        collection = databases[change["store"]][change["collection"]]
+        preimage_documents = _sorted_documents(
+            list(collection.find(deepcopy(change["selector"]))),
+            identity_fields=change["identity_fields"],
+        )
+        _assert_documents_within_scope(
+            preimage_documents,
+            scope=normalized_plan["scope"],
+            label=f"{change['store']}.{change['collection']} preimage",
+        )
+        postimage_documents = (
+            deepcopy(preimage_documents)
+            if change["mode"] == "snapshot"
+            else _sorted_documents(
+                change["desired_documents"],
+                identity_fields=change["identity_fields"],
+            )
+        )
+        _assert_documents_within_scope(
+            postimage_documents,
+            scope=normalized_plan["scope"],
+            label=f"{change['store']}.{change['collection']} postimage",
+        )
+        if change["mode"] == "replace" and (
+            len(preimage_documents) > 1 or len(postimage_documents) > 1
+        ):
+            raise InvalidRepairPlan(
+                f"replace change for {change['store']}.{change['collection']} "
+                "must target at most one preimage and one postimage document"
+            )
+        diff = _build_document_diff(
+            preimage_documents,
+            postimage_documents,
+            identity_fields=change["identity_fields"],
+        )
+        _assert_allowed_diff(
+            actual=diff,
+            expected=change["allowed_diff"],
+            identity_fields=change["identity_fields"],
+            store=change["store"],
+            collection=change["collection"],
+        )
+        if change["mode"] == "replace" and _diff_count(diff) > 1:
+            raise InvalidRepairPlan(
+                f"replace change for {change['store']}.{change['collection']} "
+                "must express one atomic insert, update or delete; split identity moves"
+            )
+        staged_changes.append(
+            {
+                "mode": change["mode"],
+                "store": change["store"],
+                "collection": change["collection"],
+                "selector": deepcopy(change["selector"]),
+                "identity_fields": list(change["identity_fields"]),
+                "preimage_documents": preimage_documents,
+                "postimage_documents": postimage_documents,
+                "diff": diff,
+            }
+        )
+
+    _assert_staged_changes_do_not_overlap(staged_changes)
+    if not any(_diff_count(item["diff"]) for item in staged_changes):
+        raise InvalidRepairPlan("repair plan does not change any scoped document")
+
+    plan_hash = build_repair_plan_hash(normalized_plan)
+    preimage_hash = _snapshot_hash(staged_changes, "preimage_documents")
+    postimage_hash = _snapshot_hash(staged_changes, "postimage_documents")
+    manifest = {
+        "schema_version": TARGETED_REPAIR_MANIFEST_SCHEMA_VERSION,
+        "repair_id": normalized_plan["repair_id"],
+        "reason": normalized_plan["reason"],
+        "scope": deepcopy(normalized_plan["scope"]),
+        "plan_hash": plan_hash,
+        "preimage_hash": preimage_hash,
+        "postimage_hash": postimage_hash,
+        "created_at": _utc_now(),
+        "changes": staged_changes,
+    }
+    manifest["manifest_hash"] = _manifest_hash(manifest)
+    return manifest
+
+
+def execute_targeted_repair(
+    *,
+    plan: Mapping[str, Any],
+    databases: Mapping[str, Any],
+    expected_preimage_hash: str,
+    manifest_path: str | Path,
+) -> dict[str, Any]:
+    """Apply one explicitly scoped repair after all safety gates pass."""
+
+    normalized_plan = _normalize_plan(plan)
+    _validate_databases(normalized_plan, databases)
+    repair_id = normalized_plan["repair_id"]
+    plan_hash = build_repair_plan_hash(normalized_plan)
+    journal = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION]
+    _ensure_journal_index(journal)
+
+    existing = journal.find_one({"repair_id": repair_id})
+    if existing is not None:
+        return _resume_or_report_existing_repair(
+            existing=existing,
+            plan_hash=plan_hash,
+            expected_preimage_hash=expected_preimage_hash,
+            databases=databases,
+            journal=journal,
+        )
+
+    manifest = stage_targeted_repair(plan=normalized_plan, databases=databases)
+    _assert_expected_hash(
+        expected=expected_preimage_hash,
+        actual=manifest["preimage_hash"],
+        label="preimage",
+    )
+    persisted_manifest_path = _persist_manifest(manifest, manifest_path)
+    receipt = {
+        "repair_id": repair_id,
+        "schema_version": TARGETED_REPAIR_SCHEMA_VERSION,
+        "status": "applying",
+        "reason": normalized_plan["reason"],
+        "scope": deepcopy(normalized_plan["scope"]),
+        "plan_hash": manifest["plan_hash"],
+        "manifest_hash": manifest["manifest_hash"],
+        "manifest_path": str(persisted_manifest_path),
+        "preimage_hash": manifest["preimage_hash"],
+        "postimage_hash": manifest["postimage_hash"],
+        "started_at": _utc_now(),
+    }
+    try:
+        journal.insert_one(deepcopy(receipt))
+    except DuplicateKeyError:
+        existing = journal.find_one({"repair_id": repair_id})
+        if existing is None:
+            raise
+        return _resume_or_report_existing_repair(
+            existing=existing,
+            plan_hash=plan_hash,
+            expected_preimage_hash=expected_preimage_hash,
+            databases=databases,
+            journal=journal,
+        )
+
+    return _apply_manifest(
+        manifest=manifest,
+        databases=databases,
+        journal=journal,
+        resumed=False,
+    )
+
+
+def preview_targeted_restore(
+    *,
+    manifest: Mapping[str, Any],
+    databases: Mapping[str, Any],
+) -> dict[str, Any]:
+    normalized_manifest = _validate_manifest(manifest)
+    _validate_manifest_databases(normalized_manifest, databases)
+    current_hash = _current_snapshot_hash(normalized_manifest, databases)
+    change_states = _manifest_change_states(normalized_manifest, databases)
+    return {
+        "repair_id": normalized_manifest["repair_id"],
+        "execute": False,
+        "current_hash": current_hash,
+        "expected_postimage_hash": normalized_manifest["postimage_hash"],
+        "target_preimage_hash": normalized_manifest["preimage_hash"],
+        "restorable": not any(item["state"] == "diverged" for item in change_states)
+        and any(item["state"] == "postimage" for item in change_states),
+        "change_states": change_states,
+        "changes": [
+            {
+                "mode": item["mode"],
+                "store": item["store"],
+                "collection": item["collection"],
+                "restore_document_count": len(item["preimage_documents"]),
+                "remove_document_count": len(item["postimage_documents"]),
+            }
+            for item in normalized_manifest["changes"]
+        ],
+    }
+
+
+def restore_targeted_repair(
+    *,
+    manifest: Mapping[str, Any],
+    databases: Mapping[str, Any],
+    expected_current_hash: str,
+    restore_id: str | None = None,
+) -> dict[str, Any]:
+    """Restore an applied repair only while its exact postimage is current."""
+
+    normalized_manifest = _validate_manifest(manifest)
+    _validate_manifest_databases(normalized_manifest, databases)
+    repair_id = normalized_manifest["repair_id"]
+    normalized_restore_id = str(restore_id or f"restore:{repair_id}").strip()
+    if not normalized_restore_id:
+        raise InvalidRepairPlan("restore_id must not be empty")
+    journal = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION]
+    _ensure_journal_index(journal)
+    receipt = journal.find_one({"repair_id": repair_id})
+    if receipt is not None:
+        _assert_receipt_matches_manifest(receipt, normalized_manifest)
+
+    current_hash = _current_snapshot_hash(normalized_manifest, databases)
+    change_states = _manifest_change_states(normalized_manifest, databases)
+    if receipt is not None and receipt.get("status") == "restored":
+        if str(receipt.get("restore_id") or "") != normalized_restore_id:
+            raise RepairIdConflict(
+                f"repair_id {repair_id!r} was restored by another restore_id"
+            )
+        if not _all_changes_at(change_states, "preimage"):
+            raise RestoreStateMismatch(
+                "restored receipt exists but current scoped state no longer matches preimage"
+            )
+        return _repair_summary(
+            normalized_manifest,
+            execute=True,
+            status="already_restored",
+            idempotent=True,
+        )
+
+    _assert_expected_hash(
+        expected=expected_current_hash,
+        actual=current_hash,
+        label="restore current state",
+    )
+    if any(item["state"] == "diverged" for item in change_states):
+        raise RestoreStateMismatch(
+            "restore is blocked because one or more changes match neither preimage nor postimage"
+        )
+    receipt_status = str((receipt or {}).get("status") or "")
+    if not _all_changes_at(change_states, "postimage") and receipt_status not in {
+        "restoring",
+        "restore_failed",
+    }:
+        raise RestoreStateMismatch(
+            "partial restore state is resumable only from a restoring receipt"
+        )
+
+    journal.update_one(
+        {"repair_id": repair_id},
+        {
+            "$set": {
+                "status": "restoring",
+                "restore_id": normalized_restore_id,
+                "restore_started_at": _utc_now(),
+            },
+            "$setOnInsert": {
+                "repair_id": repair_id,
+                "schema_version": TARGETED_REPAIR_SCHEMA_VERSION,
+                "reason": normalized_manifest.get("reason"),
+                "scope": deepcopy(normalized_manifest.get("scope") or {}),
+                "plan_hash": normalized_manifest["plan_hash"],
+                "manifest_hash": normalized_manifest["manifest_hash"],
+                "preimage_hash": normalized_manifest["preimage_hash"],
+                "postimage_hash": normalized_manifest["postimage_hash"],
+            },
+        },
+        upsert=True,
+    )
+
+    try:
+        for index in range(len(normalized_manifest["changes"]) - 1, -1, -1):
+            if change_states[index]["state"] != "postimage":
+                continue
+            _write_change_documents(
+                normalized_manifest["changes"][index],
+                databases=databases,
+                document_field="preimage_documents",
+            )
+        restored_hash = _current_snapshot_hash(normalized_manifest, databases)
+        if restored_hash != normalized_manifest["preimage_hash"]:
+            raise RestoreStateMismatch(
+                "restore write completed but scoped state does not match preimage hash"
+            )
+    except Exception as exc:
+        journal.update_one(
+            {"repair_id": repair_id},
+            {
+                "$set": {
+                    "status": "restore_failed",
+                    "restore_id": normalized_restore_id,
+                    "restore_failed_at": _utc_now(),
+                    "restore_error": f"{type(exc).__name__}: {exc}",
+                }
+            },
+        )
+        raise
+
+    receipt_update = {
+        "$set": {
+            "status": "restored",
+            "restore_id": normalized_restore_id,
+            "restored_at": _utc_now(),
+            "restored_hash": normalized_manifest["preimage_hash"],
+        },
+        "$setOnInsert": {
+            "repair_id": repair_id,
+            "schema_version": TARGETED_REPAIR_SCHEMA_VERSION,
+            "reason": normalized_manifest.get("reason"),
+            "scope": deepcopy(normalized_manifest.get("scope") or {}),
+            "plan_hash": normalized_manifest["plan_hash"],
+            "manifest_hash": normalized_manifest["manifest_hash"],
+            "preimage_hash": normalized_manifest["preimage_hash"],
+            "postimage_hash": normalized_manifest["postimage_hash"],
+        },
+    }
+    journal.update_one(
+        {"repair_id": repair_id},
+        receipt_update,
+        upsert=True,
+    )
+    return _repair_summary(
+        normalized_manifest,
+        execute=True,
+        status="restored",
+        idempotent=False,
+    )
+
+
+def load_repair_document(path: str | Path) -> dict[str, Any]:
+    return json_util.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def build_repair_plan_hash(plan: Mapping[str, Any]) -> str:
+    normalized_plan = _normalize_plan(plan)
+    return _hash_value(normalized_plan)
+
+
+def _apply_manifest(
+    *,
+    manifest: Mapping[str, Any],
+    databases: Mapping[str, Any],
+    journal,
+    resumed: bool,
+) -> dict[str, Any]:
+    repair_id = str(manifest["repair_id"])
+    journal.update_one(
+        {"repair_id": repair_id},
+        {"$set": {"status": "applying", "last_attempt_at": _utc_now()}},
+    )
+    try:
+        change_states = _manifest_change_states(manifest, databases)
+        if any(item["state"] == "diverged" for item in change_states):
+            raise PreimageHashMismatch(
+                "one or more scoped changes match neither preimage nor postimage"
+            )
+        if _all_changes_at(change_states, "postimage"):
+            current_hash = _current_snapshot_hash(manifest, databases)
+            if current_hash == manifest["postimage_hash"]:
+                journal.update_one(
+                    {"repair_id": repair_id},
+                    {
+                        "$set": {
+                            "status": "applied",
+                            "applied_at": _utc_now(),
+                            "observed_postimage_hash": current_hash,
+                        }
+                    },
+                )
+                return _repair_summary(
+                    manifest,
+                    execute=True,
+                    status="already_applied",
+                    idempotent=True,
+                )
+        for index, change in enumerate(manifest["changes"]):
+            if change_states[index]["state"] != "preimage":
+                continue
+            _write_change_documents(
+                change,
+                databases=databases,
+                document_field="postimage_documents",
+            )
+        observed_postimage_hash = _current_snapshot_hash(manifest, databases)
+        if observed_postimage_hash != manifest["postimage_hash"]:
+            raise TargetedRepairError(
+                "repair write completed but scoped state does not match postimage hash"
+            )
+    except Exception as exc:
+        rollback_succeeded = False
+        rollback_error = None
+        try:
+            _replace_manifest_documents(
+                manifest,
+                databases=databases,
+                document_field="preimage_documents",
+                reverse=True,
+            )
+            rollback_succeeded = (
+                _current_snapshot_hash(manifest, databases) == manifest["preimage_hash"]
+            )
+        except Exception as rollback_exc:  # pragma: no cover - runtime safeguard
+            rollback_error = f"{type(rollback_exc).__name__}: {rollback_exc}"
+        journal.update_one(
+            {"repair_id": repair_id},
+            {
+                "$set": {
+                    "status": "failed",
+                    "failed_at": _utc_now(),
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "rollback_succeeded": rollback_succeeded,
+                    "rollback_error": rollback_error,
+                }
+            },
+        )
+        raise
+
+    journal.update_one(
+        {"repair_id": repair_id},
+        {
+            "$set": {
+                "status": "applied",
+                "applied_at": _utc_now(),
+                "observed_postimage_hash": observed_postimage_hash,
+                "resumed": bool(resumed),
+            }
+        },
+    )
+    return _repair_summary(
+        manifest,
+        execute=True,
+        status="applied",
+        idempotent=False,
+    )
+
+
+def _resume_or_report_existing_repair(
+    *,
+    existing: Mapping[str, Any],
+    plan_hash: str,
+    expected_preimage_hash: str,
+    databases: Mapping[str, Any],
+    journal,
+) -> dict[str, Any]:
+    repair_id = str(existing.get("repair_id") or "")
+    if str(existing.get("plan_hash") or "") != plan_hash:
+        raise RepairIdConflict(
+            f"repair_id {repair_id!r} is already bound to a different plan"
+        )
+    manifest_path = str(existing.get("manifest_path") or "").strip()
+    if not manifest_path:
+        raise RepairIdConflict(
+            f"repair_id {repair_id!r} has no recoverable manifest_path"
+        )
+    manifest = _validate_manifest(load_repair_document(manifest_path))
+    _assert_receipt_matches_manifest(existing, manifest)
+    _assert_expected_hash(
+        expected=expected_preimage_hash,
+        actual=manifest["preimage_hash"],
+        label="preimage",
+    )
+    current_hash = _current_snapshot_hash(manifest, databases)
+    change_states = _manifest_change_states(manifest, databases)
+    status = str(existing.get("status") or "")
+    if status == "restored":
+        raise RepairIdConflict(
+            f"repair_id {repair_id!r} has been restored and cannot be reused"
+        )
+    if current_hash == manifest["postimage_hash"]:
+        if status != "applied":
+            journal.update_one(
+                {"repair_id": repair_id},
+                {
+                    "$set": {
+                        "status": "applied",
+                        "applied_at": _utc_now(),
+                        "observed_postimage_hash": current_hash,
+                    }
+                },
+            )
+        return _repair_summary(
+            manifest,
+            execute=True,
+            status="already_applied",
+            idempotent=True,
+        )
+    if status in {"applying", "failed"} and not any(
+        item["state"] == "diverged" for item in change_states
+    ):
+        return _apply_manifest(
+            manifest=manifest,
+            databases=databases,
+            journal=journal,
+            resumed=True,
+        )
+    raise RepairIdConflict(
+        f"repair_id {repair_id!r} exists but scoped state matches neither preimage nor postimage"
+    )
+
+
+def _replace_manifest_documents(
+    manifest: Mapping[str, Any],
+    *,
+    databases: Mapping[str, Any],
+    document_field: str,
+    reverse: bool = False,
+) -> None:
+    changes = list(manifest["changes"])
+    if reverse:
+        changes.reverse()
+    for change in changes:
+        _write_change_documents(
+            change,
+            databases=databases,
+            document_field=document_field,
+        )
+
+
+def _write_change_documents(
+    change: Mapping[str, Any],
+    *,
+    databases: Mapping[str, Any],
+    document_field: str,
+) -> None:
+    if change.get("mode", "replace") != "replace":
+        return
+    collection = databases[change["store"]][change["collection"]]
+    documents = deepcopy(list(change[document_field]))
+    if len(documents) > 1:
+        raise InvalidRepairPlan("atomic replace change contains multiple documents")
+    if documents:
+        collection.replace_one(
+            deepcopy(change["selector"]),
+            documents[0],
+            upsert=True,
+        )
+    else:
+        collection.delete_one(deepcopy(change["selector"]))
+
+
+def _current_snapshot_hash(
+    manifest: Mapping[str, Any],
+    databases: Mapping[str, Any],
+) -> str:
+    changes = []
+    for change in manifest["changes"]:
+        documents = list(
+            databases[change["store"]][change["collection"]].find(
+                deepcopy(change["selector"])
+            )
+        )
+        changes.append(
+            {
+                "mode": change.get("mode", "replace"),
+                "store": change["store"],
+                "collection": change["collection"],
+                "identity_fields": list(change["identity_fields"]),
+                "current_documents": _sorted_documents(
+                    documents,
+                    identity_fields=change["identity_fields"],
+                ),
+            }
+        )
+    return _snapshot_hash(changes, "current_documents")
+
+
+def _manifest_change_states(
+    manifest: Mapping[str, Any],
+    databases: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    states = []
+    for index, change in enumerate(manifest["changes"]):
+        current_documents = _sorted_documents(
+            list(
+                databases[change["store"]][change["collection"]].find(
+                    deepcopy(change["selector"])
+                )
+            ),
+            identity_fields=change["identity_fields"],
+        )
+        current_hash = _single_change_hash(change, current_documents)
+        preimage_hash = _single_change_hash(change, change["preimage_documents"])
+        postimage_hash = _single_change_hash(change, change["postimage_documents"])
+        if current_hash == preimage_hash == postimage_hash:
+            state = "unchanged"
+        elif current_hash == preimage_hash:
+            state = "preimage"
+        elif current_hash == postimage_hash:
+            state = "postimage"
+        else:
+            state = "diverged"
+        states.append(
+            {
+                "index": index,
+                "store": change["store"],
+                "collection": change["collection"],
+                "state": state,
+            }
+        )
+    return states
+
+
+def _all_changes_at(states, target):
+    accepted = {target, "unchanged"}
+    return all(item["state"] in accepted for item in states)
+
+
+def _single_change_hash(change, documents):
+    return _snapshot_hash(
+        [
+            {
+                "mode": change.get("mode", "replace"),
+                "store": change["store"],
+                "collection": change["collection"],
+                "identity_fields": change["identity_fields"],
+                "documents": documents,
+            }
+        ],
+        "documents",
+    )
+
+
+def _normalize_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(plan, Mapping):
+        raise InvalidRepairPlan("repair plan must be an object")
+    schema_version = int(plan.get("schema_version") or 0)
+    if schema_version != TARGETED_REPAIR_SCHEMA_VERSION:
+        raise InvalidRepairPlan(
+            f"unsupported repair plan schema_version: {schema_version}"
+        )
+    repair_id = str(plan.get("repair_id") or "").strip()
+    if not _REPAIR_ID_PATTERN.fullmatch(repair_id):
+        raise InvalidRepairPlan(
+            "repair_id must be 8-128 characters using letters, digits, '.', '_', ':' or '-'"
+        )
+    reason = str(plan.get("reason") or "").strip()
+    if not reason:
+        raise InvalidRepairPlan("reason must not be empty")
+    scope = _normalize_scope(plan.get("scope"))
+    raw_changes = plan.get("changes")
+    if not isinstance(raw_changes, Sequence) or isinstance(raw_changes, (str, bytes)):
+        raise InvalidRepairPlan("changes must be a non-empty array")
+    changes = [_normalize_change(item, scope=scope) for item in list(raw_changes or [])]
+    if not changes:
+        raise InvalidRepairPlan("changes must be a non-empty array")
+    return {
+        "schema_version": schema_version,
+        "repair_id": repair_id,
+        "reason": reason,
+        "scope": scope,
+        "changes": changes,
+    }
+
+
+def _normalize_scope(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise InvalidRepairPlan("scope must be an object")
+    account_id = str(value.get("account_id") or "").strip()
+    symbols = _normalize_scope_list(value.get("symbols"))
+    # Broker truth can persist these identifiers as strings or BSON numerics.
+    # Preserve the declared scalar types so alternate representations stay explicit.
+    broker_order_ids = _normalize_scope_list(
+        value.get("broker_order_ids"),
+        stringify=False,
+    )
+    order_sysids = _normalize_scope_list(
+        value.get("order_sysids"),
+        stringify=False,
+    )
+    if not account_id:
+        raise InvalidRepairPlan("scope.account_id must not be empty")
+    if not symbols:
+        raise InvalidRepairPlan("scope.symbols must not be empty")
+    if not broker_order_ids and not order_sysids:
+        raise InvalidRepairPlan("scope must include broker_order_ids or order_sysids")
+    normalized: dict[str, Any] = {
+        "account_id": account_id,
+        "symbols": symbols,
+        "broker_order_ids": broker_order_ids,
+        "order_sysids": order_sysids,
+    }
+    for key in _SCOPE_FIELDS:
+        if key in normalized or key == "account_id":
+            continue
+        values = _normalize_scope_list(value.get(key), stringify=False)
+        if values:
+            normalized[key] = values
+    return normalized
+
+
+def _normalize_change(value: Any, *, scope: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise InvalidRepairPlan("each change must be an object")
+    store = str(value.get("store") or "").strip()
+    collection = str(value.get("collection") or "").strip()
+    mode = str(value.get("mode") or "replace").strip().lower()
+    if store not in _SUPPORTED_STORES:
+        raise InvalidRepairPlan(f"unsupported repair store: {store!r}")
+    if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_]{1,127}", collection):
+        raise InvalidRepairPlan(f"invalid collection name: {collection!r}")
+    if collection in _PROTECTED_COLLECTIONS:
+        raise InvalidRepairPlan(
+            f"append-only/audit collection cannot be mutated: {collection}"
+        )
+    if mode not in {"replace", "snapshot"}:
+        raise InvalidRepairPlan(
+            f"unsupported change mode for {store}.{collection}: {mode!r}"
+        )
+    selector_value = deepcopy(value.get("selector"))
+    _validate_selector(selector_value)
+    selector = cast(Mapping[str, Any], selector_value)
+    _validate_selector_scope(selector, scope=scope, label=f"{store}.{collection}")
+    identity_fields = [
+        str(item or "").strip() for item in list(value.get("identity_fields") or [])
+    ]
+    if not identity_fields or any(not item for item in identity_fields):
+        raise InvalidRepairPlan(
+            f"identity_fields for {store}.{collection} must be non-empty"
+        )
+    if len(identity_fields) != len(set(identity_fields)):
+        raise InvalidRepairPlan(
+            f"identity_fields for {store}.{collection} contain duplicates"
+        )
+    desired_documents_value = deepcopy(value.get("desired_documents"))
+    if mode == "snapshot" and desired_documents_value in (None, []):
+        desired_documents_value = []
+    if not isinstance(desired_documents_value, list) or any(
+        not isinstance(item, Mapping) for item in desired_documents_value
+    ):
+        raise InvalidRepairPlan(
+            f"desired_documents for {store}.{collection} must be an array of objects"
+        )
+    desired_documents = [
+        dict(cast(Mapping[str, Any], item)) for item in desired_documents_value
+    ]
+    if mode == "snapshot" and desired_documents:
+        raise InvalidRepairPlan(
+            f"snapshot change for {store}.{collection} must not declare desired_documents"
+        )
+    if mode == "replace" and len(desired_documents) > 1:
+        raise InvalidRepairPlan(
+            f"replace change for {store}.{collection} may declare at most one desired document"
+        )
+    for document in desired_documents:
+        if not _document_matches(document, selector):
+            raise InvalidRepairPlan(
+                f"desired document for {store}.{collection} escapes its stable selector"
+            )
+    _assert_documents_within_scope(
+        desired_documents,
+        scope=scope,
+        label=f"{store}.{collection} desired_documents",
+    )
+    allowed_diff = _normalize_allowed_diff(
+        value.get("allowed_diff"),
+        identity_fields=identity_fields,
+        store=store,
+        collection=collection,
+    )
+    if mode == "snapshot" and _diff_count(allowed_diff):
+        raise InvalidRepairPlan(
+            f"snapshot change for {store}.{collection} must have an empty allowed_diff"
+        )
+    _ensure_unique_document_identities(
+        desired_documents,
+        identity_fields=identity_fields,
+        label=f"{store}.{collection} desired_documents",
+    )
+    return {
+        "mode": mode,
+        "store": store,
+        "collection": collection,
+        "selector": selector,
+        "identity_fields": identity_fields,
+        "desired_documents": [dict(item) for item in desired_documents],
+        "allowed_diff": allowed_diff,
+    }
+
+
+def _normalize_allowed_diff(
+    value: Any,
+    *,
+    identity_fields: Sequence[str],
+    store: str,
+    collection: str,
+) -> dict[str, list[dict[str, Any]]]:
+    if not isinstance(value, Mapping):
+        raise InvalidRepairPlan(
+            f"allowed_diff for {store}.{collection} must be an object"
+        )
+    extra_keys = set(value) - {"inserted", "updated", "deleted"}
+    if extra_keys:
+        raise InvalidRepairPlan(
+            f"allowed_diff for {store}.{collection} has unsupported keys: {sorted(extra_keys)}"
+        )
+    normalized: dict[str, list[dict[str, Any]]] = {}
+    for action in ("inserted", "updated", "deleted"):
+        identities = value.get(action, [])
+        if not isinstance(identities, list):
+            raise InvalidRepairPlan(
+                f"allowed_diff.{action} for {store}.{collection} must be an array"
+            )
+        normalized[action] = _sorted_identities(
+            identities,
+            identity_fields=identity_fields,
+            label=f"{store}.{collection} allowed_diff.{action}",
+        )
+    return normalized
+
+
+def _normalize_scope_list(value: Any, *, stringify: bool = True) -> list[Any]:
+    if value in (None, ""):
+        return []
+    values: list[Any] = (
+        list(value) if isinstance(value, (list, tuple, set)) else [value]
+    )
+    normalized: list[Any] = []
+    for item in values:
+        if stringify:
+            current = str(item).strip()
+        elif isinstance(item, str):
+            current = item.strip()
+        else:
+            current = deepcopy(item)
+        if current in (None, ""):
+            continue
+        if not any(_values_equal(current, existing) for existing in normalized):
+            normalized.append(current)
+    return sorted(normalized, key=_scope_value_sort_key)
+
+
+def _scope_value_sort_key(value: Any) -> tuple[int, str]:
+    if isinstance(value, bool):
+        rank = 2
+    elif isinstance(value, (int, float)):
+        rank = 0
+    elif isinstance(value, str):
+        rank = 1
+    else:
+        rank = 3
+    return rank, _canonical_json(value)
+
+
+def _validate_selector(selector: Any) -> None:
+    if not isinstance(selector, Mapping) or not selector:
+        raise InvalidRepairPlan("every change requires a non-empty selector")
+
+    def visit(value: Any, *, in_field=False) -> None:
+        if isinstance(value, Mapping):
+            for key, child in value.items():
+                key = str(key)
+                if key.startswith("$") and key not in _SAFE_QUERY_OPERATORS:
+                    raise InvalidRepairPlan(f"unsafe selector operator: {key}")
+                if key in {"$and", "$or"}:
+                    if not isinstance(child, list) or not child:
+                        raise InvalidRepairPlan(
+                            f"selector {key} requires a non-empty array"
+                        )
+                    for item in child:
+                        visit(item, in_field=False)
+                elif key in {"$eq", "$in"}:
+                    if not in_field:
+                        raise InvalidRepairPlan(f"selector {key} must follow a field")
+                    if key == "$in" and not isinstance(child, list):
+                        raise InvalidRepairPlan("selector $in requires an array")
+                else:
+                    visit(child, in_field=True)
+        elif isinstance(value, list) and not in_field:
+            for item in value:
+                visit(item, in_field=False)
+
+    visit(selector)
+
+
+def _validate_selector_scope(
+    selector: Mapping[str, Any],
+    *,
+    scope: Mapping[str, Any],
+    label: str,
+) -> None:
+    scoped_values_by_field = _scoped_values_by_field(scope)
+    stable_fields = {
+        field
+        for scope_key, fields in _SCOPE_FIELDS.items()
+        if scope_key not in {"account_id", "symbols", "trading_days"}
+        for field in fields
+    }
+    branches = _selector_branches(selector)
+    if not branches:
+        raise InvalidRepairPlan(f"selector for {label} has no logical branch")
+
+    for branch in branches:
+        for field, candidates in branch.items():
+            if field not in scoped_values_by_field:
+                continue
+            allowed = scoped_values_by_field[field]
+            if not allowed or any(
+                not any(_values_equal(candidate, scoped) for scoped in allowed)
+                for candidate in candidates
+            ):
+                raise InvalidRepairPlan(
+                    f"selector branch for {label} escapes declared scope field {field}"
+                )
+
+        account_candidates = branch.get("account_id", [])
+        document_id_candidates = branch.get("_id", [])
+        account_anchored = bool(account_candidates) and all(
+            _values_equal(item, scope["account_id"]) for item in account_candidates
+        )
+        document_anchored = bool(document_id_candidates) and _values_are_scoped(
+            document_id_candidates,
+            scope.get("document_ids") or [],
+        )
+        if not account_anchored and not document_anchored:
+            raise InvalidRepairPlan(
+                f"every selector branch for {label} requires account_id or an exact scoped _id"
+            )
+
+        stable_anchors = [
+            field
+            for field in stable_fields
+            if branch.get(field)
+            and _values_are_scoped(
+                branch[field],
+                scoped_values_by_field.get(field) or [],
+            )
+        ]
+        if not stable_anchors:
+            raise InvalidRepairPlan(
+                f"every selector branch for {label} requires a stable order/execution/document closure key"
+            )
+
+
+def _selector_branches(selector: Mapping[str, Any]) -> list[dict[str, list[Any]]]:
+    base: dict[str, list[Any]] = {}
+    and_groups = []
+    or_groups = []
+    for key, value in selector.items():
+        if key == "$and":
+            and_groups.extend(value)
+        elif key == "$or":
+            or_groups.append(value)
+        else:
+            base[str(key)] = _selector_values(value)
+
+    branches = [base]
+    for child in and_groups:
+        branches = _combine_selector_branches(branches, _selector_branches(child))
+    for alternatives in or_groups:
+        option_branches = [
+            branch for option in alternatives for branch in _selector_branches(option)
+        ]
+        branches = _combine_selector_branches(branches, option_branches)
+    return branches
+
+
+def _combine_selector_branches(left, right):
+    combined = []
+    for left_branch in left:
+        for right_branch in right:
+            branch = deepcopy(left_branch)
+            compatible = True
+            for field, candidates in right_branch.items():
+                if field in branch and not any(
+                    _values_equal(left_value, right_value)
+                    for left_value in branch[field]
+                    for right_value in candidates
+                ):
+                    compatible = False
+                    break
+                branch.setdefault(field, [])
+                for candidate in candidates:
+                    if not any(
+                        _values_equal(candidate, existing) for existing in branch[field]
+                    ):
+                        branch[field].append(candidate)
+            if compatible:
+                combined.append(branch)
+    return combined
+
+
+def _scoped_values_by_field(scope: Mapping[str, Any]) -> dict[str, list[Any]]:
+    result: dict[str, list[Any]] = {}
+    for scope_key, fields in _SCOPE_FIELDS.items():
+        raw_values = (
+            [scope.get(scope_key)]
+            if scope_key == "account_id"
+            else scope.get(scope_key)
+        )
+        values = list(raw_values or [])
+        for field in fields:
+            result.setdefault(field, []).extend(values)
+    return result
+
+
+def _values_are_scoped(candidates, allowed):
+    return (
+        bool(candidates)
+        and bool(allowed)
+        and all(
+            any(_values_equal(candidate, scoped) for scoped in allowed)
+            for candidate in candidates
+        )
+    )
+
+
+def _assert_documents_within_scope(
+    documents: Sequence[Mapping[str, Any]],
+    *,
+    scope: Mapping[str, Any],
+    label: str,
+) -> None:
+    scoped_values_by_field = _scoped_values_by_field(scope)
+    for document in documents:
+        for field, allowed in scoped_values_by_field.items():
+            value = _get_path(document, field)
+            if value in (None, "") or not allowed:
+                continue
+            if not any(_values_equal(value, scoped) for scoped in allowed):
+                raise InvalidRepairPlan(
+                    f"{label} document escapes declared scope field {field}"
+                )
+
+
+def _assert_staged_changes_do_not_overlap(changes: Sequence[Mapping[str, Any]]) -> None:
+    for index, left in enumerate(changes):
+        for right in changes[index + 1 :]:
+            if (left["store"], left["collection"]) != (
+                right["store"],
+                right["collection"],
+            ):
+                continue
+            left_documents = [
+                *left["preimage_documents"],
+                *left["postimage_documents"],
+            ]
+            right_documents = [
+                *right["preimage_documents"],
+                *right["postimage_documents"],
+            ]
+            if any(
+                _document_matches(document, right["selector"])
+                for document in left_documents
+            ) or any(
+                _document_matches(document, left["selector"])
+                for document in right_documents
+            ):
+                raise InvalidRepairPlan(
+                    f"overlapping selectors for {left['store']}.{left['collection']}"
+                )
+
+
+def _selector_values(value: Any) -> list[Any]:
+    if isinstance(value, Mapping):
+        if "$eq" in value:
+            return [value["$eq"]]
+        if "$in" in value:
+            return list(value["$in"])
+        return []
+    return [value]
+
+
+def _document_matches(document: Mapping[str, Any], selector: Mapping[str, Any]) -> bool:
+    for key, expected in selector.items():
+        if key == "$and":
+            if not all(_document_matches(document, item) for item in expected):
+                return False
+            continue
+        if key == "$or":
+            if not any(_document_matches(document, item) for item in expected):
+                return False
+            continue
+        actual = _get_path(document, key)
+        if isinstance(expected, Mapping):
+            if "$eq" in expected and not _values_equal(actual, expected["$eq"]):
+                return False
+            if "$in" in expected and not any(
+                _values_equal(actual, item) for item in expected["$in"]
+            ):
+                return False
+            continue
+        if not _values_equal(actual, expected):
+            return False
+    return True
+
+
+def _build_document_diff(
+    before: Sequence[Mapping[str, Any]],
+    after: Sequence[Mapping[str, Any]],
+    *,
+    identity_fields: Sequence[str],
+) -> dict[str, list[dict[str, Any]]]:
+    before_by_id = _documents_by_identity(
+        before,
+        identity_fields=identity_fields,
+        label="preimage",
+    )
+    after_by_id = _documents_by_identity(
+        after,
+        identity_fields=identity_fields,
+        label="postimage",
+    )
+    before_ids = set(before_by_id)
+    after_ids = set(after_by_id)
+    inserted = after_ids - before_ids
+    deleted = before_ids - after_ids
+    updated = {
+        identity
+        for identity in before_ids & after_ids
+        if _hash_value(_logical_document(before_by_id[identity], identity_fields))
+        != _hash_value(_logical_document(after_by_id[identity], identity_fields))
+    }
+    identity_values = {
+        **{
+            key: _identity_document(value, identity_fields)
+            for key, value in before_by_id.items()
+        },
+        **{
+            key: _identity_document(value, identity_fields)
+            for key, value in after_by_id.items()
+        },
+    }
+    return {
+        "inserted": [identity_values[key] for key in sorted(inserted)],
+        "updated": [identity_values[key] for key in sorted(updated)],
+        "deleted": [identity_values[key] for key in sorted(deleted)],
+    }
+
+
+def _assert_allowed_diff(
+    *,
+    actual: Mapping[str, Any],
+    expected: Mapping[str, Any],
+    identity_fields: Sequence[str],
+    store: str,
+    collection: str,
+) -> None:
+    normalized_actual = {
+        action: _sorted_identities(
+            actual.get(action, []),
+            identity_fields=identity_fields,
+            label=f"actual {action}",
+        )
+        for action in ("inserted", "updated", "deleted")
+    }
+    if _canonical_json(normalized_actual) != _canonical_json(expected):
+        raise AllowedDiffMismatch(
+            f"allowed diff mismatch for {store}.{collection}: "
+            f"expected={_canonical_json(expected)} actual={_canonical_json(normalized_actual)}"
+        )
+
+
+def _sorted_documents(
+    documents: Sequence[Mapping[str, Any]],
+    *,
+    identity_fields: Sequence[str],
+) -> list[dict[str, Any]]:
+    cloned = [deepcopy(dict(item)) for item in documents]
+    _ensure_unique_document_identities(
+        cloned,
+        identity_fields=identity_fields,
+        label="documents",
+    )
+    return sorted(
+        cloned,
+        key=lambda item: _identity_token(item, identity_fields),
+    )
+
+
+def _sorted_identities(
+    identities: Sequence[Mapping[str, Any]],
+    *,
+    identity_fields: Sequence[str],
+    label: str,
+) -> list[dict[str, Any]]:
+    normalized = []
+    for item in identities:
+        if not isinstance(item, Mapping):
+            raise InvalidRepairPlan(f"{label} contains a non-object identity")
+        if set(item) != set(identity_fields):
+            raise InvalidRepairPlan(
+                f"{label} identity keys must exactly equal {list(identity_fields)}"
+            )
+        normalized.append({field: deepcopy(item[field]) for field in identity_fields})
+    tokens = [_canonical_json(item) for item in normalized]
+    if len(tokens) != len(set(tokens)):
+        raise InvalidRepairPlan(f"{label} contains duplicate identities")
+    return sorted(normalized, key=_canonical_json)
+
+
+def _ensure_unique_document_identities(
+    documents: Sequence[Mapping[str, Any]],
+    *,
+    identity_fields: Sequence[str],
+    label: str,
+) -> None:
+    seen = set()
+    for document in documents:
+        identity = _identity_token(document, identity_fields)
+        if identity in seen:
+            raise InvalidRepairPlan(f"{label} contains duplicate identity {identity}")
+        seen.add(identity)
+
+
+def _documents_by_identity(
+    documents: Sequence[Mapping[str, Any]],
+    *,
+    identity_fields: Sequence[str],
+    label: str,
+) -> dict[str, dict[str, Any]]:
+    result = {}
+    for document in documents:
+        identity = _identity_token(document, identity_fields)
+        if identity in result:
+            raise InvalidRepairPlan(f"{label} contains duplicate identity {identity}")
+        result[identity] = deepcopy(dict(document))
+    return result
+
+
+def _identity_token(document: Mapping[str, Any], fields: Sequence[str]) -> str:
+    identity = _identity_document(document, fields)
+    if any(value in (None, "") for value in identity.values()):
+        raise InvalidRepairPlan(
+            f"document identity has empty field: {_canonical_json(identity)}"
+        )
+    return _canonical_json(identity)
+
+
+def _identity_document(
+    document: Mapping[str, Any],
+    fields: Sequence[str],
+) -> dict[str, Any]:
+    return {field: deepcopy(_get_path(document, field)) for field in fields}
+
+
+def _snapshot_hash(changes: Sequence[Mapping[str, Any]], document_field: str) -> str:
+    payload = [
+        {
+            "mode": item.get("mode", "replace"),
+            "store": item["store"],
+            "collection": item["collection"],
+            "identity_fields": list(item["identity_fields"]),
+            "documents": [
+                _logical_document(document, item["identity_fields"])
+                for document in item[document_field]
+            ],
+        }
+        for item in changes
+    ]
+    return _hash_value(payload)
+
+
+def _logical_document(
+    document: Mapping[str, Any], identity_fields: Sequence[str]
+) -> dict[str, Any]:
+    normalized = deepcopy(dict(document))
+    if "_id" not in set(identity_fields):
+        normalized.pop("_id", None)
+    return normalized
+
+
+def _manifest_hash(manifest: Mapping[str, Any]) -> str:
+    payload = {
+        key: value
+        for key, value in manifest.items()
+        if key not in {"created_at", "manifest_hash"}
+    }
+    return _hash_value(payload)
+
+
+def _validate_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(manifest, Mapping):
+        raise InvalidRepairPlan("repair manifest must be an object")
+    normalized = deepcopy(dict(manifest))
+    if (
+        int(normalized.get("schema_version") or 0)
+        != TARGETED_REPAIR_MANIFEST_SCHEMA_VERSION
+    ):
+        raise InvalidRepairPlan("unsupported repair manifest schema_version")
+    required = {
+        "repair_id",
+        "plan_hash",
+        "preimage_hash",
+        "postimage_hash",
+        "manifest_hash",
+        "changes",
+    }
+    missing = sorted(required - set(normalized))
+    if missing:
+        raise InvalidRepairPlan(f"repair manifest is missing fields: {missing}")
+    if _manifest_hash(normalized) != str(normalized["manifest_hash"]):
+        raise InvalidRepairPlan("repair manifest hash verification failed")
+    for change in normalized["changes"]:
+        mode = str(change.get("mode") or "replace")
+        if mode not in {"replace", "snapshot"}:
+            raise InvalidRepairPlan(
+                "repair manifest contains an unsupported change mode"
+            )
+        change["mode"] = mode
+        if change.get("store") not in _SUPPORTED_STORES:
+            raise InvalidRepairPlan("repair manifest contains an unsupported store")
+        if change.get("collection") in _PROTECTED_COLLECTIONS:
+            raise InvalidRepairPlan("repair manifest targets a protected collection")
+        _validate_selector(change.get("selector"))
+        identity_fields = list(change.get("identity_fields") or [])
+        if not identity_fields:
+            raise InvalidRepairPlan("repair manifest change has no identity_fields")
+        for field in ("preimage_documents", "postimage_documents"):
+            _sorted_documents(
+                list(change.get(field) or []),
+                identity_fields=identity_fields,
+            )
+    if _snapshot_hash(normalized["changes"], "preimage_documents") != str(
+        normalized["preimage_hash"]
+    ):
+        raise InvalidRepairPlan("repair manifest preimage hash verification failed")
+    if _snapshot_hash(normalized["changes"], "postimage_documents") != str(
+        normalized["postimage_hash"]
+    ):
+        raise InvalidRepairPlan("repair manifest postimage hash verification failed")
+    return normalized
+
+
+def _persist_manifest(manifest: Mapping[str, Any], path: str | Path) -> Path:
+    target = Path(path).expanduser().resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json_util.dumps(
+        manifest,
+        json_options=json_util.RELAXED_JSON_OPTIONS,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    )
+    try:
+        with target.open("x", encoding="utf-8") as handle:
+            handle.write(serialized)
+        return target
+    except FileExistsError:
+        existing = _validate_manifest(load_repair_document(target))
+        for key in (
+            "repair_id",
+            "plan_hash",
+            "preimage_hash",
+            "postimage_hash",
+            "manifest_hash",
+        ):
+            if str(existing.get(key) or "") != str(manifest.get(key) or ""):
+                raise RepairIdConflict(
+                    f"manifest path already contains different repair evidence: {target}"
+                )
+        return target
+
+
+def _assert_receipt_matches_manifest(
+    receipt: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+) -> None:
+    for key in (
+        "repair_id",
+        "plan_hash",
+        "preimage_hash",
+        "postimage_hash",
+        "manifest_hash",
+    ):
+        if str(receipt.get(key) or "") != str(manifest.get(key) or ""):
+            raise RepairIdConflict(f"repair journal and manifest disagree on {key}")
+
+
+def _assert_expected_hash(*, expected: str, actual: str, label: str) -> None:
+    normalized_expected = str(expected or "").strip().lower()
+    if not normalized_expected:
+        raise PreimageHashMismatch(f"expected {label} hash is required")
+    if normalized_expected != str(actual or "").strip().lower():
+        raise PreimageHashMismatch(
+            f"{label} hash mismatch: expected={normalized_expected} actual={actual}"
+        )
+
+
+def _validate_databases(
+    plan: Mapping[str, Any],
+    databases: Mapping[str, Any],
+) -> None:
+    required = {"order", *(item["store"] for item in plan["changes"])}
+    missing = sorted(item for item in required if item not in databases)
+    if missing:
+        raise InvalidRepairPlan(f"database mapping is missing stores: {missing}")
+
+
+def _validate_manifest_databases(
+    manifest: Mapping[str, Any],
+    databases: Mapping[str, Any],
+) -> None:
+    required = {"order", *(item["store"] for item in manifest["changes"])}
+    missing = sorted(item for item in required if item not in databases)
+    if missing:
+        raise InvalidRepairPlan(f"database mapping is missing stores: {missing}")
+
+
+def _ensure_journal_index(collection) -> None:
+    if hasattr(collection, "create_index"):
+        collection.create_index(
+            [("repair_id", 1)],
+            unique=True,
+            name="uq_targeted_repair_id",
+        )
+
+
+def _repair_summary(
+    manifest: Mapping[str, Any],
+    *,
+    execute: bool,
+    status: str,
+    idempotent: bool,
+) -> dict[str, Any]:
+    change_summaries = [
+        {
+            "index": index,
+            "mode": item["mode"],
+            "store": item["store"],
+            "collection": item["collection"],
+            "selector": deepcopy(item["selector"]),
+            "identity_fields": list(item["identity_fields"]),
+            "diff": deepcopy(item["diff"]),
+            "diff_counts": {
+                action: len(item["diff"][action])
+                for action in ("inserted", "updated", "deleted")
+            },
+        }
+        for index, item in enumerate(manifest["changes"])
+    ]
+    diff_counts: dict[str, dict[str, int]] = {}
+    for item in change_summaries:
+        key = f"{item['store']}.{item['collection']}"
+        collection_counts = diff_counts.setdefault(
+            key,
+            {"inserted": 0, "updated": 0, "deleted": 0},
+        )
+        for action in ("inserted", "updated", "deleted"):
+            collection_counts[action] += item["diff_counts"][action]
+    return {
+        "repair_id": manifest["repair_id"],
+        "execute": bool(execute),
+        "status": status,
+        "idempotent": bool(idempotent),
+        "plan_hash": manifest["plan_hash"],
+        "preimage_hash": manifest["preimage_hash"],
+        "postimage_hash": manifest["postimage_hash"],
+        "manifest_hash": manifest["manifest_hash"],
+        "changes": change_summaries,
+        "changed_collections": [
+            f"{item['store']}.{item['collection']}"
+            for item in manifest["changes"]
+            if _diff_count(item["diff"])
+        ],
+        "diff_counts": diff_counts,
+    }
+
+
+def _diff_count(diff: Mapping[str, Any]) -> int:
+    return sum(
+        len(diff.get(action, [])) for action in ("inserted", "updated", "deleted")
+    )
+
+
+def _get_path(document: Mapping[str, Any], path: str) -> Any:
+    current: Any = document
+    for part in str(path).split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _values_equal(left: Any, right: Any) -> bool:
+    return _canonical_json(left) == _canonical_json(right)
+
+
+def _canonical_json(value: Any) -> str:
+    return json_util.dumps(
+        value,
+        json_options=json_util.CANONICAL_JSON_OPTIONS,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _hash_value(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+__all__ = [
+    "AllowedDiffMismatch",
+    "InvalidRepairPlan",
+    "PreimageHashMismatch",
+    "RepairIdConflict",
+    "RestoreStateMismatch",
+    "TARGETED_REPAIR_JOURNAL_COLLECTION",
+    "build_repair_plan_hash",
+    "execute_targeted_repair",
+    "load_repair_document",
+    "preview_targeted_restore",
+    "restore_targeted_repair",
+    "stage_targeted_repair",
+]

--- a/freshquant/order_management/repository.py
+++ b/freshquant/order_management/repository.py
@@ -15,6 +15,7 @@ from freshquant.order_management.broker_identity import (
     normalize_side,
     normalize_symbol,
     normalize_trading_day,
+    resolve_trading_day,
 )
 from freshquant.order_management.db import DBOrderManagement
 
@@ -32,14 +33,28 @@ _EXECUTION_IMMUTABLE_FIELDS = (
     "trade_time",
 )
 
+_CANONICAL_EXECUTION_RECORD_VERSION = 2
+
 
 class OrderManagementRepository:
     def __init__(self, database=None):
         self.database = database if database is not None else DBOrderManagement
-        self._ensure_canonical_indexes()
+        self._canonical_indexes_ready = False
 
     def _ensure_canonical_indexes(self):
+        if self._canonical_indexes_ready:
+            return
         for collection, field, name in (
+            (
+                self.orders,
+                "internal_order_id",
+                "uq_om_orders_internal_order_id",
+            ),
+            (
+                self.orders,
+                "broker_correlation_token",
+                "uq_om_orders_broker_correlation_token",
+            ),
             (
                 self.broker_orders,
                 "broker_order_key",
@@ -66,6 +81,11 @@ class OrderManagementRepository:
                 "uq_om_entry_slices_entry_slice_id",
             ),
             (
+                self.sell_allocations,
+                "allocation_id",
+                "uq_om_sell_allocations_allocation_id",
+            ),
+            (
                 self.exit_allocations,
                 "allocation_id",
                 "uq_om_exit_allocations_allocation_id",
@@ -80,6 +100,7 @@ class OrderManagementRepository:
                 partialFilterExpression={field: {"$type": "string"}},
                 name=name,
             )
+        self._canonical_indexes_ready = True
 
     @property
     def order_requests(self):
@@ -207,10 +228,57 @@ class OrderManagementRepository:
         return list(cursor)
 
     def insert_order(self, document):
-        self.orders.insert_one(document)
-        return document
+        self._ensure_canonical_indexes()
+        payload = _without_mongo_id(document)
+        internal_order_id = normalize_identifier(payload.get("internal_order_id"))
+        if internal_order_id is None:
+            raise BrokerIdentityConflict("internal_order_id is required")
+        payload["internal_order_id"] = internal_order_id
+        try:
+            self.orders.update_one(
+                {"internal_order_id": internal_order_id},
+                {"$setOnInsert": payload},
+                upsert=True,
+            )
+        except DuplicateKeyError:
+            pass
+        saved = self.find_order(internal_order_id)
+        if saved is None:
+            raise BrokerIdentityConflict("canonical order insert did not persist")
+        conflicts = identity_conflicts(saved, payload)
+        if conflicts:
+            raise BrokerIdentityConflict(
+                "order conflicts with canonical identity: "
+                + ", ".join(sorted(conflicts))
+            )
+        saved_request_id = normalize_identifier(saved.get("request_id"))
+        incoming_request_id = normalize_identifier(payload.get("request_id"))
+        if (
+            saved_request_id is not None
+            and incoming_request_id is not None
+            and saved_request_id != incoming_request_id
+        ):
+            raise BrokerIdentityConflict(
+                "order conflicts with canonical request ownership"
+            )
+        saved_correlation_token = normalize_identifier(
+            saved.get("broker_correlation_token")
+        )
+        incoming_correlation_token = normalize_identifier(
+            payload.get("broker_correlation_token")
+        )
+        if (
+            saved_correlation_token is not None
+            and incoming_correlation_token is not None
+            and saved_correlation_token != incoming_correlation_token
+        ):
+            raise BrokerIdentityConflict(
+                "order conflicts with canonical broker correlation ownership"
+            )
+        return saved
 
     def upsert_broker_order(self, document, unique_keys):
+        self._ensure_canonical_indexes()
         query = {key: document[key] for key in unique_keys}
         payload = _without_mongo_id(document)
         existing = self._find_canonical_broker_order(document, query=query)
@@ -236,7 +304,53 @@ class OrderManagementRepository:
         saved = self._find_canonical_broker_order(document, query=query)
         return saved, result.upserted_id is not None
 
+    def update_broker_order_fields(self, broker_order_key, updates):
+        self._ensure_canonical_indexes()
+        normalized_key = normalize_identifier(broker_order_key)
+        if normalized_key is None:
+            raise BrokerIdentityConflict("broker_order_key is required")
+        current = self.find_broker_order(normalized_key)
+        if current is None:
+            return None
+        payload = _without_mongo_id(updates)
+        _assert_broker_order_identity_consistent(current, {**current, **payload})
+        self.broker_orders.update_one(
+            {"broker_order_key": normalized_key},
+            {"$set": payload},
+            upsert=False,
+        )
+        return self.find_broker_order(normalized_key)
+
+    def compare_and_set_broker_order(self, *, before, after):
+        self._ensure_canonical_indexes()
+        before_payload = _without_mongo_id(before)
+        after_payload = _without_mongo_id(after)
+        broker_order_key = normalize_identifier(
+            after_payload.get("broker_order_key")
+            or before_payload.get("broker_order_key")
+        )
+        if broker_order_key is None:
+            raise BrokerIdentityConflict("broker_order_key is required")
+        before_payload["broker_order_key"] = broker_order_key
+        after_payload["broker_order_key"] = broker_order_key
+        _assert_broker_order_identity_consistent(before_payload, after_payload)
+        result = self.broker_orders.replace_one(
+            _exact_projection_selector(
+                before_payload,
+                identity_field="broker_order_key",
+            ),
+            after_payload,
+            upsert=False,
+        )
+        if result.matched_count:
+            return self.find_broker_order(broker_order_key)
+        current = self.find_broker_order(broker_order_key)
+        if current is not None and _without_mongo_id(current) == after_payload:
+            return current
+        return None
+
     def move_broker_order_key(self, old_key, new_key, document):
+        self._ensure_canonical_indexes()
         old_key = normalize_identifier(old_key)
         new_key = normalize_identifier(new_key)
         if new_key is None:
@@ -315,11 +429,47 @@ class OrderManagementRepository:
         return document
 
     def upsert_trade_fact(self, document, unique_keys):
+        self.preflight_execution_replay(document)
         return self._upsert_execution_document(
             collection=self.trade_facts,
             document=document,
             unique_keys=unique_keys,
+            document_id_field="trade_fact_id",
         )
+
+    def preflight_execution_replay(self, document):
+        execution_identity = normalize_identifier(document.get("execution_identity"))
+        if execution_identity is None:
+            return
+        states = []
+        for label, collection in (
+            ("trade_fact", self.trade_facts),
+            ("execution_fill", self.execution_fills),
+        ):
+            canonical = (
+                collection.find_one({"execution_identity": execution_identity})
+                if execution_identity is not None
+                else None
+            )
+            if canonical is not None:
+                _assert_execution_identity_consistent(canonical, document)
+            legacy = _find_legacy_execution_candidate(
+                collection,
+                document,
+                repository=self,
+            )
+            if canonical is not None and legacy is not None:
+                raise BrokerIdentityConflict(
+                    f"execution replay has duplicate canonical and legacy {label} rows"
+                )
+            states.append(
+                {
+                    "label": label,
+                    "canonical": canonical,
+                    "legacy": legacy,
+                }
+            )
+        _assert_execution_replay_pair_state(states)
 
     def find_order(self, internal_order_id):
         return self.orders.find_one({"internal_order_id": internal_order_id})
@@ -330,8 +480,19 @@ class OrderManagementRepository:
     def find_broker_order_by_broker_order_id(self, broker_order_id):
         return self.broker_orders.find_one({"broker_order_id": str(broker_order_id)})
 
+    def list_broker_orders_by_broker_order_id(self, broker_order_id):
+        if broker_order_id in (None, "", "None"):
+            return []
+        return list(self.broker_orders.find({"broker_order_id": str(broker_order_id)}))
+
     def find_order_by_request_id(self, request_id):
         return self.orders.find_one({"request_id": request_id})
+
+    def find_order_by_broker_correlation_token(self, token):
+        normalized = normalize_identifier(token)
+        if normalized is None:
+            return None
+        return self.orders.find_one({"broker_correlation_token": normalized})
 
     def find_order_by_broker_order_id(self, broker_order_id):
         return self.orders.find_one({"broker_order_id": str(broker_order_id)})
@@ -349,15 +510,67 @@ class OrderManagementRepository:
         return self.find_order(internal_order_id)
 
     def upsert_execution_fill(self, document, unique_keys):
+        self.preflight_execution_replay(document)
         return self._upsert_execution_document(
             collection=self.execution_fills,
             document=document,
             unique_keys=unique_keys,
+            document_id_field="execution_fill_id",
+            legacy_projection_status_resolver=(
+                lambda incoming: _resolve_legacy_execution_projection_status(
+                    self,
+                    incoming,
+                )
+            ),
         )
 
-    def _upsert_execution_document(self, *, collection, document, unique_keys):
+    def _upsert_execution_document(
+        self,
+        *,
+        collection,
+        document,
+        unique_keys,
+        document_id_field,
+        legacy_projection_status=None,
+        legacy_projection_status_resolver=None,
+    ):
+        self._ensure_canonical_indexes()
         query = {key: document[key] for key in unique_keys}
         payload = _without_mongo_id(document)
+        if normalize_identifier(payload.get("execution_identity")) is not None:
+            payload.setdefault(
+                "execution_record_version", _CANONICAL_EXECUTION_RECORD_VERSION
+            )
+        existing = _find_canonical_execution_document(
+            collection,
+            document,
+            query=query,
+        )
+        if existing is not None:
+            _assert_execution_identity_consistent(existing, document)
+            return existing, False
+
+        legacy = _find_legacy_execution_candidate(
+            collection,
+            document,
+            repository=self,
+        )
+        if legacy is not None:
+            resolved_legacy_projection_status = legacy_projection_status
+            if callable(legacy_projection_status_resolver):
+                resolved_legacy_projection_status = legacy_projection_status_resolver(
+                    document
+                )
+            saved = _migrate_legacy_execution_candidate(
+                collection,
+                legacy=legacy,
+                incoming=document,
+                document_id_field=document_id_field,
+                legacy_projection_status=resolved_legacy_projection_status,
+            )
+            _assert_execution_identity_consistent(saved, document)
+            return saved, False
+
         try:
             result = collection.update_one(
                 query,
@@ -384,6 +597,205 @@ class OrderManagementRepository:
             _assert_execution_identity_consistent(saved, document)
         return saved, result.upserted_id is not None
 
+    def prepare_execution_projection(self, execution_identity, projection_plan):
+        normalized_identity = normalize_identifier(execution_identity)
+        if normalized_identity is None:
+            raise BrokerIdentityConflict("execution projection requires identity")
+        group_progress = _initial_projection_group_progress(projection_plan)
+        self.execution_fills.update_one(
+            {
+                "execution_identity": normalized_identity,
+                "projection_status": "PENDING",
+                "projection_plan": None,
+            },
+            {
+                "$set": {
+                    "projection_plan": projection_plan,
+                    "projection_group_progress": group_progress,
+                }
+            },
+        )
+        saved = self.execution_fills.find_one(
+            {"execution_identity": normalized_identity}
+        )
+        if saved is None:
+            raise BrokerIdentityConflict("execution projection fill is missing")
+        status = normalize_identifier(saved.get("projection_status"))
+        if status not in {"PENDING", "APPLIED"}:
+            raise BrokerIdentityConflict(
+                "execution projection state is not recoverable"
+            )
+        return saved
+
+    def get_execution_projection_group_progress(
+        self,
+        execution_identity,
+        operation_id,
+    ):
+        normalized_identity = normalize_identifier(execution_identity)
+        normalized_operation_id = normalize_identifier(operation_id)
+        if normalized_identity is None or normalized_operation_id is None:
+            raise BrokerIdentityConflict(
+                "execution projection group progress requires identity"
+            )
+        saved = self.execution_fills.find_one(
+            {"execution_identity": normalized_identity}
+        )
+        if saved is None:
+            raise BrokerIdentityConflict("execution projection fill is missing")
+        progress_by_operation = saved.get("projection_group_progress")
+        if not isinstance(progress_by_operation, dict):
+            raise BrokerIdentityConflict(
+                "execution projection group progress is missing"
+            )
+        try:
+            return int(progress_by_operation[normalized_operation_id])
+        except (KeyError, TypeError, ValueError, OverflowError) as exc:
+            raise BrokerIdentityConflict(
+                "execution projection group progress is invalid"
+            ) from exc
+
+    def advance_execution_projection_group_progress(
+        self,
+        execution_identity,
+        operation_id,
+        *,
+        expected_step,
+        next_step,
+    ):
+        normalized_identity = normalize_identifier(execution_identity)
+        normalized_operation_id = normalize_identifier(operation_id)
+        if normalized_identity is None or normalized_operation_id is None:
+            raise BrokerIdentityConflict(
+                "execution projection group progress requires identity"
+            )
+        field = f"projection_group_progress.{normalized_operation_id}"
+        result = self.execution_fills.update_one(
+            {
+                "execution_identity": normalized_identity,
+                "projection_status": "PENDING",
+                field: int(expected_step),
+            },
+            {"$set": {field: int(next_step)}},
+            upsert=False,
+        )
+        current = self.get_execution_projection_group_progress(
+            normalized_identity,
+            normalized_operation_id,
+        )
+        if result.matched_count or current == int(next_step):
+            return current
+        raise BrokerIdentityConflict(
+            "execution projection group progress compare-and-set conflict"
+        )
+
+    def mark_execution_projection_applied(self, execution_identity, *, applied_at):
+        normalized_identity = normalize_identifier(execution_identity)
+        if normalized_identity is None:
+            raise BrokerIdentityConflict("execution projection requires identity")
+        self.execution_fills.update_one(
+            {
+                "execution_identity": normalized_identity,
+                "projection_status": "PENDING",
+            },
+            {
+                "$set": {
+                    "projection_status": "APPLIED",
+                    "projection_applied_at": applied_at,
+                }
+            },
+        )
+        saved = self.execution_fills.find_one(
+            {"execution_identity": normalized_identity}
+        )
+        if saved is None or saved.get("projection_status") != "APPLIED":
+            raise BrokerIdentityConflict(
+                "execution projection could not be marked applied"
+            )
+        return saved
+
+    def compare_and_set_projection_document(
+        self,
+        projection_type,
+        *,
+        before,
+        after,
+    ):
+        targets = {
+            "buy_lot": (self.buy_lots, "buy_lot_id"),
+            "lot_slice": (self.lot_slices, "lot_slice_id"),
+            "position_entry": (self.position_entries, "entry_id"),
+            "entry_slice": (self.entry_slices, "entry_slice_id"),
+        }
+        target = targets.get(str(projection_type or ""))
+        if target is None:
+            raise BrokerIdentityConflict("execution projection target is unsupported")
+        collection, identity_field = target
+        before_payload = _without_mongo_id(before) if before is not None else None
+        after_payload = _without_mongo_id(after) if after is not None else None
+        identity = normalize_identifier(
+            (after_payload or before_payload or {}).get(identity_field)
+        )
+        if identity is None:
+            raise BrokerIdentityConflict(
+                f"execution projection requires {identity_field}"
+            )
+        if before_payload is not None:
+            before_payload[identity_field] = identity
+        if after_payload is not None:
+            after_payload[identity_field] = identity
+
+        if before_payload is None:
+            if after_payload is None:
+                return None
+            try:
+                collection.update_one(
+                    {identity_field: identity},
+                    {"$setOnInsert": after_payload},
+                    upsert=True,
+                )
+            except DuplicateKeyError:
+                pass
+            return _assert_projection_cas_result(
+                collection,
+                identity_field=identity_field,
+                identity=identity,
+                expected=after_payload,
+            )
+
+        if after_payload is None:
+            result = collection.delete_one(
+                _exact_projection_selector(
+                    before_payload,
+                    identity_field=identity_field,
+                )
+            )
+            if result.deleted_count:
+                return None
+            current = list(collection.find({identity_field: identity}))
+            if not current:
+                return None
+            raise BrokerIdentityConflict(
+                f"execution projection compare-and-set conflict at {projection_type}:{identity}"
+            )
+
+        result = collection.replace_one(
+            _exact_projection_selector(
+                before_payload,
+                identity_field=identity_field,
+            ),
+            after_payload,
+            upsert=False,
+        )
+        if result.matched_count:
+            return after_payload
+        return _assert_projection_cas_result(
+            collection,
+            identity_field=identity_field,
+            identity=identity,
+            expected=after_payload,
+        )
+
     def find_buy_lot_by_origin_trade_fact_id(self, origin_trade_fact_id):
         return self.buy_lots.find_one({"origin_trade_fact_id": origin_trade_fact_id})
 
@@ -406,6 +818,7 @@ class OrderManagementRepository:
         return self.position_entries.find_one({"entry_id": entry_id})
 
     def replace_position_entry(self, document):
+        self._ensure_canonical_indexes()
         self.position_entries.replace_one(
             {"entry_id": document["entry_id"]},
             document,
@@ -420,12 +833,14 @@ class OrderManagementRepository:
         return slices
 
     def replace_entry_slices_for_entry(self, entry_id, slices):
+        self._ensure_canonical_indexes()
         self.entry_slices.delete_many({"entry_id": entry_id})
         if slices:
             self.entry_slices.insert_many(slices)
         return slices
 
     def upsert_entry_slices(self, slices):
+        self._ensure_canonical_indexes()
         for document in list(slices or []):
             self.entry_slices.replace_one(
                 {"entry_slice_id": document["entry_slice_id"]},
@@ -443,14 +858,18 @@ class OrderManagementRepository:
         return slices
 
     def insert_sell_allocations(self, allocations):
-        if allocations:
-            self.sell_allocations.insert_many(allocations)
-        return allocations
+        self._ensure_canonical_indexes()
+        return _insert_allocations_fail_closed(
+            self.sell_allocations,
+            allocations,
+        )
 
     def insert_exit_allocations(self, allocations):
-        if allocations:
-            self.exit_allocations.insert_many(allocations)
-        return allocations
+        self._ensure_canonical_indexes()
+        return _insert_allocations_fail_closed(
+            self.exit_allocations,
+            allocations,
+        )
 
     def insert_reconciliation_gap(self, document):
         self.reconciliation_gaps.insert_one(document)
@@ -541,6 +960,12 @@ class OrderManagementRepository:
         if execution_fill_ids is not None:
             query["execution_fill_id"] = {"$in": list(execution_fill_ids)}
         return list(self.execution_fills.find(query))
+
+    def list_lot_slices(self, *, buy_lot_ids=None):
+        query = {}
+        if buy_lot_ids is not None:
+            query["buy_lot_id"] = {"$in": list(buy_lot_ids)}
+        return list(self.lot_slices.find(query))
 
     def list_position_entries(self, *, symbol=None, entry_ids=None, status=None):
         query = {}
@@ -652,6 +1077,12 @@ class OrderManagementRepository:
             query["entry_id"] = {"$in": list(entry_ids)}
         return list(self.exit_allocations.find(query))
 
+    def list_sell_allocations(self, *, buy_lot_ids=None):
+        query = {}
+        if buy_lot_ids is not None:
+            query["buy_lot_id"] = {"$in": list(buy_lot_ids)}
+        return list(self.sell_allocations.find(query))
+
     def find_exit_allocation_reference_errors(self, *, entry_ids=None):
         allocations = self.list_exit_allocations(entry_ids=entry_ids)
         if entry_ids is None:
@@ -706,6 +1137,88 @@ class OrderManagementRepository:
         return list(self.ingest_rejections.find(query))
 
 
+def _insert_allocations_fail_closed(collection, allocations):
+    documents = [_without_mongo_id(item) for item in list(allocations or [])]
+    allocation_ids = []
+    for document in documents:
+        allocation_id = normalize_identifier(document.get("allocation_id"))
+        if allocation_id is None:
+            raise BrokerIdentityConflict(
+                "execution projection allocation_id is required"
+            )
+        document["allocation_id"] = allocation_id
+        allocation_ids.append(allocation_id)
+    if len(allocation_ids) != len(set(allocation_ids)):
+        raise BrokerIdentityConflict(
+            "execution projection contains duplicate allocation_id"
+        )
+
+    for document in documents:
+        allocation_id = document["allocation_id"]
+        try:
+            collection.update_one(
+                {"allocation_id": allocation_id},
+                {"$setOnInsert": document},
+                upsert=True,
+            )
+        except DuplicateKeyError:
+            pass
+        _assert_projection_cas_result(
+            collection,
+            identity_field="allocation_id",
+            identity=allocation_id,
+            expected=document,
+        )
+    return allocations
+
+
+def _initial_projection_group_progress(projection_plan):
+    progress = {}
+    for group_name in ("lot_slice_groups", "entry_slice_groups"):
+        for group in list((projection_plan or {}).get(group_name) or []):
+            operation_id = normalize_identifier(group.get("operation_id"))
+            if operation_id is None:
+                raise BrokerIdentityConflict(
+                    "execution projection group operation_id is required"
+                )
+            if operation_id in progress:
+                raise BrokerIdentityConflict(
+                    "execution projection group operation_id is duplicated"
+                )
+            progress[operation_id] = 0
+    return progress
+
+
+def _exact_projection_selector(document, *, identity_field):
+    payload = _without_mongo_id(document)
+    return {
+        identity_field: payload[identity_field],
+        "$expr": {
+            "$eq": [
+                {"$unsetField": {"field": "_id", "input": "$$ROOT"}},
+                payload,
+            ]
+        },
+    }
+
+
+def _assert_projection_cas_result(
+    collection,
+    *,
+    identity_field,
+    identity,
+    expected,
+):
+    current = list(collection.find({identity_field: identity}))
+    if len(current) == 1 and _without_mongo_id(current[0]) == _without_mongo_id(
+        expected
+    ):
+        return current[0]
+    raise BrokerIdentityConflict(
+        f"execution projection compare-and-set conflict at {identity_field}:{identity}"
+    )
+
+
 def _without_mongo_id(document):
     return {key: value for key, value in dict(document or {}).items() if key != "_id"}
 
@@ -726,6 +1239,417 @@ def _find_canonical_execution_document(collection, document, *, query):
         if canonical is not None:
             return canonical
     return collection.find_one(query)
+
+
+def _assert_execution_replay_pair_state(states):
+    legacy_states = [state for state in states if state.get("legacy") is not None]
+    if legacy_states:
+        for state in states:
+            if state.get("legacy") is not None:
+                continue
+            canonical = state.get("canonical")
+            if canonical is None or not canonical.get("legacy_identity_migrated"):
+                raise BrokerIdentityConflict(
+                    "legacy execution replay requires paired trade_fact and "
+                    "execution_fill rows"
+                )
+        for state in states:
+            canonical = state.get("canonical")
+            if canonical is not None and not canonical.get("legacy_identity_migrated"):
+                raise BrokerIdentityConflict(
+                    "legacy execution replay conflicts with a canonical V2 counterpart"
+                )
+        return
+
+    canonical_states = [state for state in states if state.get("canonical") is not None]
+    if len(canonical_states) in (0, len(states)):
+        return
+    canonical = canonical_states[0]["canonical"]
+    try:
+        record_version = int(canonical.get("execution_record_version") or 0)
+    except (TypeError, ValueError, OverflowError):
+        record_version = 0
+    if record_version >= _CANONICAL_EXECUTION_RECORD_VERSION and not canonical.get(
+        "legacy_identity_migrated"
+    ):
+        return
+    raise BrokerIdentityConflict(
+        "execution replay has an unpaired legacy or unversioned counterpart"
+    )
+
+
+def _find_legacy_execution_candidate(collection, incoming, *, repository):
+    execution_identity = normalize_identifier(incoming.get("execution_identity"))
+    broker_trade_id = normalize_identifier(incoming.get("broker_trade_id"))
+    if execution_identity is None or broker_trade_id is None:
+        return None
+    broker_trade_id_variants = [broker_trade_id]
+    if broker_trade_id.isdigit():
+        broker_trade_id_variants.append(int(broker_trade_id))
+    candidates = [
+        item
+        for item in collection.find(
+            {"broker_trade_id": {"$in": broker_trade_id_variants}}
+        )
+        if normalize_identifier(item.get("execution_identity")) is None
+    ]
+    if not candidates:
+        return None
+    if len(candidates) != 1:
+        raise BrokerIdentityConflict(
+            "legacy execution replay is ambiguous for broker_trade_id"
+        )
+    candidate = candidates[0]
+    _assert_legacy_execution_match(candidate, incoming, repository=repository)
+    return candidate
+
+
+def _migrate_legacy_execution_candidate(
+    collection,
+    *,
+    legacy,
+    incoming,
+    document_id_field,
+    legacy_projection_status,
+):
+    selector = _legacy_execution_selector(
+        legacy,
+        document_id_field=document_id_field,
+    )
+    updates = {
+        "execution_identity": incoming["execution_identity"],
+        "broker_trade_id": incoming["broker_trade_id"],
+        "account_id": incoming["account_id"],
+        "trading_day": incoming["trading_day"],
+        "broker_order_key": incoming.get("broker_order_key"),
+        "internal_order_id": incoming.get("internal_order_id"),
+        "broker_order_id": incoming.get("broker_order_id"),
+        "order_sysid": incoming.get("order_sysid"),
+        "legacy_identity_migrated": True,
+        "execution_record_version": 1,
+        "execution_record_origin": "legacy",
+    }
+    if legacy_projection_status is not None:
+        updates["projection_status"] = legacy_projection_status
+        if legacy_projection_status == "APPLIED":
+            updates["projection_legacy_proven_applied"] = True
+        elif legacy_projection_status == "PENDING":
+            updates["projection_legacy_replay_required"] = True
+    collection.update_one(
+        selector,
+        {"$set": {key: value for key, value in updates.items() if value is not None}},
+        upsert=False,
+    )
+    saved = collection.find_one(selector)
+    if saved is None:
+        raise BrokerIdentityConflict("legacy execution migration lost canonical row")
+    return saved
+
+
+def _legacy_execution_selector(document, *, document_id_field):
+    if document.get("_id") is not None:
+        return {"_id": document["_id"]}
+    document_id = normalize_identifier(document.get(document_id_field))
+    if document_id is not None:
+        return {document_id_field: document_id}
+    return {
+        "broker_trade_id": document.get("broker_trade_id"),
+        "internal_order_id": document.get("internal_order_id"),
+        "trade_time": document.get("trade_time"),
+    }
+
+
+def _assert_legacy_execution_match(existing, incoming, *, repository):
+    required_fields = (
+        "broker_trade_id",
+        "symbol",
+        "side",
+        "quantity",
+        "price",
+        "trade_time",
+    )
+    conflicts = {}
+    for field in required_fields:
+        left = _normalize_execution_field(field, existing.get(field))
+        right = _normalize_execution_field(field, incoming.get(field))
+        if left is None or right is None or left != right:
+            conflicts[field] = (left, right)
+
+    existing_day = _resolve_execution_trading_day(existing)
+    incoming_day = _resolve_execution_trading_day(incoming)
+    if existing_day is None or incoming_day is None or existing_day != incoming_day:
+        conflicts["trading_day"] = (existing_day, incoming_day)
+
+    existing_clock = _normalize_execution_clock(existing.get("time"))
+    incoming_clock = _normalize_execution_clock(incoming.get("time"))
+    if (
+        existing_clock is None
+        or incoming_clock is None
+        or existing_clock != incoming_clock
+    ):
+        conflicts["time"] = (existing_clock, incoming_clock)
+
+    existing_account = _resolve_legacy_execution_account(
+        existing,
+        repository=repository,
+    )
+    incoming_account = normalize_account_id(incoming.get("account_id"))
+    if (
+        existing_account is None
+        or incoming_account is None
+        or existing_account != incoming_account
+    ):
+        conflicts["account_id"] = (existing_account, incoming_account)
+
+    for field in ("internal_order_id", "broker_order_id"):
+        left = normalize_identifier(existing.get(field))
+        right = normalize_identifier(incoming.get(field))
+        if left is not None and right is not None and left != right:
+            conflicts[field] = (left, right)
+
+    if conflicts:
+        raise BrokerIdentityConflict(
+            "legacy execution replay cannot be proven identical: "
+            + ", ".join(sorted(conflicts))
+        )
+
+
+def _resolve_execution_trading_day(document):
+    try:
+        return normalize_trading_day(
+            resolve_trading_day(
+                document,
+                report_time=document.get("trade_time"),
+            )
+        )
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _normalize_execution_clock(value):
+    normalized = str(value or "").strip()
+    if not normalized:
+        return None
+    digits = "".join(character for character in normalized if character.isdigit())
+    if len(digits) == 6:
+        return digits
+    return normalized
+
+
+def _resolve_legacy_execution_account(document, *, repository):
+    candidates = set()
+
+    def add(value):
+        normalized = normalize_account_id(value)
+        if normalized is not None:
+            candidates.add(normalized)
+
+    add(document.get("account_id"))
+    add(_account_from_broker_order_key(document.get("broker_order_key")))
+
+    internal_order_id = normalize_identifier(document.get("internal_order_id"))
+    if internal_order_id is not None:
+        order = repository.find_order(internal_order_id)
+        if order is not None:
+            add(order.get("account_id"))
+            add(_account_from_broker_order_key(order.get("broker_order_key")))
+
+    broker_order_key = normalize_identifier(document.get("broker_order_key"))
+    if broker_order_key is not None:
+        broker_order = repository.find_broker_order(broker_order_key)
+        if broker_order is not None:
+            add(broker_order.get("account_id"))
+            add(_account_from_broker_order_key(broker_order.get("broker_order_key")))
+
+    broker_order_id = normalize_identifier(document.get("broker_order_id"))
+    if broker_order_id is not None:
+        list_orders = getattr(repository, "list_orders_by_broker_order_id", None)
+        if callable(list_orders):
+            orders = list_orders(broker_order_id)
+        else:
+            order = repository.find_order_by_broker_order_id(broker_order_id)
+            orders = [order] if order is not None else []
+        for order in orders:
+            add(order.get("account_id"))
+
+        list_broker_orders = getattr(
+            repository, "list_broker_orders_by_broker_order_id", None
+        )
+        if callable(list_broker_orders):
+            broker_orders = list_broker_orders(broker_order_id)
+        else:
+            broker_order = repository.find_broker_order_by_broker_order_id(
+                broker_order_id
+            )
+            broker_orders = [broker_order] if broker_order is not None else []
+        for broker_order in broker_orders:
+            add(broker_order.get("account_id"))
+
+    if len(candidates) != 1:
+        return None
+    return next(iter(candidates))
+
+
+def _account_from_broker_order_key(value):
+    normalized = normalize_identifier(value)
+    if normalized is None or not normalized.startswith("account:"):
+        return None
+    account_id, separator, _remainder = normalized[len("account:") :].partition(":day:")
+    if not separator:
+        return None
+    return normalize_account_id(account_id)
+
+
+def _resolve_legacy_execution_projection_status(repository, incoming):
+    execution_identity = normalize_identifier(incoming.get("execution_identity"))
+    if execution_identity is None:
+        raise BrokerIdentityConflict("legacy execution projection requires identity")
+    trade_fact = repository.trade_facts.find_one(
+        {"execution_identity": execution_identity}
+    )
+    if trade_fact is None:
+        raise BrokerIdentityConflict(
+            "legacy execution projection requires paired canonical trade_fact"
+        )
+    side = normalize_side(trade_fact.get("side"))
+    if side == "buy":
+        return _resolve_legacy_buy_projection_status(repository, trade_fact)
+    if side == "sell":
+        return _resolve_legacy_sell_projection_status(repository, trade_fact)
+    raise BrokerIdentityConflict("legacy execution projection side is unsupported")
+
+
+def _resolve_legacy_buy_projection_status(repository, trade_fact):
+    from freshquant.order_management.entry_aggregation import (
+        find_entry_for_broker_order,
+        list_aggregation_members,
+    )
+
+    trade_fact_id = normalize_identifier(trade_fact.get("trade_fact_id"))
+    broker_order_key = normalize_identifier(
+        trade_fact.get("broker_order_key") or trade_fact.get("internal_order_id")
+    )
+    buy_lot = (
+        repository.find_buy_lot_by_origin_trade_fact_id(trade_fact_id)
+        if trade_fact_id is not None
+        else None
+    )
+    lot_slices = (
+        repository.list_lot_slices(buy_lot_ids=[buy_lot["buy_lot_id"]])
+        if buy_lot is not None
+        else []
+    )
+    entries = repository.list_position_entries(symbol=trade_fact.get("symbol"))
+    entry = (
+        find_entry_for_broker_order(entries, broker_order_key)
+        if broker_order_key is not None
+        else None
+    )
+    entry_slices = (
+        repository.list_entry_slices(entry_ids=[entry["entry_id"]])
+        if entry is not None
+        else []
+    )
+    evidence_present = bool(buy_lot or lot_slices or entry or entry_slices)
+    if not evidence_present:
+        return "PENDING"
+
+    expected_quantity = int(trade_fact.get("quantity") or 0)
+    expected_price = Decimal(str(trade_fact.get("price") or 0)).normalize()
+    buy_lot_complete = bool(
+        buy_lot is not None
+        and int(buy_lot.get("original_quantity") or 0) == expected_quantity
+        and Decimal(str(buy_lot.get("buy_price_real") or 0)).normalize()
+        == expected_price
+        and sum(int(item.get("original_quantity") or 0) for item in lot_slices)
+        == int(buy_lot.get("original_quantity") or 0)
+    )
+    entry_complete = bool(
+        entry is not None
+        and broker_order_key
+        in {
+            normalize_identifier(item.get("broker_order_key"))
+            for item in list_aggregation_members(entry)
+        }
+        and entry_slices
+        and sum(int(item.get("original_quantity") or 0) for item in entry_slices)
+        == int(entry.get("original_quantity") or 0)
+    )
+    if buy_lot_complete and entry_complete:
+        return "APPLIED"
+    raise BrokerIdentityConflict(
+        "legacy buy execution projection is partial or cannot be proven applied"
+    )
+
+
+def _resolve_legacy_sell_projection_status(repository, trade_fact):
+    trade_fact_id = normalize_identifier(trade_fact.get("trade_fact_id"))
+    if trade_fact_id is None:
+        raise BrokerIdentityConflict(
+            "legacy sell execution projection requires trade_fact_id"
+        )
+    expected_quantity = int(trade_fact.get("quantity") or 0)
+    exit_allocations = [
+        item
+        for item in repository.list_exit_allocations()
+        if normalize_identifier(item.get("exit_trade_fact_id")) == trade_fact_id
+    ]
+    sell_allocations = [
+        item
+        for item in repository.list_sell_allocations()
+        if normalize_identifier(item.get("sell_trade_fact_id")) == trade_fact_id
+    ]
+    entries = repository.list_position_entries(symbol=trade_fact.get("symbol"))
+    buy_lots = repository.list_buy_lots(trade_fact.get("symbol"))
+    entry_history = [
+        allocation
+        for entry in entries
+        for allocation in list(entry.get("sell_history") or [])
+        if normalize_identifier(allocation.get("exit_trade_fact_id")) == trade_fact_id
+    ]
+    lot_history = [
+        allocation
+        for buy_lot in buy_lots
+        for allocation in list(buy_lot.get("sell_history") or [])
+        if normalize_identifier(allocation.get("sell_trade_fact_id")) == trade_fact_id
+    ]
+    evidence_present = bool(
+        exit_allocations or sell_allocations or entry_history or lot_history
+    )
+    if not evidence_present:
+        return "PENDING"
+
+    exit_quantity = sum(
+        int(item.get("allocated_quantity") or 0) for item in exit_allocations
+    )
+    sell_quantity = sum(
+        int(item.get("allocated_quantity") or 0) for item in sell_allocations
+    )
+    entry_history_quantity = sum(
+        int(item.get("allocated_quantity") or 0) for item in entry_history
+    )
+    lot_history_quantity = sum(
+        int(item.get("allocated_quantity") or 0) for item in lot_history
+    )
+    v2_complete = bool(
+        exit_allocations
+        and not sell_allocations
+        and exit_quantity == expected_quantity
+        and entry_history_quantity == expected_quantity
+        and not lot_history
+    )
+    legacy_complete = bool(
+        sell_allocations
+        and not exit_allocations
+        and sell_quantity == expected_quantity
+        and lot_history_quantity == expected_quantity
+        and not entry_history
+    )
+    if v2_complete or legacy_complete:
+        return "APPLIED"
+    raise BrokerIdentityConflict(
+        "legacy sell execution projection is partial or cannot be proven applied"
+    )
 
 
 def _assert_execution_identity_consistent(existing, incoming):

--- a/freshquant/order_management/repository.py
+++ b/freshquant/order_management/repository.py
@@ -1,11 +1,85 @@
 # -*- coding: utf-8 -*-
 
+from decimal import Decimal, InvalidOperation
+
+from pymongo.errors import DuplicateKeyError
+
+from freshquant.order_management.allocation_integrity import (
+    find_exit_allocation_integrity_errors,
+)
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityConflict,
+    identity_conflicts,
+    normalize_account_id,
+    normalize_identifier,
+    normalize_side,
+    normalize_symbol,
+    normalize_trading_day,
+)
 from freshquant.order_management.db import DBOrderManagement
+
+_EXECUTION_IMMUTABLE_FIELDS = (
+    "execution_identity",
+    "broker_trade_id",
+    "broker_order_key",
+    "internal_order_id",
+    "account_id",
+    "trading_day",
+    "symbol",
+    "side",
+    "quantity",
+    "price",
+    "trade_time",
+)
 
 
 class OrderManagementRepository:
     def __init__(self, database=None):
         self.database = database if database is not None else DBOrderManagement
+        self._ensure_canonical_indexes()
+
+    def _ensure_canonical_indexes(self):
+        for collection, field, name in (
+            (
+                self.broker_orders,
+                "broker_order_key",
+                "uq_om_broker_orders_broker_order_key",
+            ),
+            (
+                self.trade_facts,
+                "execution_identity",
+                "uq_om_trade_facts_execution_identity",
+            ),
+            (
+                self.execution_fills,
+                "execution_identity",
+                "uq_om_execution_fills_execution_identity",
+            ),
+            (
+                self.position_entries,
+                "entry_id",
+                "uq_om_position_entries_entry_id",
+            ),
+            (
+                self.entry_slices,
+                "entry_slice_id",
+                "uq_om_entry_slices_entry_slice_id",
+            ),
+            (
+                self.exit_allocations,
+                "allocation_id",
+                "uq_om_exit_allocations_allocation_id",
+            ),
+        ):
+            create_index = getattr(collection, "create_index", None)
+            if not callable(create_index):
+                continue
+            create_index(
+                [(field, 1)],
+                unique=True,
+                partialFilterExpression={field: {"$type": "string"}},
+                name=name,
+            )
 
     @property
     def order_requests(self):
@@ -138,24 +212,114 @@ class OrderManagementRepository:
 
     def upsert_broker_order(self, document, unique_keys):
         query = {key: document[key] for key in unique_keys}
-        existing = self.broker_orders.find_one(query)
+        payload = _without_mongo_id(document)
+        existing = self._find_canonical_broker_order(document, query=query)
         if existing is not None:
-            self.broker_orders.update_one(query, {"$set": document})
-            return self.broker_orders.find_one(query), False
-        self.broker_orders.insert_one(document)
-        return document, True
+            _assert_broker_order_identity_consistent(existing, document)
+        try:
+            result = self.broker_orders.update_one(
+                query,
+                {"$set": payload},
+                upsert=True,
+            )
+        except DuplicateKeyError:
+            existing = self._find_canonical_broker_order(document, query=query)
+            if existing is None:
+                raise
+            _assert_broker_order_identity_consistent(existing, document)
+            self.broker_orders.update_one(
+                {"broker_order_key": existing["broker_order_key"]},
+                {"$set": payload},
+                upsert=False,
+            )
+            return self.find_broker_order(existing["broker_order_key"]), False
+        saved = self._find_canonical_broker_order(document, query=query)
+        return saved, result.upserted_id is not None
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        old_key = normalize_identifier(old_key)
+        new_key = normalize_identifier(new_key)
+        if new_key is None:
+            raise ValueError("new broker_order_key is required")
+        payload = _without_mongo_id({**document, "broker_order_key": new_key})
+        if old_key is None or old_key == new_key:
+            saved, _created = self.upsert_broker_order(
+                payload,
+                unique_keys=["broker_order_key"],
+            )
+            return saved
+
+        target = self.find_broker_order(new_key)
+        if target is not None:
+            return self._merge_broker_order_target(
+                old_key=old_key,
+                new_key=new_key,
+                target=target,
+                document=payload,
+            )
+
+        try:
+            result = self.broker_orders.update_one(
+                {"broker_order_key": old_key},
+                {"$set": payload},
+                upsert=False,
+            )
+        except DuplicateKeyError:
+            target = self.find_broker_order(new_key)
+            if target is None:
+                raise
+            return self._merge_broker_order_target(
+                old_key=old_key,
+                new_key=new_key,
+                target=target,
+                document=payload,
+            )
+        if result.matched_count:
+            return self.find_broker_order(new_key)
+
+        saved, _created = self.upsert_broker_order(
+            payload,
+            unique_keys=["broker_order_key"],
+        )
+        return saved
+
+    def _find_canonical_broker_order(self, document, *, query):
+        broker_order_key = normalize_identifier(document.get("broker_order_key"))
+        if broker_order_key is not None:
+            canonical = self.find_broker_order(broker_order_key)
+            if canonical is not None:
+                return canonical
+        return self.broker_orders.find_one(query)
+
+    def _merge_broker_order_target(self, *, old_key, new_key, target, document):
+        placeholder = self.find_broker_order(old_key)
+        if placeholder is not None:
+            _assert_broker_order_identity_consistent(target, placeholder)
+        _assert_broker_order_identity_consistent(target, document)
+        merged = {
+            **_without_mongo_id(placeholder or {}),
+            **_without_mongo_id(target),
+            **_without_mongo_id(document),
+            "broker_order_key": new_key,
+        }
+        self.broker_orders.update_one(
+            {"broker_order_key": new_key},
+            {"$set": merged},
+            upsert=False,
+        )
+        self.broker_orders.delete_one({"broker_order_key": old_key})
+        return self.find_broker_order(new_key)
 
     def insert_order_event(self, document):
         self.order_events.insert_one(document)
         return document
 
     def upsert_trade_fact(self, document, unique_keys):
-        query = {key: document[key] for key in unique_keys}
-        existing = self.trade_facts.find_one(query)
-        if existing is not None:
-            return existing, False
-        self.trade_facts.insert_one(document)
-        return document, True
+        return self._upsert_execution_document(
+            collection=self.trade_facts,
+            document=document,
+            unique_keys=unique_keys,
+        )
 
     def find_order(self, internal_order_id):
         return self.orders.find_one({"internal_order_id": internal_order_id})
@@ -185,12 +349,40 @@ class OrderManagementRepository:
         return self.find_order(internal_order_id)
 
     def upsert_execution_fill(self, document, unique_keys):
+        return self._upsert_execution_document(
+            collection=self.execution_fills,
+            document=document,
+            unique_keys=unique_keys,
+        )
+
+    def _upsert_execution_document(self, *, collection, document, unique_keys):
         query = {key: document[key] for key in unique_keys}
-        existing = self.execution_fills.find_one(query)
-        if existing is not None:
+        payload = _without_mongo_id(document)
+        try:
+            result = collection.update_one(
+                query,
+                {"$setOnInsert": payload},
+                upsert=True,
+            )
+        except DuplicateKeyError:
+            existing = _find_canonical_execution_document(
+                collection,
+                document,
+                query=query,
+            )
+            if existing is None:
+                raise
+            _assert_execution_identity_consistent(existing, document)
             return existing, False
-        self.execution_fills.insert_one(document)
-        return document, True
+
+        saved = _find_canonical_execution_document(
+            collection,
+            document,
+            query=query,
+        )
+        if result.upserted_id is None and saved is not None:
+            _assert_execution_identity_consistent(saved, document)
+        return saved, result.upserted_id is not None
 
     def find_buy_lot_by_origin_trade_fact_id(self, origin_trade_fact_id):
         return self.buy_lots.find_one({"origin_trade_fact_id": origin_trade_fact_id})
@@ -231,6 +423,15 @@ class OrderManagementRepository:
         self.entry_slices.delete_many({"entry_id": entry_id})
         if slices:
             self.entry_slices.insert_many(slices)
+        return slices
+
+    def upsert_entry_slices(self, slices):
+        for document in list(slices or []):
+            self.entry_slices.replace_one(
+                {"entry_slice_id": document["entry_slice_id"]},
+                document,
+                upsert=True,
+            )
         return slices
 
     def replace_open_slices(self, slices):
@@ -367,6 +568,22 @@ class OrderManagementRepository:
             query["entry_id"] = {"$in": list(entry_ids)}
         return list(self.entry_slices.find(query))
 
+    def list_entry_slices(
+        self,
+        *,
+        symbol=None,
+        entry_ids=None,
+        entry_slice_ids=None,
+    ):
+        query = {}
+        if symbol is not None:
+            query["symbol"] = symbol
+        if entry_ids is not None:
+            query["entry_id"] = {"$in": list(entry_ids)}
+        if entry_slice_ids is not None:
+            query["entry_slice_id"] = {"$in": list(entry_slice_ids)}
+        return list(self.entry_slices.find(query))
+
     def insert_external_candidate(self, document):
         self.external_candidates.insert_one(document)
         return document
@@ -435,6 +652,37 @@ class OrderManagementRepository:
             query["entry_id"] = {"$in": list(entry_ids)}
         return list(self.exit_allocations.find(query))
 
+    def find_exit_allocation_reference_errors(self, *, entry_ids=None):
+        allocations = self.list_exit_allocations(entry_ids=entry_ids)
+        if entry_ids is None:
+            entries = self.list_position_entries()
+            slices = self.list_entry_slices()
+        else:
+            scope_entry_ids = {
+                normalize_identifier(item) for item in list(entry_ids or [])
+            } - {None}
+            scope_entry_ids.update(
+                normalize_identifier(item.get("entry_id")) for item in allocations
+            )
+            scope_entry_ids.discard(None)
+            entries = self.list_position_entries(entry_ids=scope_entry_ids)
+            referenced_slice_ids = {
+                normalize_identifier(item.get("entry_slice_id")) for item in allocations
+            } - {None}
+            scoped_slices = self.list_entry_slices(entry_ids=scope_entry_ids)
+            referenced_slices = self.list_entry_slices(
+                entry_slice_ids=referenced_slice_ids
+            )
+            slices = _deduplicate_documents(
+                [*scoped_slices, *referenced_slices],
+                identity_field="entry_slice_id",
+            )
+        return find_exit_allocation_integrity_errors(
+            position_entries=entries,
+            entry_slices=slices,
+            exit_allocations=allocations,
+        )
+
     def list_reconciliation_gaps(self, *, symbol=None, state=None):
         query = {}
         if symbol is not None:
@@ -456,3 +704,82 @@ class OrderManagementRepository:
         if reason_code is not None:
             query["reason_code"] = reason_code
         return list(self.ingest_rejections.find(query))
+
+
+def _without_mongo_id(document):
+    return {key: value for key, value in dict(document or {}).items() if key != "_id"}
+
+
+def _assert_broker_order_identity_consistent(existing, incoming):
+    conflicts = identity_conflicts(existing, incoming)
+    if conflicts:
+        raise BrokerIdentityConflict(
+            "broker order conflicts with canonical identity: "
+            + ", ".join(sorted(conflicts))
+        )
+
+
+def _find_canonical_execution_document(collection, document, *, query):
+    execution_identity = normalize_identifier(document.get("execution_identity"))
+    if execution_identity is not None:
+        canonical = collection.find_one({"execution_identity": execution_identity})
+        if canonical is not None:
+            return canonical
+    return collection.find_one(query)
+
+
+def _assert_execution_identity_consistent(existing, incoming):
+    conflicts = {}
+    for field in _EXECUTION_IMMUTABLE_FIELDS:
+        left = _normalize_execution_field(field, existing.get(field))
+        right = _normalize_execution_field(field, incoming.get(field))
+        if left is not None and right is not None and left != right:
+            conflicts[field] = (left, right)
+    if conflicts:
+        raise BrokerIdentityConflict(
+            "execution replay conflicts with canonical identity: "
+            + ", ".join(sorted(conflicts))
+        )
+
+
+def _normalize_execution_field(field, value):
+    if field == "account_id":
+        return normalize_account_id(value)
+    if field == "trading_day":
+        return normalize_trading_day(value)
+    if field == "symbol":
+        return normalize_symbol(value)
+    if field == "side":
+        return normalize_side(value)
+    if field == "quantity":
+        try:
+            normalized = int(value)
+            return normalized if normalized == float(value) else value
+        except (TypeError, ValueError, OverflowError):
+            return value
+    if field == "price":
+        if value is None:
+            return None
+        try:
+            return Decimal(str(value)).normalize()
+        except (InvalidOperation, ValueError):
+            return value
+    if field == "trade_time":
+        try:
+            return int(value)
+        except (TypeError, ValueError, OverflowError):
+            return normalize_identifier(value)
+    return normalize_identifier(value)
+
+
+def _deduplicate_documents(documents, *, identity_field):
+    result = []
+    seen = set()
+    for document in documents:
+        identity = normalize_identifier(document.get(identity_field))
+        marker = identity if identity is not None else id(document)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        result.append(document)
+    return result

--- a/freshquant/order_management/submit/credit_order_resolver.py
+++ b/freshquant/order_management/submit/credit_order_resolver.py
@@ -80,7 +80,7 @@ def build_credit_subject_lookup(
     settings_provider=None,
 ):
     repository = repository or CreditSubjectRepository()
-    configured_account_id = account_id or _get_configured_account_id(
+    configured_account_id = account_id or get_configured_account_id(
         query_param=query_param,
         settings_provider=settings_provider,
     )
@@ -98,7 +98,7 @@ def build_credit_subjects_available(
     settings_provider=None,
 ):
     repository = repository or CreditSubjectRepository()
-    configured_account_id = account_id or _get_configured_account_id(
+    configured_account_id = account_id or get_configured_account_id(
         query_param=query_param,
         settings_provider=settings_provider,
     )
@@ -109,7 +109,7 @@ def build_credit_subjects_available(
     return _available
 
 
-def _get_configured_account_id(query_param=None, settings_provider=None):
+def get_configured_account_id(query_param=None, settings_provider=None):
     if settings_provider is not None:
         raw_value = getattr(settings_provider.xtquant, "account", "")
     elif query_param is not None:

--- a/freshquant/order_management/submit/execution_bridge.py
+++ b/freshquant/order_management/submit/execution_bridge.py
@@ -5,6 +5,10 @@ from datetime import time as dt_time
 from datetime import timezone
 
 from freshquant.carnation import xtconstant
+from freshquant.order_management.broker_correlation import (
+    build_broker_correlation_token,
+    normalize_broker_correlation_token,
+)
 from freshquant.order_management.repository import OrderManagementRepository
 from freshquant.order_management.tracking.service import OrderTrackingService
 
@@ -40,6 +44,24 @@ def prepare_submit_execution(
         )
         return {"status": "skipped", "reason": "already_canceled"}
 
+    message_correlation_token = normalize_broker_correlation_token(
+        order_message.get("broker_correlation_token")
+    )
+    order_correlation_token = normalize_broker_correlation_token(
+        order.get("broker_correlation_token")
+    )
+    if (
+        message_correlation_token is not None
+        and order_correlation_token is not None
+        and message_correlation_token != order_correlation_token
+    ):
+        raise ValueError("broker correlation token conflicts with internal order")
+    broker_correlation_token = (
+        order_correlation_token
+        or message_correlation_token
+        or build_broker_correlation_token(internal_order_id)
+    )
+
     runtime_resolution = _resolve_runtime_execution(
         order_message,
         order,
@@ -55,6 +77,7 @@ def prepare_submit_execution(
             "broker_order_type": runtime_resolution.get("broker_order_type"),
             "price_mode_resolved": runtime_resolution.get("price_mode_resolved"),
             "broker_price_type": runtime_resolution.get("broker_price_type"),
+            "broker_correlation_token": broker_correlation_token,
             "updated_at": _utc_now_iso(),
         },
     )
@@ -85,6 +108,8 @@ def prepare_submit_execution(
             "credit_available_amount": runtime_resolution.get(
                 "credit_available_amount"
             ),
+            "broker_correlation_token": broker_correlation_token,
+            "broker_order_remark": broker_correlation_token,
         }
     )
     return {"status": "execute", "order_message": resolved_message}

--- a/freshquant/order_management/submit/service.py
+++ b/freshquant/order_management/submit/service.py
@@ -4,10 +4,15 @@ import json
 from datetime import datetime, timezone
 
 from freshquant.carnation.config import STOCK_ORDER_QUEUE
+from freshquant.order_management.broker_identity import (
+    normalize_account_id,
+    resolve_trading_day,
+)
 from freshquant.order_management.repository import OrderManagementRepository
 from freshquant.order_management.submit.credit_order_resolver import (
     build_credit_subject_lookup,
     build_credit_subjects_available,
+    get_configured_account_id,
     get_configured_account_type,
     resolve_submit_credit_order,
 )
@@ -30,6 +35,7 @@ class OrderSubmitService:
         queue_client=None,
         position_management_service=None,
         account_type_loader=None,
+        account_id_loader=None,
         credit_subject_lookup=None,
         credit_subjects_available=None,
         credit_order_resolver=None,
@@ -45,6 +51,7 @@ class OrderSubmitService:
             or _load_position_management_service(runtime_logger=runtime_logger)
         )
         self.account_type_loader = account_type_loader or get_configured_account_type
+        self.account_id_loader = account_id_loader or get_configured_account_id
         self.credit_subject_lookup = (
             credit_subject_lookup or _default_credit_subject_lookup
         )
@@ -73,6 +80,17 @@ class OrderSubmitService:
             account_type = _normalize_account_type(
                 payload.get("account_type") or self.account_type_loader()
             )
+            account_id = normalize_account_id(
+                payload.get("account_id") or self.account_id_loader()
+            )
+            if account_id is None:
+                raise ValueError("account_id is required")
+            trading_day = resolve_trading_day(
+                payload,
+                report_time=datetime.now(timezone.utc),
+            )
+            if trading_day is None:  # pragma: no cover - current time is always valid
+                raise ValueError("trading_day is required")
             credit_trade_mode = _normalize_mode(payload.get("credit_trade_mode"))
             price_mode = _normalize_mode(payload.get("price_mode"))
             self._emit_runtime(
@@ -156,6 +174,8 @@ class OrderSubmitService:
                     "price": price,
                     "quantity": quantity,
                     "account_type": account_type,
+                    "account_id": account_id,
+                    "trading_day": trading_day,
                     "credit_trade_mode": credit_trade_mode,
                     "price_mode": price_mode,
                     **credit_resolution,
@@ -197,12 +217,15 @@ class OrderSubmitService:
                 "scope_ref_id": payload.get("scope_ref_id"),
                 "strategy_context": payload.get("strategy_context"),
                 "account_type": account_type,
+                "account_id": account_id,
+                "trading_day": trading_day,
                 "credit_trade_mode": credit_trade_mode,
                 "price_mode": price_mode,
                 "credit_trade_mode_resolved": credit_resolution[
                     "credit_trade_mode_resolved"
                 ],
                 "broker_order_type": credit_resolution["broker_order_type"],
+                "broker_correlation_token": order["broker_correlation_token"],
             }
             if position_decision is not None:
                 queue_payload["position_management_state"] = position_decision.state
@@ -225,7 +248,9 @@ class OrderSubmitService:
                 symbol=symbol,
                 request_id=request_id,
                 internal_order_id=order["internal_order_id"],
-                extra_payload={"queue_payload": queue_payload},
+                extra_payload={
+                    "queue_payload": _build_runtime_queue_payload(queue_payload)
+                },
             )
             self.queue_client.lpush(
                 STOCK_ORDER_QUEUE,
@@ -385,6 +410,12 @@ class OrderSubmitService:
 def _normalize_symbol(symbol):
     normalized = normalize_to_base_code(symbol)
     return normalized or symbol
+
+
+def _build_runtime_queue_payload(queue_payload):
+    runtime_payload = dict(queue_payload or {})
+    runtime_payload.pop("account_id", None)
+    return runtime_payload
 
 
 def _load_queue_client():

--- a/freshquant/order_management/time_helpers.py
+++ b/freshquant/order_management/time_helpers.py
@@ -1,9 +1,17 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
+from datetime import datetime, timedelta, timezone, tzinfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-_BEIJING_TIMEZONE = ZoneInfo("Asia/Shanghai")
+
+def _resolve_beijing_timezone() -> tzinfo:
+    try:
+        return ZoneInfo("Asia/Shanghai")
+    except ZoneInfoNotFoundError:
+        return timezone(timedelta(hours=8))
+
+
+_BEIJING_TIMEZONE = _resolve_beijing_timezone()
 
 
 def beijing_datetime_from_epoch(timestamp):

--- a/freshquant/order_management/tracking/service.py
+++ b/freshquant/order_management/tracking/service.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
 
+import hashlib
+import json
 from datetime import datetime, timezone
 
+from freshquant.order_management.broker_correlation import (
+    build_broker_correlation_token,
+    looks_like_broker_correlation_token,
+    normalize_broker_correlation_token,
+)
 from freshquant.order_management.broker_identity import (
     BrokerIdentityConflict,
     BrokerIdentityError,
@@ -34,12 +41,22 @@ class OrderTrackingService:
     def submit_order(self, payload):
         request_id = payload.get("request_id") or new_request_id()
         internal_order_id = payload.get("internal_order_id") or new_internal_order_id()
+        raw_correlation_token = payload.get("broker_correlation_token")
+        broker_correlation_token = normalize_broker_correlation_token(
+            raw_correlation_token
+        )
+        if raw_correlation_token not in (None, "", "None"):
+            if broker_correlation_token is None:
+                raise BrokerIdentityError("broker correlation token is invalid")
+        else:
+            broker_correlation_token = build_broker_correlation_token(internal_order_id)
         now = _utc_now_iso()
+        trading_day = resolve_trading_day(payload)
         initial_broker_order_key = (
             build_broker_order_key(
                 account_id=payload.get("account_id"),
                 order_sysid=payload.get("order_sysid"),
-                trading_day=resolve_trading_day(payload),
+                trading_day=trading_day,
                 symbol=payload.get("symbol"),
                 side=payload.get("action"),
                 broker_order_id=payload.get("broker_order_id"),
@@ -56,6 +73,7 @@ class OrderTrackingService:
             "intent_id": payload.get("intent_id"),
             "account_type": payload.get("account_type"),
             "account_id": normalize_account_id(payload.get("account_id")),
+            "trading_day": trading_day,
             "symbol": payload.get("symbol"),
             "price": payload.get("price"),
             "quantity": payload.get("quantity"),
@@ -67,6 +85,7 @@ class OrderTrackingService:
             "scope_type": payload.get("scope_type"),
             "scope_ref_id": payload.get("scope_ref_id"),
             "req_id": payload.get("req_id") or request_id,
+            "broker_correlation_token": broker_correlation_token,
             "state": "ACCEPTED",
             "created_at": now,
         }
@@ -77,10 +96,11 @@ class OrderTrackingService:
             "broker_order_key": initial_broker_order_key,
             "broker_order_type": payload.get("broker_order_type"),
             "broker_price_type": payload.get("broker_price_type"),
+            "broker_correlation_token": broker_correlation_token,
             "account_type": payload.get("account_type"),
             "account_id": normalize_account_id(payload.get("account_id")),
             "order_sysid": normalize_identifier(payload.get("order_sysid")),
-            "trading_day": resolve_trading_day(payload),
+            "trading_day": trading_day,
             "trace_id": payload.get("trace_id"),
             "intent_id": payload.get("intent_id"),
             "symbol": payload.get("symbol"),
@@ -116,10 +136,11 @@ class OrderTrackingService:
                     "broker_order_id": payload.get("broker_order_id"),
                     "broker_order_type": payload.get("broker_order_type"),
                     "broker_price_type": payload.get("broker_price_type"),
+                    "broker_correlation_token": broker_correlation_token,
                     "account_type": payload.get("account_type"),
                     "account_id": normalize_account_id(payload.get("account_id")),
                     "order_sysid": normalize_identifier(payload.get("order_sysid")),
-                    "trading_day": resolve_trading_day(payload),
+                    "trading_day": trading_day,
                     "trace_id": payload.get("trace_id"),
                     "intent_id": payload.get("intent_id"),
                     "symbol": payload.get("symbol"),
@@ -347,8 +368,9 @@ class OrderTrackingService:
     def ingest_trade_report_with_meta(self, report):
         report = _normalize_trade_report_identity(report)
         current_order = self.repository.find_order(report["internal_order_id"])
+        create_broker_only_order = current_order is None
         if current_order is None:
-            current_order = self._create_broker_only_order(
+            current_order = self._build_broker_only_order(
                 {**report, "state": "PARTIAL_FILLED"}
             )
         else:
@@ -367,11 +389,7 @@ class OrderTrackingService:
         )
         if current_order.get("broker_order_key") != broker_order_key:
             identity_updates["broker_order_key"] = broker_order_key
-        if identity_updates:
-            current_order = self.repository.update_order(
-                report["internal_order_id"],
-                {**identity_updates, "updated_at": _utc_now_iso()},
-            )
+        effective_order = {**current_order, **identity_updates}
 
         execution_identity = build_execution_identity(report)
         execution_fill = {
@@ -379,9 +397,9 @@ class OrderTrackingService:
             or new_execution_fill_id(),
             "broker_order_key": broker_order_key,
             "internal_order_id": report["internal_order_id"],
-            "request_id": current_order.get("request_id") if current_order else None,
+            "request_id": effective_order.get("request_id"),
             "broker_order_id": report.get("broker_order_id")
-            or (current_order.get("broker_order_id") if current_order else None),
+            or effective_order.get("broker_order_id"),
             "broker_trade_id": report["broker_trade_id"],
             "execution_identity": execution_identity,
             "account_id": report.get("account_id"),
@@ -396,6 +414,9 @@ class OrderTrackingService:
             "time": report.get("time"),
             "source": report.get("source", "unknown"),
             "provisional": report.get("provisional", False),
+            "projection_status": "PENDING",
+            "projection_plan": None,
+            "execution_record_version": 2,
         }
         trade_fact = {
             "trade_fact_id": report.get("trade_fact_id") or new_trade_fact_id(),
@@ -416,7 +437,10 @@ class OrderTrackingService:
             "time": report.get("time"),
             "source": report.get("source", "unknown"),
             "provisional": report.get("provisional", False),
+            "execution_record_version": 2,
         }
+        if hasattr(self.repository, "preflight_execution_replay"):
+            self.repository.preflight_execution_replay(execution_fill)
         saved_trade_fact, created = self.repository.upsert_trade_fact(
             trade_fact,
             unique_keys=["execution_identity"],
@@ -431,10 +455,26 @@ class OrderTrackingService:
         else:
             saved_execution_fill = dict(execution_fill)
             created_execution_fill = created
+            if not created_execution_fill:
+                saved_execution_fill["projection_status"] = "APPLIED"
         _assert_execution_replay_consistent(saved_trade_fact, trade_fact)
         _assert_execution_replay_consistent(saved_execution_fill, execution_fill)
+        if create_broker_only_order:
+            self.repository.insert_order(effective_order)
+            current_order = effective_order
+        elif identity_updates:
+            current_order = self.repository.update_order(
+                report["internal_order_id"],
+                {**identity_updates, "updated_at": _utc_now_iso()},
+            )
+        else:
+            current_order = effective_order
         created = bool(created_execution_fill)
-        if created:
+        projection_pending = (
+            str(saved_execution_fill.get("projection_status") or "").upper()
+            == "PENDING"
+        )
+        if created or projection_pending:
             self._migrate_broker_order_placeholder(
                 placeholder_key=placeholder_key,
                 broker_order_key=broker_order_key,
@@ -446,6 +486,7 @@ class OrderTrackingService:
                 saved_execution_fill,
                 current_order=current_order,
             )
+        if created:
             self.repository.insert_order_event(
                 {
                     "event_id": new_event_id(),
@@ -462,7 +503,7 @@ class OrderTrackingService:
             "created": created,
         }
 
-    def _create_broker_only_order(self, report):
+    def _build_broker_only_order(self, report):
         internal_order_id = normalize_identifier(report.get("internal_order_id"))
         if internal_order_id is None:
             internal_order_id = build_broker_only_internal_order_id(
@@ -484,6 +525,9 @@ class OrderTrackingService:
             "broker_order_id": normalize_identifier(report.get("broker_order_id")),
             "broker_order_type": report.get("broker_order_type")
             or report.get("order_type"),
+            "broker_correlation_token": normalize_broker_correlation_token(
+                report.get("broker_correlation_token") or report.get("order_remark")
+            ),
             "account_type": report.get("account_type"),
             "account_id": normalize_account_id(report.get("account_id")),
             "order_sysid": normalize_identifier(report.get("order_sysid")),
@@ -500,6 +544,10 @@ class OrderTrackingService:
             "created_at": now,
             "updated_at": now,
         }
+        return document
+
+    def _create_broker_only_order(self, report):
+        document = self._build_broker_only_order(report)
         self.repository.insert_order(document)
         return document
 
@@ -536,6 +584,11 @@ class OrderTrackingService:
                 or current_order.get("broker_order_id")
                 or source.get("broker_order_id")
             ),
+            "broker_correlation_token": normalize_broker_correlation_token(
+                report.get("broker_correlation_token") or report.get("order_remark")
+            )
+            or current_order.get("broker_correlation_token")
+            or source.get("broker_correlation_token"),
             "account_type": current_order.get("account_type")
             or report.get("account_type")
             or source.get("account_type"),
@@ -638,10 +691,22 @@ class OrderTrackingService:
             "symbol": normalize_symbol(report.get("symbol"))
             or broker_order.get("symbol"),
             "side": normalize_side(report.get("side")) or broker_order.get("side"),
+            "broker_correlation_token": normalize_broker_correlation_token(
+                report.get("broker_correlation_token") or report.get("order_remark")
+            )
+            or broker_order.get("broker_correlation_token"),
         }
+        update_fields = {
+            key: value for key, value in updates.items() if value is not None
+        }
+        if hasattr(self.repository, "update_broker_order_fields"):
+            return self.repository.update_broker_order_fields(
+                broker_order_key,
+                update_fields,
+            )
         next_document = {
             **broker_order,
-            **{key: value for key, value in updates.items() if value is not None},
+            **update_fields,
         }
         saved_broker_order, _ = self.repository.upsert_broker_order(
             next_document,
@@ -656,99 +721,132 @@ class OrderTrackingService:
             self.repository, "upsert_broker_order"
         ):
             return None
-        broker_order = self.repository.find_broker_order(broker_order_key)
-        if broker_order is None:
-            broker_order = {
-                "broker_order_key": broker_order_key,
-                "internal_order_id": (
-                    current_order.get("internal_order_id")
-                    if current_order
-                    else broker_order_key
-                ),
-                "request_id": (
-                    current_order.get("request_id") if current_order else None
-                ),
-                "broker_order_id": execution_fill.get("broker_order_id"),
-                "account_id": execution_fill.get("account_id"),
-                "order_sysid": execution_fill.get("order_sysid"),
-                "trading_day": execution_fill.get("trading_day"),
-                "account_type": (
-                    current_order.get("account_type") if current_order else None
-                ),
-                "trace_id": current_order.get("trace_id") if current_order else None,
-                "intent_id": current_order.get("intent_id") if current_order else None,
-                "symbol": execution_fill.get("symbol"),
-                "side": execution_fill.get("side"),
-                "state": "PARTIAL_FILLED",
-                "source_type": execution_fill.get("source"),
-                "submitted_at": (
-                    current_order.get("submitted_at") if current_order else None
-                ),
-                "requested_quantity": None,
-                "filled_quantity": 0,
-                "avg_filled_price": None,
-                "fill_count": 0,
-                "first_fill_time": None,
-                "last_fill_time": None,
-                "updated_at": _utc_now_iso(),
-            }
-        conflicts = identity_conflicts(broker_order, execution_fill)
-        if conflicts:
-            raise BrokerIdentityConflict(
-                "execution fill conflicts with broker aggregate: "
-                + ", ".join(sorted(conflicts))
-            )
-        fills = _list_broker_execution_fills(
-            self.repository,
-            broker_order_key=broker_order_key,
-            fallback_fill=execution_fill,
-        )
-        for fill in fills:
-            conflicts = identity_conflicts(broker_order, fill)
+        for _attempt in range(8):
+            broker_order = self.repository.find_broker_order(broker_order_key)
+            if broker_order is None:
+                broker_order = {
+                    "broker_order_key": broker_order_key,
+                    "internal_order_id": (
+                        current_order.get("internal_order_id")
+                        if current_order
+                        else broker_order_key
+                    ),
+                    "request_id": (
+                        current_order.get("request_id") if current_order else None
+                    ),
+                    "broker_order_id": execution_fill.get("broker_order_id"),
+                    "account_id": execution_fill.get("account_id"),
+                    "order_sysid": execution_fill.get("order_sysid"),
+                    "trading_day": execution_fill.get("trading_day"),
+                    "account_type": (
+                        current_order.get("account_type") if current_order else None
+                    ),
+                    "trace_id": (
+                        current_order.get("trace_id") if current_order else None
+                    ),
+                    "intent_id": (
+                        current_order.get("intent_id") if current_order else None
+                    ),
+                    "symbol": execution_fill.get("symbol"),
+                    "side": execution_fill.get("side"),
+                    "state": "PARTIAL_FILLED",
+                    "source_type": execution_fill.get("source"),
+                    "submitted_at": (
+                        current_order.get("submitted_at") if current_order else None
+                    ),
+                    "requested_quantity": None,
+                    "filled_quantity": 0,
+                    "avg_filled_price": None,
+                    "fill_count": 0,
+                    "fill_set_fingerprint": None,
+                    "aggregate_revision": 0,
+                    "first_fill_time": None,
+                    "last_fill_time": None,
+                    "updated_at": _utc_now_iso(),
+                }
+                broker_order, _ = self.repository.upsert_broker_order(
+                    broker_order,
+                    unique_keys=["broker_order_key"],
+                )
+                continue
+            conflicts = identity_conflicts(broker_order, execution_fill)
             if conflicts:
                 raise BrokerIdentityConflict(
-                    "broker aggregate contains mixed execution identities: "
+                    "execution fill conflicts with broker aggregate: "
                     + ", ".join(sorted(conflicts))
                 )
-        next_quantity = sum(int(fill.get("quantity") or 0) for fill in fills)
-        next_fill_count = len(fills)
-        next_notional = sum(
-            int(fill.get("quantity") or 0) * float(fill.get("price") or 0)
-            for fill in fills
+            fills = _list_broker_execution_fills(
+                self.repository,
+                broker_order_key=broker_order_key,
+                fallback_fill=execution_fill,
+            )
+            for fill in fills:
+                conflicts = identity_conflicts(broker_order, fill)
+                if conflicts:
+                    raise BrokerIdentityConflict(
+                        "broker aggregate contains mixed execution identities: "
+                        + ", ".join(sorted(conflicts))
+                    )
+            next_quantity = sum(int(fill.get("quantity") or 0) for fill in fills)
+            next_fill_count = len(fills)
+            next_notional = sum(
+                int(fill.get("quantity") or 0) * float(fill.get("price") or 0)
+                for fill in fills
+            )
+            next_avg_price = (
+                round(next_notional / next_quantity, 6) if next_quantity > 0 else None
+            )
+            first_fill_time, last_fill_time = _fill_time_bounds(fills)
+            requested_quantity = broker_order.get("requested_quantity")
+            next_state = "PARTIAL_FILLED"
+            if requested_quantity not in (None, "") and next_quantity >= int(
+                requested_quantity
+            ):
+                next_state = "FILLED"
+            fill_set_fingerprint = _fill_set_fingerprint(fills)
+            next_document = {
+                **broker_order,
+                "broker_order_id": execution_fill.get("broker_order_id")
+                or broker_order.get("broker_order_id"),
+                "account_id": execution_fill.get("account_id")
+                or broker_order.get("account_id"),
+                "order_sysid": execution_fill.get("order_sysid")
+                or broker_order.get("order_sysid"),
+                "trading_day": execution_fill.get("trading_day")
+                or broker_order.get("trading_day"),
+                "filled_quantity": next_quantity,
+                "avg_filled_price": next_avg_price,
+                "fill_count": next_fill_count,
+                "fill_set_fingerprint": fill_set_fingerprint,
+                "aggregate_revision": int(broker_order.get("aggregate_revision") or 0)
+                + 1,
+                "first_fill_time": first_fill_time,
+                "last_fill_time": last_fill_time,
+                "state": next_state,
+                "updated_at": _utc_now_iso(),
+            }
+            if hasattr(self.repository, "compare_and_set_broker_order"):
+                saved_broker_order = self.repository.compare_and_set_broker_order(
+                    before=broker_order,
+                    after=next_document,
+                )
+                if saved_broker_order is None:
+                    continue
+            else:
+                saved_broker_order, _ = self.repository.upsert_broker_order(
+                    next_document,
+                    unique_keys=["broker_order_key"],
+                )
+            latest_fills = _list_broker_execution_fills(
+                self.repository,
+                broker_order_key=broker_order_key,
+                fallback_fill=execution_fill,
+            )
+            if _fill_set_fingerprint(latest_fills) == fill_set_fingerprint:
+                return saved_broker_order
+        raise BrokerIdentityConflict(
+            "broker aggregate could not converge after concurrent updates"
         )
-        next_avg_price = (
-            round(next_notional / next_quantity, 6) if next_quantity > 0 else None
-        )
-        first_fill_time, last_fill_time = _fill_time_bounds(fills)
-        requested_quantity = broker_order.get("requested_quantity")
-        next_state = "PARTIAL_FILLED"
-        if requested_quantity not in (None, "") and next_quantity >= int(
-            requested_quantity
-        ):
-            next_state = "FILLED"
-        next_document = {
-            **broker_order,
-            "broker_order_id": execution_fill.get("broker_order_id")
-            or broker_order.get("broker_order_id"),
-            "account_id": execution_fill.get("account_id")
-            or broker_order.get("account_id"),
-            "order_sysid": execution_fill.get("order_sysid")
-            or broker_order.get("order_sysid"),
-            "trading_day": execution_fill.get("trading_day")
-            or broker_order.get("trading_day"),
-            "filled_quantity": next_quantity,
-            "avg_filled_price": next_avg_price,
-            "fill_count": next_fill_count,
-            "first_fill_time": first_fill_time,
-            "last_fill_time": last_fill_time,
-            "state": next_state,
-            "updated_at": _utc_now_iso(),
-        }
-        saved_broker_order, _ = self.repository.upsert_broker_order(
-            next_document,
-            unique_keys=["broker_order_key"],
-        )
-        return saved_broker_order
 
 
 def _utc_now_iso():
@@ -827,6 +925,14 @@ def _normalize_trade_report_identity(report):
 
 
 def _non_empty_identity_fields(payload):
+    raw_correlation_token = payload.get("broker_correlation_token") or payload.get(
+        "order_remark"
+    )
+    broker_correlation_token = normalize_broker_correlation_token(raw_correlation_token)
+    if broker_correlation_token is None and looks_like_broker_correlation_token(
+        raw_correlation_token
+    ):
+        raise BrokerIdentityConflict("broker correlation token is malformed")
     normalized = {
         "account_id": normalize_account_id(payload.get("account_id")),
         "order_sysid": normalize_identifier(payload.get("order_sysid")),
@@ -836,6 +942,7 @@ def _non_empty_identity_fields(payload):
         "broker_order_id": normalize_identifier(
             payload.get("broker_order_id") or payload.get("order_id")
         ),
+        "broker_correlation_token": broker_correlation_token,
     }
     return {key: value for key, value in normalized.items() if value is not None}
 
@@ -847,6 +954,21 @@ def _assert_order_report_identity(current_order, report):
         "trading_day": resolve_trading_day(current_order),
     }
     conflicts = identity_conflicts(current_identity, report_identity)
+    current_correlation_token = normalize_broker_correlation_token(
+        current_order.get("broker_correlation_token")
+    )
+    report_correlation_token = normalize_broker_correlation_token(
+        report_identity.get("broker_correlation_token")
+    )
+    if (
+        current_correlation_token is not None
+        and report_correlation_token is not None
+        and current_correlation_token != report_correlation_token
+    ):
+        conflicts["broker_correlation_token"] = (
+            current_correlation_token,
+            report_correlation_token,
+        )
     if conflicts:
         raise BrokerIdentityConflict(
             "broker report conflicts with internal order: "
@@ -917,6 +1039,20 @@ def _fill_time_bounds(fills):
     if not values:
         return None, None
     return min(values), max(values)
+
+
+def _fill_set_fingerprint(fills):
+    payload = sorted(
+        (
+            str(fill.get("execution_identity") or fill.get("execution_fill_id") or ""),
+            int(fill.get("quantity") or 0),
+            str(fill.get("price") or ""),
+            int(fill.get("trade_time") or 0),
+        )
+        for fill in fills
+    )
+    serialized = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
 def _pick_first_time(previous, current):

--- a/freshquant/order_management/tracking/service.py
+++ b/freshquant/order_management/tracking/service.py
@@ -2,6 +2,19 @@
 
 from datetime import datetime, timezone
 
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityConflict,
+    BrokerIdentityError,
+    build_broker_only_internal_order_id,
+    build_broker_order_key,
+    build_execution_identity,
+    identity_conflicts,
+    normalize_account_id,
+    normalize_identifier,
+    normalize_side,
+    normalize_symbol,
+    resolve_trading_day,
+)
 from freshquant.order_management.ids import (
     new_event_id,
     new_execution_fill_id,
@@ -22,6 +35,18 @@ class OrderTrackingService:
         request_id = payload.get("request_id") or new_request_id()
         internal_order_id = payload.get("internal_order_id") or new_internal_order_id()
         now = _utc_now_iso()
+        initial_broker_order_key = (
+            build_broker_order_key(
+                account_id=payload.get("account_id"),
+                order_sysid=payload.get("order_sysid"),
+                trading_day=resolve_trading_day(payload),
+                symbol=payload.get("symbol"),
+                side=payload.get("action"),
+                broker_order_id=payload.get("broker_order_id"),
+                strict=False,
+            )
+            or internal_order_id
+        )
 
         request_document = {
             "request_id": request_id,
@@ -30,6 +55,7 @@ class OrderTrackingService:
             "trace_id": payload.get("trace_id"),
             "intent_id": payload.get("intent_id"),
             "account_type": payload.get("account_type"),
+            "account_id": normalize_account_id(payload.get("account_id")),
             "symbol": payload.get("symbol"),
             "price": payload.get("price"),
             "quantity": payload.get("quantity"),
@@ -48,9 +74,13 @@ class OrderTrackingService:
             "internal_order_id": internal_order_id,
             "request_id": request_id,
             "broker_order_id": payload.get("broker_order_id"),
+            "broker_order_key": initial_broker_order_key,
             "broker_order_type": payload.get("broker_order_type"),
             "broker_price_type": payload.get("broker_price_type"),
             "account_type": payload.get("account_type"),
+            "account_id": normalize_account_id(payload.get("account_id")),
+            "order_sysid": normalize_identifier(payload.get("order_sysid")),
+            "trading_day": resolve_trading_day(payload),
             "trace_id": payload.get("trace_id"),
             "intent_id": payload.get("intent_id"),
             "symbol": payload.get("symbol"),
@@ -80,13 +110,16 @@ class OrderTrackingService:
         if hasattr(self.repository, "upsert_broker_order"):
             self.repository.upsert_broker_order(
                 {
-                    "broker_order_key": internal_order_id,
+                    "broker_order_key": initial_broker_order_key,
                     "internal_order_id": internal_order_id,
                     "request_id": request_id,
                     "broker_order_id": payload.get("broker_order_id"),
                     "broker_order_type": payload.get("broker_order_type"),
                     "broker_price_type": payload.get("broker_price_type"),
                     "account_type": payload.get("account_type"),
+                    "account_id": normalize_account_id(payload.get("account_id")),
+                    "order_sysid": normalize_identifier(payload.get("order_sysid")),
+                    "trading_day": resolve_trading_day(payload),
                     "trace_id": payload.get("trace_id"),
                     "intent_id": payload.get("intent_id"),
                     "symbol": payload.get("symbol"),
@@ -191,12 +224,48 @@ class OrderTrackingService:
         return self.ingest_order_report_with_meta(report)["order"]
 
     def ingest_order_report_with_meta(self, report):
+        report = dict(report)
         internal_order_id = report["internal_order_id"]
         current_order = self.repository.find_order(internal_order_id)
+        if current_order is None:
+            current_order = self._create_broker_only_order(report)
+            broker_order_key = _resolve_broker_order_key(
+                report, current_order=current_order
+            )
+            self._sync_broker_order_report(
+                broker_order_key,
+                report,
+                current_order=current_order,
+                placeholder_key=internal_order_id,
+            )
+            self.repository.insert_order_event(
+                {
+                    "event_id": new_event_id(),
+                    "request_id": None,
+                    "internal_order_id": internal_order_id,
+                    "event_type": report.get(
+                        "event_type", "broker_only_order_reported"
+                    ),
+                    "state": current_order["state"],
+                    "created_at": _utc_now_iso(),
+                }
+            )
+            return {"order": current_order, "changed": True, "absorbed": False}
+
+        _assert_order_report_identity(current_order, report)
+        placeholder_key = current_order.get("broker_order_key") or internal_order_id
+        merged_identity = {**current_order, **_non_empty_identity_fields(report)}
+        broker_order_key = _resolve_broker_order_key(
+            merged_identity, current_order=merged_identity
+        )
         current_state = current_order["state"]
-        updates = {}
-        if report.get("broker_order_id") and not current_order.get("broker_order_id"):
-            updates["broker_order_id"] = report.get("broker_order_id")
+        updates = {
+            key: value
+            for key, value in _non_empty_identity_fields(report).items()
+            if current_order.get(key) != value
+        }
+        if current_order.get("broker_order_key") != broker_order_key:
+            updates["broker_order_key"] = broker_order_key
         if report.get("submitted_at") and not current_order.get("submitted_at"):
             updates["submitted_at"] = report.get("submitted_at")
         if current_state == report["state"]:
@@ -204,12 +273,15 @@ class OrderTrackingService:
                 updates["updated_at"] = _utc_now_iso()
                 updated_order = self.repository.update_order(internal_order_id, updates)
                 self._sync_broker_order_report(
-                    internal_order_id,
+                    broker_order_key,
                     {
+                        **report,
                         "broker_order_id": report.get("broker_order_id"),
                         "submitted_at": report.get("submitted_at"),
                         "state": current_state,
                     },
+                    current_order=updated_order,
+                    placeholder_key=placeholder_key,
                 )
                 return {
                     "order": updated_order,
@@ -222,12 +294,15 @@ class OrderTrackingService:
                 updates["updated_at"] = _utc_now_iso()
                 current_order = self.repository.update_order(internal_order_id, updates)
                 self._sync_broker_order_report(
-                    internal_order_id,
+                    broker_order_key,
                     {
+                        **report,
                         "broker_order_id": report.get("broker_order_id"),
                         "submitted_at": report.get("submitted_at"),
                         "state": current_order.get("state"),
                     },
+                    current_order=current_order,
+                    placeholder_key=placeholder_key,
                 )
             return {"order": current_order, "changed": False, "absorbed": True}
         next_state = self.state_machine.transition(current_state, report["state"])
@@ -239,6 +314,7 @@ class OrderTrackingService:
                 "state": next_state,
                 "broker_order_id": report.get("broker_order_id"),
                 "submitted_at": report.get("submitted_at"),
+                **updates,
                 "updated_at": now,
             },
         )
@@ -253,12 +329,15 @@ class OrderTrackingService:
             }
         )
         self._sync_broker_order_report(
-            internal_order_id,
+            broker_order_key,
             {
+                **report,
                 "broker_order_id": report.get("broker_order_id"),
                 "submitted_at": report.get("submitted_at"),
                 "state": next_state,
             },
+            current_order=updated_order,
+            placeholder_key=placeholder_key,
         )
         return {"order": updated_order, "changed": True, "absorbed": False}
 
@@ -266,10 +345,35 @@ class OrderTrackingService:
         return self.ingest_trade_report_with_meta(report)["trade_fact"]
 
     def ingest_trade_report_with_meta(self, report):
+        report = _normalize_trade_report_identity(report)
         current_order = self.repository.find_order(report["internal_order_id"])
+        if current_order is None:
+            current_order = self._create_broker_only_order(
+                {**report, "state": "PARTIAL_FILLED"}
+            )
+        else:
+            _assert_order_report_identity(current_order, report)
+
+        placeholder_key = current_order.get("broker_order_key") or current_order.get(
+            "internal_order_id"
+        )
+        identity_updates = {
+            key: value
+            for key, value in _non_empty_identity_fields(report).items()
+            if current_order.get(key) != value
+        }
         broker_order_key = _resolve_broker_order_key(
             report, current_order=current_order
         )
+        if current_order.get("broker_order_key") != broker_order_key:
+            identity_updates["broker_order_key"] = broker_order_key
+        if identity_updates:
+            current_order = self.repository.update_order(
+                report["internal_order_id"],
+                {**identity_updates, "updated_at": _utc_now_iso()},
+            )
+
+        execution_identity = build_execution_identity(report)
         execution_fill = {
             "execution_fill_id": report.get("execution_fill_id")
             or new_execution_fill_id(),
@@ -279,6 +383,10 @@ class OrderTrackingService:
             "broker_order_id": report.get("broker_order_id")
             or (current_order.get("broker_order_id") if current_order else None),
             "broker_trade_id": report["broker_trade_id"],
+            "execution_identity": execution_identity,
+            "account_id": report.get("account_id"),
+            "order_sysid": report.get("order_sysid"),
+            "trading_day": report.get("trading_day"),
             "symbol": report["symbol"],
             "side": report["side"],
             "quantity": report["quantity"],
@@ -291,8 +399,14 @@ class OrderTrackingService:
         }
         trade_fact = {
             "trade_fact_id": report.get("trade_fact_id") or new_trade_fact_id(),
+            "broker_order_key": broker_order_key,
             "internal_order_id": report["internal_order_id"],
+            "broker_order_id": report.get("broker_order_id"),
             "broker_trade_id": report["broker_trade_id"],
+            "execution_identity": execution_identity,
+            "account_id": report.get("account_id"),
+            "order_sysid": report.get("order_sysid"),
+            "trading_day": report.get("trading_day"),
             "symbol": report["symbol"],
             "side": report["side"],
             "quantity": report["quantity"],
@@ -305,19 +419,28 @@ class OrderTrackingService:
         }
         saved_trade_fact, created = self.repository.upsert_trade_fact(
             trade_fact,
-            unique_keys=["broker_trade_id"],
+            unique_keys=["execution_identity"],
         )
         if hasattr(self.repository, "upsert_execution_fill"):
             saved_execution_fill, created_execution_fill = (
                 self.repository.upsert_execution_fill(
                     execution_fill,
-                    unique_keys=["broker_trade_id"],
+                    unique_keys=["execution_identity"],
                 )
             )
         else:
             saved_execution_fill = dict(execution_fill)
             created_execution_fill = created
+        _assert_execution_replay_consistent(saved_trade_fact, trade_fact)
+        _assert_execution_replay_consistent(saved_execution_fill, execution_fill)
+        created = bool(created_execution_fill)
         if created:
+            self._migrate_broker_order_placeholder(
+                placeholder_key=placeholder_key,
+                broker_order_key=broker_order_key,
+                current_order=current_order,
+                report=report,
+            )
             broker_order = self._apply_fill_to_broker_order(
                 broker_order_key,
                 saved_execution_fill,
@@ -326,7 +449,7 @@ class OrderTrackingService:
             self.repository.insert_order_event(
                 {
                     "event_id": new_event_id(),
-                    "request_id": None,
+                    "request_id": current_order.get("request_id"),
                     "internal_order_id": report["internal_order_id"],
                     "event_type": "trade_reported",
                     "state": (broker_order or {}).get("state", "PARTIAL_FILLED"),
@@ -339,11 +462,163 @@ class OrderTrackingService:
             "created": created,
         }
 
-    def _sync_broker_order_report(self, broker_order_key, report):
+    def _create_broker_only_order(self, report):
+        internal_order_id = normalize_identifier(report.get("internal_order_id"))
+        if internal_order_id is None:
+            internal_order_id = build_broker_only_internal_order_id(
+                account_id=report.get("account_id"),
+                order_sysid=report.get("order_sysid"),
+                trading_day=resolve_trading_day(report),
+                symbol=report.get("symbol"),
+                side=report.get("side"),
+                broker_order_id=report.get("broker_order_id"),
+            )
+        broker_order_key = _resolve_broker_order_key(
+            {**report, "internal_order_id": internal_order_id}
+        )
+        now = _utc_now_iso()
+        document = {
+            "internal_order_id": internal_order_id,
+            "request_id": None,
+            "broker_order_key": broker_order_key,
+            "broker_order_id": normalize_identifier(report.get("broker_order_id")),
+            "broker_order_type": report.get("broker_order_type")
+            or report.get("order_type"),
+            "account_type": report.get("account_type"),
+            "account_id": normalize_account_id(report.get("account_id")),
+            "order_sysid": normalize_identifier(report.get("order_sysid")),
+            "trading_day": resolve_trading_day(report),
+            "trace_id": report.get("trace_id"),
+            "intent_id": report.get("intent_id"),
+            "symbol": normalize_symbol(report.get("symbol")),
+            "side": normalize_side(report.get("side")),
+            "state": report.get("state") or "PARTIAL_FILLED",
+            "source_type": "broker_only",
+            "submitted_at": report.get("submitted_at"),
+            "filled_quantity": 0,
+            "avg_filled_price": None,
+            "created_at": now,
+            "updated_at": now,
+        }
+        self.repository.insert_order(document)
+        return document
+
+    def _migrate_broker_order_placeholder(
+        self,
+        *,
+        placeholder_key,
+        broker_order_key,
+        current_order,
+        report,
+    ):
         if not hasattr(self.repository, "find_broker_order") or not hasattr(
             self.repository, "upsert_broker_order"
         ):
             return None
+        placeholder_key = normalize_identifier(placeholder_key)
+        broker_order_key = normalize_identifier(broker_order_key)
+        if broker_order_key is None:
+            raise BrokerIdentityError("broker_order_key is required")
+        target = self.repository.find_broker_order(broker_order_key)
+        placeholder = (
+            self.repository.find_broker_order(placeholder_key)
+            if placeholder_key and placeholder_key != broker_order_key
+            else None
+        )
+        source = target or placeholder or {}
+        next_document = {
+            **source,
+            "broker_order_key": broker_order_key,
+            "internal_order_id": current_order.get("internal_order_id"),
+            "request_id": current_order.get("request_id"),
+            "broker_order_id": normalize_identifier(
+                report.get("broker_order_id")
+                or current_order.get("broker_order_id")
+                or source.get("broker_order_id")
+            ),
+            "account_type": current_order.get("account_type")
+            or report.get("account_type")
+            or source.get("account_type"),
+            "account_id": normalize_account_id(
+                report.get("account_id")
+                or current_order.get("account_id")
+                or source.get("account_id")
+            ),
+            "order_sysid": normalize_identifier(
+                report.get("order_sysid")
+                or current_order.get("order_sysid")
+                or source.get("order_sysid")
+            ),
+            "trading_day": resolve_trading_day({**source, **current_order, **report}),
+            "symbol": normalize_symbol(
+                report.get("symbol")
+                or current_order.get("symbol")
+                or source.get("symbol")
+            ),
+            "side": normalize_side(
+                report.get("side") or current_order.get("side") or source.get("side")
+            ),
+            "trace_id": current_order.get("trace_id") or source.get("trace_id"),
+            "intent_id": current_order.get("intent_id") or source.get("intent_id"),
+            "source_type": source.get("source_type")
+            or current_order.get("source_type")
+            or report.get("source"),
+            "submitted_at": current_order.get("submitted_at")
+            or report.get("submitted_at")
+            or source.get("submitted_at"),
+            "requested_quantity": source.get("requested_quantity"),
+            "filled_quantity": int(source.get("filled_quantity") or 0),
+            "avg_filled_price": source.get("avg_filled_price"),
+            "fill_count": int(source.get("fill_count") or 0),
+            "first_fill_time": source.get("first_fill_time"),
+            "last_fill_time": source.get("last_fill_time"),
+            "state": report.get("state")
+            or source.get("state")
+            or current_order.get("state"),
+            "updated_at": _utc_now_iso(),
+        }
+        if (
+            placeholder_key
+            and placeholder_key != broker_order_key
+            and hasattr(self.repository, "move_broker_order_key")
+        ):
+            return self.repository.move_broker_order_key(
+                placeholder_key,
+                broker_order_key,
+                next_document,
+            )
+        saved, _ = self.repository.upsert_broker_order(
+            next_document,
+            unique_keys=["broker_order_key"],
+        )
+        if placeholder_key and placeholder_key != broker_order_key:
+            _delete_broker_order(self.repository, placeholder_key)
+        return saved
+
+    def _sync_broker_order_report(
+        self,
+        broker_order_key,
+        report,
+        *,
+        current_order=None,
+        placeholder_key=None,
+    ):
+        if not hasattr(self.repository, "find_broker_order") or not hasattr(
+            self.repository, "upsert_broker_order"
+        ):
+            return None
+        current_order = current_order or self.repository.find_order(
+            report.get("internal_order_id") or broker_order_key
+        )
+        if current_order is not None:
+            self._migrate_broker_order_placeholder(
+                placeholder_key=placeholder_key
+                or current_order.get("broker_order_key")
+                or current_order.get("internal_order_id"),
+                broker_order_key=broker_order_key,
+                current_order=current_order,
+                report=report,
+            )
         broker_order = self.repository.find_broker_order(broker_order_key)
         if broker_order is None:
             return None
@@ -354,6 +629,15 @@ class OrderTrackingService:
             or broker_order.get("broker_order_id"),
             "submitted_at": report.get("submitted_at")
             or broker_order.get("submitted_at"),
+            "account_id": normalize_account_id(report.get("account_id"))
+            or broker_order.get("account_id"),
+            "order_sysid": normalize_identifier(report.get("order_sysid"))
+            or broker_order.get("order_sysid"),
+            "trading_day": resolve_trading_day(report)
+            or broker_order.get("trading_day"),
+            "symbol": normalize_symbol(report.get("symbol"))
+            or broker_order.get("symbol"),
+            "side": normalize_side(report.get("side")) or broker_order.get("side"),
         }
         next_document = {
             **broker_order,
@@ -385,6 +669,9 @@ class OrderTrackingService:
                     current_order.get("request_id") if current_order else None
                 ),
                 "broker_order_id": execution_fill.get("broker_order_id"),
+                "account_id": execution_fill.get("account_id"),
+                "order_sysid": execution_fill.get("order_sysid"),
+                "trading_day": execution_fill.get("trading_day"),
                 "account_type": (
                     current_order.get("account_type") if current_order else None
                 ),
@@ -405,20 +692,34 @@ class OrderTrackingService:
                 "last_fill_time": None,
                 "updated_at": _utc_now_iso(),
             }
-        previous_quantity = int(broker_order.get("filled_quantity") or 0)
-        previous_fill_count = int(broker_order.get("fill_count") or 0)
-        previous_notional = previous_quantity * float(
-            broker_order.get("avg_filled_price") or 0
+        conflicts = identity_conflicts(broker_order, execution_fill)
+        if conflicts:
+            raise BrokerIdentityConflict(
+                "execution fill conflicts with broker aggregate: "
+                + ", ".join(sorted(conflicts))
+            )
+        fills = _list_broker_execution_fills(
+            self.repository,
+            broker_order_key=broker_order_key,
+            fallback_fill=execution_fill,
         )
-        fill_quantity = int(execution_fill.get("quantity") or 0)
-        fill_price = float(execution_fill.get("price") or 0)
-        next_quantity = previous_quantity + fill_quantity
-        next_fill_count = previous_fill_count + 1
+        for fill in fills:
+            conflicts = identity_conflicts(broker_order, fill)
+            if conflicts:
+                raise BrokerIdentityConflict(
+                    "broker aggregate contains mixed execution identities: "
+                    + ", ".join(sorted(conflicts))
+                )
+        next_quantity = sum(int(fill.get("quantity") or 0) for fill in fills)
+        next_fill_count = len(fills)
+        next_notional = sum(
+            int(fill.get("quantity") or 0) * float(fill.get("price") or 0)
+            for fill in fills
+        )
         next_avg_price = (
-            round((previous_notional + fill_quantity * fill_price) / next_quantity, 6)
-            if next_quantity > 0
-            else None
+            round(next_notional / next_quantity, 6) if next_quantity > 0 else None
         )
+        first_fill_time, last_fill_time = _fill_time_bounds(fills)
         requested_quantity = broker_order.get("requested_quantity")
         next_state = "PARTIAL_FILLED"
         if requested_quantity not in (None, "") and next_quantity >= int(
@@ -429,17 +730,17 @@ class OrderTrackingService:
             **broker_order,
             "broker_order_id": execution_fill.get("broker_order_id")
             or broker_order.get("broker_order_id"),
+            "account_id": execution_fill.get("account_id")
+            or broker_order.get("account_id"),
+            "order_sysid": execution_fill.get("order_sysid")
+            or broker_order.get("order_sysid"),
+            "trading_day": execution_fill.get("trading_day")
+            or broker_order.get("trading_day"),
             "filled_quantity": next_quantity,
             "avg_filled_price": next_avg_price,
             "fill_count": next_fill_count,
-            "first_fill_time": _pick_first_time(
-                broker_order.get("first_fill_time"),
-                execution_fill.get("trade_time"),
-            ),
-            "last_fill_time": _pick_last_time(
-                broker_order.get("last_fill_time"),
-                execution_fill.get("trade_time"),
-            ),
+            "first_fill_time": first_fill_time,
+            "last_fill_time": last_fill_time,
             "state": next_state,
             "updated_at": _utc_now_iso(),
         }
@@ -455,16 +756,167 @@ def _utc_now_iso():
 
 
 def _resolve_broker_order_key(report, *, current_order=None):
-    broker_order_key = ""
-    if current_order and current_order.get("internal_order_id"):
-        broker_order_key = str(current_order.get("internal_order_id") or "").strip()
-    if not broker_order_key:
-        broker_order_key = str(
-            report.get("broker_order_key") or report.get("internal_order_id") or ""
-        ).strip()
-    if not broker_order_key:
-        raise ValueError("broker_order_key is required")
-    return broker_order_key
+    identity = dict(current_order or {})
+    identity.update(_non_empty_identity_fields(report))
+    broker_order_key = build_broker_order_key(
+        account_id=identity.get("account_id"),
+        order_sysid=identity.get("order_sysid"),
+        trading_day=resolve_trading_day(identity),
+        symbol=identity.get("symbol"),
+        side=identity.get("side"),
+        broker_order_id=identity.get("broker_order_id"),
+        strict=False,
+    )
+    if broker_order_key is not None:
+        return broker_order_key
+    fallback_key = normalize_identifier(
+        (current_order or {}).get("broker_order_key")
+        or report.get("broker_order_key")
+        or (current_order or {}).get("internal_order_id")
+        or report.get("internal_order_id")
+    )
+    if fallback_key is None:
+        raise BrokerIdentityError("broker_order_key is required")
+    return fallback_key
+
+
+def _normalize_trade_report_identity(report):
+    normalized = dict(report)
+    normalized["account_id"] = normalize_account_id(report.get("account_id"))
+    normalized["order_sysid"] = normalize_identifier(report.get("order_sysid"))
+    normalized["broker_order_id"] = normalize_identifier(
+        report.get("broker_order_id") or report.get("order_id")
+    )
+    normalized["broker_trade_id"] = normalize_identifier(
+        report.get("broker_trade_id") or report.get("traded_id")
+    )
+    normalized["symbol"] = normalize_symbol(
+        report.get("symbol") or report.get("stock_code")
+    )
+    normalized["side"] = normalize_side(report.get("side"))
+    normalized["trading_day"] = resolve_trading_day(report)
+    if normalized["account_id"] is None:
+        raise BrokerIdentityError("execution report requires account_id")
+    if normalized["broker_trade_id"] is None:
+        raise BrokerIdentityError("broker_trade_id is required")
+    if normalized["symbol"] is None:
+        raise BrokerIdentityError("trade symbol is required")
+    if normalized["side"] is None:
+        raise BrokerIdentityError("unknown broker order side")
+    if normalized["trading_day"] is None:
+        raise BrokerIdentityError("trade trading_day is required")
+    try:
+        quantity = int(report.get("quantity"))
+    except (TypeError, ValueError, OverflowError):
+        raise BrokerIdentityError("execution quantity must be a positive integer")
+    if quantity <= 0 or quantity != float(report.get("quantity")):
+        raise BrokerIdentityError("execution quantity must be a positive integer")
+    normalized["quantity"] = quantity
+    internal_order_id = normalize_identifier(report.get("internal_order_id"))
+    if internal_order_id is None:
+        internal_order_id = build_broker_only_internal_order_id(
+            account_id=normalized["account_id"],
+            order_sysid=normalized["order_sysid"],
+            trading_day=normalized["trading_day"],
+            symbol=normalized["symbol"],
+            side=normalized["side"],
+            broker_order_id=normalized["broker_order_id"],
+        )
+    normalized["internal_order_id"] = internal_order_id
+    return normalized
+
+
+def _non_empty_identity_fields(payload):
+    normalized = {
+        "account_id": normalize_account_id(payload.get("account_id")),
+        "order_sysid": normalize_identifier(payload.get("order_sysid")),
+        "trading_day": resolve_trading_day(payload),
+        "symbol": normalize_symbol(payload.get("symbol") or payload.get("stock_code")),
+        "side": normalize_side(payload.get("side")),
+        "broker_order_id": normalize_identifier(
+            payload.get("broker_order_id") or payload.get("order_id")
+        ),
+    }
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _assert_order_report_identity(current_order, report):
+    report_identity = _non_empty_identity_fields(report)
+    current_identity = {
+        **current_order,
+        "trading_day": resolve_trading_day(current_order),
+    }
+    conflicts = identity_conflicts(current_identity, report_identity)
+    if conflicts:
+        raise BrokerIdentityConflict(
+            "broker report conflicts with internal order: "
+            + ", ".join(sorted(conflicts))
+        )
+
+
+def _assert_execution_replay_consistent(existing, incoming):
+    conflicts = identity_conflicts(existing, incoming)
+    for field in (
+        "execution_identity",
+        "broker_trade_id",
+        "broker_order_key",
+        "internal_order_id",
+        "quantity",
+        "price",
+        "trade_time",
+    ):
+        left = existing.get(field)
+        right = incoming.get(field)
+        if left is not None and right is not None and left != right:
+            conflicts[field] = (left, right)
+    if conflicts:
+        raise BrokerIdentityConflict(
+            "execution replay conflicts with canonical fill: "
+            + ", ".join(sorted(conflicts))
+        )
+
+
+def _list_broker_execution_fills(repository, *, broker_order_key, fallback_fill):
+    if hasattr(repository, "list_execution_fills"):
+        fills = repository.list_execution_fills(broker_order_keys=[broker_order_key])
+    elif isinstance(getattr(repository, "execution_fills", None), list):
+        fills = [
+            fill
+            for fill in repository.execution_fills
+            if fill.get("broker_order_key") == broker_order_key
+        ]
+    else:
+        fills = [fallback_fill]
+    deduplicated = {}
+    for fill in fills:
+        key = fill.get("execution_identity") or fill.get("execution_fill_id")
+        deduplicated[key] = fill
+    return list(deduplicated.values())
+
+
+def _delete_broker_order(repository, broker_order_key):
+    if hasattr(repository, "delete_broker_order"):
+        repository.delete_broker_order(broker_order_key)
+        return
+    broker_orders = getattr(repository, "broker_orders", None)
+    if isinstance(broker_orders, list):
+        repository.broker_orders = [
+            order
+            for order in broker_orders
+            if order.get("broker_order_key") != broker_order_key
+        ]
+        return
+    if hasattr(broker_orders, "delete_one"):
+        broker_orders.delete_one({"broker_order_key": broker_order_key})
+
+
+def _fill_time_bounds(fills):
+    values = [
+        fill.get("trade_time") for fill in fills if fill.get("trade_time") is not None
+    ]
+    if not values:
+        return None, None
+    return min(values), max(values)
 
 
 def _pick_first_time(previous, current):

--- a/freshquant/tests/test_freshquant_deploy_plan.py
+++ b/freshquant/tests/test_freshquant_deploy_plan.py
@@ -29,6 +29,56 @@ def test_order_management_paths_expand_to_api_and_host_runtime() -> None:
     assert "fqnext_xt_auto_repay_worker" in plan["host_programs"]
 
 
+def test_shared_order_ledger_repository_restarts_all_runtime_consumers() -> None:
+    module = load_module()
+
+    plan = module.build_deploy_plan(
+        changed_paths=["freshquant/order_management/repository.py"]
+    )
+
+    assert plan["deployment_surfaces"] == [
+        "api",
+        "guardian",
+        "position_management",
+        "tpsl",
+        "order_management",
+    ]
+    assert plan["host_surfaces"] == [
+        "guardian",
+        "position_management",
+        "tpsl",
+        "order_management",
+    ]
+    assert "fqnext_guardian_event" in plan["host_programs"]
+    assert "fqnext_xt_account_sync_worker" in plan["host_programs"]
+    assert "fqnext_tpsl_worker" in plan["host_programs"]
+    assert "fqnext_xtquant_broker" in plan["host_programs"]
+    assert any("共同加载" in note for note in plan["notes"])
+
+
+def test_shared_entry_adapter_restarts_all_runtime_consumers() -> None:
+    module = load_module()
+
+    plan = module.build_deploy_plan(
+        changed_paths=["freshquant/order_management/entry_adapter.py"]
+    )
+
+    assert plan["deployment_surfaces"] == [
+        "api",
+        "guardian",
+        "position_management",
+        "tpsl",
+        "order_management",
+    ]
+    assert plan["host_surfaces"] == [
+        "guardian",
+        "position_management",
+        "tpsl",
+        "order_management",
+    ]
+    assert any("共享 V2/compat" in note for note in plan["notes"])
+
+
 def test_xt_auto_repay_paths_expand_to_order_management_host_runtime() -> None:
     module = load_module()
 

--- a/freshquant/tests/test_guardian_strategy.py
+++ b/freshquant/tests/test_guardian_strategy.py
@@ -6,6 +6,10 @@ import types
 import pendulum
 import pytest
 
+from freshquant.order_management.guardian.arranger import arrange_entry
+from freshquant.order_management.guardian.read_model import (
+    build_arranged_fill_read_model,
+)
 from freshquant.position_management.errors import PositionManagementRejectedError
 
 
@@ -1127,3 +1131,105 @@ def test_guardian_sell_carries_selected_source_entries_in_strategy_context(
             {"entry_id": "entry_old", "quantity": 100},
         ],
     }
+
+
+def test_guardian_688772_event_sells_only_first_canonical_slice_without_tpsl_profile(
+    monkeypatch,
+):
+    captured = {}
+    fake_redis = FakeRedis()
+    signal = _make_signal(code="688772", position="SELL_SHORT", price=14.81)
+    fire_time = signal["fire_time"]
+    entry = {
+        "entry_id": "entry_688772",
+        "symbol": "688772",
+        "entry_price": 14.70,
+        "original_quantity": 10000,
+        "remaining_quantity": 10000,
+        "date": int(fire_time.subtract(days=1).format("YYYYMMDD")),
+        "time": fire_time.subtract(days=1).format("HH:mm:ss"),
+        "trade_time": int(fire_time.subtract(days=1).timestamp()),
+    }
+    canonical_slices = arrange_entry(
+        entry,
+        lot_amount=50000,
+        grid_interval=1.03,
+    )
+    arranged_fills = build_arranged_fill_read_model(canonical_slices)
+
+    assert [
+        (int(item["quantity"]), float(item["price"]))
+        for item in reversed(arranged_fills)
+    ] == [
+        (3400, 14.70),
+        (3300, 15.14),
+        (3200, 15.59),
+        (100, 16.06),
+    ]
+
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.get_arranged_stock_fill_list",
+        lambda _code: arranged_fills,
+    )
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.get_stock_holding_codes",
+        lambda: ["688772"],
+    )
+    monkeypatch.setattr("freshquant.strategy.guardian.queryMustPoolCodes", lambda: [])
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.eval_stock_threshold_price",
+        lambda _code, _price: {
+            "bot_river_price": 14.70,
+            "top_river_price": 14.81,
+        },
+    )
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian._get_position_reader",
+        lambda: types.SimpleNamespace(get_can_use_volume=lambda _code: 10000),
+    )
+    monkeypatch.setattr("freshquant.strategy.guardian.redis_db", fake_redis)
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.order_alert",
+        FakeOrderAlert(),
+    )
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.logger",
+        types.SimpleNamespace(info=lambda *args, **kwargs: None),
+    )
+
+    def fake_submit(action, symbol, price, quantity, **kwargs):
+        captured.update(
+            {
+                "action": action,
+                "symbol": symbol,
+                "price": price,
+                "quantity": quantity,
+                "kwargs": kwargs,
+            }
+        )
+        return {
+            "request_id": "req_688772_sell",
+            "internal_order_id": "ord_688772_sell",
+            "queue_payload": {},
+        }
+
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.submit_guardian_order",
+        fake_submit,
+    )
+
+    StrategyGuardian().on_signal(signal)
+
+    assert captured["action"] == "sell"
+    assert captured["symbol"] == "688772"
+    assert captured["price"] == 14.81
+    assert captured["quantity"] == 3400
+    assert signal["quantity"] == 3400
+    sell_sources = captured["kwargs"]["strategy_context"]["guardian_sell_sources"]
+    assert sell_sources == {
+        "profitable_fill_count": 1,
+        "requested_quantity": 3400,
+        "submit_quantity": 3400,
+        "entries": [{"entry_id": "entry_688772", "quantity": 3400}],
+    }
+    assert sum(item["quantity"] for item in sell_sources["entries"]) == 3400

--- a/freshquant/tests/test_memory_runtime_config_bootstrap.py
+++ b/freshquant/tests/test_memory_runtime_config_bootstrap.py
@@ -2,8 +2,26 @@ from __future__ import annotations
 
 import importlib
 
+import pytest
 
-def test_memory_runtime_config_reads_bootstrap_file(tmp_path, monkeypatch):
+
+@pytest.fixture
+def isolated_bootstrap_modules(monkeypatch):
+    import freshquant.bootstrap_config as bootstrap_module
+    import freshquant.runtime.memory.config as memory_config_module
+
+    yield bootstrap_module, memory_config_module
+
+    # ``importlib.reload`` mutates these process-global module dictionaries.
+    # Restore the environment first, then rebuild both snapshots for later tests.
+    monkeypatch.undo()
+    importlib.reload(bootstrap_module)
+    importlib.reload(memory_config_module)
+
+
+def test_memory_runtime_config_reads_bootstrap_file(
+    tmp_path, monkeypatch, isolated_bootstrap_modules
+):
     bootstrap_file = tmp_path / "freshquant_bootstrap.yaml"
     bootstrap_file.write_text(
         "\n".join(
@@ -22,8 +40,7 @@ def test_memory_runtime_config_reads_bootstrap_file(tmp_path, monkeypatch):
     )
     monkeypatch.setenv("FRESHQUANT_BOOTSTRAP_FILE", str(bootstrap_file))
 
-    import freshquant.bootstrap_config as bootstrap_module
-    import freshquant.runtime.memory.config as memory_config_module
+    bootstrap_module, memory_config_module = isolated_bootstrap_modules
 
     bootstrap_module = importlib.reload(bootstrap_module)
     memory_config_module = importlib.reload(memory_config_module)

--- a/freshquant/tests/test_order_ledger_v2_rebuild.py
+++ b/freshquant/tests/test_order_ledger_v2_rebuild.py
@@ -37,12 +37,13 @@ def _get_rebuild_service_class():
 
 def _sample_xt_order(**overrides):
     payload = {
+        "account_id": "acct-1",
         "order_id": 70001,
         "stock_code": "600000.SH",
         "order_type": "buy",
         "order_volume": 100,
         "price": 12.34,
-        "order_time": 1709947800,
+        "order_time": 1710000000,
         "order_status": "filled",
     }
     payload.update(overrides)
@@ -51,13 +52,14 @@ def _sample_xt_order(**overrides):
 
 def _sample_xt_trade(**overrides):
     payload = {
+        "account_id": "acct-1",
         "traded_id": "T-70001",
         "order_id": 70001,
         "stock_code": "600000.SH",
         "order_type": "buy",
         "traded_volume": 100,
         "traded_price": 12.30,
-        "traded_time": 1709947865,
+        "traded_time": 1710000065,
     }
     payload.update(overrides)
     return payload
@@ -65,6 +67,7 @@ def _sample_xt_trade(**overrides):
 
 def _sample_xt_sell_order(**overrides):
     payload = {
+        "account_id": "acct-1",
         "order_id": 70002,
         "stock_code": "000001.SZ",
         "order_type": "sell",
@@ -79,6 +82,7 @@ def _sample_xt_sell_order(**overrides):
 
 def _sample_xt_sell_trade(**overrides):
     payload = {
+        "account_id": "acct-1",
         "traded_id": "T-SELL-1",
         "order_id": 70002,
         "stock_code": "000001.SZ",
@@ -99,6 +103,22 @@ def _sample_xt_position(**overrides):
     }
     payload.update(overrides)
     return payload
+
+
+def _expected_broker_key(payload):
+    from freshquant.order_management.broker_identity import (
+        build_broker_order_key,
+        resolve_trading_day,
+    )
+
+    return build_broker_order_key(
+        account_id=payload.get("account_id"),
+        order_sysid=payload.get("order_sysid"),
+        trading_day=resolve_trading_day(payload),
+        symbol=payload.get("symbol") or payload.get("stock_code"),
+        side=payload.get("side") or payload.get("order_type"),
+        broker_order_id=payload.get("broker_order_id") or payload.get("order_id"),
+    )
 
 
 def test_rebuild_plan_requires_broker_truth_only():
@@ -142,9 +162,10 @@ def test_rebuild_default_lot_amount_lookup_falls_back_to_50000():
 
 def test_rebuild_service_builds_broker_orders_and_execution_fills():
     service = _get_rebuild_service_class()()
+    xt_order = _sample_xt_order()
 
     result = service.build_from_truth(
-        xt_orders=[_sample_xt_order()],
+        xt_orders=[xt_order],
         xt_trades=[_sample_xt_trade()],
         xt_positions=None,
         now_ts=1775000000,
@@ -159,15 +180,21 @@ def test_rebuild_service_builds_broker_orders_and_execution_fills():
     execution_fill = result["execution_fill_documents"][0]
 
     assert broker_order["broker_order_id"] == "70001"
-    assert broker_order["broker_order_key"] == "70001"
+    assert broker_order["broker_order_key"] == _expected_broker_key(xt_order)
+    assert broker_order["account_id"] == "acct-1"
+    assert broker_order["trading_day"] == 20240310
     assert broker_order["symbol"] == "600000"
     assert broker_order["requested_quantity"] == 100
     assert broker_order["filled_quantity"] == 100
     assert broker_order["fill_count"] == 1
     assert execution_fill["broker_trade_id"] == "T-70001"
     assert execution_fill["broker_order_key"] == broker_order["broker_order_key"]
-    assert execution_fill["date"] == 20240309
-    assert execution_fill["time"] == "09:31:05"
+    assert execution_fill["account_id"] == "acct-1"
+    assert execution_fill["execution_fill_id"].startswith("fill_")
+    assert execution_fill["execution_identity"].startswith("execution:")
+    assert execution_fill["execution_fill_id"] != execution_fill["execution_identity"]
+    assert execution_fill["date"] == 20240310
+    assert execution_fill["time"] == "00:01:05"
 
 
 def test_rebuild_service_creates_trade_only_broker_order_fallback():
@@ -234,20 +261,18 @@ def test_rebuild_service_matches_orders_by_symbol_and_side_not_raw_order_id_only
     assert result["broker_orders"] == 2
     assert result["execution_fills"] == 1
 
-    broker_orders = {
-        item["broker_order_key"]: item for item in result["broker_order_documents"]
-    }
+    broker_orders = result["broker_order_documents"]
     execution_fill = result["execution_fill_documents"][0]
 
-    assert broker_orders["940572674"]["symbol"] == "300760"
-    assert broker_orders["940572674"]["side"] == "sell"
-    assert broker_orders["940572674"]["filled_quantity"] == 0
+    unmatched_order = next(item for item in broker_orders if item["symbol"] == "300760")
+    assert unmatched_order["side"] == "sell"
+    assert unmatched_order["filled_quantity"] == 0
     assert any(
         item["source_type"] == "trade_only"
         and item["symbol"] == "002475"
         and item["side"] == "buy"
         and item["filled_quantity"] == 200
-        for item in broker_orders.values()
+        for item in broker_orders
     )
     assert execution_fill["symbol"] == "002475"
     assert execution_fill["side"] == "buy"
@@ -374,6 +399,178 @@ def test_rebuild_service_splits_trade_only_reused_order_ids_across_trade_days():
     assert broker_orders[0]["broker_order_key"] != broker_orders[1]["broker_order_key"]
 
 
+def test_rebuild_service_scopes_reused_order_sysid_by_account_and_trading_day():
+    service = _get_rebuild_service_class()()
+
+    result = service.build_from_truth(
+        xt_orders=[
+            _sample_xt_order(
+                account_id="acct-1",
+                order_id=901,
+                order_sysid="1263",
+                stock_code="600917.SH",
+                order_time=1779775200,
+            ),
+            _sample_xt_order(
+                account_id="acct-1",
+                order_id=901,
+                order_sysid="1263",
+                stock_code="688772.SH",
+                order_time=1785810600,
+            ),
+        ],
+        xt_trades=[
+            _sample_xt_trade(
+                account_id="acct-1",
+                order_id=901,
+                order_sysid="1263",
+                traded_id="T-SYSID-OLD",
+                stock_code="600917.SH",
+                traded_volume=300,
+                traded_price=5.16,
+                traded_time=1779775260,
+            ),
+            _sample_xt_trade(
+                account_id="acct-1",
+                order_id=901,
+                order_sysid="1263",
+                traded_id="T-SYSID-NEW",
+                stock_code="688772.SH",
+                traded_volume=10000,
+                traded_price=14.70,
+                traded_time=1785810660,
+            ),
+        ],
+        xt_positions=None,
+        now_ts=1785810700,
+    )
+
+    assert result["broker_orders"] == 2
+    assert result["execution_fills"] == 2
+    assert {item["symbol"] for item in result["broker_order_documents"]} == {
+        "600917",
+        "688772",
+    }
+    assert (
+        len({item["broker_order_key"] for item in result["broker_order_documents"]})
+        == 2
+    )
+    assert {
+        (item["symbol"], item["quantity"], item["account_id"], item["side"])
+        for item in result["execution_fill_documents"]
+    } == {
+        ("600917", 300, "acct-1", "buy"),
+        ("688772", 10000, "acct-1", "buy"),
+    }
+
+
+def test_rebuild_service_deduplicates_execution_replay_by_execution_identity():
+    service = _get_rebuild_service_class()()
+    trade = _sample_xt_trade(traded_id="T-REPLAY-1")
+
+    result = service.build_from_truth(
+        xt_orders=[_sample_xt_order()],
+        xt_trades=[trade, dict(trade)],
+        xt_positions=None,
+        now_ts=1775000000,
+    )
+
+    assert result["execution_fills"] == 1
+    assert result["broker_order_documents"][0]["filled_quantity"] == 100
+    assert result["broker_order_documents"][0]["fill_count"] == 1
+
+
+def test_rebuild_service_rejects_conflicting_execution_replay():
+    from freshquant.order_management.broker_identity import BrokerIdentityConflict
+
+    service = _get_rebuild_service_class()()
+    first = _sample_xt_trade(traded_id="T-REPLAY-CONFLICT")
+    conflicting = {**first, "traded_volume": 200}
+
+    with pytest.raises(BrokerIdentityConflict, match="quantity"):
+        service.build_from_truth(
+            xt_orders=[_sample_xt_order()],
+            xt_trades=[first, conflicting],
+            xt_positions=None,
+            now_ts=1775000000,
+        )
+
+
+def test_rebuild_service_scopes_shared_trade_id_across_accounts_and_days():
+    service = _get_rebuild_service_class()()
+
+    result = service.build_from_truth(
+        xt_orders=[],
+        xt_trades=[
+            _sample_xt_trade(
+                account_id="acct-1",
+                traded_id="T-SHARED",
+                order_id=99001,
+                stock_code="000001.SZ",
+                order_type="sell",
+                traded_time=1710000000,
+            ),
+            _sample_xt_trade(
+                account_id="acct-2",
+                traded_id="T-SHARED",
+                order_id=99001,
+                stock_code="000001.SZ",
+                order_type="sell",
+                traded_time=1710000000,
+            ),
+            _sample_xt_trade(
+                account_id="acct-1",
+                traded_id="T-SHARED",
+                order_id=99001,
+                stock_code="000001.SZ",
+                order_type="sell",
+                traded_time=1710086400,
+            ),
+        ],
+        xt_positions=None,
+        now_ts=1775000000,
+    )
+
+    fills = result["execution_fill_documents"]
+    trade_facts = result["unmatched_sell_trade_facts"]
+    assert len(fills) == 3
+    assert len({item["execution_identity"] for item in fills}) == 3
+    assert len({item["execution_fill_id"] for item in fills}) == 3
+    assert len({item["trade_fact_id"] for item in trade_facts}) == 3
+    assert all(item["trade_fact_id"] != "T-SHARED" for item in trade_facts)
+
+
+def test_rebuild_primary_join_rejects_known_symbol_conflict():
+    from freshquant.order_management.broker_identity import BrokerIdentityError
+
+    service = _get_rebuild_service_class()()
+
+    with pytest.raises(BrokerIdentityError, match="symbol"):
+        service.build_from_truth(
+            xt_orders=[
+                _sample_xt_order(
+                    account_id="acct-1",
+                    order_id=901,
+                    order_sysid="1263",
+                    stock_code="600917.SH",
+                    date=20260804,
+                )
+            ],
+            xt_trades=[
+                _sample_xt_trade(
+                    account_id="acct-1",
+                    order_id=901,
+                    order_sysid="1263",
+                    traded_id="T-PRIMARY-CONFLICT",
+                    stock_code="688772.SH",
+                    date=20260804,
+                )
+            ],
+            xt_positions=None,
+            now_ts=1785810700,
+        )
+
+
 def test_rebuild_service_aggregates_buy_fills_into_single_broker_order_entry():
     service = _get_rebuild_service_class()(
         lot_amount_lookup=lambda _symbol: 3000,
@@ -430,7 +627,9 @@ def test_rebuild_service_aggregates_buy_fills_into_single_broker_order_entry():
     assert position_entry["entry_price"] == pytest.approx(10.333333, abs=1e-6)
     assert [
         item["broker_order_key"] for item in position_entry["aggregation_members"]
-    ] == ["81001"]
+    ] == [
+        _expected_broker_key(_sample_xt_order(order_id=81001, stock_code="000001.SZ"))
+    ]
     assert position_entry["aggregation_window"]["member_count"] == 1
 
 
@@ -490,8 +689,20 @@ def test_rebuild_service_conservatively_clusters_close_buy_orders():
     assert [
         item["broker_order_key"] for item in position_entry["aggregation_members"]
     ] == [
-        "81101",
-        "81102",
+        _expected_broker_key(
+            _sample_xt_order(
+                order_id=81101,
+                stock_code="000001.SZ",
+                order_time=1710000000,
+            )
+        ),
+        _expected_broker_key(
+            _sample_xt_order(
+                order_id=81102,
+                stock_code="000001.SZ",
+                order_time=1710000240,
+            )
+        ),
     ]
     assert position_entry["aggregation_window"]["member_count"] == 2
 
@@ -837,19 +1048,22 @@ def test_rebuild_service_keeps_sell_before_future_buy_as_unmatched():
 
     assert result["position_entries"] == 1
     assert result["exit_allocations"] == 0
-    assert result["unmatched_sell_trade_facts"] == [
-        {
-            "trade_fact_id": "T-SELL-85001",
-            "symbol": "002475",
-            "side": "sell",
-            "quantity": 1600,
-            "price": 49.02,
-            "trade_time": 1710000000,
-            "date": 20240310,
-            "time": "00:00:00",
-            "source": "broker_rebuild",
-        }
-    ]
+    assert len(result["unmatched_sell_trade_facts"]) == 1
+    unmatched = result["unmatched_sell_trade_facts"][0]
+    assert unmatched["trade_fact_id"].startswith("trade_")
+    assert unmatched["trade_fact_id"] != "T-SELL-85001"
+    assert {
+        key: value for key, value in unmatched.items() if key != "trade_fact_id"
+    } == {
+        "symbol": "002475",
+        "side": "sell",
+        "quantity": 1600,
+        "price": 49.02,
+        "trade_time": 1710000000,
+        "date": 20240310,
+        "time": "00:00:00",
+        "source": "broker_rebuild",
+    }
     assert result["position_entry_documents"][0]["remaining_quantity"] == 1000
 
 
@@ -923,29 +1137,36 @@ def test_rebuild_service_partially_allocates_known_inventory_before_marking_unma
     assert result["exit_allocations"] == 1
     assert result["position_entry_documents"][0]["remaining_quantity"] == 0
     assert result["position_entry_documents"][1]["remaining_quantity"] == 200
-    assert result["unmatched_sell_trade_facts"] == [
-        {
-            "trade_fact_id": "T-SELL-86002:unmatched",
-            "symbol": "300760",
-            "side": "sell",
-            "quantity": 100,
-            "price": 166.7,
-            "trade_time": 1710000600,
-            "date": 20240310,
-            "time": "00:10:00",
-            "source": "broker_rebuild",
-        }
-    ]
-    assert result["replay_warnings"] == [
-        {
-            "code": "sell_exceeds_known_inventory",
-            "broker_order_key": "86002",
-            "execution_fill_id": "T-SELL-86002",
-            "symbol": "300760",
-            "allocated_quantity": 100,
-            "unmatched_quantity": 100,
-        }
-    ]
+    assert len(result["unmatched_sell_trade_facts"]) == 1
+    unmatched = result["unmatched_sell_trade_facts"][0]
+    assert unmatched["trade_fact_id"].startswith("trade_")
+    assert unmatched["trade_fact_id"].endswith(":unmatched")
+    assert {
+        key: value for key, value in unmatched.items() if key != "trade_fact_id"
+    } == {
+        "symbol": "300760",
+        "side": "sell",
+        "quantity": 100,
+        "price": 166.7,
+        "trade_time": 1710000600,
+        "date": 20240310,
+        "time": "00:10:00",
+        "source": "broker_rebuild",
+    }
+    warning = result["replay_warnings"][0]
+    sell_fill = next(
+        item
+        for item in result["execution_fill_documents"]
+        if item["broker_trade_id"] == "T-SELL-86002"
+    )
+    assert warning == {
+        "code": "sell_exceeds_known_inventory",
+        "broker_order_key": sell_fill["broker_order_key"],
+        "execution_fill_id": sell_fill["execution_fill_id"],
+        "symbol": "300760",
+        "allocated_quantity": 100,
+        "unmatched_quantity": 100,
+    }
 
 
 def test_rebuild_service_keeps_unmatched_sell_evidence_when_no_entry_can_be_replayed():
@@ -974,13 +1195,15 @@ def test_rebuild_service_keeps_unmatched_sell_evidence_when_no_entry_can_be_repl
     assert result["entry_slices"] == 0
     assert result["exit_allocations"] == 0
     assert len(result["unmatched_sell_trade_facts"]) == 1
-    assert result["unmatched_sell_trade_facts"][0]["trade_fact_id"] == "T-SELL-82001"
+    assert result["unmatched_sell_trade_facts"][0]["trade_fact_id"].startswith("trade_")
+    assert result["unmatched_sell_trade_facts"][0]["trade_fact_id"] != ("T-SELL-82001")
     assert result["unmatched_sell_trade_facts"][0]["quantity"] == 300
+    sell_fill = result["execution_fill_documents"][0]
     assert result["replay_warnings"] == [
         {
             "code": "unmatched_sell",
-            "broker_order_key": "82001",
-            "execution_fill_id": "T-SELL-82001",
+            "broker_order_key": sell_fill["broker_order_key"],
+            "execution_fill_id": sell_fill["execution_fill_id"],
             "symbol": "000001",
             "quantity": 300,
         }
@@ -1037,16 +1260,21 @@ def test_rebuild_service_records_shortfall_when_sell_exceeds_open_entries():
     assert result["position_entries"] == 1
     assert result["exit_allocations"] > 0
     assert len(result["unmatched_sell_trade_facts"]) == 1
-    assert (
-        result["unmatched_sell_trade_facts"][0]["trade_fact_id"]
-        == "T-SELL-83012:unmatched"
+    assert result["unmatched_sell_trade_facts"][0]["trade_fact_id"].startswith("trade_")
+    assert result["unmatched_sell_trade_facts"][0]["trade_fact_id"].endswith(
+        ":unmatched"
     )
     assert result["unmatched_sell_trade_facts"][0]["quantity"] == 600
+    sell_fill = next(
+        item
+        for item in result["execution_fill_documents"]
+        if item["broker_trade_id"] == "T-SELL-83012"
+    )
     assert result["replay_warnings"] == [
         {
             "code": "sell_exceeds_known_inventory",
-            "broker_order_key": "83012",
-            "execution_fill_id": "T-SELL-83012",
+            "broker_order_key": sell_fill["broker_order_key"],
+            "execution_fill_id": sell_fill["execution_fill_id"],
             "symbol": "000001",
             "allocated_quantity": 1000,
             "unmatched_quantity": 600,
@@ -1161,7 +1389,15 @@ def test_rebuild_service_merges_auto_open_gap_into_nearby_clustered_entry():
     assert position_entry["trade_time"] == 1710000000
     assert position_entry["entry_price"] == pytest.approx(10.01, abs=1e-6)
     assert position_entry["aggregation_window"]["member_count"] == 2
-    assert position_entry["aggregation_members"][0]["broker_order_key"] == "81301"
+    assert position_entry["aggregation_members"][0][
+        "broker_order_key"
+    ] == _expected_broker_key(
+        _sample_xt_order(
+            order_id=81301,
+            stock_code="000001.SZ",
+            order_time=1710000000,
+        )
+    )
     assert position_entry["aggregation_members"][1]["trade_time"] == 1710000240
 
 
@@ -1208,7 +1444,7 @@ def test_rebuild_service_rejects_non_board_lot_xt_positions_delta():
     assert rejection["reason_code"] == "non_board_lot_quantity"
 
 
-def test_rebuild_service_keeps_odd_lot_execution_fill_only_as_ingest_rejection():
+def test_rebuild_service_accepts_positive_odd_lot_execution_fill():
     service = _get_rebuild_service_class()(
         lot_amount_lookup=lambda _symbol: 3000,
         grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
@@ -1241,19 +1477,114 @@ def test_rebuild_service_keeps_odd_lot_execution_fill_only_as_ingest_rejection()
 
     assert result["broker_orders"] == 1
     assert result["execution_fills"] == 1
-    assert result["position_entries"] == 0
-    assert result["entry_slices"] == 0
+    assert result["position_entries"] == 1
+    assert result["entry_slices"] > 0
     assert result["exit_allocations"] == 0
-    assert result["ingest_rejections"] == 1
+    assert result["ingest_rejections"] == 0
 
     execution_fill = result["execution_fill_documents"][0]
-    rejection = result["ingest_rejection_documents"][0]
+    position_entry = result["position_entry_documents"][0]
 
     assert execution_fill["broker_trade_id"] == "T-ODD-83001"
-    assert rejection["broker_trade_id"] == "T-ODD-83001"
-    assert rejection["symbol"] == "000001"
-    assert rejection["quantity"] == 150
-    assert rejection["reason_code"] == "non_board_lot_quantity"
+    assert execution_fill["quantity"] == 150
+    assert position_entry["original_quantity"] == 150
+    assert position_entry["remaining_quantity"] == 150
+
+
+def test_rebuild_service_accepts_fragmented_sell_executions_and_conserves_quantity():
+    service = _get_rebuild_service_class()(
+        lot_amount_lookup=lambda _symbol: 50000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    buy_time = 1785778200
+    sell_time = 1785864600
+    fragments = [164, 203, 340, 358, 200, 2653, 3000, 1000, 2082]
+
+    result = service.build_from_truth(
+        xt_orders=[
+            _sample_xt_order(
+                order_id=1209008130,
+                stock_code="688772.SH",
+                order_volume=10000,
+                price=14.70,
+                order_time=buy_time,
+            ),
+            _sample_xt_sell_order(
+                order_id=1477443586,
+                stock_code="688772.SH",
+                order_volume=10000,
+                price=14.80,
+                order_time=sell_time,
+            ),
+        ],
+        xt_trades=[
+            _sample_xt_trade(
+                traded_id="T-688772-BUY",
+                order_id=1209008130,
+                stock_code="688772.SH",
+                traded_volume=10000,
+                traded_price=14.70,
+                traded_time=buy_time + 5,
+            ),
+            *[
+                _sample_xt_sell_trade(
+                    traded_id=f"T-688772-SELL-{index}",
+                    order_id=1477443586,
+                    stock_code="688772.SH",
+                    traded_volume=quantity,
+                    traded_price=14.80,
+                    traded_time=sell_time + index,
+                )
+                for index, quantity in enumerate(fragments, start=1)
+            ],
+        ],
+        xt_positions=None,
+        now_ts=sell_time + 20,
+    )
+
+    assert result["execution_fills"] == 10
+    assert result["ingest_rejections"] == 0
+    assert (
+        sum(
+            item["quantity"]
+            for item in result["execution_fill_documents"]
+            if item["side"] == "sell"
+        )
+        == 10000
+    )
+    assert (
+        sum(item["allocated_quantity"] for item in result["exit_allocation_documents"])
+        == 10000
+    )
+    assert len(result["exit_allocation_documents"]) == 12
+    assert result["position_entry_documents"][0]["remaining_quantity"] == 0
+    assert result["position_entry_documents"][0]["status"] == "CLOSED"
+    assert sorted(
+        (
+            float(item["guardian_price"]),
+            int(item["original_quantity"]),
+        )
+        for item in result["entry_slice_documents"]
+        if item["symbol"] == "688772"
+    ) == [
+        (14.70, 3400),
+        (15.14, 3300),
+        (15.59, 3200),
+        (16.06, 100),
+    ]
+    allocated_by_slice = {}
+    for allocation in result["exit_allocation_documents"]:
+        allocated_by_slice.setdefault(allocation["entry_slice_id"], 0)
+        allocated_by_slice[allocation["entry_slice_id"]] += int(
+            allocation["allocated_quantity"]
+        )
+    assert sorted(allocated_by_slice.values()) == [100, 3200, 3300, 3400]
+    assert all(
+        int(item["remaining_quantity"]) == 0
+        for item in result["entry_slice_documents"]
+        if item["symbol"] == "688772"
+    )
+    assert result["allocation_reference_errors"] == []
 
 
 def test_rebuild_service_auto_closes_entries_when_xt_positions_are_smaller_than_ledger():

--- a/freshquant/tests/test_order_management_broker_correlation.py
+++ b/freshquant/tests/test_order_management_broker_correlation.py
@@ -1,0 +1,24 @@
+from freshquant.order_management.broker_correlation import (
+    build_broker_correlation_token,
+    normalize_broker_correlation_token,
+)
+
+
+def test_broker_correlation_token_is_stable_unique_and_xt_remark_safe():
+    first = build_broker_correlation_token("ord_example_a")
+    replayed = build_broker_correlation_token("ord_example_a")
+    second = build_broker_correlation_token("ord_example_b")
+
+    assert first == replayed
+    assert first != second
+    assert first.startswith("FQOM")
+    assert len(first) == 24
+    assert first.isascii()
+    assert first.isalnum()
+    assert normalize_broker_correlation_token(f"  {first}  ") == first
+
+
+def test_broker_correlation_token_rejects_user_remarks_and_truncated_tokens():
+    assert normalize_broker_correlation_token("manual order") is None
+    assert normalize_broker_correlation_token("FQOMshort") is None
+    assert normalize_broker_correlation_token("FQOMabcd_efghijklmnopqrs") is None

--- a/freshquant/tests/test_order_management_db.py
+++ b/freshquant/tests/test_order_management_db.py
@@ -161,6 +161,15 @@ class _FakeDatabase(dict):
 
 def _matches_query(document, query):
     for key, expected in query.items():
+        if key == "$expr":
+            operands = list((expected or {}).get("$eq") or [])
+            expected_document = operands[1] if len(operands) == 2 else None
+            actual_document = {
+                field: value for field, value in document.items() if field != "_id"
+            }
+            if actual_document != expected_document:
+                return False
+            continue
         actual = document.get(key)
         if isinstance(expected, dict):
             if "$in" in expected and actual not in set(expected["$in"]):
@@ -386,8 +395,33 @@ def test_repository_creates_partial_unique_indexes_for_canonical_identities():
     from freshquant.order_management.repository import OrderManagementRepository
 
     database = _FakeDatabase()
-    OrderManagementRepository(database=database)
+    repository = OrderManagementRepository(database=database)
 
+    assert database == {}
+
+    repository._ensure_canonical_indexes()
+    repository._ensure_canonical_indexes()
+
+    assert database["om_orders"].indexes == [
+        (
+            [("internal_order_id", 1)],
+            {
+                "unique": True,
+                "partialFilterExpression": {"internal_order_id": {"$type": "string"}},
+                "name": "uq_om_orders_internal_order_id",
+            },
+        ),
+        (
+            [("broker_correlation_token", 1)],
+            {
+                "unique": True,
+                "partialFilterExpression": {
+                    "broker_correlation_token": {"$type": "string"}
+                },
+                "name": "uq_om_orders_broker_correlation_token",
+            },
+        ),
+    ]
     assert database["om_broker_orders"].indexes == [
         (
             [("broker_order_key", 1)],
@@ -438,6 +472,16 @@ def test_repository_creates_partial_unique_indexes_for_canonical_identities():
             },
         )
     ]
+    assert database["om_sell_allocations"].indexes == [
+        (
+            [("allocation_id", 1)],
+            {
+                "unique": True,
+                "partialFilterExpression": {"allocation_id": {"$type": "string"}},
+                "name": "uq_om_sell_allocations_allocation_id",
+            },
+        )
+    ]
     assert database["om_exit_allocations"].indexes == [
         (
             [("allocation_id", 1)],
@@ -485,6 +529,50 @@ def test_repository_upserts_existing_broker_order_without_setting_mongo_id():
     assert created is False
     assert saved["_id"] == "mongo-id-1"
     assert saved["state"] == "FILLED"
+
+
+def test_insert_order_is_idempotent_during_concurrent_canonical_insert():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    canonical = {
+        "internal_order_id": "ord-broker-only-race",
+        "request_id": None,
+        "account_id": "acct-1",
+        "trading_day": 20260805,
+        "symbol": "688772",
+        "side": "buy",
+        "state": "PARTIAL_FILLED",
+    }
+    database = _FakeDatabase()
+    database["om_orders"] = _DuplicateOnFirstUpsertCollection(canonical)
+    repository = OrderManagementRepository(database=database)
+
+    saved = repository.insert_order(dict(canonical))
+
+    assert saved == canonical
+    assert database["om_orders"].rows == [canonical]
+
+
+def test_insert_order_rejects_concurrent_document_with_different_owner():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    canonical = {
+        "internal_order_id": "ord-broker-only-race",
+        "request_id": "request-existing",
+        "account_id": "acct-1",
+        "trading_day": 20260805,
+        "symbol": "688772",
+        "side": "buy",
+        "state": "PARTIAL_FILLED",
+    }
+    database = _FakeDatabase()
+    database["om_orders"] = _DuplicateOnFirstUpsertCollection(canonical)
+    repository = OrderManagementRepository(database=database)
+
+    with pytest.raises(BrokerIdentityConflict, match="request ownership"):
+        repository.insert_order({**canonical, "request_id": "request-other"})
+
+    assert database["om_orders"].rows == [canonical]
 
 
 def test_move_broker_order_key_merges_existing_placeholder_into_canonical_target():
@@ -575,6 +663,691 @@ def test_duplicate_key_race_is_idempotent_only_for_consistent_execution():
             {**canonical, "execution_fill_id": "fill-conflict", "quantity": 203},
             unique_keys=["execution_identity"],
         )
+
+
+def test_legacy_execution_replay_migrates_fill_and_trade_fact_in_place():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    database["om_orders"].rows.append(
+        {
+            "internal_order_id": "ord-legacy",
+            "account_id": "acct-legacy",
+            "broker_order_id": "broker-order-legacy",
+        }
+    )
+    legacy_common = {
+        "broker_order_key": "ord-legacy",
+        "internal_order_id": "ord-legacy",
+        "broker_order_id": "broker-order-legacy",
+        "broker_trade_id": 362,
+        "symbol": "688772",
+        "side": "sell",
+        "quantity": 164,
+        "price": 14.8,
+        "trade_time": 1785895200,
+        "date": 20260805,
+        "time": "10:00:00",
+        "source": "xt_trade_callback",
+    }
+    database["om_trade_facts"].rows.append(
+        {"trade_fact_id": "trade-fact-legacy", **legacy_common}
+    )
+    database["om_execution_fills"].rows.append(
+        {"execution_fill_id": "fill-legacy", **legacy_common}
+    )
+    canonical_common = {
+        **legacy_common,
+        "broker_order_key": (
+            "account:acct-legacy:day:20260805:symbol:688772:"
+            "side:sell:order:broker-order-legacy"
+        ),
+        "execution_identity": "execution:acct-legacy:20260805:trade-legacy",
+        "broker_trade_id": "362",
+        "account_id": "acct-legacy",
+        "trading_day": 20260805,
+    }
+
+    saved_trade_fact, created_trade_fact = repository.upsert_trade_fact(
+        {"trade_fact_id": "ignored-new-trade-fact", **canonical_common},
+        unique_keys=["execution_identity"],
+    )
+    saved_fill, created_fill = repository.upsert_execution_fill(
+        {
+            "execution_fill_id": "ignored-new-fill",
+            **canonical_common,
+            "projection_status": "PENDING",
+            "projection_plan": None,
+        },
+        unique_keys=["execution_identity"],
+    )
+    replayed_trade_fact, replayed_trade_fact_created = repository.upsert_trade_fact(
+        {"trade_fact_id": "ignored-replay-trade-fact", **canonical_common},
+        unique_keys=["execution_identity"],
+    )
+    replayed_fill, replayed_fill_created = repository.upsert_execution_fill(
+        {
+            "execution_fill_id": "ignored-replay-fill",
+            **canonical_common,
+            "projection_status": "PENDING",
+            "projection_plan": None,
+        },
+        unique_keys=["execution_identity"],
+    )
+
+    assert created_trade_fact is False
+    assert created_fill is False
+    assert len(database["om_trade_facts"].rows) == 1
+    assert len(database["om_execution_fills"].rows) == 1
+    assert saved_trade_fact["trade_fact_id"] == "trade-fact-legacy"
+    assert saved_fill["execution_fill_id"] == "fill-legacy"
+    assert (
+        saved_trade_fact["execution_identity"] == canonical_common["execution_identity"]
+    )
+    assert saved_fill["execution_identity"] == canonical_common["execution_identity"]
+    assert saved_fill["projection_status"] == "PENDING"
+    assert saved_fill["projection_legacy_replay_required"] is True
+    assert saved_fill.get("projection_legacy_proven_applied") is None
+    assert replayed_trade_fact_created is False
+    assert replayed_fill_created is False
+    assert replayed_trade_fact["trade_fact_id"] == "trade-fact-legacy"
+    assert replayed_fill["execution_fill_id"] == "fill-legacy"
+
+
+def test_legacy_buy_execution_with_complete_projection_evidence_is_applied():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    canonical_broker_order_key = (
+        "account:acct-legacy:day:20260805:symbol:688772:"
+        "side:buy:order:broker-order-legacy-buy"
+    )
+    database["om_orders"].rows.append(
+        {
+            "internal_order_id": "ord-legacy-buy",
+            "account_id": "acct-legacy",
+            "broker_order_id": "broker-order-legacy-buy",
+        }
+    )
+    legacy_common = {
+        "broker_order_key": "ord-legacy-buy",
+        "internal_order_id": "ord-legacy-buy",
+        "broker_order_id": "broker-order-legacy-buy",
+        "broker_trade_id": 501,
+        "symbol": "688772",
+        "side": "buy",
+        "quantity": 10000,
+        "price": 14.0,
+        "trade_time": 1785895200,
+        "date": 20260805,
+        "time": "10:00:00",
+        "source": "xt_trade_callback",
+    }
+    database["om_trade_facts"].rows.append(
+        {"trade_fact_id": "trade-fact-legacy-buy", **legacy_common}
+    )
+    database["om_execution_fills"].rows.append(
+        {"execution_fill_id": "fill-legacy-buy", **legacy_common}
+    )
+    database["om_buy_lots"].rows.append(
+        {
+            "buy_lot_id": "lot-legacy-buy",
+            "origin_trade_fact_id": "trade-fact-legacy-buy",
+            "symbol": "688772",
+            "original_quantity": 10000,
+            "remaining_quantity": 10000,
+            "buy_price_real": 14.0,
+        }
+    )
+    database["om_lot_slices"].rows.extend(
+        [
+            {
+                "lot_slice_id": "lot-slice-legacy-buy-1",
+                "buy_lot_id": "lot-legacy-buy",
+                "original_quantity": 3400,
+            },
+            {
+                "lot_slice_id": "lot-slice-legacy-buy-2",
+                "buy_lot_id": "lot-legacy-buy",
+                "original_quantity": 6600,
+            },
+        ]
+    )
+    database["om_position_entries"].rows.append(
+        {
+            "entry_id": "entry-legacy-buy",
+            "symbol": "688772",
+            "source_ref_type": "broker_order",
+            "source_ref_id": canonical_broker_order_key,
+            "original_quantity": 10000,
+            "remaining_quantity": 10000,
+            "entry_price": 14.0,
+        }
+    )
+    database["om_entry_slices"].rows.extend(
+        [
+            {
+                "entry_slice_id": "entry-slice-legacy-buy-1",
+                "entry_id": "entry-legacy-buy",
+                "original_quantity": 3400,
+            },
+            {
+                "entry_slice_id": "entry-slice-legacy-buy-2",
+                "entry_id": "entry-legacy-buy",
+                "original_quantity": 6600,
+            },
+        ]
+    )
+    canonical_common = {
+        **legacy_common,
+        "broker_order_key": canonical_broker_order_key,
+        "execution_identity": "execution:acct-legacy:20260805:legacy-buy",
+        "broker_trade_id": "501",
+        "account_id": "acct-legacy",
+        "trading_day": 20260805,
+    }
+
+    repository.upsert_trade_fact(
+        {"trade_fact_id": "ignored-new-buy-fact", **canonical_common},
+        unique_keys=["execution_identity"],
+    )
+    saved_fill, created = repository.upsert_execution_fill(
+        {
+            "execution_fill_id": "ignored-new-buy-fill",
+            **canonical_common,
+            "projection_status": "PENDING",
+            "projection_plan": None,
+        },
+        unique_keys=["execution_identity"],
+    )
+
+    assert created is False
+    assert saved_fill["execution_fill_id"] == "fill-legacy-buy"
+    assert saved_fill["projection_status"] == "APPLIED"
+    assert saved_fill["projection_legacy_proven_applied"] is True
+
+
+def test_legacy_sell_execution_with_complete_projection_evidence_is_applied():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    database["om_orders"].rows.append(
+        {
+            "internal_order_id": "ord-legacy-sell",
+            "account_id": "acct-legacy",
+            "broker_order_id": "broker-order-legacy-sell",
+        }
+    )
+    legacy_common = {
+        "broker_order_key": "ord-legacy-sell",
+        "internal_order_id": "ord-legacy-sell",
+        "broker_order_id": "broker-order-legacy-sell",
+        "broker_trade_id": 502,
+        "symbol": "688772",
+        "side": "sell",
+        "quantity": 164,
+        "price": 14.8,
+        "trade_time": 1785895200,
+        "date": 20260805,
+        "time": "10:00:00",
+        "source": "xt_trade_callback",
+    }
+    database["om_trade_facts"].rows.append(
+        {"trade_fact_id": "trade-fact-legacy-sell", **legacy_common}
+    )
+    database["om_execution_fills"].rows.append(
+        {"execution_fill_id": "fill-legacy-sell", **legacy_common}
+    )
+    database["om_exit_allocations"].rows.append(
+        {
+            "allocation_id": "exit-allocation-legacy-sell",
+            "entry_id": "entry-legacy-sell",
+            "entry_slice_id": "entry-slice-legacy-sell",
+            "exit_trade_fact_id": "trade-fact-legacy-sell",
+            "allocated_quantity": 164,
+        }
+    )
+    database["om_position_entries"].rows.append(
+        {
+            "entry_id": "entry-legacy-sell",
+            "symbol": "688772",
+            "sell_history": [
+                {
+                    "exit_trade_fact_id": "trade-fact-legacy-sell",
+                    "allocated_quantity": 164,
+                }
+            ],
+        }
+    )
+    canonical_common = {
+        **legacy_common,
+        "broker_order_key": (
+            "account:acct-legacy:day:20260805:symbol:688772:"
+            "side:sell:order:broker-order-legacy-sell"
+        ),
+        "execution_identity": "execution:acct-legacy:20260805:legacy-sell",
+        "broker_trade_id": "502",
+        "account_id": "acct-legacy",
+        "trading_day": 20260805,
+    }
+
+    repository.upsert_trade_fact(
+        {"trade_fact_id": "ignored-new-sell-fact", **canonical_common},
+        unique_keys=["execution_identity"],
+    )
+    saved_fill, created = repository.upsert_execution_fill(
+        {
+            "execution_fill_id": "ignored-new-sell-fill",
+            **canonical_common,
+            "projection_status": "PENDING",
+            "projection_plan": None,
+        },
+        unique_keys=["execution_identity"],
+    )
+
+    assert created is False
+    assert saved_fill["execution_fill_id"] == "fill-legacy-sell"
+    assert saved_fill["projection_status"] == "APPLIED"
+    assert saved_fill["projection_legacy_proven_applied"] is True
+
+
+def test_legacy_buy_execution_with_partial_projection_evidence_fails_closed():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    database["om_orders"].rows.append(
+        {
+            "internal_order_id": "ord-legacy-partial",
+            "account_id": "acct-legacy",
+            "broker_order_id": "broker-order-legacy-partial",
+        }
+    )
+    legacy_common = {
+        "broker_order_key": "ord-legacy-partial",
+        "internal_order_id": "ord-legacy-partial",
+        "broker_order_id": "broker-order-legacy-partial",
+        "broker_trade_id": 503,
+        "symbol": "688772",
+        "side": "buy",
+        "quantity": 10000,
+        "price": 14.0,
+        "trade_time": 1785895200,
+        "date": 20260805,
+        "time": "10:00:00",
+    }
+    database["om_trade_facts"].rows.append(
+        {"trade_fact_id": "trade-fact-legacy-partial", **legacy_common}
+    )
+    database["om_execution_fills"].rows.append(
+        {"execution_fill_id": "fill-legacy-partial", **legacy_common}
+    )
+    database["om_buy_lots"].rows.append(
+        {
+            "buy_lot_id": "lot-legacy-partial",
+            "origin_trade_fact_id": "trade-fact-legacy-partial",
+            "symbol": "688772",
+            "original_quantity": 10000,
+            "remaining_quantity": 10000,
+            "buy_price_real": 14.0,
+        }
+    )
+    database["om_lot_slices"].rows.append(
+        {
+            "lot_slice_id": "lot-slice-legacy-partial",
+            "buy_lot_id": "lot-legacy-partial",
+            "original_quantity": 10000,
+        }
+    )
+    canonical_common = {
+        **legacy_common,
+        "broker_order_key": (
+            "account:acct-legacy:day:20260805:symbol:688772:"
+            "side:buy:order:broker-order-legacy-partial"
+        ),
+        "execution_identity": "execution:acct-legacy:20260805:legacy-partial",
+        "broker_trade_id": "503",
+        "account_id": "acct-legacy",
+        "trading_day": 20260805,
+    }
+
+    repository.upsert_trade_fact(
+        {"trade_fact_id": "ignored-new-partial-fact", **canonical_common},
+        unique_keys=["execution_identity"],
+    )
+    with pytest.raises(BrokerIdentityConflict, match="partial"):
+        repository.upsert_execution_fill(
+            {
+                "execution_fill_id": "ignored-new-partial-fill",
+                **canonical_common,
+                "projection_status": "PENDING",
+                "projection_plan": None,
+            },
+            unique_keys=["execution_identity"],
+        )
+
+    assert database["om_execution_fills"].rows[0].get("execution_identity") is None
+
+
+def test_legacy_execution_replay_with_ambiguous_trade_id_fails_closed():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    database["om_orders"].rows.append(
+        {
+            "internal_order_id": "ord-legacy",
+            "account_id": "acct-legacy",
+        }
+    )
+    for execution_fill_id in ("fill-legacy-1", "fill-legacy-2"):
+        database["om_execution_fills"].rows.append(
+            {
+                "execution_fill_id": execution_fill_id,
+                "broker_order_key": "ord-legacy",
+                "internal_order_id": "ord-legacy",
+                "broker_trade_id": "trade-ambiguous",
+                "symbol": "688772",
+                "side": "sell",
+                "quantity": 164,
+                "price": 14.8,
+                "trade_time": 1785895200,
+                "date": 20260805,
+                "time": "10:00:00",
+            }
+        )
+
+    with pytest.raises(BrokerIdentityConflict, match="ambiguous"):
+        repository.upsert_execution_fill(
+            {
+                "execution_fill_id": "fill-new",
+                "broker_order_key": "ord-legacy",
+                "internal_order_id": "ord-legacy",
+                "broker_trade_id": "trade-ambiguous",
+                "execution_identity": "execution:ambiguous",
+                "account_id": "acct-legacy",
+                "trading_day": 20260805,
+                "symbol": "688772",
+                "side": "sell",
+                "quantity": 164,
+                "price": 14.8,
+                "trade_time": 1785895200,
+                "date": 20260805,
+                "time": "10:00:00",
+                "projection_status": "PENDING",
+                "projection_plan": None,
+            },
+            unique_keys=["execution_identity"],
+        )
+
+    assert len(database["om_execution_fills"].rows) == 2
+    assert all(
+        item.get("execution_identity") is None
+        for item in database["om_execution_fills"].rows
+    )
+
+
+def test_legacy_execution_replay_without_provable_account_fails_closed():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    legacy_common = {
+        "broker_order_key": "unknown-order",
+        "internal_order_id": "unknown-order",
+        "broker_trade_id": "trade-unowned",
+        "symbol": "688772",
+        "side": "sell",
+        "quantity": 164,
+        "price": 14.8,
+        "trade_time": 1785895200,
+        "date": 20260805,
+        "time": "10:00:00",
+    }
+    database["om_trade_facts"].rows.append(
+        {"trade_fact_id": "fact-unowned", **legacy_common}
+    )
+    database["om_execution_fills"].rows.append(
+        {"execution_fill_id": "fill-unowned", **legacy_common}
+    )
+
+    with pytest.raises(BrokerIdentityConflict, match="account_id"):
+        repository.upsert_execution_fill(
+            {
+                "execution_fill_id": "fill-new",
+                "broker_order_key": "unknown-order",
+                "internal_order_id": "unknown-order",
+                "broker_trade_id": "trade-unowned",
+                "execution_identity": "execution:unowned",
+                "account_id": "acct-legacy",
+                "trading_day": 20260805,
+                "symbol": "688772",
+                "side": "sell",
+                "quantity": 164,
+                "price": 14.8,
+                "trade_time": 1785895200,
+                "date": 20260805,
+                "time": "10:00:00",
+                "projection_status": "PENDING",
+                "projection_plan": None,
+            },
+            unique_keys=["execution_identity"],
+        )
+
+    assert len(database["om_execution_fills"].rows) == 1
+    assert database["om_execution_fills"].rows[0].get("execution_identity") is None
+
+
+@pytest.mark.parametrize("legacy_collection", ["om_trade_facts", "om_execution_fills"])
+def test_legacy_execution_replay_requires_paired_fact_and_fill(legacy_collection):
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    database["om_orders"].rows.append(
+        {
+            "internal_order_id": "ord-legacy-pair",
+            "account_id": "acct-legacy",
+        }
+    )
+    legacy = {
+        "broker_order_key": "ord-legacy-pair",
+        "internal_order_id": "ord-legacy-pair",
+        "broker_trade_id": "trade-legacy-pair",
+        "symbol": "688772",
+        "side": "sell",
+        "quantity": 164,
+        "price": 14.8,
+        "trade_time": 1785895200,
+        "date": 20260805,
+        "time": "10:00:00",
+    }
+    identity_field = (
+        "trade_fact_id"
+        if legacy_collection == "om_trade_facts"
+        else "execution_fill_id"
+    )
+    database[legacy_collection].rows.append(
+        {identity_field: f"legacy-{identity_field}", **legacy}
+    )
+    incoming = {
+        **legacy,
+        "execution_identity": "execution:acct-legacy:20260805:trade-legacy-pair",
+        "account_id": "acct-legacy",
+        "trading_day": 20260805,
+        "broker_order_key": (
+            "account:acct-legacy:day:20260805:symbol:688772:"
+            "side:sell:order:ord-legacy-pair"
+        ),
+    }
+
+    with pytest.raises(BrokerIdentityConflict, match="requires paired"):
+        repository.preflight_execution_replay(incoming)
+
+    assert len(database[legacy_collection].rows) == 1
+    assert database[legacy_collection].rows[0].get("execution_identity") is None
+    other_collection = (
+        "om_execution_fills"
+        if legacy_collection == "om_trade_facts"
+        else "om_trade_facts"
+    )
+    assert database[other_collection].rows == []
+
+
+def test_legacy_account_proof_enumerates_all_broker_order_candidates():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    for account_id in ("acct-a", "acct-b"):
+        database["om_orders"].rows.append(
+            {
+                "internal_order_id": f"ord-{account_id}",
+                "broker_order_id": "shared-broker-order",
+                "account_id": account_id,
+            }
+        )
+    legacy_common = {
+        "broker_trade_id": "shared-trade",
+        "broker_order_id": "shared-broker-order",
+        "symbol": "688772",
+        "side": "sell",
+        "quantity": 164,
+        "price": 14.8,
+        "trade_time": 1785895200,
+        "date": 20260805,
+        "time": "10:00:00",
+    }
+    database["om_trade_facts"].rows.append(
+        {"trade_fact_id": "legacy-fact-shared", **legacy_common}
+    )
+    database["om_execution_fills"].rows.append(
+        {"execution_fill_id": "legacy-fill-shared", **legacy_common}
+    )
+
+    with pytest.raises(BrokerIdentityConflict, match="account_id"):
+        repository.preflight_execution_replay(
+            {
+                **legacy_common,
+                "execution_identity": "execution:acct-a:20260805:shared-trade",
+                "account_id": "acct-a",
+                "trading_day": 20260805,
+            }
+        )
+
+
+def test_tracking_legacy_account_proof_uses_preupdate_order_snapshot():
+    from freshquant.order_management.repository import OrderManagementRepository
+    from freshquant.order_management.tracking.service import OrderTrackingService
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    database["om_orders"].rows.append(
+        {
+            "internal_order_id": "ord-unowned",
+            "broker_order_id": "broker-unowned",
+            "symbol": "688772",
+            "side": "sell",
+            "state": "SUBMITTED",
+        }
+    )
+    legacy_common = {
+        "broker_order_key": "ord-unowned",
+        "internal_order_id": "ord-unowned",
+        "broker_order_id": "broker-unowned",
+        "broker_trade_id": "trade-unowned-tracking",
+        "symbol": "688772",
+        "side": "sell",
+        "quantity": 164,
+        "price": 14.8,
+        "trade_time": 1785895200,
+        "date": 20260805,
+        "time": "10:00:00",
+        "source": "xt_trade_callback",
+    }
+    database["om_trade_facts"].rows.append(
+        {"trade_fact_id": "legacy-fact-unowned", **legacy_common}
+    )
+    database["om_execution_fills"].rows.append(
+        {"execution_fill_id": "legacy-fill-unowned", **legacy_common}
+    )
+    service = OrderTrackingService(repository=repository)
+
+    with pytest.raises(BrokerIdentityConflict, match="account_id"):
+        service.ingest_trade_report_with_meta(
+            {
+                **legacy_common,
+                "account_id": "arbitrary-account",
+                "trading_day": 20260805,
+            }
+        )
+
+    assert database["om_orders"].rows[0].get("account_id") is None
+    assert all(
+        item.get("execution_identity") is None
+        for collection in ("om_trade_facts", "om_execution_fills")
+        for item in database[collection].rows
+    )
+
+
+def test_projection_cas_preserves_concurrent_document_change():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    before = {
+        "entry_id": "entry-cas",
+        "remaining_quantity": 100,
+        "status": "OPEN",
+    }
+    database["om_position_entries"].rows.append(dict(before))
+    database["om_position_entries"].rows[0]["remaining_quantity"] = 77
+
+    with pytest.raises(BrokerIdentityConflict, match="compare-and-set conflict"):
+        repository.compare_and_set_projection_document(
+            "position_entry",
+            before=before,
+            after={**before, "remaining_quantity": 0, "status": "CLOSED"},
+        )
+
+    assert database["om_position_entries"].rows == [
+        {**before, "remaining_quantity": 77}
+    ]
+
+
+def test_allocation_inserts_require_unique_id_and_never_overwrite():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+
+    with pytest.raises(BrokerIdentityConflict, match="allocation_id is required"):
+        repository.insert_sell_allocations([{"allocated_quantity": 100}])
+    with pytest.raises(BrokerIdentityConflict, match="duplicate allocation_id"):
+        repository.insert_sell_allocations(
+            [
+                {"allocation_id": "alloc-1", "allocated_quantity": 100},
+                {"allocation_id": "alloc-1", "allocated_quantity": 100},
+            ]
+        )
+
+    repository.insert_sell_allocations(
+        [{"allocation_id": "alloc-1", "allocated_quantity": 100}]
+    )
+    repository.insert_sell_allocations(
+        [{"allocation_id": "alloc-1", "allocated_quantity": 100}]
+    )
+    with pytest.raises(BrokerIdentityConflict, match="compare-and-set conflict"):
+        repository.insert_sell_allocations(
+            [{"allocation_id": "alloc-1", "allocated_quantity": 200}]
+        )
+
+    assert database["om_sell_allocations"].rows == [
+        {"allocation_id": "alloc-1", "allocated_quantity": 100}
+    ]
 
 
 def test_allocation_integrity_rejects_slice_owned_by_another_entry():

--- a/freshquant/tests/test_order_management_db.py
+++ b/freshquant/tests/test_order_management_db.py
@@ -1,4 +1,10 @@
 import importlib
+from types import SimpleNamespace
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+from freshquant.order_management.broker_identity import BrokerIdentityConflict
 
 
 def test_order_management_db_uses_bootstrap_dedicated_database(tmp_path, monkeypatch):
@@ -69,6 +75,11 @@ def test_order_management_projection_db_defaults_to_bootstrap_mongodb_db(
 class _FakeCollection:
     def __init__(self):
         self.rows = []
+        self.indexes = []
+
+    def create_index(self, keys, **options):
+        self.indexes.append((list(keys), dict(options)))
+        return options.get("name")
 
     def insert_one(self, document):
         self.rows.append(dict(document))
@@ -90,23 +101,55 @@ class _FakeCollection:
         for index, item in enumerate(self.rows):
             if _matches_query(item, query):
                 self.rows[index] = dict(document)
-                return
+                return SimpleNamespace(matched_count=1, upserted_id=None)
         if upsert:
             self.rows.append(dict(document))
+            return SimpleNamespace(matched_count=0, upserted_id=len(self.rows))
+        return SimpleNamespace(matched_count=0, upserted_id=None)
 
-    def update_one(self, query, update):
+    def update_one(self, query, update, upsert=False):
         query = dict(query or {})
         updates = dict((update or {}).get("$set") or {})
+        assert "_id" not in updates
         for index, item in enumerate(self.rows):
             if _matches_query(item, query):
                 next_item = dict(item)
                 next_item.update(updates)
                 self.rows[index] = next_item
-                return
+                return SimpleNamespace(matched_count=1, upserted_id=None)
+        if upsert:
+            inserted = dict(query)
+            inserted.update(dict((update or {}).get("$setOnInsert") or {}))
+            inserted.update(updates)
+            self.rows.append(inserted)
+            return SimpleNamespace(matched_count=0, upserted_id=len(self.rows))
+        return SimpleNamespace(matched_count=0, upserted_id=None)
 
     def delete_many(self, query):
         query = dict(query or {})
         self.rows = [item for item in self.rows if not _matches_query(item, query)]
+
+    def delete_one(self, query):
+        query = dict(query or {})
+        for index, item in enumerate(self.rows):
+            if _matches_query(item, query):
+                del self.rows[index]
+                return SimpleNamespace(deleted_count=1)
+        return SimpleNamespace(deleted_count=0)
+
+
+class _DuplicateOnFirstUpsertCollection(_FakeCollection):
+    def __init__(self, concurrent_document):
+        super().__init__()
+        self.concurrent_document = dict(concurrent_document)
+        self.raise_duplicate = True
+
+    def update_one(self, query, update, upsert=False):
+        if upsert and self.raise_duplicate:
+            self.raise_duplicate = False
+            self.rows.append(dict(self.concurrent_document))
+            raise DuplicateKeyError("simulated concurrent canonical insert")
+        return super().update_one(query, update, upsert=upsert)
 
 
 class _FakeDatabase(dict):
@@ -164,6 +207,29 @@ def test_order_management_repository_supports_v2_collections_and_basic_crud():
     assert saved_order == updated_broker_order
     assert repository.list_broker_orders(symbol="000001") == [updated_broker_order]
 
+    repository.upsert_broker_order(
+        {
+            "broker_order_key": "internal_placeholder",
+            "symbol": "000002",
+            "state": "SUBMITTING",
+        },
+        unique_keys=["broker_order_key"],
+    )
+    moved_order = repository.move_broker_order_key(
+        "internal_placeholder",
+        "account:acct-1:day:20260805:sysid:123",
+        {
+            "symbol": "000002",
+            "state": "FILLED",
+        },
+    )
+    assert repository.find_broker_order("internal_placeholder") is None
+    assert moved_order == {
+        "broker_order_key": "account:acct-1:day:20260805:sysid:123",
+        "symbol": "000002",
+        "state": "FILLED",
+    }
+
     execution_fill = {
         "execution_fill_id": "fill_1",
         "broker_trade_id": "trade_1",
@@ -213,6 +279,7 @@ def test_order_management_repository_supports_v2_collections_and_basic_crud():
         "entry_id": "entry_1",
         "symbol": "000001",
         "status": "PARTIALLY_EXITED",
+        "original_quantity": 400,
         "remaining_quantity": 200,
     }
     repository.replace_position_entry(updated_entry)
@@ -238,19 +305,54 @@ def test_order_management_repository_supports_v2_collections_and_basic_crud():
             "entry_slice_id": "slice_2",
             "entry_id": "entry_1",
             "symbol": "000001",
+            "original_quantity": 200,
             "remaining_quantity": 200,
         }
     ]
     repository.replace_entry_slices_for_entry("entry_1", replacement_slices)
     assert repository.list_open_entry_slices(symbol="000001") == replacement_slices
+    closed_slice = {
+        "entry_slice_id": "slice_closed",
+        "entry_id": "entry_1",
+        "symbol": "000001",
+        "original_quantity": 0,
+        "remaining_quantity": 0,
+        "status": "CLOSED",
+    }
+    repository.upsert_entry_slices([closed_slice])
+    repository.upsert_entry_slices(
+        [{**replacement_slices[0], "remaining_quantity": 0, "status": "CLOSED"}]
+    )
+    assert {
+        item["entry_slice_id"]
+        for item in repository.list_entry_slices(entry_ids=["entry_1"])
+    } == {"slice_2", "slice_closed"}
 
     allocation = {
         "allocation_id": "alloc_1",
         "entry_id": "entry_1",
         "symbol": "000001",
+        "allocated_quantity": 200,
     }
     repository.insert_exit_allocations([allocation])
     assert repository.list_exit_allocations(entry_ids=["entry_1"]) == [allocation]
+    assert repository.find_exit_allocation_reference_errors() == [
+        {
+            "allocation_id": "alloc_1",
+            "reference_type": "entry_slice_id",
+            "reference_id": None,
+        },
+        {
+            "allocation_id": None,
+            "reference_type": "entry_slice_allocation_quantity",
+            "reference_id": "slice_2",
+            "expected_quantity": 200,
+            "actual_quantity": 0,
+        },
+    ]
+
+    repository.exit_allocations.rows[0]["entry_slice_id"] = "slice_2"
+    assert repository.find_exit_allocation_reference_errors() == []
 
     binding = {"entry_id": "entry_1", "symbol": "000001", "enabled": True}
     repository.upsert_entry_stoploss_binding(binding)
@@ -278,3 +380,301 @@ def test_order_management_repository_supports_v2_collections_and_basic_crud():
     }
     repository.insert_ingest_rejection(rejection)
     assert repository.list_ingest_rejections(symbol="000001") == [rejection]
+
+
+def test_repository_creates_partial_unique_indexes_for_canonical_identities():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    OrderManagementRepository(database=database)
+
+    assert database["om_broker_orders"].indexes == [
+        (
+            [("broker_order_key", 1)],
+            {
+                "unique": True,
+                "partialFilterExpression": {"broker_order_key": {"$type": "string"}},
+                "name": "uq_om_broker_orders_broker_order_key",
+            },
+        )
+    ]
+    assert database["om_trade_facts"].indexes == [
+        (
+            [("execution_identity", 1)],
+            {
+                "unique": True,
+                "partialFilterExpression": {"execution_identity": {"$type": "string"}},
+                "name": "uq_om_trade_facts_execution_identity",
+            },
+        )
+    ]
+    assert database["om_execution_fills"].indexes == [
+        (
+            [("execution_identity", 1)],
+            {
+                "unique": True,
+                "partialFilterExpression": {"execution_identity": {"$type": "string"}},
+                "name": "uq_om_execution_fills_execution_identity",
+            },
+        )
+    ]
+    assert database["om_position_entries"].indexes == [
+        (
+            [("entry_id", 1)],
+            {
+                "unique": True,
+                "partialFilterExpression": {"entry_id": {"$type": "string"}},
+                "name": "uq_om_position_entries_entry_id",
+            },
+        )
+    ]
+    assert database["om_entry_slices"].indexes == [
+        (
+            [("entry_slice_id", 1)],
+            {
+                "unique": True,
+                "partialFilterExpression": {"entry_slice_id": {"$type": "string"}},
+                "name": "uq_om_entry_slices_entry_slice_id",
+            },
+        )
+    ]
+    assert database["om_exit_allocations"].indexes == [
+        (
+            [("allocation_id", 1)],
+            {
+                "unique": True,
+                "partialFilterExpression": {"allocation_id": {"$type": "string"}},
+                "name": "uq_om_exit_allocations_allocation_id",
+            },
+        )
+    ]
+
+
+def test_repository_upserts_existing_broker_order_without_setting_mongo_id():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    database["om_broker_orders"].rows.append(
+        {
+            "_id": "mongo-id-1",
+            "broker_order_key": "canonical-1",
+            "account_id": "acct-1",
+            "trading_day": 20260805,
+            "order_sysid": "123",
+            "symbol": "688772",
+            "side": "buy",
+            "state": "SUBMITTED",
+        }
+    )
+
+    saved, created = repository.upsert_broker_order(
+        {
+            "_id": "mongo-id-1",
+            "broker_order_key": "canonical-1",
+            "account_id": "acct-1",
+            "trading_day": 20260805,
+            "order_sysid": "123",
+            "symbol": "688772",
+            "side": "buy",
+            "state": "FILLED",
+        },
+        unique_keys=["broker_order_key"],
+    )
+
+    assert created is False
+    assert saved["_id"] == "mongo-id-1"
+    assert saved["state"] == "FILLED"
+
+
+def test_move_broker_order_key_merges_existing_placeholder_into_canonical_target():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    database["om_broker_orders"].rows.extend(
+        [
+            {
+                "_id": "placeholder-id",
+                "broker_order_key": "ord-placeholder",
+                "internal_order_id": "ord-internal",
+                "account_id": "acct-1",
+                "symbol": "688772",
+                "side": "buy",
+                "state": "SUBMITTING",
+            },
+            {
+                "_id": "canonical-id",
+                "broker_order_key": "account:acct-1:day:20260805:sysid:557",
+                "internal_order_id": "ord-broker-only",
+                "account_id": "acct-1",
+                "trading_day": 20260805,
+                "order_sysid": "557",
+                "symbol": "688772",
+                "side": "buy",
+                "state": "PARTIAL_FILLED",
+                "filled_quantity": 100,
+            },
+        ]
+    )
+
+    saved = repository.move_broker_order_key(
+        "ord-placeholder",
+        "account:acct-1:day:20260805:sysid:557",
+        {
+            "_id": "canonical-id",
+            "internal_order_id": "ord-internal",
+            "account_id": "acct-1",
+            "trading_day": 20260805,
+            "order_sysid": "557",
+            "symbol": "688772",
+            "side": "buy",
+            "state": "FILLED",
+            "filled_quantity": 10000,
+        },
+    )
+
+    assert repository.find_broker_order("ord-placeholder") is None
+    assert saved["_id"] == "canonical-id"
+    assert saved["internal_order_id"] == "ord-internal"
+    assert saved["filled_quantity"] == 10000
+    assert len(database["om_broker_orders"].rows) == 1
+
+
+def test_duplicate_key_race_is_idempotent_only_for_consistent_execution():
+    from freshquant.order_management.repository import OrderManagementRepository
+
+    canonical = {
+        "execution_fill_id": "fill-existing",
+        "execution_identity": "execution:canonical-1",
+        "broker_trade_id": "trade-1",
+        "broker_order_key": "canonical-order-1",
+        "internal_order_id": "ord-1",
+        "account_id": "acct-1",
+        "trading_day": 20260805,
+        "symbol": "688772",
+        "side": "sell",
+        "quantity": 164,
+        "price": 14.8,
+        "trade_time": 1785895200,
+    }
+    database = _FakeDatabase()
+    database["om_execution_fills"] = _DuplicateOnFirstUpsertCollection(canonical)
+    repository = OrderManagementRepository(database=database)
+
+    replay, created = repository.upsert_execution_fill(
+        {**canonical, "execution_fill_id": "fill-replay"},
+        unique_keys=["execution_identity"],
+    )
+
+    assert created is False
+    assert replay == canonical
+
+    with pytest.raises(BrokerIdentityConflict, match="quantity"):
+        repository.upsert_execution_fill(
+            {**canonical, "execution_fill_id": "fill-conflict", "quantity": 203},
+            unique_keys=["execution_identity"],
+        )
+
+
+def test_allocation_integrity_rejects_slice_owned_by_another_entry():
+    from freshquant.order_management.allocation_integrity import (
+        find_exit_allocation_integrity_errors,
+    )
+
+    errors = find_exit_allocation_integrity_errors(
+        position_entries=[
+            {
+                "entry_id": "entry-1",
+                "symbol": "688772",
+                "original_quantity": 100,
+                "remaining_quantity": 0,
+            },
+            {
+                "entry_id": "entry-2",
+                "symbol": "688772",
+                "original_quantity": 100,
+                "remaining_quantity": 100,
+            },
+        ],
+        entry_slices=[
+            {
+                "entry_slice_id": "slice-2",
+                "entry_id": "entry-2",
+                "symbol": "688772",
+                "original_quantity": 100,
+                "remaining_quantity": 0,
+            }
+        ],
+        exit_allocations=[
+            {
+                "allocation_id": "allocation-1",
+                "entry_id": "entry-1",
+                "entry_slice_id": "slice-2",
+                "symbol": "688772",
+                "allocated_quantity": 100,
+            }
+        ],
+    )
+
+    assert errors == [
+        {
+            "allocation_id": "allocation-1",
+            "reference_type": "entry_slice_owner",
+            "reference_id": "slice-2",
+            "expected_entry_id": "entry-1",
+            "actual_entry_id": "entry-2",
+        }
+    ]
+
+
+def test_allocation_integrity_enforces_entry_and_slice_quantity_conservation():
+    from freshquant.order_management.allocation_integrity import (
+        find_exit_allocation_integrity_errors,
+    )
+
+    errors = find_exit_allocation_integrity_errors(
+        position_entries=[
+            {
+                "entry_id": "entry-1",
+                "symbol": "688772",
+                "original_quantity": 300,
+                "remaining_quantity": 100,
+            }
+        ],
+        entry_slices=[
+            {
+                "entry_slice_id": "slice-1",
+                "entry_id": "entry-1",
+                "symbol": "688772",
+                "original_quantity": 300,
+                "remaining_quantity": 100,
+            }
+        ],
+        exit_allocations=[
+            {
+                "allocation_id": "allocation-1",
+                "entry_id": "entry-1",
+                "entry_slice_id": "slice-1",
+                "symbol": "688772",
+                "allocated_quantity": 100,
+            }
+        ],
+    )
+
+    assert errors == [
+        {
+            "allocation_id": None,
+            "reference_type": "entry_allocation_quantity",
+            "reference_id": "entry-1",
+            "expected_quantity": 200,
+            "actual_quantity": 100,
+        },
+        {
+            "allocation_id": None,
+            "reference_type": "entry_slice_allocation_quantity",
+            "reference_id": "slice-1",
+            "expected_quantity": 200,
+            "actual_quantity": 100,
+        },
+    ]

--- a/freshquant/tests/test_order_management_execution_bridge.py
+++ b/freshquant/tests/test_order_management_execution_bridge.py
@@ -84,6 +84,44 @@ def test_prepare_submit_execution_skips_canceled_order_before_submit():
     assert repository.find_order("ord_skip_1")["state"] == "CANCELED"
 
 
+def test_prepare_submit_execution_pins_xt_order_remark_to_internal_order():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "000001",
+            "price": 10.0,
+            "quantity": 100,
+            "source": "strategy",
+            "remark": "human readable remark",
+            "internal_order_id": "ord_correlation_1",
+        }
+    )
+
+    result = prepare_submit_execution(
+        {
+            "internal_order_id": "ord_correlation_1",
+            "action": "buy",
+            "symbol": "000001",
+            "price": 10.0,
+            "quantity": 100,
+            "remark": "human readable remark",
+        },
+        repository=repository,
+        tracking_service=tracking_service,
+        continuous_auction_provider=lambda: False,
+    )
+
+    order = repository.find_order("ord_correlation_1")
+    token = order["broker_correlation_token"]
+    assert result["status"] == "execute"
+    assert result["order_message"]["broker_correlation_token"] == token
+    assert result["order_message"]["broker_order_remark"] == token
+    assert result["order_message"]["remark"] == "human readable remark"
+    assert len(token) == 24
+
+
 def test_finalize_submit_execution_marks_order_submitted_with_broker_order_id():
     repository = InMemoryRepository()
     tracking_service = OrderTrackingService(repository=repository)

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -427,6 +427,20 @@ def _build_service(
     return repository, service
 
 
+def test_reconcile_service_constructor_defers_default_tpsl_service(monkeypatch):
+    constructed = []
+    monkeypatch.setattr(
+        xt_reports_module,
+        "_get_tpsl_service",
+        lambda: constructed.append(True),
+    )
+
+    _repository, service = _build_service()
+
+    assert constructed == []
+    assert service.ingest_service.tpsl_service is not None
+
+
 def test_detect_external_candidates_from_position_delta():
     repository, service = _build_service()
     tracking_service = OrderTrackingService(repository=repository)
@@ -822,6 +836,9 @@ def test_reconcile_matches_inflight_internal_order_before_creating_external_orde
             "broker_order_id": None,
         }
     )
+    correlation_token = repository.find_order("ord_internal_1")[
+        "broker_correlation_token"
+    ]
 
     results = service.reconcile_trade_reports(
         [
@@ -831,6 +848,7 @@ def test_reconcile_matches_inflight_internal_order_before_creating_external_orde
                 "traded_id": "T90002",
                 "stock_code": "000001.SZ",
                 "order_type": 23,
+                "order_remark": correlation_token,
                 "traded_volume": 200,
                 "traded_price": 10.5,
                 "traded_time": 1_030,
@@ -872,6 +890,9 @@ def test_reconcile_matches_partial_inflight_internal_order_without_externalizing
             "broker_order_id": None,
         }
     )
+    correlation_token = repository.find_order("ord_internal_partial_1")[
+        "broker_correlation_token"
+    ]
 
     results = service.reconcile_trade_reports(
         [
@@ -881,6 +902,7 @@ def test_reconcile_matches_partial_inflight_internal_order_without_externalizing
                 "traded_id": "T90003",
                 "stock_code": "000001.SZ",
                 "order_type": 23,
+                "order_remark": correlation_token,
                 "traded_volume": 300,
                 "traded_price": 10.5,
                 "traded_time": 1_030,
@@ -897,6 +919,209 @@ def test_reconcile_matches_partial_inflight_internal_order_without_externalizing
     assert repository.trade_facts[0]["internal_order_id"] == "ord_internal_partial_1"
     assert repository.trade_facts[0]["quantity"] == 300
     assert repository.order_requests[0]["quantity"] == 600
+
+
+def test_inflight_match_rejects_single_candidate_from_different_account():
+    repository, service = _build_service()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-other",
+            "trading_day": 20260805,
+            "symbol": "000001",
+            "price": 10.5,
+            "quantity": 200,
+            "source": "strategy",
+            "internal_order_id": "ord_wrong_account",
+        }
+    )
+
+    status, matched_order = service._match_inflight_internal_order(
+        {
+            "account_id": "acct-target",
+            "trading_day": 20260805,
+            "symbol": "000001",
+            "side": "buy",
+            "quantity": 200,
+            "price": 10.5,
+        }
+    )
+
+    assert status == "missing"
+    assert matched_order is None
+
+
+def test_inflight_match_selects_only_candidate_from_trade_account():
+    repository, service = _build_service()
+    tracking_service = OrderTrackingService(repository=repository)
+    for account_id, internal_order_id in (
+        ("acct-target", "ord_target_account"),
+        ("acct-other", "ord_other_account"),
+    ):
+        tracking_service.submit_order(
+            {
+                "action": "buy",
+                "account_id": account_id,
+                "trading_day": 20260805,
+                "symbol": "000001",
+                "price": 10.5,
+                "quantity": 200,
+                "source": "strategy",
+                "internal_order_id": internal_order_id,
+            }
+        )
+
+    status, matched_order = service._match_inflight_internal_order(
+        {
+            "account_id": "acct-target",
+            "trading_day": 20260805,
+            "symbol": "000001",
+            "side": "buy",
+            "quantity": 200,
+            "price": 10.5,
+        }
+    )
+
+    assert status == "matched"
+    assert matched_order["internal_order_id"] == "ord_target_account"
+
+
+def test_inflight_match_rejects_candidate_from_different_trading_day():
+    repository, service = _build_service()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-target",
+            "trading_day": 20260804,
+            "symbol": "000001",
+            "price": 10.5,
+            "quantity": 200,
+            "source": "strategy",
+            "internal_order_id": "ord_previous_day",
+        }
+    )
+
+    status, matched_order = service._match_inflight_internal_order(
+        {
+            "account_id": "acct-target",
+            "trading_day": 20260805,
+            "symbol": "000001",
+            "side": "buy",
+            "quantity": 200,
+            "price": 10.5,
+        }
+    )
+
+    assert status == "missing"
+    assert matched_order is None
+
+
+def test_inflight_match_rejects_candidate_missing_critical_identity():
+    repository, service = _build_service()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-target",
+            "symbol": "000001",
+            "price": 10.5,
+            "quantity": 200,
+            "source": "strategy",
+            "internal_order_id": "ord_missing_day",
+        }
+    )
+
+    status, matched_order = service._match_inflight_internal_order(
+        {
+            "account_id": "acct-target",
+            "trading_day": 20260805,
+            "symbol": "000001",
+            "side": "buy",
+            "quantity": 200,
+            "price": 10.5,
+        }
+    )
+
+    assert status == "missing"
+    assert matched_order is None
+
+
+@pytest.mark.parametrize(
+    ("field", "conflicting_value"),
+    [
+        ("account_id", "acct-other"),
+        ("trading_day", 20260804),
+        ("symbol", "000002"),
+        ("action", "sell"),
+    ],
+)
+def test_inflight_match_rejects_known_request_identity_conflict(
+    field,
+    conflicting_value,
+):
+    repository, service = _build_service()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-target",
+            "trading_day": 20260805,
+            "symbol": "000001",
+            "price": 10.5,
+            "quantity": 200,
+            "source": "strategy",
+            "internal_order_id": "ord_request_conflict",
+        }
+    )
+    repository.order_requests[0][field] = conflicting_value
+
+    status, matched_order = service._match_inflight_internal_order(
+        {
+            "account_id": "acct-target",
+            "trading_day": 20260805,
+            "symbol": "000001",
+            "side": "buy",
+            "quantity": 200,
+            "price": 10.5,
+        }
+    )
+
+    assert status == "missing"
+    assert matched_order is None
+
+
+@pytest.mark.parametrize("missing_field", ["account_id", "trading_day"])
+def test_inflight_match_requires_trade_account_and_trading_day(missing_field):
+    repository, service = _build_service()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-target",
+            "trading_day": 20260805,
+            "symbol": "000001",
+            "price": 10.5,
+            "quantity": 200,
+            "source": "strategy",
+            "internal_order_id": "ord_complete_identity",
+        }
+    )
+    normalized_trade = {
+        "account_id": "acct-target",
+        "trading_day": 20260805,
+        "symbol": "000001",
+        "side": "buy",
+        "quantity": 200,
+        "price": 10.5,
+    }
+    normalized_trade.pop(missing_field)
+
+    status, matched_order = service._match_inflight_internal_order(normalized_trade)
+
+    assert status == "missing"
+    assert matched_order is None
 
 
 def test_reconcile_trade_report_ingests_known_internal_sell_order(monkeypatch):
@@ -1245,6 +1470,42 @@ def test_build_auto_open_entry_uses_beijing_date_time():
 
     assert entry["date"] == 20240310
     assert entry["time"] == "00:00:00"
+
+
+def test_auto_reconciled_688772_uses_canonical_four_slice_arrangement(monkeypatch):
+    repository, service = _build_service(monkeypatch)
+    positions = [
+        {
+            "stock_code": "688772.SH",
+            "volume": 10000,
+            "avg_price": 14.70,
+            "last_price": 14.70,
+        }
+    ]
+    for detected_at in (1_000, 1_015, 1_030):
+        service.detect_external_candidates(
+            positions=positions,
+            detected_at=detected_at,
+        )
+
+    confirmed = service.confirm_expired_candidates(now=1_030)
+
+    assert len(confirmed) == 1
+    slices = sorted(repository.entry_slices, key=lambda item: item["slice_seq"])
+    assert [
+        (
+            item["guardian_price"],
+            item["original_quantity"],
+            item["remaining_quantity"],
+        )
+        for item in slices
+    ] == [
+        (14.70, 3400, 3400),
+        (15.14, 3300, 3300),
+        (15.59, 3200, 3200),
+        (16.06, 100, 100),
+    ]
+    assert sum(item["original_quantity"] for item in slices) == 10000
 
 
 def test_load_previous_close_from_realtime_uses_beijing_midnight_when_local_fromtimestamp_differs(
@@ -2077,7 +2338,7 @@ def test_confirm_expired_candidates_keeps_entry_truth_when_arrangement_materiali
     )
     monkeypatch.setattr(
         reconcile_service_module,
-        "_arrange_entry_slices",
+        "arrange_entry",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("arrange boom")),
         raising=False,
     )

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -320,6 +320,13 @@ class InMemoryRepository:
         self.entry_slices.extend(dict(item) for item in slices)
         return slices
 
+    def upsert_entry_slices(self, slices):
+        by_id = {item["entry_slice_id"]: item for item in self.entry_slices}
+        for item in slices:
+            by_id[item["entry_slice_id"]] = dict(item)
+        self.entry_slices = list(by_id.values())
+        return slices
+
     def list_open_entry_slices(self, *, symbol=None, entry_ids=None):
         rows = [
             item
@@ -764,6 +771,7 @@ def test_reconcile_matches_external_trade_report_to_existing_candidate(monkeypat
     results = service.reconcile_trade_reports(
         [
             {
+                "account_id": "acct-test",
                 "order_id": 90001,
                 "traded_id": "T90001",
                 "stock_code": "000001.SZ",
@@ -796,6 +804,8 @@ def test_reconcile_matches_inflight_internal_order_before_creating_external_orde
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": "acct-test",
+            "trading_day": 19700101,
             "symbol": "000001",
             "price": 10.5,
             "quantity": 200,
@@ -816,6 +826,7 @@ def test_reconcile_matches_inflight_internal_order_before_creating_external_orde
     results = service.reconcile_trade_reports(
         [
             {
+                "account_id": "acct-test",
                 "order_id": 90002,
                 "traded_id": "T90002",
                 "stock_code": "000001.SZ",
@@ -843,6 +854,8 @@ def test_reconcile_matches_partial_inflight_internal_order_without_externalizing
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": "acct-test",
+            "trading_day": 19700101,
             "symbol": "000001",
             "price": 10.5,
             "quantity": 600,
@@ -863,6 +876,7 @@ def test_reconcile_matches_partial_inflight_internal_order_without_externalizing
     results = service.reconcile_trade_reports(
         [
             {
+                "account_id": "acct-test",
                 "order_id": 90003,
                 "traded_id": "T90003",
                 "stock_code": "000001.SZ",
@@ -908,6 +922,8 @@ def test_reconcile_trade_report_ingests_known_internal_sell_order(monkeypatch):
     tracking_service.submit_order(
         {
             "action": "sell",
+            "account_id": "acct-test",
+            "trading_day": 19700101,
             "symbol": "000001",
             "price": 10.5,
             "quantity": 200,
@@ -922,6 +938,7 @@ def test_reconcile_trade_report_ingests_known_internal_sell_order(monkeypatch):
 
     outcome = service.reconcile_trade_report(
         {
+            "account_id": "acct-test",
             "order_id": 90011,
             "traded_id": "T90011",
             "stock_code": "000001.SZ",
@@ -975,6 +992,7 @@ def test_reconcile_trade_report_uses_matching_duplicate_broker_order_candidate(
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": "acct-test",
             "symbol": "002262",
             "price": 21.0,
             "quantity": 2300,
@@ -997,6 +1015,7 @@ def test_reconcile_trade_report_uses_matching_duplicate_broker_order_candidate(
     tracking_service.submit_order(
         {
             "action": "sell",
+            "account_id": "acct-test",
             "symbol": "002262",
             "price": 22.41,
             "quantity": 2300,
@@ -1019,6 +1038,7 @@ def test_reconcile_trade_report_uses_matching_duplicate_broker_order_candidate(
 
     outcome = service.reconcile_trade_report(
         {
+            "account_id": "acct-test",
             "order_id": 1477443585,
             "traded_id": "0103000030649603",
             "stock_code": "002262.SZ",
@@ -1038,7 +1058,7 @@ def test_reconcile_trade_report_uses_matching_duplicate_broker_order_candidate(
     assert outcome.result["trade_fact"]["side"] == "sell"
     assert repository.trade_facts[0]["internal_order_id"] == "ord_new_sell_duplicate"
     assert repository.execution_fills[0]["broker_order_key"] == (
-        "ord_new_sell_duplicate"
+        "account:acct-test:day:20260429:symbol:002262:" "side:sell:order:1477443585"
     )
 
 
@@ -1368,6 +1388,127 @@ def test_sell_side_non_board_lot_gap_is_rejected_without_reducing_holdings(monke
     )
 
 
+def test_closed_v2_entry_keeps_symbol_authoritative_over_legacy_buy_lot(monkeypatch):
+    repository, service = _build_service(monkeypatch)
+    repository.replace_position_entry(
+        {
+            "entry_id": "entry_closed_v2",
+            "symbol": "000001",
+            "original_quantity": 100,
+            "remaining_quantity": 0,
+            "status": "CLOSED",
+        }
+    )
+    repository.insert_buy_lot(
+        {
+            "buy_lot_id": "legacy_open_lot",
+            "origin_trade_fact_id": "legacy_trade",
+            "symbol": "000001",
+            "remaining_quantity": 100,
+        }
+    )
+
+    gaps = service.detect_external_candidates(positions=[], detected_at=1_000)
+
+    assert gaps == []
+    assert repository.reconciliation_gaps == []
+
+
+def test_close_gap_does_not_fall_back_to_legacy_when_v2_entry_exists(monkeypatch):
+    repository, service = _build_service(monkeypatch)
+    repository.replace_position_entry(
+        {
+            "entry_id": "entry_closed_v2",
+            "symbol": "000001",
+            "original_quantity": 100,
+            "remaining_quantity": 0,
+            "status": "CLOSED",
+        }
+    )
+    repository.insert_buy_lot(
+        {
+            "buy_lot_id": "legacy_open_lot",
+            "origin_trade_fact_id": "legacy_trade",
+            "symbol": "000001",
+            "remaining_quantity": 100,
+            "sell_history": [],
+        }
+    )
+    gap = {
+        "gap_id": "gap_closed_v2",
+        "symbol": "000001",
+        "side": "sell",
+        "quantity_delta": 100,
+        "price_estimate": 10.0,
+        "state": "OPEN",
+    }
+    repository.insert_reconciliation_gap(gap)
+
+    confirmed = service._confirm_close_gap(gap, now=1_030)
+
+    assert confirmed["state"] == "REJECTED"
+    assert confirmed["resolution_type"] == "v2_inventory_insufficient"
+    assert repository.buy_lots[0]["remaining_quantity"] == 100
+    assert repository.sell_allocations == []
+
+
+def test_close_gap_updates_open_slice_by_id_without_deleting_closed_slice(monkeypatch):
+    repository, _service = _build_service(monkeypatch)
+    repository.replace_position_entry(
+        {
+            "entry_id": "entry_mixed_slices",
+            "symbol": "000001",
+            "original_quantity": 200,
+            "remaining_quantity": 100,
+            "status": "PARTIALLY_EXITED",
+        }
+    )
+    repository.replace_entry_slices_for_entry(
+        "entry_mixed_slices",
+        [
+            {
+                "entry_slice_id": "slice_closed",
+                "entry_id": "entry_mixed_slices",
+                "symbol": "000001",
+                "guardian_price": 10.0,
+                "original_quantity": 100,
+                "remaining_quantity": 0,
+                "remaining_amount": 0.0,
+                "sort_key": 10.0,
+                "slice_seq": 0,
+                "status": "CLOSED",
+            },
+            {
+                "entry_slice_id": "slice_open",
+                "entry_id": "entry_mixed_slices",
+                "symbol": "000001",
+                "guardian_price": 10.3,
+                "original_quantity": 100,
+                "remaining_quantity": 100,
+                "remaining_amount": 1030.0,
+                "sort_key": 10.3,
+                "slice_seq": 1,
+                "status": "OPEN",
+            },
+        ],
+    )
+
+    remaining, allocations = reconcile_service_module._allocate_gap_to_entry_slices(
+        repository=repository,
+        symbol="000001",
+        quantity=100,
+        resolution_id="resolution_mixed_slices",
+    )
+
+    assert remaining == 0
+    assert len(allocations) == 1
+    slices_by_id = {item["entry_slice_id"]: item for item in repository.entry_slices}
+    assert set(slices_by_id) == {"slice_closed", "slice_open"}
+    assert slices_by_id["slice_closed"]["status"] == "CLOSED"
+    assert slices_by_id["slice_open"]["status"] == "CLOSED"
+    assert allocations[0]["entry_slice_id"] in slices_by_id
+
+
 def test_partial_trade_shrinks_pending_gap_before_auto_close(monkeypatch):
     repository, service = _build_service(monkeypatch)
     buy_lot = build_buy_lot_from_trade_fact(
@@ -1399,6 +1540,7 @@ def test_partial_trade_shrinks_pending_gap_before_auto_close(monkeypatch):
     results = service.reconcile_trade_reports(
         [
             {
+                "account_id": "acct-test",
                 "order_id": 90003,
                 "traded_id": "T90003",
                 "stock_code": "000001.SZ",

--- a/freshquant/tests/test_order_management_submit_service.py
+++ b/freshquant/tests/test_order_management_submit_service.py
@@ -1,8 +1,12 @@
+import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import freshquant.order_management.submit.service as submit_service_module
 from freshquant.order_management.submit.service import OrderSubmitService
 from freshquant.position_management.models import PositionDecision
+
+TEST_ACCOUNT_ID = "acct-configured"
 
 
 class FakeQueueClient:
@@ -12,6 +16,14 @@ class FakeQueueClient:
     def lpush(self, queue_name, payload):
         self.messages.append((queue_name, payload))
         return len(self.messages)
+
+
+class CapturingRuntimeLogger:
+    def __init__(self):
+        self.events = []
+
+    def emit(self, event):
+        self.events.append(event)
 
 
 class InMemoryRepository:
@@ -85,6 +97,7 @@ def test_submit_service_enqueues_buy_and_marks_order_queued():
         queue_client=queue_client,
         position_management_service=AllowingPositionService(),
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: TEST_ACCOUNT_ID,
     )
 
     result = service.submit_order(
@@ -116,6 +129,7 @@ def test_submit_service_enqueues_cancel_and_preserves_cancel_requested_state():
         repository=repository,
         queue_client=queue_client,
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: TEST_ACCOUNT_ID,
     )
     create_result = service.submit_order(
         {
@@ -154,6 +168,7 @@ def test_credit_buy_persists_resolved_credit_metadata_and_queue_payload():
         queue_client=queue_client,
         position_management_service=AllowingPositionService(),
         account_type_loader=lambda: "CREDIT",
+        account_id_loader=lambda: TEST_ACCOUNT_ID,
         credit_subject_lookup=lambda _symbol: {"fin_status": 48},
         credit_subjects_available=lambda: True,
     )
@@ -188,6 +203,7 @@ def test_submit_service_default_runtime_logger_uses_isolated_test_runtime_root()
         queue_client=queue_client,
         position_management_service=AllowingPositionService(),
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: TEST_ACCOUNT_ID,
     )
 
     service.submit_order(
@@ -210,3 +226,83 @@ def test_submit_service_default_runtime_logger_uses_isolated_test_runtime_root()
 
     assert snapshot["written"] >= 1
     assert not emitted_path.is_relative_to(formal_root)
+
+
+def test_submit_service_pins_configured_account_and_beijing_trading_day(monkeypatch):
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            value = cls(2026, 8, 5, 1, 30, tzinfo=timezone.utc)
+            return value if tz is not None else value.replace(tzinfo=None)
+
+    monkeypatch.setattr(submit_service_module, "datetime", FixedDateTime)
+    repository = InMemoryRepository()
+    queue_client = FakeQueueClient()
+    runtime_logger = CapturingRuntimeLogger()
+    service = OrderSubmitService(
+        repository=repository,
+        queue_client=queue_client,
+        position_management_service=AllowingPositionService(),
+        account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: TEST_ACCOUNT_ID,
+        runtime_logger=runtime_logger,
+    )
+
+    result = service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "000001",
+            "price": 10.12,
+            "quantity": 500,
+            "source": "api",
+        }
+    )
+
+    assert repository.order_requests[0]["account_id"] == TEST_ACCOUNT_ID
+    assert repository.order_requests[0]["trading_day"] == 20260805
+    assert repository.orders[0]["account_id"] == TEST_ACCOUNT_ID
+    assert repository.orders[0]["trading_day"] == 20260805
+    queued = json.loads(queue_client.messages[0][1])
+    assert queued["account_id"] == TEST_ACCOUNT_ID
+    assert queued["trading_day"] == 20260805
+    assert result["queue_payload"]["account_id"] == TEST_ACCOUNT_ID
+
+    queue_events = [
+        event
+        for event in runtime_logger.events
+        if event.get("node") == "queue_payload_build"
+    ]
+    assert len(queue_events) == 1
+    assert "account_id" not in queue_events[0]["payload"]["queue_payload"]
+
+
+def test_submit_service_fails_closed_without_configured_account():
+    repository = InMemoryRepository()
+    queue_client = FakeQueueClient()
+    service = OrderSubmitService(
+        repository=repository,
+        queue_client=queue_client,
+        position_management_service=AllowingPositionService(),
+        account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: None,
+        runtime_logger=CapturingRuntimeLogger(),
+    )
+
+    try:
+        service.submit_order(
+            {
+                "action": "buy",
+                "symbol": "000001",
+                "price": 10.12,
+                "quantity": 500,
+                "source": "api",
+            }
+        )
+    except ValueError as error:
+        assert str(error) == "account_id is required"
+    else:
+        raise AssertionError("Expected missing account_id to fail closed")
+
+    assert repository.order_requests == []
+    assert repository.orders == []
+    assert queue_client.messages == []

--- a/freshquant/tests/test_order_management_tracking_service.py
+++ b/freshquant/tests/test_order_management_tracking_service.py
@@ -1,8 +1,13 @@
+import pytest
+
+from freshquant.order_management.broker_identity import BrokerIdentityError
 from freshquant.order_management.tracking.service import OrderTrackingService
 from freshquant.order_management.tracking.state_machine import (
     InvalidOrderTransition,
     OrderStateMachine,
 )
+
+TEST_ACCOUNT_ID = "acct-test"
 
 
 class InMemoryRepository:
@@ -49,6 +54,13 @@ class InMemoryRepository:
         saved = dict(document)
         self.execution_fills.append(saved)
         return saved, True
+
+    def list_execution_fills(self, *, broker_order_keys=None, **_kwargs):
+        rows = list(self.execution_fills)
+        if broker_order_keys is not None:
+            allowed = set(broker_order_keys)
+            rows = [item for item in rows if item.get("broker_order_key") in allowed]
+        return rows
 
     def find_order(self, internal_order_id):
         for order in self.orders:
@@ -140,6 +152,7 @@ def test_ingest_trade_report_is_idempotent_by_broker_trade_id():
     internal_order_id = repository.orders[0]["internal_order_id"]
     report = {
         "internal_order_id": internal_order_id,
+        "account_id": TEST_ACCOUNT_ID,
         "broker_trade_id": "T-001",
         "symbol": "000001",
         "side": "buy",
@@ -171,6 +184,7 @@ def test_ingest_trade_report_preserves_date_and_time_fields():
     internal_order_id = repository.orders[0]["internal_order_id"]
     report = {
         "internal_order_id": internal_order_id,
+        "account_id": TEST_ACCOUNT_ID,
         "broker_trade_id": "T-002",
         "symbol": "000001",
         "side": "buy",
@@ -203,6 +217,7 @@ def test_ingest_trade_report_with_meta_returns_created_flag():
     internal_order_id = repository.orders[0]["internal_order_id"]
     report = {
         "internal_order_id": internal_order_id,
+        "account_id": TEST_ACCOUNT_ID,
         "broker_trade_id": "T-003",
         "symbol": "000001",
         "side": "buy",
@@ -231,11 +246,13 @@ def test_ingest_trade_report_aggregates_execution_fills_into_one_broker_order():
             "quantity": 200,
             "source": "strategy",
             "internal_order_id": "ord_exec_agg_1",
+            "account_id": TEST_ACCOUNT_ID,
         }
     )
     service.ingest_order_report(
         {
             "internal_order_id": "ord_exec_agg_1",
+            "account_id": TEST_ACCOUNT_ID,
             "broker_order_id": "B-EXEC-1",
             "state": "QUEUED",
             "event_type": "xt_order_reported",
@@ -245,6 +262,7 @@ def test_ingest_trade_report_aggregates_execution_fills_into_one_broker_order():
     first = service.ingest_trade_report_with_meta(
         {
             "internal_order_id": "ord_exec_agg_1",
+            "account_id": TEST_ACCOUNT_ID,
             "broker_order_id": "B-EXEC-1",
             "broker_trade_id": "T-EXEC-1",
             "symbol": "000001",
@@ -258,6 +276,7 @@ def test_ingest_trade_report_aggregates_execution_fills_into_one_broker_order():
     second = service.ingest_trade_report_with_meta(
         {
             "internal_order_id": "ord_exec_agg_1",
+            "account_id": TEST_ACCOUNT_ID,
             "broker_order_id": "B-EXEC-1",
             "broker_trade_id": "T-EXEC-2",
             "symbol": "000001",
@@ -272,7 +291,10 @@ def test_ingest_trade_report_aggregates_execution_fills_into_one_broker_order():
     assert first["created"] is True
     assert second["created"] is True
     assert len(repository.execution_fills) == 2
-    aggregate = repository.find_broker_order("ord_exec_agg_1")
+    broker_order_key = (
+        "account:acct-test:day:20240310:symbol:000001:" "side:buy:order:B-EXEC-1"
+    )
+    aggregate = repository.find_broker_order(broker_order_key)
     assert aggregate["broker_order_id"] == "B-EXEC-1"
     assert aggregate["filled_quantity"] == 200
     assert aggregate["fill_count"] == 2
@@ -295,12 +317,14 @@ def test_ingest_trade_report_duplicate_trade_does_not_double_count_broker_order(
             "quantity": 100,
             "source": "strategy",
             "internal_order_id": "ord_exec_dup_1",
+            "account_id": TEST_ACCOUNT_ID,
         }
     )
 
     first = service.ingest_trade_report_with_meta(
         {
             "internal_order_id": "ord_exec_dup_1",
+            "account_id": TEST_ACCOUNT_ID,
             "broker_trade_id": "T-DUP-1",
             "symbol": "000001",
             "side": "buy",
@@ -313,6 +337,7 @@ def test_ingest_trade_report_duplicate_trade_does_not_double_count_broker_order(
     second = service.ingest_trade_report_with_meta(
         {
             "internal_order_id": "ord_exec_dup_1",
+            "account_id": TEST_ACCOUNT_ID,
             "broker_trade_id": "T-DUP-1",
             "symbol": "000001",
             "side": "buy",
@@ -331,7 +356,7 @@ def test_ingest_trade_report_duplicate_trade_does_not_double_count_broker_order(
     assert aggregate["fill_count"] == 1
 
 
-def test_ingest_trade_report_keeps_known_orders_on_internal_broker_order_key():
+def test_ingest_trade_report_migrates_known_order_to_canonical_broker_order_key():
     repository = InMemoryRepository()
     service = OrderTrackingService(repository=repository)
     service.submit_order(
@@ -342,12 +367,14 @@ def test_ingest_trade_report_keeps_known_orders_on_internal_broker_order_key():
             "quantity": 100,
             "source": "strategy",
             "internal_order_id": "ord_exec_alias_1",
+            "account_id": TEST_ACCOUNT_ID,
         }
     )
 
     service.ingest_trade_report_with_meta(
         {
             "internal_order_id": "ord_exec_alias_1",
+            "account_id": TEST_ACCOUNT_ID,
             "broker_order_key": "border_exec_alias_1",
             "broker_order_id": "B-EXEC-ALIAS-1",
             "broker_trade_id": "T-EXEC-ALIAS-1",
@@ -360,11 +387,15 @@ def test_ingest_trade_report_keeps_known_orders_on_internal_broker_order_key():
         }
     )
 
-    aggregate = repository.find_broker_order("ord_exec_alias_1")
+    broker_order_key = (
+        "account:acct-test:day:20240310:symbol:000001:" "side:buy:order:B-EXEC-ALIAS-1"
+    )
+    aggregate = repository.find_broker_order(broker_order_key)
     assert aggregate["internal_order_id"] == "ord_exec_alias_1"
     assert aggregate["broker_order_id"] == "B-EXEC-ALIAS-1"
     assert aggregate["state"] == "FILLED"
-    assert repository.execution_fills[0]["broker_order_key"] == "ord_exec_alias_1"
+    assert repository.execution_fills[0]["broker_order_key"] == broker_order_key
+    assert repository.find_broker_order("ord_exec_alias_1") is None
 
 
 def test_ingest_order_report_is_idempotent_when_state_is_unchanged():
@@ -529,3 +560,73 @@ def test_cancel_order_allows_transition_from_broker_bypassed():
     )
 
     assert repository.find_order("ord_bypass_cancel_1")["state"] == "CANCEL_REQUESTED"
+
+
+def test_execution_identity_does_not_deduplicate_same_trade_id_across_accounts():
+    repository = InMemoryRepository()
+    service = OrderTrackingService(repository=repository)
+    for account_id, internal_order_id in (
+        ("acct-a", "ord-account-a"),
+        ("acct-b", "ord-account-b"),
+    ):
+        service.submit_order(
+            {
+                "action": "buy",
+                "account_id": account_id,
+                "symbol": "000001",
+                "price": 12.34,
+                "quantity": 100,
+                "source": "strategy",
+                "internal_order_id": internal_order_id,
+            }
+        )
+        service.ingest_trade_report_with_meta(
+            {
+                "internal_order_id": internal_order_id,
+                "account_id": account_id,
+                "broker_trade_id": "shared-trade-id",
+                "symbol": "000001",
+                "side": "buy",
+                "quantity": 100,
+                "price": 12.30,
+                "trade_time": 1710000000,
+                "source": "xt_trade_callback",
+            }
+        )
+
+    assert len(repository.trade_facts) == 2
+    assert len(repository.execution_fills) == 2
+    assert len({item["execution_identity"] for item in repository.execution_fills}) == 2
+
+
+def test_execution_report_without_account_fails_closed():
+    repository = InMemoryRepository()
+    service = OrderTrackingService(repository=repository)
+    service.submit_order(
+        {
+            "action": "buy",
+            "account_id": TEST_ACCOUNT_ID,
+            "symbol": "000001",
+            "price": 12.34,
+            "quantity": 100,
+            "source": "strategy",
+            "internal_order_id": "ord-missing-account",
+        }
+    )
+
+    with pytest.raises(BrokerIdentityError, match="account_id"):
+        service.ingest_trade_report_with_meta(
+            {
+                "internal_order_id": "ord-missing-account",
+                "broker_trade_id": "trade-missing-account",
+                "symbol": "000001",
+                "side": "buy",
+                "quantity": 100,
+                "price": 12.30,
+                "trade_time": 1710000000,
+                "source": "xt_trade_callback",
+            }
+        )
+
+    assert repository.trade_facts == []
+    assert repository.execution_fills == []

--- a/freshquant/tests/test_order_management_tracking_service.py
+++ b/freshquant/tests/test_order_management_tracking_service.py
@@ -74,6 +74,21 @@ class InMemoryRepository:
                 return order
         return None
 
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def compare_and_set_broker_order(self, *, before, after):
+        current = self.find_broker_order(before["broker_order_key"])
+        if current != before:
+            return None
+        current.clear()
+        current.update(after)
+        return current
+
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)
         if order is None:
@@ -630,3 +645,157 @@ def test_execution_report_without_account_fails_closed():
 
     assert repository.trade_facts == []
     assert repository.execution_fills == []
+
+
+def test_broker_fill_aggregate_retries_after_interleaved_order_report_update():
+    class InterleavingRepository(InMemoryRepository):
+        def __init__(self):
+            super().__init__()
+            self.inject_report_update = False
+
+        def compare_and_set_broker_order(self, *, before, after):
+            if self.inject_report_update:
+                self.inject_report_update = False
+                self.update_broker_order_fields(
+                    before["broker_order_key"],
+                    {
+                        "submitted_at": "2026-08-05T01:31:00+00:00",
+                        "report_marker": "interleaved",
+                    },
+                )
+                return None
+            return super().compare_and_set_broker_order(before=before, after=after)
+
+    repository = InterleavingRepository()
+    service = OrderTrackingService(repository=repository)
+    service.submit_order(
+        {
+            "action": "buy",
+            "account_id": TEST_ACCOUNT_ID,
+            "trading_day": 20260805,
+            "symbol": "000001",
+            "price": 12.34,
+            "quantity": 100,
+            "source": "strategy",
+            "internal_order_id": "ord-interleaved-report",
+        }
+    )
+    service.ingest_order_report(
+        {
+            "internal_order_id": "ord-interleaved-report",
+            "account_id": TEST_ACCOUNT_ID,
+            "trading_day": 20260805,
+            "broker_order_id": "B-INTERLEAVED",
+            "symbol": "000001",
+            "side": "buy",
+            "state": "QUEUED",
+            "event_type": "xt_order_reported",
+        }
+    )
+    repository.inject_report_update = True
+
+    service.ingest_trade_report_with_meta(
+        {
+            "internal_order_id": "ord-interleaved-report",
+            "account_id": TEST_ACCOUNT_ID,
+            "trading_day": 20260805,
+            "broker_order_id": "B-INTERLEAVED",
+            "broker_trade_id": "T-INTERLEAVED",
+            "symbol": "000001",
+            "side": "buy",
+            "quantity": 100,
+            "price": 12.30,
+            "trade_time": 1785893460,
+            "source": "xt_trade_callback",
+        }
+    )
+
+    key = "account:acct-test:day:20260805:symbol:000001:" "side:buy:order:B-INTERLEAVED"
+    aggregate = repository.find_broker_order(key)
+    assert aggregate["filled_quantity"] == 100
+    assert aggregate["fill_count"] == 1
+    assert aggregate["state"] == "FILLED"
+    assert aggregate["submitted_at"] == "2026-08-05T01:31:00+00:00"
+    assert aggregate["report_marker"] == "interleaved"
+
+
+def test_broker_fill_aggregate_rechecks_fill_fingerprint_after_cas():
+    class LateFillRepository(InMemoryRepository):
+        def __init__(self):
+            super().__init__()
+            self.inject_late_fill = False
+
+        def compare_and_set_broker_order(self, *, before, after):
+            saved = super().compare_and_set_broker_order(before=before, after=after)
+            if saved is not None and self.inject_late_fill:
+                self.inject_late_fill = False
+                self.execution_fills.append(
+                    {
+                        "execution_fill_id": "fill-late",
+                        "execution_identity": "acct-test|20260805|000001|buy|T-LATE",
+                        "broker_order_key": after["broker_order_key"],
+                        "internal_order_id": "ord-late-fill",
+                        "account_id": TEST_ACCOUNT_ID,
+                        "trading_day": 20260805,
+                        "broker_order_id": "B-LATE-FILL",
+                        "broker_trade_id": "T-LATE",
+                        "symbol": "000001",
+                        "side": "buy",
+                        "quantity": 100,
+                        "price": 12.50,
+                        "trade_time": 1785893465,
+                    }
+                )
+            return saved
+
+    repository = LateFillRepository()
+    service = OrderTrackingService(repository=repository)
+    service.submit_order(
+        {
+            "action": "buy",
+            "account_id": TEST_ACCOUNT_ID,
+            "trading_day": 20260805,
+            "symbol": "000001",
+            "price": 12.34,
+            "quantity": 200,
+            "source": "strategy",
+            "internal_order_id": "ord-late-fill",
+        }
+    )
+    service.ingest_order_report(
+        {
+            "internal_order_id": "ord-late-fill",
+            "account_id": TEST_ACCOUNT_ID,
+            "trading_day": 20260805,
+            "broker_order_id": "B-LATE-FILL",
+            "symbol": "000001",
+            "side": "buy",
+            "state": "QUEUED",
+            "event_type": "xt_order_reported",
+        }
+    )
+    repository.inject_late_fill = True
+
+    service.ingest_trade_report_with_meta(
+        {
+            "internal_order_id": "ord-late-fill",
+            "account_id": TEST_ACCOUNT_ID,
+            "trading_day": 20260805,
+            "broker_order_id": "B-LATE-FILL",
+            "broker_trade_id": "T-FIRST",
+            "symbol": "000001",
+            "side": "buy",
+            "quantity": 100,
+            "price": 12.30,
+            "trade_time": 1785893460,
+            "source": "xt_trade_callback",
+        }
+    )
+
+    key = "account:acct-test:day:20260805:symbol:000001:" "side:buy:order:B-LATE-FILL"
+    aggregate = repository.find_broker_order(key)
+    assert aggregate["filled_quantity"] == 200
+    assert aggregate["fill_count"] == 2
+    assert aggregate["avg_filled_price"] == 12.4
+    assert aggregate["state"] == "FILLED"
+    assert aggregate["aggregate_revision"] >= 2

--- a/freshquant/tests/test_order_management_xt_ingest.py
+++ b/freshquant/tests/test_order_management_xt_ingest.py
@@ -1,6 +1,9 @@
+from datetime import datetime, timezone
+
 import pytest
 
 import freshquant.order_management.ingest.xt_reports as xt_reports_module
+import freshquant.order_management.submit.service as submit_service_module
 from freshquant.order_management.broker_identity import (
     BrokerIdentityConflict,
     BrokerIdentityError,
@@ -12,9 +15,7 @@ from freshquant.order_management.ingest.xt_reports import (
     normalize_xt_order_report,
     normalize_xt_trade_report,
 )
-from freshquant.order_management.projection.stock_fills import (
-    build_arranged_fills_view,
-)
+from freshquant.order_management.submit.service import OrderSubmitService
 from freshquant.order_management.tracking.service import OrderTrackingService
 
 
@@ -70,6 +71,103 @@ class InMemoryRepository:
         self.execution_fills.append(saved)
         return saved, True
 
+    def prepare_execution_projection(self, execution_identity, projection_plan):
+        for execution_fill in self.execution_fills:
+            if execution_fill.get("execution_identity") != execution_identity:
+                continue
+            if execution_fill.get("projection_status") != "PENDING":
+                return execution_fill
+            stored_plan = execution_fill.get("projection_plan")
+            if stored_plan is None:
+                execution_fill["projection_plan"] = projection_plan
+                execution_fill["projection_group_progress"] = {
+                    group["operation_id"]: 0
+                    for group_name in ("lot_slice_groups", "entry_slice_groups")
+                    for group in projection_plan.get(group_name) or []
+                }
+            return execution_fill
+        raise AssertionError("execution fill not found")
+
+    def get_execution_projection_group_progress(
+        self,
+        execution_identity,
+        operation_id,
+    ):
+        execution_fill = next(
+            item
+            for item in self.execution_fills
+            if item.get("execution_identity") == execution_identity
+        )
+        return int(execution_fill["projection_group_progress"][operation_id])
+
+    def advance_execution_projection_group_progress(
+        self,
+        execution_identity,
+        operation_id,
+        *,
+        expected_step,
+        next_step,
+    ):
+        execution_fill = next(
+            item
+            for item in self.execution_fills
+            if item.get("execution_identity") == execution_identity
+        )
+        progress = execution_fill["projection_group_progress"]
+        current = int(progress[operation_id])
+        if current == int(next_step):
+            return current
+        if current != int(expected_step):
+            raise BrokerIdentityConflict("projection progress CAS mismatch")
+        progress[operation_id] = int(next_step)
+        return int(next_step)
+
+    def mark_execution_projection_applied(self, execution_identity, *, applied_at):
+        for execution_fill in self.execution_fills:
+            if execution_fill.get("execution_identity") != execution_identity:
+                continue
+            execution_fill["projection_status"] = "APPLIED"
+            execution_fill["projection_applied_at"] = applied_at
+            return execution_fill
+        raise AssertionError("execution fill not found")
+
+    def compare_and_set_projection_document(
+        self,
+        projection_type,
+        *,
+        before,
+        after,
+    ):
+        targets = {
+            "buy_lot": (self.buy_lots, "buy_lot_id"),
+            "lot_slice": (self.lot_slices, "lot_slice_id"),
+            "position_entry": (self.position_entries, "entry_id"),
+            "entry_slice": (self.entry_slices, "entry_slice_id"),
+        }
+        collection, identity_field = targets[projection_type]
+        identity = (after or before)[identity_field]
+        matches = [
+            (index, document)
+            for index, document in enumerate(collection)
+            if document.get(identity_field) == identity
+        ]
+        if len(matches) > 1:
+            raise BrokerIdentityConflict("projection CAS found duplicate identity")
+        current = matches[0][1] if matches else None
+        if current == after:
+            return current
+        if current != before:
+            raise BrokerIdentityConflict("projection CAS preimage mismatch")
+        if after is None:
+            if matches:
+                del collection[matches[0][0]]
+            return None
+        if matches:
+            collection[matches[0][0]] = dict(after)
+        else:
+            collection.append(dict(after))
+        return after
+
     def list_execution_fills(self, *, broker_order_keys=None, **_kwargs):
         rows = list(self.execution_fills)
         if broker_order_keys is not None:
@@ -87,6 +185,12 @@ class InMemoryRepository:
         for request in self.order_requests:
             if request["request_id"] == request_id:
                 return request
+        return None
+
+    def find_order_by_request_id(self, request_id):
+        for order in self.orders:
+            if order.get("request_id") == request_id:
+                return order
         return None
 
     def find_broker_order(self, broker_order_key):
@@ -108,8 +212,28 @@ class InMemoryRepository:
             if str(order.get("broker_order_id")) == str(broker_order_id)
         ]
 
-    def list_orders(self):
-        return list(self.orders)
+    def find_order_by_broker_correlation_token(self, token):
+        for order in self.orders:
+            if order.get("broker_correlation_token") == token:
+                return order
+        return None
+
+    def list_orders(
+        self,
+        symbol=None,
+        states=None,
+        missing_broker_only=False,
+        **_kwargs,
+    ):
+        rows = list(self.orders)
+        if symbol is not None:
+            rows = [item for item in rows if item.get("symbol") == symbol]
+        if states is not None:
+            allowed = set(states)
+            rows = [item for item in rows if item.get("state") in allowed]
+        if missing_broker_only:
+            rows = [item for item in rows if item.get("broker_order_id") in (None, "")]
+        return rows
 
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)
@@ -124,6 +248,12 @@ class InMemoryRepository:
                 return buy_lot
         return None
 
+    def find_buy_lot(self, buy_lot_id):
+        for buy_lot in self.buy_lots:
+            if buy_lot["buy_lot_id"] == buy_lot_id:
+                return buy_lot
+        return None
+
     def insert_buy_lot(self, document):
         self.buy_lots.append(document)
         return document
@@ -133,6 +263,13 @@ class InMemoryRepository:
             item for item in self.lot_slices if item["buy_lot_id"] != buy_lot_id
         ]
         self.lot_slices.extend(slices)
+
+    def list_lot_slices(self, *, buy_lot_ids=None):
+        rows = list(self.lot_slices)
+        if buy_lot_ids is not None:
+            allowed = set(buy_lot_ids)
+            rows = [item for item in rows if item.get("buy_lot_id") in allowed]
+        return [dict(item) for item in rows]
 
     def list_buy_lots(self, symbol):
         return [item for item in self.buy_lots if item["symbol"] == symbol]
@@ -160,8 +297,7 @@ class InMemoryRepository:
         self.lot_slices.extend(slices)
 
     def insert_sell_allocations(self, allocations):
-        self.sell_allocations.extend(allocations)
-        return allocations
+        return self._insert_allocations(self.sell_allocations, allocations)
 
     def replace_position_entry(self, document):
         for index, current in enumerate(self.position_entries):
@@ -170,6 +306,12 @@ class InMemoryRepository:
                 return document
         self.position_entries.append(dict(document))
         return document
+
+    def find_position_entry(self, entry_id):
+        for item in self.position_entries:
+            if item.get("entry_id") == entry_id:
+                return item
+        return None
 
     def list_position_entries(self, *, symbol=None, entry_ids=None, status=None):
         rows = list(self.position_entries)
@@ -220,7 +362,26 @@ class InMemoryRepository:
         return [dict(item) for item in rows]
 
     def insert_exit_allocations(self, allocations):
-        self.exit_allocations.extend(dict(item) for item in allocations)
+        return self._insert_allocations(self.exit_allocations, allocations)
+
+    @staticmethod
+    def _insert_allocations(collection, allocations):
+        seen = set()
+        for raw_document in allocations:
+            document = dict(raw_document)
+            allocation_id = str(document.get("allocation_id") or "").strip()
+            if not allocation_id or allocation_id in seen:
+                raise BrokerIdentityConflict("allocation_id is missing or duplicate")
+            seen.add(allocation_id)
+            existing = [
+                item
+                for item in collection
+                if item.get("allocation_id") == allocation_id
+            ]
+            if len(existing) > 1 or (existing and existing[0] != document):
+                raise BrokerIdentityConflict("allocation_id conflicts")
+            if not existing:
+                collection.append(document)
         return allocations
 
     def insert_ingest_rejection(self, document):
@@ -288,6 +449,36 @@ def _stub_ingest_side_effects(monkeypatch):
         )(),
         raising=False,
     )
+
+
+def test_ingest_service_defers_default_tpsl_construction_until_buy_notification(
+    monkeypatch,
+):
+    constructed = []
+    notifications = []
+
+    class FakeTpslService:
+        def on_new_buy_trade(self, *, symbol, buy_price):
+            notifications.append((symbol, buy_price))
+
+    monkeypatch.setattr(
+        xt_reports_module,
+        "_get_tpsl_service",
+        lambda: constructed.append(True) or FakeTpslService(),
+    )
+
+    service = OrderManagementXtIngestService(
+        repository=InMemoryRepository(),
+        tracking_service=object(),
+    )
+
+    assert constructed == []
+
+    service._notify_new_buy_trade(symbol="000001", price=10.5)
+    service._notify_new_buy_trade(symbol="000001", price=10.6)
+
+    assert constructed == [True]
+    assert notifications == [("000001", 10.5), ("000001", 10.6)]
 
 
 def _noop_sync_stock_fills_compat(symbol, repository=None):
@@ -651,6 +842,392 @@ def test_normalize_xt_order_report_maps_broker_order_back_to_internal_order():
     assert normalized["state"] == "CANCELED"
 
 
+def test_configured_submit_identity_binds_first_xt_report_to_original_order(
+    monkeypatch,
+):
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            value = cls(2026, 8, 5, 1, 30, tzinfo=timezone.utc)
+            return value if tz is not None else value.replace(tzinfo=None)
+
+    class QueueClient:
+        def __init__(self):
+            self.messages = []
+
+        def lpush(self, queue_name, payload):
+            self.messages.append((queue_name, payload))
+            return len(self.messages)
+
+    class RuntimeLogger:
+        def emit(self, _event):
+            return None
+
+    monkeypatch.setattr(submit_service_module, "datetime", FixedDateTime)
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    submit_service = OrderSubmitService(
+        repository=repository,
+        tracking_service=tracking_service,
+        queue_client=QueueClient(),
+        position_management_service=object(),
+        account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-configured",
+        runtime_logger=RuntimeLogger(),
+    )
+    submitted = submit_service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "688772",
+            "price": 14.7,
+            "quantity": 10000,
+            "source": "api",
+        }
+    )
+    ingest_service = OrderManagementXtIngestService(
+        repository=repository,
+        tracking_service=tracking_service,
+        tpsl_service=None,
+        runtime_logger=RuntimeLogger(),
+    )
+
+    normalized = ingest_service.ingest_order_report(
+        {
+            "order_id": 90001,
+            "account_id": "acct-configured",
+            "stock_code": "688772.SH",
+            "order_type": 23,
+            "order_remark": submitted["queue_payload"]["broker_correlation_token"],
+            "order_time": int(
+                datetime(2026, 8, 5, 1, 31, tzinfo=timezone.utc).timestamp()
+            ),
+            "order_status": 50,
+        }
+    )
+
+    assert repository.order_requests[0]["trading_day"] == 20260805
+    assert repository.orders[0]["trading_day"] == 20260805
+    assert normalized["internal_order_id"] == submitted["internal_order_id"]
+    assert repository.orders[0]["internal_order_id"] == submitted["internal_order_id"]
+    assert repository.orders[0]["broker_order_id"] == "90001"
+    assert len(repository.orders) == 1
+    assert len(submitted["queue_payload"]["broker_correlation_token"]) == 24
+
+
+def test_first_xt_report_with_multiple_unbound_candidates_fails_closed():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    for internal_order_id in ("ord-unbound-a", "ord-unbound-b"):
+        tracking_service.submit_order(
+            {
+                "action": "buy",
+                "account_id": "acct-configured",
+                "trading_day": 20260805,
+                "symbol": "688772",
+                "price": 14.7,
+                "quantity": 10000,
+                "source": "api",
+                "internal_order_id": internal_order_id,
+            }
+        )
+
+    with pytest.raises(BrokerIdentityConflict, match="correlation token"):
+        normalize_xt_order_report(
+            {
+                "order_id": 90002,
+                "account_id": "acct-configured",
+                "stock_code": "688772.SH",
+                "order_type": 23,
+                "order_time": int(
+                    datetime(2026, 8, 5, 1, 31, tzinfo=timezone.utc).timestamp()
+                ),
+                "order_status": 50,
+            },
+            repository=repository,
+        )
+
+    assert len(repository.orders) == 2
+    assert all(order.get("broker_order_id") is None for order in repository.orders)
+    assert repository.ingest_rejections[-1]["reason_code"] == (
+        "broker_identity_conflict"
+    )
+
+
+@pytest.mark.parametrize(
+    ("order_remark", "error_match"),
+    [
+        ("FQOMshort", "malformed"),
+        ("FQOM00000000000000000000", "unknown"),
+    ],
+)
+def test_first_xt_report_with_invalid_correlation_token_is_quarantined(
+    order_remark,
+    error_match,
+):
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-configured",
+            "trading_day": 20260805,
+            "symbol": "688772",
+            "price": 14.7,
+            "quantity": 10000,
+            "source": "api",
+            "internal_order_id": "ord-invalid-token",
+        }
+    )
+    assert (
+        repository.find_order("ord-invalid-token")["broker_correlation_token"]
+        != order_remark
+    )
+
+    with pytest.raises(BrokerIdentityConflict, match=error_match):
+        normalize_xt_order_report(
+            {
+                "order_id": 90007,
+                "account_id": "acct-configured",
+                "stock_code": "688772.SH",
+                "order_type": 23,
+                "order_remark": order_remark,
+                "order_time": int(
+                    datetime(2026, 8, 5, 1, 31, tzinfo=timezone.utc).timestamp()
+                ),
+                "order_status": 50,
+            },
+            repository=repository,
+        )
+
+    assert repository.find_order("ord-invalid-token")["broker_order_id"] is None
+    assert repository.ingest_rejections[-1]["reason_code"] == (
+        "broker_identity_conflict"
+    )
+
+
+def test_explicit_internal_order_id_conflicting_with_token_is_quarantined():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    for internal_order_id in ("ord-pinned-owner", "ord-token-owner"):
+        tracking_service.submit_order(
+            {
+                "action": "buy",
+                "account_id": "acct-configured",
+                "trading_day": 20260805,
+                "symbol": "688772",
+                "price": 14.7,
+                "quantity": 10000,
+                "source": "api",
+                "internal_order_id": internal_order_id,
+            }
+        )
+    token_order = repository.find_order("ord-token-owner")
+
+    with pytest.raises(BrokerIdentityConflict, match="pinned internal order"):
+        normalize_xt_order_report(
+            {
+                "internal_order_id": "ord-pinned-owner",
+                "order_id": 90008,
+                "account_id": "acct-configured",
+                "stock_code": "688772.SH",
+                "order_type": 23,
+                "order_remark": token_order["broker_correlation_token"],
+                "order_time": int(
+                    datetime(2026, 8, 5, 1, 31, tzinfo=timezone.utc).timestamp()
+                ),
+                "order_status": 50,
+            },
+            repository=repository,
+        )
+
+    assert all(order.get("broker_order_id") is None for order in repository.orders)
+    assert repository.ingest_rejections[-1]["reason_code"] == (
+        "broker_identity_conflict"
+    )
+
+
+def test_first_xt_report_without_token_never_binds_unique_unbound_order():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-configured",
+            "trading_day": 20260805,
+            "symbol": "688772",
+            "price": 14.7,
+            "quantity": 10000,
+            "source": "api",
+            "broker_order_type": 27,
+            "internal_order_id": "ord-unbound-only",
+        }
+    )
+
+    with pytest.raises(BrokerIdentityConflict, match="correlation token"):
+        normalize_xt_order_report(
+            {
+                "order_id": 90003,
+                "account_id": "acct-configured",
+                "stock_code": "688772.SH",
+                "order_type": 23,
+                "order_volume": 100,
+                "price": 99.99,
+                "order_time": int(
+                    datetime(2026, 8, 5, 1, 31, tzinfo=timezone.utc).timestamp()
+                ),
+                "order_status": 50,
+            },
+            repository=repository,
+        )
+
+    assert repository.orders[0]["broker_order_id"] is None
+    assert repository.ingest_rejections[-1]["reason_code"] == (
+        "broker_identity_conflict"
+    )
+
+
+def test_correlation_token_rejects_conflicting_broker_order_type():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-configured",
+            "trading_day": 20260805,
+            "symbol": "688772",
+            "price": 14.7,
+            "quantity": 10000,
+            "source": "api",
+            "broker_order_type": 27,
+            "internal_order_id": "ord-token-type-conflict",
+        }
+    )
+    order = repository.find_order("ord-token-type-conflict")
+
+    with pytest.raises(BrokerIdentityConflict, match="broker_order_type"):
+        normalize_xt_order_report(
+            {
+                "order_id": 90004,
+                "account_id": "acct-configured",
+                "stock_code": "688772.SH",
+                "order_type": 23,
+                "order_remark": order["broker_correlation_token"],
+                "order_time": int(
+                    datetime(2026, 8, 5, 1, 31, tzinfo=timezone.utc).timestamp()
+                ),
+                "order_status": 50,
+            },
+            repository=repository,
+        )
+
+    assert order["broker_order_id"] is None
+
+
+def test_legacy_bound_candidate_plus_unbound_candidate_fails_closed():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-configured",
+            "trading_day": 20260805,
+            "symbol": "688772",
+            "price": 14.7,
+            "quantity": 10000,
+            "source": "api",
+            "internal_order_id": "ord-legacy-bound",
+        }
+    )
+    repository.update_order(
+        "ord-legacy-bound",
+        {"state": "SUBMITTED", "broker_order_id": "90005"},
+    )
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-configured",
+            "trading_day": 20260805,
+            "symbol": "688772",
+            "price": 14.7,
+            "quantity": 10000,
+            "source": "api",
+            "internal_order_id": "ord-unbound-current",
+        }
+    )
+
+    with pytest.raises(BrokerIdentityConflict, match="correlation token"):
+        normalize_xt_order_report(
+            {
+                "order_id": 90005,
+                "account_id": "acct-configured",
+                "stock_code": "688772.SH",
+                "order_type": 23,
+                "order_time": int(
+                    datetime(2026, 8, 5, 1, 31, tzinfo=timezone.utc).timestamp()
+                ),
+                "order_status": 50,
+            },
+            repository=repository,
+        )
+
+    assert repository.find_order("ord-unbound-current")["broker_order_id"] is None
+
+
+def test_correlation_token_rejects_broker_identity_owned_by_another_order():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-configured",
+            "trading_day": 20260805,
+            "symbol": "688772",
+            "price": 14.7,
+            "quantity": 10000,
+            "source": "api",
+            "internal_order_id": "ord-existing-broker-owner",
+        }
+    )
+    repository.update_order(
+        "ord-existing-broker-owner",
+        {"state": "SUBMITTED", "broker_order_id": "90006"},
+    )
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-configured",
+            "trading_day": 20260805,
+            "symbol": "688772",
+            "price": 14.7,
+            "quantity": 10000,
+            "source": "api",
+            "internal_order_id": "ord-token-new-owner",
+        }
+    )
+    token_order = repository.find_order("ord-token-new-owner")
+
+    with pytest.raises(BrokerIdentityConflict, match="already owned"):
+        normalize_xt_order_report(
+            {
+                "order_id": 90006,
+                "account_id": "acct-configured",
+                "stock_code": "688772.SH",
+                "order_type": 23,
+                "order_remark": token_order["broker_correlation_token"],
+                "order_time": int(
+                    datetime(2026, 8, 5, 1, 31, tzinfo=timezone.utc).timestamp()
+                ),
+                "order_status": 50,
+            },
+            repository=repository,
+        )
+
+    assert (
+        repository.find_order("ord-existing-broker-owner")["broker_order_id"] == "90006"
+    )
+    assert token_order["broker_order_id"] is None
+
+
 def test_normalize_xt_order_report_creates_deterministic_broker_only_identity():
     repository = InMemoryRepository()
 
@@ -968,6 +1545,379 @@ def test_repeated_callback_does_not_duplicate_trade_fact_or_projection():
     assert len(repository.list_open_slices("000001")) == 4
 
 
+def test_pending_buy_projection_replay_recovers_missing_entry(monkeypatch):
+    _stub_ingest_side_effects(monkeypatch)
+    repository, ingest_service = _bootstrap_service()
+    original_compare_and_set = repository.compare_and_set_projection_document
+    failed = False
+
+    def fail_before_entry_write(projection_type, *, before, after):
+        nonlocal failed
+        if projection_type == "position_entry" and not failed:
+            failed = True
+            raise RuntimeError("simulated crash before entry write")
+        return original_compare_and_set(
+            projection_type,
+            before=before,
+            after=after,
+        )
+
+    monkeypatch.setattr(
+        repository,
+        "compare_and_set_projection_document",
+        fail_before_entry_write,
+    )
+    report = _buy_report("T-PENDING-BUY")
+
+    with pytest.raises(RuntimeError, match="before entry write"):
+        ingest_service.ingest_trade_report(
+            report,
+            lot_amount=3000,
+            grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+        )
+
+    execution_fill = repository.execution_fills[0]
+    assert execution_fill["projection_status"] == "PENDING"
+    assert execution_fill["projection_plan"] is not None
+    assert repository.position_entries == []
+    assert len(repository.buy_lots) == 1
+
+    monkeypatch.setattr(
+        repository,
+        "compare_and_set_projection_document",
+        original_compare_and_set,
+    )
+    replay = ingest_service.ingest_trade_report(
+        report,
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    second_replay = ingest_service.ingest_trade_report(
+        report,
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    assert replay["created"] is False
+    assert replay["position_entry"] is not None
+    assert repository.execution_fills[0]["projection_status"] == "APPLIED"
+    assert len(repository.position_entries) == 1
+    assert len(repository.buy_lots) == 1
+    assert len(repository.entry_slices) == 4
+    assert second_replay["created"] is False
+    assert len(repository.position_entries) == 1
+
+
+def test_projection_apply_cas_preserves_concurrent_entry_change(monkeypatch):
+    repository = InMemoryRepository()
+    before = {
+        "entry_id": "entry-cas",
+        "symbol": "000001",
+        "remaining_quantity": 900,
+        "status": "OPEN",
+    }
+    after = {**before, "remaining_quantity": 400}
+    repository.position_entries.append(dict(before))
+    original_compare_and_set = repository.compare_and_set_projection_document
+
+    def concurrent_change(projection_type, *, before, after):
+        if projection_type == "position_entry":
+            repository.position_entries[0] = {
+                **repository.position_entries[0],
+                "remaining_quantity": 777,
+            }
+        return original_compare_and_set(
+            projection_type,
+            before=before,
+            after=after,
+        )
+
+    monkeypatch.setattr(
+        repository,
+        "compare_and_set_projection_document",
+        concurrent_change,
+    )
+    projection_plan = {
+        "version": 1,
+        "side": "sell",
+        "buy_lots": [],
+        "lot_slice_groups": [],
+        "position_entries": [{"before": before, "after": after}],
+        "entry_slice_groups": [],
+        "sell_allocations": [],
+        "exit_allocations": [],
+    }
+
+    with pytest.raises(BrokerIdentityConflict, match="preimage mismatch"):
+        xt_reports_module._apply_execution_projection_plan(
+            repository=repository,
+            projection_plan=projection_plan,
+        )
+
+    assert repository.position_entries[0]["remaining_quantity"] == 777
+
+
+def test_projection_apply_cas_preserves_concurrent_slice_change(monkeypatch):
+    repository = InMemoryRepository()
+    before = [
+        {
+            "entry_slice_id": "slice-cas-1",
+            "entry_id": "entry-cas",
+            "remaining_quantity": 500,
+        },
+        {
+            "entry_slice_id": "slice-cas-2",
+            "entry_id": "entry-cas",
+            "remaining_quantity": 400,
+        },
+    ]
+    after = [
+        {**before[0], "remaining_quantity": 0},
+        dict(before[1]),
+    ]
+    repository.entry_slices.extend(dict(item) for item in before)
+    original_compare_and_set = repository.compare_and_set_projection_document
+
+    def concurrent_change(projection_type, *, before, after):
+        if projection_type == "entry_slice":
+            repository.entry_slices[0] = {
+                **repository.entry_slices[0],
+                "remaining_quantity": 333,
+            }
+        return original_compare_and_set(
+            projection_type,
+            before=before,
+            after=after,
+        )
+
+    monkeypatch.setattr(
+        repository,
+        "compare_and_set_projection_document",
+        concurrent_change,
+    )
+    projection_plan = {
+        "version": 1,
+        "side": "sell",
+        "buy_lots": [],
+        "lot_slice_groups": [],
+        "position_entries": [],
+        "entry_slice_groups": [
+            {
+                "entry_id": "entry-cas",
+                "before": before,
+                "after": after,
+            }
+        ],
+        "sell_allocations": [],
+        "exit_allocations": [],
+    }
+
+    with pytest.raises(BrokerIdentityConflict, match="preimage mismatch"):
+        xt_reports_module._apply_execution_projection_plan(
+            repository=repository,
+            projection_plan=projection_plan,
+        )
+
+    assert repository.entry_slices[0]["remaining_quantity"] == 333
+
+
+def test_projection_group_recovery_accepts_only_deterministic_prefix_states():
+    before = [
+        {"entry_slice_id": "slice-1", "remaining_quantity": 500},
+        {"entry_slice_id": "slice-2", "remaining_quantity": 400},
+    ]
+    after = [
+        {**before[0], "remaining_quantity": 0},
+        {**before[1], "remaining_quantity": 0},
+    ]
+
+    assert (
+        xt_reports_module._assert_projection_group_recoverable(
+            [after[0], before[1]],
+            before=before,
+            after=after,
+            identity_field="entry_slice_id",
+            label="entry_slices:entry-1",
+        )
+        == 1
+    )
+    for current in (
+        [],
+        [before[0]],
+        [before[0], after[1]],
+        [*before, {"entry_slice_id": "slice-extra", "remaining_quantity": 1}],
+    ):
+        with pytest.raises(BrokerIdentityConflict, match="diverged"):
+            xt_reports_module._assert_projection_group_recoverable(
+                current,
+                before=before,
+                after=after,
+                identity_field="entry_slice_id",
+                label="entry_slices:entry-1",
+            )
+
+
+@pytest.mark.parametrize(
+    "allocations",
+    [
+        [{"allocated_quantity": 100}],
+        [
+            {"allocation_id": "alloc-duplicate", "allocated_quantity": 100},
+            {"allocation_id": "alloc-duplicate", "allocated_quantity": 100},
+        ],
+    ],
+)
+def test_projection_plan_rejects_missing_or_duplicate_allocation_ids(allocations):
+    projection_plan = {
+        "version": 1,
+        "side": "sell",
+        "buy_lots": [],
+        "lot_slice_groups": [],
+        "position_entries": [],
+        "entry_slice_groups": [],
+        "sell_allocations": [],
+        "exit_allocations": allocations,
+    }
+
+    with pytest.raises(BrokerIdentityConflict, match="allocation"):
+        xt_reports_module._apply_execution_projection_plan(
+            repository=InMemoryRepository(),
+            projection_plan=projection_plan,
+        )
+
+
+def test_projection_allocation_insert_does_not_overwrite_concurrent_value(
+    monkeypatch,
+):
+    repository = InMemoryRepository()
+    expected = {"allocation_id": "alloc-cas", "allocated_quantity": 100}
+    concurrent = {"allocation_id": "alloc-cas", "allocated_quantity": 77}
+    original_insert = repository.insert_exit_allocations
+
+    def concurrent_insert(allocations):
+        repository.exit_allocations.append(dict(concurrent))
+        return original_insert(allocations)
+
+    monkeypatch.setattr(repository, "insert_exit_allocations", concurrent_insert)
+    projection_plan = {
+        "version": 1,
+        "side": "sell",
+        "buy_lots": [],
+        "lot_slice_groups": [],
+        "position_entries": [],
+        "entry_slice_groups": [],
+        "sell_allocations": [],
+        "exit_allocations": [expected],
+    }
+
+    with pytest.raises(BrokerIdentityConflict, match="allocation_id conflicts"):
+        xt_reports_module._apply_execution_projection_plan(
+            repository=repository,
+            projection_plan=projection_plan,
+        )
+
+    assert repository.exit_allocations == [concurrent]
+
+
+def test_projection_allocation_insert_requires_final_postimage(monkeypatch):
+    repository = InMemoryRepository()
+    expected = {"allocation_id": "alloc-final", "allocated_quantity": 100}
+    monkeypatch.setattr(
+        repository,
+        "insert_exit_allocations",
+        lambda _allocations: None,
+    )
+
+    with pytest.raises(BrokerIdentityConflict, match="allocation is missing"):
+        xt_reports_module._persist_projection_allocations(
+            repository,
+            allocation_type="exit",
+            documents=[expected],
+        )
+
+    assert repository.exit_allocations == []
+
+
+def test_final_projection_assertion_detects_postimage_changed_after_apply(monkeypatch):
+    _stub_ingest_side_effects(monkeypatch)
+    repository, ingest_service = _bootstrap_service()
+    original_build_entry_projections = xt_reports_module._build_entry_projections
+
+    def mutate_applied_entry(symbol, *, repository):
+        repository.position_entries[0]["concurrent_marker"] = "changed-after-apply"
+        return original_build_entry_projections(symbol, repository=repository)
+
+    monkeypatch.setattr(
+        xt_reports_module,
+        "_build_entry_projections",
+        mutate_applied_entry,
+    )
+
+    with pytest.raises(
+        BrokerIdentityConflict,
+        match="postimage diverged at position_entry",
+    ):
+        ingest_service.ingest_trade_report(
+            _buy_report("T-FINAL-POSTIMAGE"),
+            lot_amount=3000,
+            grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+        )
+
+    execution_fill = next(
+        item
+        for item in repository.execution_fills
+        if item.get("broker_trade_id") == "T-FINAL-POSTIMAGE"
+    )
+    assert execution_fill["projection_status"] == "PENDING"
+    assert repository.position_entries[0]["concurrent_marker"] == "changed-after-apply"
+
+
+def test_historical_execution_without_projection_state_is_not_reapplied():
+    repository = InMemoryRepository()
+    trade_fact = {
+        "trade_fact_id": "trade-legacy",
+        "execution_identity": "execution-legacy",
+        "broker_order_key": "legacy-order",
+        "internal_order_id": "legacy-order",
+        "broker_trade_id": "legacy-trade",
+        "symbol": "000001",
+        "side": "buy",
+        "quantity": 900,
+        "price": 10.0,
+        "trade_time": 1710000000,
+        "date": 20240310,
+        "time": "09:30:00",
+    }
+    execution_fill = {
+        "execution_fill_id": "fill-legacy",
+        **{key: value for key, value in trade_fact.items() if key != "trade_fact_id"},
+    }
+
+    class LegacyReplayTrackingService:
+        def ingest_trade_report_with_meta(self, _report):
+            return {
+                "trade_fact": trade_fact,
+                "execution_fill": execution_fill,
+                "created": False,
+            }
+
+    ingest_service = OrderManagementXtIngestService(
+        repository=repository,
+        tracking_service=LegacyReplayTrackingService(),
+        tpsl_service=None,
+    )
+    result = ingest_service.ingest_trade_report(
+        dict(trade_fact),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    assert result["created"] is False
+    assert repository.buy_lots == []
+    assert repository.position_entries == []
+    assert repository.entry_slices == []
+
+
 def test_execution_fragment_quantity_is_accepted_into_entry_ledger():
     repository, ingest_service = _bootstrap_service()
 
@@ -1036,6 +1986,38 @@ def test_multiple_buy_trade_reports_for_same_order_update_one_position_entry():
     assert repository.position_entries[0]["entry_type"] == "broker_execution_cluster"
     assert repository.position_entries[0]["original_quantity"] == 1800
     assert repository.position_entries[0]["remaining_quantity"] == 1800
+
+
+def test_late_buy_fill_after_sell_keeps_entry_and_slice_inventory_consistent():
+    repository, ingest_service = _bootstrap_service()
+    ingest_service.ingest_trade_report(
+        _buy_report("T-LATE-BUY-1", quantity=900),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    ingest_service.ingest_trade_report(
+        _sell_report("T-LATE-BUY-SELL", quantity=500),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    result = ingest_service.ingest_trade_report(
+        _buy_report(
+            "T-LATE-BUY-2",
+            quantity=100,
+            trade_time=1710007200,
+            time="11:00:00",
+        ),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    entry = result["position_entry"]
+    slices = repository.list_entry_slices(entry_ids=[entry["entry_id"]])
+    assert entry["original_quantity"] == 1000
+    assert entry["remaining_quantity"] == 500
+    assert sum(int(item["original_quantity"]) for item in slices) == 1000
+    assert sum(int(item["remaining_quantity"]) for item in slices) == 500
 
 
 def test_trade_report_conservatively_merges_close_buy_orders_into_one_clustered_entry():
@@ -1263,6 +2245,76 @@ def test_repeated_sell_callback_does_not_duplicate_sell_allocations(monkeypatch)
     assert repository.buy_lots[0]["remaining_quantity"] == 900
 
 
+def test_pending_sell_projection_replay_recovers_missing_allocation(monkeypatch):
+    _stub_ingest_side_effects(monkeypatch)
+    repository, ingest_service = _bootstrap_service()
+    ingest_service.ingest_trade_report(
+        _buy_report("T-BUY-BEFORE-PENDING-SELL"),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    original_insert_exit_allocations = repository.insert_exit_allocations
+    failed = False
+
+    def fail_before_allocation_write(allocations):
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise RuntimeError("simulated crash before allocation write")
+        return original_insert_exit_allocations(allocations)
+
+    monkeypatch.setattr(
+        repository,
+        "insert_exit_allocations",
+        fail_before_allocation_write,
+    )
+    report = _sell_report("T-PENDING-SELL")
+
+    with pytest.raises(RuntimeError, match="before allocation write"):
+        ingest_service.ingest_trade_report(
+            report,
+            lot_amount=3000,
+            grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+        )
+
+    sell_fill = next(
+        item
+        for item in repository.execution_fills
+        if item.get("broker_trade_id") == "T-PENDING-SELL"
+    )
+    assert sell_fill["projection_status"] == "PENDING"
+    assert sell_fill["projection_plan"] is not None
+    assert repository.exit_allocations == []
+    assert repository.position_entries[0]["remaining_quantity"] == 400
+
+    monkeypatch.setattr(
+        repository,
+        "insert_exit_allocations",
+        original_insert_exit_allocations,
+    )
+    replay = ingest_service.ingest_trade_report(
+        report,
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    second_replay = ingest_service.ingest_trade_report(
+        report,
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    assert replay["created"] is False
+    assert (
+        sum(int(item["allocated_quantity"]) for item in repository.exit_allocations)
+        == 500
+    )
+    assert repository.position_entries[0]["remaining_quantity"] == 400
+    assert sell_fill["projection_status"] == "APPLIED"
+    assert second_replay["created"] is False
+    assert second_replay["exit_allocations"] == []
+    assert len(repository.exit_allocations) == 2
+
+
 def test_sell_trade_skips_legacy_allocation_when_v2_entries_are_authoritative(
     monkeypatch,
 ):
@@ -1316,7 +2368,7 @@ def test_sell_trade_skips_legacy_allocation_when_v2_entries_are_authoritative(
     assert sync_calls == [("000001", repository)]
 
 
-def test_sell_trade_does_not_fall_back_to_stale_legacy_when_v2_entry_is_closed(
+def test_sell_trade_fails_closed_when_v2_entry_has_no_open_inventory(
     monkeypatch,
 ):
     _stub_ingest_side_effects(monkeypatch)
@@ -1333,18 +2385,53 @@ def test_sell_trade_does_not_fall_back_to_stale_legacy_when_v2_entry_is_closed(
         entry_slice["remaining_quantity"] = 0
         entry_slice["status"] = "CLOSED"
 
-    result = ingest_service.ingest_trade_report(
-        _sell_report(),
-        lot_amount=3000,
-        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
-    )
+    with pytest.raises(BrokerIdentityConflict, match="no open V2 inventory"):
+        ingest_service.ingest_trade_report(
+            _sell_report(),
+            lot_amount=3000,
+            grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+        )
 
-    assert result["exit_allocations"] == []
-    assert result["sell_allocations"] == []
     assert repository.exit_allocations == []
     assert repository.sell_allocations == []
     assert repository.buy_lots[0]["remaining_quantity"] == 900
     assert sum(item["remaining_quantity"] for item in repository.lot_slices) == 900
+    sell_fill = next(
+        item
+        for item in repository.execution_fills
+        if item.get("broker_trade_id") == "T-101"
+    )
+    assert sell_fill["projection_status"] == "PENDING"
+
+
+@pytest.mark.parametrize("slice_state", ["missing", "quantity_mismatch"])
+def test_sell_trade_fails_closed_when_v2_slice_inventory_is_invalid(slice_state):
+    repository, ingest_service = _bootstrap_service()
+    ingest_service.ingest_trade_report(
+        _buy_report(),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    if slice_state == "missing":
+        repository.entry_slices = []
+    else:
+        repository.entry_slices[0]["remaining_quantity"] -= 1
+
+    with pytest.raises(BrokerIdentityConflict, match="V2 entry slices"):
+        ingest_service.ingest_trade_report(
+            _sell_report(),
+            lot_amount=3000,
+            grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+        )
+
+    assert repository.exit_allocations == []
+    assert repository.position_entries[0]["remaining_quantity"] == 900
+    sell_fill = next(
+        item
+        for item in repository.execution_fills
+        if item.get("broker_trade_id") == "T-101"
+    )
+    assert sell_fill["projection_status"] == "PENDING"
 
 
 def test_order_report_updates_existing_order_state():

--- a/freshquant/tests/test_order_management_xt_ingest.py
+++ b/freshquant/tests/test_order_management_xt_ingest.py
@@ -1,4 +1,12 @@
+import pytest
+
 import freshquant.order_management.ingest.xt_reports as xt_reports_module
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityConflict,
+    BrokerIdentityError,
+    build_broker_only_internal_order_id,
+    build_broker_order_key,
+)
 from freshquant.order_management.ingest.xt_reports import (
     OrderManagementXtIngestService,
     normalize_xt_order_report,
@@ -62,6 +70,13 @@ class InMemoryRepository:
         self.execution_fills.append(saved)
         return saved, True
 
+    def list_execution_fills(self, *, broker_order_keys=None, **_kwargs):
+        rows = list(self.execution_fills)
+        if broker_order_keys is not None:
+            allowed = set(broker_order_keys)
+            rows = [item for item in rows if item.get("broker_order_key") in allowed]
+        return rows
+
     def find_order(self, internal_order_id):
         for order in self.orders:
             if order["internal_order_id"] == internal_order_id:
@@ -92,6 +107,9 @@ class InMemoryRepository:
             for order in self.orders
             if str(order.get("broker_order_id")) == str(broker_order_id)
         ]
+
+    def list_orders(self):
+        return list(self.orders)
 
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)
@@ -171,6 +189,23 @@ class InMemoryRepository:
         self.entry_slices.extend(dict(item) for item in slices)
         return slices
 
+    def upsert_entry_slices(self, slices):
+        for document in slices:
+            for index, current in enumerate(self.entry_slices):
+                if current["entry_slice_id"] == document["entry_slice_id"]:
+                    self.entry_slices[index] = dict(document)
+                    break
+            else:
+                self.entry_slices.append(dict(document))
+        return slices
+
+    def list_entry_slices(self, *, entry_ids=None):
+        rows = list(self.entry_slices)
+        if entry_ids is not None:
+            allowed = set(entry_ids)
+            rows = [item for item in rows if item.get("entry_id") in allowed]
+        return [dict(item) for item in rows]
+
     def list_open_entry_slices(self, *, symbol=None, entry_ids=None):
         rows = [
             item
@@ -199,11 +234,25 @@ def _bootstrap_service():
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": "acct-test",
+            "trading_day": 20240102,
             "symbol": "000001",
             "price": 10.0,
             "quantity": 900,
             "source": "xt_trade_callback",
             "internal_order_id": "ord_test_1",
+        }
+    )
+    tracking_service.submit_order(
+        {
+            "action": "sell",
+            "account_id": "acct-test",
+            "trading_day": 20240103,
+            "symbol": "000001",
+            "price": 10.8,
+            "quantity": 500,
+            "source": "xt_trade_callback",
+            "internal_order_id": "ord_test_sell_1",
         }
     )
     ingest_service = OrderManagementXtIngestService(
@@ -249,6 +298,7 @@ def _noop_sync_stock_fills_compat(symbol, repository=None):
 def _buy_report(broker_trade_id="T-100", **overrides):
     payload = {
         "internal_order_id": "ord_test_1",
+        "account_id": "acct-test",
         "broker_trade_id": broker_trade_id,
         "symbol": "000001",
         "side": "buy",
@@ -265,7 +315,8 @@ def _buy_report(broker_trade_id="T-100", **overrides):
 
 def _sell_report(broker_trade_id="T-101", **overrides):
     payload = {
-        "internal_order_id": "ord_test_1",
+        "internal_order_id": "ord_test_sell_1",
+        "account_id": "acct-test",
         "broker_trade_id": broker_trade_id,
         "symbol": "000001",
         "side": "sell",
@@ -284,6 +335,7 @@ def test_normalize_xt_trade_report_extracts_side_symbol_and_timestamp():
     normalized = normalize_xt_trade_report(
         {
             "order_id": "O-100",
+            "account_id": "acct-test",
             "traded_id": "T-100",
             "stock_code": "000001.SZ",
             "order_type": 23,
@@ -294,7 +346,7 @@ def test_normalize_xt_trade_report_extracts_side_symbol_and_timestamp():
         }
     )
 
-    assert normalized["internal_order_id"] == "O-100"
+    assert normalized["internal_order_id"].startswith("ord_broker_")
     assert normalized["broker_trade_id"] == "T-100"
     assert normalized["symbol"] == "000001"
     assert normalized["side"] == "buy"
@@ -305,6 +357,7 @@ def test_normalize_xt_trade_report_treats_credit_fin_buy_as_buy():
     normalized = normalize_xt_trade_report(
         {
             "order_id": "O-200",
+            "account_id": "acct-test",
             "traded_id": "T-200",
             "stock_code": "600000.SH",
             "order_type": 27,
@@ -321,6 +374,7 @@ def test_normalize_xt_trade_report_treats_sell_repay_as_sell():
     normalized = normalize_xt_trade_report(
         {
             "order_id": "O-201",
+            "account_id": "acct-test",
             "traded_id": "T-201",
             "stock_code": "600000.SH",
             "order_type": 31,
@@ -333,7 +387,7 @@ def test_normalize_xt_trade_report_treats_sell_repay_as_sell():
     assert normalized["side"] == "sell"
 
 
-def test_normalize_xt_trade_report_prefers_order_domain_broker_order_type():
+def test_normalize_xt_trade_report_does_not_attach_side_conflict_candidate():
     repository = InMemoryRepository()
     tracking_service = OrderTrackingService(repository=repository)
     tracking_service.submit_order(
@@ -358,6 +412,7 @@ def test_normalize_xt_trade_report_prefers_order_domain_broker_order_type():
 
     normalized = normalize_xt_trade_report(
         {
+            "account_id": "acct-test",
             "order_id": "92001",
             "traded_id": "T-202",
             "stock_code": "600000.SH",
@@ -369,8 +424,9 @@ def test_normalize_xt_trade_report_prefers_order_domain_broker_order_type():
         repository=repository,
     )
 
-    assert normalized["internal_order_id"] == "ord_credit_ingest_1"
-    assert normalized["side"] == "buy"
+    assert normalized["internal_order_id"].startswith("ord_broker_")
+    assert normalized["internal_order_id"] != "ord_credit_ingest_1"
+    assert normalized["side"] == "sell"
 
 
 def test_normalize_xt_trade_report_disambiguates_reused_broker_order_id():
@@ -379,6 +435,7 @@ def test_normalize_xt_trade_report_disambiguates_reused_broker_order_id():
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": "acct-test",
             "symbol": "002262",
             "price": 21.0,
             "quantity": 2300,
@@ -401,6 +458,7 @@ def test_normalize_xt_trade_report_disambiguates_reused_broker_order_id():
     tracking_service.submit_order(
         {
             "action": "sell",
+            "account_id": "acct-test",
             "symbol": "002262",
             "price": 22.41,
             "quantity": 2300,
@@ -424,6 +482,7 @@ def test_normalize_xt_trade_report_disambiguates_reused_broker_order_id():
     normalized = normalize_xt_trade_report(
         {
             "order_id": "1477443585",
+            "account_id": "acct-test",
             "traded_id": "0103000030649603",
             "stock_code": "002262.SZ",
             "order_type": 24,
@@ -446,6 +505,7 @@ def test_normalize_xt_order_report_disambiguates_reused_broker_order_id():
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": "acct-test",
             "symbol": "002262",
             "price": 21.0,
             "quantity": 2300,
@@ -468,6 +528,7 @@ def test_normalize_xt_order_report_disambiguates_reused_broker_order_id():
     tracking_service.submit_order(
         {
             "action": "sell",
+            "account_id": "acct-test",
             "symbol": "002262",
             "price": 22.41,
             "quantity": 2300,
@@ -491,6 +552,7 @@ def test_normalize_xt_order_report_disambiguates_reused_broker_order_id():
     normalized = normalize_xt_order_report(
         {
             "order_id": 1477443585,
+            "account_id": "acct-test",
             "stock_code": "002262.SZ",
             "order_type": 24,
             "order_time": 1777428846,
@@ -558,6 +620,8 @@ def test_normalize_xt_order_report_maps_broker_order_back_to_internal_order():
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": "acct-test",
+            "trading_day": 20240310,
             "symbol": "000001",
             "price": 10.0,
             "quantity": 900,
@@ -573,7 +637,9 @@ def test_normalize_xt_order_report_maps_broker_order_back_to_internal_order():
     normalized = normalize_xt_order_report(
         {
             "order_id": 81001,
+            "account_id": "acct-test",
             "stock_code": "000001.SZ",
+            "order_type": 23,
             "order_time": 1710000000,
             "order_status": 54,
         },
@@ -585,27 +651,75 @@ def test_normalize_xt_order_report_maps_broker_order_back_to_internal_order():
     assert normalized["state"] == "CANCELED"
 
 
-def test_normalize_xt_order_report_returns_none_for_unknown_broker_order():
+def test_normalize_xt_order_report_creates_deterministic_broker_only_identity():
     repository = InMemoryRepository()
 
     normalized = normalize_xt_order_report(
         {
             "order_id": 89991,
+            "account_id": "acct-test",
             "stock_code": "000001.SZ",
+            "order_type": 23,
             "order_time": 1710000000,
             "order_status": 54,
         },
         repository=repository,
     )
 
+    assert normalized["internal_order_id"].startswith("ord_broker_")
+    assert normalized["internal_order_id"] != "89991"
+
+
+def test_broker_only_internal_order_id_requires_complete_identity():
+    with pytest.raises(BrokerIdentityError, match="broker order identity requires"):
+        build_broker_only_internal_order_id(
+            account_id="acct-test",
+            broker_order_id="89992",
+        )
+
+
+def test_order_report_does_not_guess_unique_incomplete_candidate():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-test",
+            "symbol": "000001",
+            "price": 10.0,
+            "quantity": 900,
+            "source": "strategy",
+            "internal_order_id": "ord_incomplete_identity",
+        }
+    )
+    repository.update_order(
+        "ord_incomplete_identity",
+        {"state": "SUBMITTED", "broker_order_id": "89992"},
+    )
+
+    normalized = normalize_xt_order_report(
+        {
+            "account_id": "acct-test",
+            "order_id": 89992,
+            "stock_code": "000001.SZ",
+            "order_status": 54,
+        },
+        repository=repository,
+    )
+
     assert normalized is None
+    assert repository.ingest_rejections[-1]["reason_code"] == (
+        "incomplete_broker_order_identity"
+    )
 
 
 def test_normalize_xt_order_report_keeps_cancel_requested_state_for_pending_cancel():
     normalized = normalize_xt_order_report(
         {
             "order_id": 81002,
+            "account_id": "acct-test",
             "stock_code": "000001.SZ",
+            "order_type": 23,
             "order_time": 1710000000,
             "order_status": 51,
         }
@@ -678,16 +792,13 @@ def test_sell_trade_report_creates_sell_allocations_and_updates_projection():
         grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
     )
 
-    arranged_fills = build_arranged_fills_view(repository.list_open_slices("000001"))
-
-    assert len(result["sell_allocations"]) == 2
+    assert result["sell_allocations"] == []
     assert len(result["exit_allocations"]) == 2
+    assert repository.sell_allocations == []
+    assert repository.buy_lots[0]["remaining_quantity"] == 900
+    assert sum(item["remaining_quantity"] for item in repository.lot_slices) == 900
     assert repository.position_entries[0]["remaining_quantity"] == 400
     assert repository.position_entries[0]["status"] == "PARTIALLY_EXITED"
-    assert [(item["price"], item["quantity"]) for item in arranged_fills] == [
-        (10.93, 200),
-        (10.61, 200),
-    ]
 
 
 def test_sell_trade_report_prefers_guardian_source_entries_when_allocating_entry_slices():
@@ -857,7 +968,7 @@ def test_repeated_callback_does_not_duplicate_trade_fact_or_projection():
     assert len(repository.list_open_slices("000001")) == 4
 
 
-def test_non_board_lot_trade_report_is_rejected_from_entry_ledger():
+def test_execution_fragment_quantity_is_accepted_into_entry_ledger():
     repository, ingest_service = _bootstrap_service()
 
     result = ingest_service.ingest_trade_report(
@@ -872,13 +983,11 @@ def test_non_board_lot_trade_report_is_rejected_from_entry_ledger():
 
     assert len(repository.trade_facts) == 1
     assert len(repository.execution_fills) == 1
-    assert repository.position_entries == []
-    assert repository.entry_slices == []
-    assert repository.buy_lots == []
-    assert len(repository.ingest_rejections) == 1
-    assert repository.ingest_rejections[0]["reason_code"] == "non_board_lot_quantity"
-    assert result["position_entry"] is None
-    assert result["projections"]["open_buy_fills"] == []
+    assert repository.position_entries[0]["original_quantity"] == 18
+    assert sum(int(item["original_quantity"]) for item in repository.entry_slices) == 18
+    assert repository.buy_lots[0]["original_quantity"] == 18
+    assert repository.ingest_rejections == []
+    assert result["position_entry"]["original_quantity"] == 18
 
 
 def test_multiple_buy_trade_reports_for_same_order_update_one_position_entry():
@@ -890,6 +999,8 @@ def test_multiple_buy_trade_reports_for_same_order_update_one_position_entry():
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": "acct-test",
+            "trading_day": 20240102,
             "symbol": "000001",
             "price": 10.0,
             "quantity": 1800,
@@ -1143,15 +1254,13 @@ def test_repeated_sell_callback_does_not_duplicate_sell_allocations(monkeypatch)
         grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
     )
 
-    arranged_fills = build_arranged_fills_view(repository.list_open_slices("000001"))
-
-    assert len(first["sell_allocations"]) == 2
+    assert first["sell_allocations"] == []
+    assert len(first["exit_allocations"]) == 2
     assert second["sell_allocations"] == []
-    assert len(repository.sell_allocations) == 2
-    assert [(item["price"], item["quantity"]) for item in arranged_fills] == [
-        (10.93, 200),
-        (10.61, 200),
-    ]
+    assert second["exit_allocations"] == []
+    assert repository.sell_allocations == []
+    assert len(repository.exit_allocations) == 2
+    assert repository.buy_lots[0]["remaining_quantity"] == 900
 
 
 def test_sell_trade_skips_legacy_allocation_when_v2_entries_are_authoritative(
@@ -1207,12 +1316,45 @@ def test_sell_trade_skips_legacy_allocation_when_v2_entries_are_authoritative(
     assert sync_calls == [("000001", repository)]
 
 
+def test_sell_trade_does_not_fall_back_to_stale_legacy_when_v2_entry_is_closed(
+    monkeypatch,
+):
+    _stub_ingest_side_effects(monkeypatch)
+    repository, ingest_service = _bootstrap_service()
+    ingest_service.ingest_trade_report(
+        _buy_report(),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    for entry in repository.position_entries:
+        entry["remaining_quantity"] = 0
+        entry["status"] = "CLOSED"
+    for entry_slice in repository.entry_slices:
+        entry_slice["remaining_quantity"] = 0
+        entry_slice["status"] = "CLOSED"
+
+    result = ingest_service.ingest_trade_report(
+        _sell_report(),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    assert result["exit_allocations"] == []
+    assert result["sell_allocations"] == []
+    assert repository.exit_allocations == []
+    assert repository.sell_allocations == []
+    assert repository.buy_lots[0]["remaining_quantity"] == 900
+    assert sum(item["remaining_quantity"] for item in repository.lot_slices) == 900
+
+
 def test_order_report_updates_existing_order_state():
     repository = InMemoryRepository()
     tracking_service = OrderTrackingService(repository=repository)
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": "acct-test",
+            "trading_day": 20240310,
             "symbol": "000001",
             "price": 10.0,
             "quantity": 300,
@@ -1232,10 +1374,270 @@ def test_order_report_updates_existing_order_state():
     ingest_service.ingest_order_report(
         {
             "order_id": 90088,
+            "account_id": "acct-test",
             "stock_code": "000001.SZ",
+            "order_type": 23,
             "order_time": 1710000000,
             "order_status": 54,
         }
     )
 
     assert repository.find_order("ord_order_state_1")["state"] == "CANCELED"
+
+
+def test_broker_order_key_primary_identity_includes_trading_day():
+    first = build_broker_order_key(
+        account_id="acct-test",
+        trading_day=20260526,
+        order_sysid="1263",
+    )
+    second = build_broker_order_key(
+        account_id="acct-test",
+        trading_day=20260804,
+        order_sysid="1263",
+    )
+
+    assert first == "account:acct-test:day:20260526:sysid:1263"
+    assert second == "account:acct-test:day:20260804:sysid:1263"
+    assert first != second
+
+
+def test_unique_600917_candidate_cannot_match_688772_trade():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-test",
+            "symbol": "600917",
+            "price": 5.16,
+            "quantity": 38700,
+            "source": "manual",
+            "internal_order_id": "ord-600917-history",
+        }
+    )
+    repository.update_order(
+        "ord-600917-history",
+        {
+            "broker_order_id": "1209008130",
+            "trading_day": 20260804,
+            "state": "FILLED",
+        },
+    )
+
+    normalized = normalize_xt_trade_report(
+        {
+            "account_id": "acct-test",
+            "order_id": "1209008130",
+            "order_sysid": "1263",
+            "traded_id": "trade-688772-buy",
+            "stock_code": "688772.SH",
+            "order_type": 23,
+            "traded_volume": 10000,
+            "traded_price": 14.70,
+            "traded_time": 1785808800,
+        },
+        repository=repository,
+    )
+
+    assert normalized["internal_order_id"].startswith("ord_broker_")
+    assert normalized["internal_order_id"] != "ord-600917-history"
+    assert normalized["symbol"] == "688772"
+    assert normalized["trading_day"] == 20260804
+
+
+def test_pinned_internal_order_symbol_conflict_is_quarantined():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-test",
+            "symbol": "600917",
+            "price": 5.16,
+            "quantity": 38700,
+            "source": "manual",
+            "internal_order_id": "ord-pinned-600917",
+        }
+    )
+
+    with pytest.raises(BrokerIdentityConflict, match="symbol"):
+        normalize_xt_trade_report(
+            {
+                "internal_order_id": "ord-pinned-600917",
+                "account_id": "acct-test",
+                "order_id": "1209008130",
+                "traded_id": "trade-pinned-mismatch",
+                "stock_code": "688772.SH",
+                "order_type": 23,
+                "traded_volume": 10000,
+                "traded_price": 14.70,
+                "traded_time": 1785808800,
+            },
+            repository=repository,
+        )
+
+    assert repository.ingest_rejections[-1]["reason_code"] == "broker_identity_conflict"
+    assert repository.trade_facts == []
+
+
+def test_unknown_xt_order_type_is_quarantined_instead_of_defaulting_to_sell():
+    repository = InMemoryRepository()
+
+    with pytest.raises(BrokerIdentityError, match="side"):
+        normalize_xt_trade_report(
+            {
+                "account_id": "acct-test",
+                "order_id": "unknown-side-order",
+                "traded_id": "unknown-side-trade",
+                "stock_code": "688772.SH",
+                "order_type": 999,
+                "traded_volume": 164,
+                "traded_price": 14.80,
+                "traded_time": 1785895200,
+            },
+            repository=repository,
+        )
+
+    assert repository.ingest_rejections[-1]["reason_code"] == "unknown_order_side"
+
+
+def test_164_share_sell_execution_is_allocated_directly():
+    repository, ingest_service = _bootstrap_service()
+    ingest_service.ingest_trade_report(
+        _buy_report(quantity=900),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    result = ingest_service.ingest_trade_report(
+        _sell_report("T-SELL-164", quantity=164),
+        lot_amount=3000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    assert (
+        sum(int(item["allocated_quantity"]) for item in result["exit_allocations"])
+        == 164
+    )
+    assert repository.position_entries[0]["remaining_quantity"] == 736
+    assert repository.ingest_rejections == []
+
+
+def test_nine_sell_fragments_conserve_quantity_and_replay_idempotently():
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "account_id": "acct-test",
+            "symbol": "688772",
+            "price": 14.70,
+            "quantity": 10000,
+            "source": "manual",
+            "internal_order_id": "ord-688772-buy",
+        }
+    )
+    tracking_service.submit_order(
+        {
+            "action": "sell",
+            "account_id": "acct-test",
+            "symbol": "688772",
+            "price": 14.80,
+            "quantity": 10000,
+            "source": "guardian",
+            "internal_order_id": "ord-688772-sell",
+        }
+    )
+    ingest_service = OrderManagementXtIngestService(
+        repository=repository,
+        tracking_service=tracking_service,
+        tpsl_service=type(
+            "FakeTpslService",
+            (),
+            {"on_new_buy_trade": lambda self, symbol, buy_price: None},
+        )(),
+    )
+    xt_reports_module._sync_stock_fills_compat = _noop_sync_stock_fills_compat
+    ingest_service.ingest_trade_report(
+        _buy_report(
+            "T-688772-BUY",
+            internal_order_id="ord-688772-buy",
+            symbol="688772",
+            quantity=10000,
+            price=14.70,
+            trade_time=1785808800,
+            date=20260804,
+            time="10:00:00",
+        ),
+        lot_amount=50000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+    fragments = (164, 203, 340, 358, 200, 2653, 3000, 1000, 2082)
+    reports = []
+    for index, quantity in enumerate(fragments, start=1):
+        report = _sell_report(
+            f"T-688772-SELL-{index}",
+            internal_order_id="ord-688772-sell",
+            symbol="688772",
+            quantity=quantity,
+            price=14.80,
+            trade_time=1785895200 + index,
+            date=20260805,
+            time=f"10:00:{index:02d}",
+        )
+        reports.append(report)
+        ingest_service.ingest_trade_report(
+            report,
+            lot_amount=50000,
+            grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+        )
+
+    replay = ingest_service.ingest_trade_report(
+        reports[-1],
+        lot_amount=50000,
+        grid_interval_lookup=lambda _symbol, _trade_fact: 1.03,
+    )
+
+    entry = repository.list_position_entries(symbol="688772")[0]
+    entry_slice_ids = {
+        item["entry_slice_id"]
+        for item in repository.entry_slices
+        if item["symbol"] == "688772"
+    }
+    allocations = list(repository.exit_allocations)
+    sell_fills = [
+        item
+        for item in repository.execution_fills
+        if item["symbol"] == "688772" and item["side"] == "sell"
+    ]
+
+    assert fragments == (164, 203, 340, 358, 200, 2653, 3000, 1000, 2082)
+    assert sum(fragments) == 10000
+    assert len(sell_fills) == 9
+    assert sum(int(item["quantity"]) for item in sell_fills) == 10000
+    assert sum(int(item["allocated_quantity"]) for item in allocations) == 10000
+    assert entry["remaining_quantity"] == 0
+    assert len(entry_slice_ids) == 4
+    assert sorted(
+        (
+            float(item["guardian_price"]),
+            int(item["original_quantity"]),
+        )
+        for item in repository.entry_slices
+        if item["symbol"] == "688772"
+    ) == [
+        (14.70, 3400),
+        (15.14, 3300),
+        (15.59, 3200),
+        (16.06, 100),
+    ]
+    assert all(
+        int(item["remaining_quantity"]) == 0
+        for item in repository.entry_slices
+        if item["symbol"] == "688772"
+    )
+    assert all(item["entry_slice_id"] in entry_slice_ids for item in allocations)
+    assert replay["created"] is False
+    assert replay["exit_allocations"] == []
+    assert repository.ingest_rejections == []

--- a/freshquant/tests/test_order_reconcile_runtime_observability.py
+++ b/freshquant/tests/test_order_reconcile_runtime_observability.py
@@ -262,6 +262,8 @@ def test_reconcile_trade_reports_emits_runtime_events(monkeypatch):
             "request_id": "req_recon_1",
             "trace_id": "trc_recon_1",
             "intent_id": "int_recon_1",
+            "account_id": "acct-1",
+            "trading_day": 20260805,
         }
     )
     tracking_service.mark_order_queued("ord_recon_1")
@@ -290,6 +292,8 @@ def test_reconcile_trade_reports_emits_runtime_events(monkeypatch):
                 "traded_volume": 200,
                 "traded_price": 10.5,
                 "traded_time": 1030,
+                "account_id": "acct-1",
+                "trading_day": 20260805,
             }
         ]
     )
@@ -340,6 +344,8 @@ def test_known_internal_trade_report_still_emits_xt_ingest_events(monkeypatch):
             "request_id": "req_recon_known_1",
             "trace_id": "trc_recon_known_1",
             "intent_id": "int_recon_known_1",
+            "account_id": "acct-1",
+            "trading_day": 20260805,
         }
     )
     repository.update_order(
@@ -369,6 +375,8 @@ def test_known_internal_trade_report_still_emits_xt_ingest_events(monkeypatch):
             "traded_volume": 200,
             "traded_price": 10.5,
             "traded_time": 1030,
+            "account_id": "acct-1",
+            "trading_day": 20260805,
         }
     )
 
@@ -424,6 +432,8 @@ def test_known_internal_sell_trade_report_ignores_missing_legacy_slices(
             "quantity": 900,
             "source": "strategy",
             "internal_order_id": "ord_recon_seed_buy_1",
+            "account_id": "acct-1",
+            "trading_day": 20240310,
         }
     )
     repository.update_order(
@@ -447,6 +457,8 @@ def test_known_internal_sell_trade_report_ignores_missing_legacy_slices(
             "trade_time": 1710000000,
             "date": 20240310,
             "time": "09:31:00",
+            "account_id": "acct-1",
+            "trading_day": 20240310,
             "source": "xt_trade_callback",
         },
         lot_amount=3000,
@@ -466,6 +478,8 @@ def test_known_internal_sell_trade_report_ignores_missing_legacy_slices(
             "request_id": "req_recon_known_sell_1",
             "trace_id": "trc_recon_known_sell_1",
             "intent_id": "int_recon_known_sell_1",
+            "account_id": "acct-1",
+            "trading_day": 20240310,
         }
     )
     repository.update_order(
@@ -489,6 +503,8 @@ def test_known_internal_sell_trade_report_ignores_missing_legacy_slices(
             "traded_volume": 500,
             "traded_price": 10.8,
             "traded_time": 1710003600,
+            "account_id": "acct-1",
+            "trading_day": 20240310,
         }
     )
 

--- a/freshquant/tests/test_order_reconcile_runtime_observability.py
+++ b/freshquant/tests/test_order_reconcile_runtime_observability.py
@@ -275,6 +275,7 @@ def test_reconcile_trade_reports_emits_runtime_events(monkeypatch):
             "broker_order_id": None,
         }
     )
+    pending_order = repository.find_order("ord_recon_1")
     runtime_logger = FakeRuntimeLogger()
     service = ExternalOrderReconcileService(
         repository=repository,
@@ -294,6 +295,7 @@ def test_reconcile_trade_reports_emits_runtime_events(monkeypatch):
                 "traded_time": 1030,
                 "account_id": "acct-1",
                 "trading_day": 20260805,
+                "order_remark": pending_order["broker_correlation_token"],
             }
         ]
     )
@@ -352,6 +354,7 @@ def test_known_internal_trade_report_still_emits_xt_ingest_events(monkeypatch):
         "ord_recon_known_1",
         {"broker_order_id": "90012", "state": "SUBMITTED"},
     )
+    known_order = repository.find_order("ord_recon_known_1")
     reconcile_runtime_logger = FakeRuntimeLogger()
     ingest_runtime_logger = FakeRuntimeLogger()
     ingest_service = OrderManagementXtIngestService(
@@ -377,6 +380,7 @@ def test_known_internal_trade_report_still_emits_xt_ingest_events(monkeypatch):
             "traded_time": 1030,
             "account_id": "acct-1",
             "trading_day": 20260805,
+            "order_remark": known_order["broker_correlation_token"],
         }
     )
 
@@ -486,6 +490,7 @@ def test_known_internal_sell_trade_report_ignores_missing_legacy_slices(
         "ord_recon_known_sell_1",
         {"broker_order_id": "90021", "state": "SUBMITTED"},
     )
+    known_sell_order = repository.find_order("ord_recon_known_sell_1")
     reconcile_runtime_logger = FakeRuntimeLogger()
     service = ExternalOrderReconcileService(
         repository=repository,
@@ -505,6 +510,7 @@ def test_known_internal_sell_trade_report_ignores_missing_legacy_slices(
             "traded_time": 1710003600,
             "account_id": "acct-1",
             "trading_day": 20240310,
+            "order_remark": known_sell_order["broker_correlation_token"],
         }
     )
 

--- a/freshquant/tests/test_order_submit_runtime_observability.py
+++ b/freshquant/tests/test_order_submit_runtime_observability.py
@@ -112,6 +112,7 @@ def test_submit_order_emits_runtime_trace_steps():
         queue_client=FakeQueueClient(),
         position_management_service=AllowingPositionService(),
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
         runtime_logger=runtime_logger,
     )
 
@@ -151,6 +152,7 @@ def test_submit_order_emits_runtime_error_when_queue_push_fails():
         queue_client=ExplodingQueueClient(),
         position_management_service=AllowingPositionService(),
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
         runtime_logger=runtime_logger,
     )
 
@@ -186,6 +188,7 @@ def test_submit_order_emits_failed_runtime_event_for_position_management_rejecti
         queue_client=FakeQueueClient(),
         position_management_service=RejectingPositionService(),
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
         runtime_logger=runtime_logger,
     )
 
@@ -245,6 +248,7 @@ def test_cancel_order_emits_runtime_trace_steps():
         queue_client=FakeQueueClient(),
         position_management_service=AllowingPositionService(),
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
         runtime_logger=runtime_logger,
     )
 
@@ -292,6 +296,7 @@ def test_cancel_order_emits_runtime_error_when_queue_push_fails():
         queue_client=ExplodingQueueClient(),
         position_management_service=AllowingPositionService(),
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
         runtime_logger=runtime_logger,
     )
 

--- a/freshquant/tests/test_position_management_guardian_placeholder.py
+++ b/freshquant/tests/test_position_management_guardian_placeholder.py
@@ -135,6 +135,7 @@ def test_submit_service_carries_guardian_placeholder_meta_to_queue():
         queue_client=queue_client,
         position_management_service=PlaceholderPositionService(),
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
     )
 
     result = service.submit_order(
@@ -174,6 +175,7 @@ def test_submit_service_marks_placeholder_for_guardian_strategy_identifier(
         queue_client=FakeQueueClient(),
         position_management_service=position_service,
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
     )
     monkeypatch.setattr(
         "freshquant.position_management.service._resolve_guardian_strategy_identifier",

--- a/freshquant/tests/test_position_management_submit_gate.py
+++ b/freshquant/tests/test_position_management_submit_gate.py
@@ -113,6 +113,7 @@ def test_strategy_order_is_blocked_before_tracking_when_position_management_reje
         queue_client=queue_client,
         position_management_service=position_management_service,
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
     )
 
     with pytest.raises(PositionManagementRejectedError):
@@ -140,6 +141,7 @@ def test_api_order_bypasses_position_management():
         queue_client=queue_client,
         position_management_service=position_management_service,
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
     )
 
     result = service.submit_order(
@@ -166,6 +168,7 @@ def test_allowed_strategy_order_carries_position_management_summary_to_queue():
         queue_client=queue_client,
         position_management_service=position_management_service,
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
     )
 
     result = service.submit_order(
@@ -193,6 +196,7 @@ def test_strategy_order_persists_strategy_context_to_tracking_and_queue():
         queue_client=queue_client,
         position_management_service=position_management_service,
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
     )
     strategy_context = {
         "guardian_buy_grid": {
@@ -318,6 +322,7 @@ def _build_submit_service_with_default_position_loader(
         queue_client=FakeQueueClient(),
         position_management_service=position_service,
         account_type_loader=lambda: "STOCK",
+        account_id_loader=lambda: "acct-test",
         runtime_logger=runtime_logger,
     )
     return submit_service, position_repository

--- a/freshquant/tests/test_stock_pool_service.py
+++ b/freshquant/tests/test_stock_pool_service.py
@@ -4,6 +4,16 @@ import types
 from datetime import datetime
 
 import pymongo
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_stock_service_after_stubbed_reload(monkeypatch):
+    yield
+    monkeypatch.undo()
+    stock_service = sys.modules.get("freshquant.stock_service")
+    if stock_service is not None:
+        importlib.reload(stock_service)
 
 
 class FakeCursor:

--- a/freshquant/tests/test_targeted_order_ledger_repair.py
+++ b/freshquant/tests/test_targeted_order_ledger_repair.py
@@ -7,12 +7,17 @@ from types import SimpleNamespace
 
 import pytest
 from bson import ObjectId
+from pymongo.errors import DuplicateKeyError
 
+import freshquant.order_management.repair.targeted_ledger as targeted_ledger_module
 from freshquant.order_management.repair.targeted_ledger import (
     TARGETED_REPAIR_JOURNAL_COLLECTION,
     AllowedDiffMismatch,
     InvalidRepairPlan,
     PreimageHashMismatch,
+    RepairIdConflict,
+    RestoreStateMismatch,
+    TargetedRepairError,
     execute_targeted_repair,
     load_repair_document,
     preview_targeted_restore,
@@ -26,12 +31,21 @@ if str(REPO_ROOT) not in sys.path:
 
 from script.maintenance.targeted_order_ledger_repair import run_repair_plan
 
+EXISTING_BROKER_ORDER_DOCUMENT_ID = ObjectId("66b0a0000000000000000917")
+REPAIRED_BROKER_ORDER_DOCUMENT_ID = ObjectId("66b0a0000000000000000772")
+BROKER_TRADE_DOCUMENT_ID = ObjectId("66b0a0000000000000000001")
+
 
 class MemoryCollection:
     def __init__(self, documents=None):
         self.documents = [_with_mongo_id(item) for item in list(documents or [])]
+        self.unique_fields = {"_id"}
 
-    def create_index(self, *_args, **_kwargs):
+    def create_index(self, keys, **kwargs):
+        if kwargs.get("unique") and len(keys) == 1:
+            self.unique_fields.add(keys[0][0])
+            for index, document in enumerate(self.documents):
+                self._assert_unique(document, excluding_index=index)
         return None
 
     def find(self, query=None):
@@ -43,16 +57,17 @@ class MemoryCollection:
         return rows[0] if rows else None
 
     def insert_one(self, document):
-        if self.find_one({"repair_id": document.get("repair_id")}) is not None:
-            raise AssertionError("duplicate repair_id")
         document = _with_mongo_id(document)
+        self._assert_unique(document)
         self.documents.append(document)
-        return SimpleNamespace(inserted_id=document.get("repair_id"))
+        return SimpleNamespace(inserted_id=document.get("_id"))
 
     def insert_many(self, documents, ordered=False):
         del ordered
         rows = [_with_mongo_id(item) for item in documents]
-        self.documents.extend(rows)
+        for row in rows:
+            self._assert_unique(row)
+            self.documents.append(row)
         return SimpleNamespace(inserted_ids=list(range(len(rows))))
 
     def delete_many(self, query):
@@ -74,11 +89,13 @@ class MemoryCollection:
                 continue
             replacement = deepcopy(document)
             replacement.setdefault("_id", item.get("_id"))
+            self._assert_unique(replacement, excluding_index=index)
             self.documents[index] = replacement
             return SimpleNamespace(matched_count=1, upserted_id=None)
         if not upsert:
             return SimpleNamespace(matched_count=0, upserted_id=None)
         replacement = _with_mongo_id(document)
+        self._assert_unique(replacement)
         self.documents.append(replacement)
         return SimpleNamespace(matched_count=0, upserted_id=replacement["_id"])
 
@@ -94,8 +111,20 @@ class MemoryCollection:
         document.update(deepcopy(update.get("$setOnInsert") or {}))
         document.update(deepcopy(update.get("$set") or {}))
         document = _with_mongo_id(document)
+        self._assert_unique(document)
         self.documents.append(document)
         return SimpleNamespace(matched_count=0, upserted_id=document.get("repair_id"))
+
+    def _assert_unique(self, document, excluding_index=None):
+        for field in self.unique_fields:
+            if field not in document:
+                continue
+            value = document.get(field)
+            for index, existing in enumerate(self.documents):
+                if excluding_index is not None and index == excluding_index:
+                    continue
+                if existing.get(field) == value:
+                    raise DuplicateKeyError(f"duplicate key for {field}")
 
 
 class MemoryDatabase:
@@ -238,6 +267,252 @@ def test_execute_rejects_stale_preimage_hash_before_writing(tmp_path: Path):
     assert not (tmp_path / "repair.json").exists()
 
 
+def test_apply_compare_and_swap_preserves_concurrent_document_update(
+    monkeypatch,
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    collection = databases["order"]["om_broker_orders"]
+    original_replace = collection.replace_one
+    raced = False
+
+    def replace_with_concurrent_update(query, document, upsert=False):
+        nonlocal raced
+        if not raced and document.get("internal_order_id") == "order-600917":
+            raced = True
+            collection.documents[0].update(
+                {
+                    "filled_quantity": 777,
+                    "filled_price": 99.0,
+                    "concurrent_marker": "preserve-me",
+                }
+            )
+        return original_replace(query, document, upsert=upsert)
+
+    monkeypatch.setattr(collection, "replace_one", replace_with_concurrent_update)
+
+    with pytest.raises(TargetedRepairError, match="compare-and-swap replace failed"):
+        execute_targeted_repair(
+            plan=plan,
+            databases=databases,
+            expected_preimage_hash=preview["preimage_hash"],
+            manifest_path=tmp_path / "repair.json",
+        )
+
+    assert collection.documents[0]["filled_quantity"] == 777
+    assert collection.documents[0]["filled_price"] == 99.0
+    assert collection.documents[0]["concurrent_marker"] == "preserve-me"
+    assert all(
+        item.get("internal_order_id") != "order-688772" for item in collection.documents
+    )
+
+
+def test_rollback_compare_and_swap_does_not_overwrite_concurrent_update(
+    monkeypatch,
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    collection = databases["order"]["om_broker_orders"]
+    original_insert = collection.insert_one
+    original_replace = collection.replace_one
+    rollback_raced = False
+
+    def fail_second_change(document):
+        if document.get("internal_order_id") == "order-688772":
+            raise RuntimeError("force second change failure")
+        return original_insert(document)
+
+    def replace_with_rollback_race(query, document, upsert=False):
+        nonlocal rollback_raced
+        if (
+            not rollback_raced
+            and document.get("internal_order_id") == "order-600917"
+            and document.get("filled_quantity") == 48700
+        ):
+            rollback_raced = True
+            collection.documents[0].update(
+                {
+                    "filled_quantity": 777,
+                    "filled_price": 99.0,
+                    "concurrent_marker": "preserve-rollback-race",
+                }
+            )
+        return original_replace(query, document, upsert=upsert)
+
+    monkeypatch.setattr(collection, "insert_one", fail_second_change)
+    monkeypatch.setattr(collection, "replace_one", replace_with_rollback_race)
+
+    with pytest.raises(RuntimeError, match="force second change failure"):
+        execute_targeted_repair(
+            plan=plan,
+            databases=databases,
+            expected_preimage_hash=preview["preimage_hash"],
+            manifest_path=tmp_path / "repair.json",
+        )
+
+    assert collection.documents[0]["filled_quantity"] == 777
+    assert collection.documents[0]["filled_price"] == 99.0
+    assert collection.documents[0]["concurrent_marker"] == "preserve-rollback-race"
+    receipt = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents[0]
+    assert receipt["rollback_succeeded"] is False
+    assert "compare-and-swap replace failed" in receipt["rollback_error"]
+
+
+def test_concurrent_execute_cannot_take_over_active_apply_lease(
+    monkeypatch,
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    manifest_path = tmp_path / "repair.json"
+    original_write = targeted_ledger_module._write_change_documents
+    nested_attempted = False
+
+    def write_with_competing_execute(
+        change,
+        *,
+        databases,
+        document_field,
+    ):
+        nonlocal nested_attempted
+        if document_field == "postimage_documents" and not nested_attempted:
+            nested_attempted = True
+            with pytest.raises(RepairIdConflict, match="active apply attempt"):
+                execute_targeted_repair(
+                    plan=plan,
+                    databases=databases,
+                    expected_preimage_hash=preview["preimage_hash"],
+                    manifest_path=manifest_path,
+                )
+        return original_write(
+            change,
+            databases=databases,
+            document_field=document_field,
+        )
+
+    monkeypatch.setattr(
+        targeted_ledger_module,
+        "_write_change_documents",
+        write_with_competing_execute,
+    )
+
+    result = execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+
+    assert nested_attempted is True
+    assert result["status"] == "applied"
+    receipt = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents[0]
+    assert receipt["status"] == "applied"
+    assert receipt["receipt_version"] == 2
+    assert receipt["apply_lease_expires_at"] is None
+
+
+def test_apply_stops_before_writing_when_receipt_disappears(
+    monkeypatch,
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    original = deepcopy(databases["order"]["om_broker_orders"].documents)
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    journal = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION]
+    original_update = journal.update_one
+    removed = False
+
+    def update_after_receipt_loss(query, update, upsert=False):
+        nonlocal removed
+        if not removed and query.get("status") == "applying":
+            removed = True
+            journal.documents.clear()
+            return SimpleNamespace(matched_count=0, upserted_id=None)
+        return original_update(query, update, upsert=upsert)
+
+    monkeypatch.setattr(journal, "update_one", update_after_receipt_loss)
+
+    with pytest.raises(RepairIdConflict, match="lost apply attempt ownership"):
+        execute_targeted_repair(
+            plan=plan,
+            databases=databases,
+            expected_preimage_hash=preview["preimage_hash"],
+            manifest_path=tmp_path / "repair.json",
+        )
+
+    assert removed is True
+    assert databases["order"]["om_broker_orders"].documents == original
+    assert journal.documents == []
+
+
+def test_insert_compare_and_swap_preserves_competing_fixed_id_document(
+    monkeypatch,
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    collection = databases["order"]["om_broker_orders"]
+    original_insert = collection.insert_one
+    raced = False
+
+    def insert_with_fixed_id_race(document):
+        nonlocal raced
+        if document.get("_id") == REPAIRED_BROKER_ORDER_DOCUMENT_ID and not raced:
+            raced = True
+            concurrent = deepcopy(document)
+            concurrent["filled_quantity"] = 777
+            concurrent["filled_price"] = 99.0
+            concurrent["concurrent_marker"] = "preserve-fixed-id-race"
+            original_insert(concurrent)
+        return original_insert(document)
+
+    monkeypatch.setattr(collection, "insert_one", insert_with_fixed_id_race)
+
+    with pytest.raises(
+        TargetedRepairError,
+        match="fixed _id already contains a different document",
+    ):
+        execute_targeted_repair(
+            plan=plan,
+            databases=databases,
+            expected_preimage_hash=preview["preimage_hash"],
+            manifest_path=tmp_path / "repair.json",
+        )
+
+    documents_by_id = {item["_id"]: item for item in collection.documents}
+    assert (
+        documents_by_id[EXISTING_BROKER_ORDER_DOCUMENT_ID]["filled_quantity"] == 48700
+    )
+    competing = documents_by_id[REPAIRED_BROKER_ORDER_DOCUMENT_ID]
+    assert competing["filled_quantity"] == 777
+    assert competing["filled_price"] == 99.0
+    assert competing["concurrent_marker"] == "preserve-fixed-id-race"
+    receipt = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents[0]
+    assert receipt["status"] == "failed"
+    assert receipt["rollback_succeeded"] is False
+
+
+def test_insert_requires_same_fixed_id_in_document_and_selector():
+    databases = _databases()
+    plan = _plan()
+    insert_change = plan["changes"][1]
+    insert_change["selector"] = {
+        "account_id": "acct-A",
+        "internal_order_id": "order-688772",
+    }
+    insert_change["desired_documents"][0].pop("_id")
+
+    with pytest.raises(InvalidRepairPlan, match="requires a fixed non-empty _id"):
+        stage_targeted_repair(plan=plan, databases=databases)
+
+
 def test_allowed_diff_blocks_unplanned_delete():
     databases = _databases()
     plan = _plan()
@@ -298,7 +573,10 @@ def test_repair_id_is_idempotent_after_successful_apply(tmp_path: Path):
     assert repaired_by_symbol["688772"]["filled_quantity"] == 10000
     assert repaired_by_symbol["688772"]["filled_price"] == 14.7
     assert all("_id" in item for item in repaired_by_symbol.values())
-    assert "_id" not in preview["changes"][1]["postimage_documents"][0]
+    assert (
+        preview["changes"][1]["postimage_documents"][0]["_id"]
+        == REPAIRED_BROKER_ORDER_DOCUMENT_ID
+    )
     assert len(databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents) == 1
     persisted = load_repair_document(manifest_path)
     assert persisted["manifest_hash"] == preview["manifest_hash"]
@@ -342,6 +620,232 @@ def test_restore_round_trip_requires_exact_postimage_and_is_idempotent(tmp_path:
     assert receipt["status"] == "restored"
     assert receipt["restore_id"] == "restore:fix-504-688772-v1"
 
+    already_restored_preview = preview_targeted_restore(
+        manifest=manifest,
+        databases=databases,
+    )
+    assert already_restored_preview["receipt_status"] == "restored"
+    assert already_restored_preview["restorable"] is True
+
+
+def test_concurrent_restore_cannot_take_over_active_restore_lease(
+    monkeypatch,
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    manifest_path = tmp_path / "repair.json"
+    execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+    manifest = load_repair_document(manifest_path)
+    restore_preview = preview_targeted_restore(
+        manifest=manifest,
+        databases=databases,
+    )
+    original_write = targeted_ledger_module._write_change_documents
+    nested_attempted = False
+
+    def write_with_competing_restore(
+        change,
+        *,
+        databases,
+        document_field,
+    ):
+        nonlocal nested_attempted
+        if document_field == "preimage_documents" and not nested_attempted:
+            nested_attempted = True
+            with pytest.raises(RepairIdConflict, match="active restore attempt"):
+                restore_targeted_repair(
+                    manifest=manifest,
+                    databases=databases,
+                    expected_current_hash=restore_preview["current_hash"],
+                )
+        return original_write(
+            change,
+            databases=databases,
+            document_field=document_field,
+        )
+
+    monkeypatch.setattr(
+        targeted_ledger_module,
+        "_write_change_documents",
+        write_with_competing_restore,
+    )
+
+    result = restore_targeted_repair(
+        manifest=manifest,
+        databases=databases,
+        expected_current_hash=restore_preview["current_hash"],
+    )
+
+    assert nested_attempted is True
+    assert result["status"] == "restored"
+    receipt = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents[0]
+    assert receipt["status"] == "restored"
+    assert receipt["receipt_version"] == 4
+    assert receipt["restore_lease_expires_at"] is None
+
+
+def test_execute_is_rejected_while_restore_lifecycle_is_active(
+    monkeypatch,
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    manifest_path = tmp_path / "repair.json"
+    execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+    manifest = load_repair_document(manifest_path)
+    restore_preview = preview_targeted_restore(
+        manifest=manifest,
+        databases=databases,
+    )
+    original_write = targeted_ledger_module._write_change_documents
+    nested_attempted = False
+
+    def write_with_competing_execute(
+        change,
+        *,
+        databases,
+        document_field,
+    ):
+        nonlocal nested_attempted
+        if document_field == "preimage_documents" and not nested_attempted:
+            nested_attempted = True
+            with pytest.raises(RepairIdConflict, match="restore lifecycle state"):
+                execute_targeted_repair(
+                    plan=plan,
+                    databases=databases,
+                    expected_preimage_hash=preview["preimage_hash"],
+                    manifest_path=manifest_path,
+                )
+        return original_write(
+            change,
+            databases=databases,
+            document_field=document_field,
+        )
+
+    monkeypatch.setattr(
+        targeted_ledger_module,
+        "_write_change_documents",
+        write_with_competing_execute,
+    )
+
+    result = restore_targeted_repair(
+        manifest=manifest,
+        databases=databases,
+        expected_current_hash=restore_preview["current_hash"],
+    )
+
+    assert nested_attempted is True
+    assert result["status"] == "restored"
+    receipt = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents[0]
+    assert receipt["status"] == "restored"
+
+
+def test_restore_preview_rejects_partial_state_without_restoring_receipt(
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    manifest_path = tmp_path / "repair.json"
+    execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+    databases["order"]["om_broker_orders"].delete_one(
+        {"account_id": "acct-A", "internal_order_id": "order-688772"}
+    )
+    manifest = load_repair_document(manifest_path)
+
+    restore_preview = preview_targeted_restore(
+        manifest=manifest,
+        databases=databases,
+    )
+
+    assert restore_preview["receipt_status"] == "applied"
+    assert restore_preview["restorable"] is False
+    with pytest.raises(
+        RestoreStateMismatch,
+        match="partial restore state is resumable only from a restoring receipt",
+    ):
+        restore_targeted_repair(
+            manifest=manifest,
+            databases=databases,
+            expected_current_hash=restore_preview["current_hash"],
+        )
+
+
+def test_restore_requires_existing_matching_repair_receipt():
+    databases = _databases()
+    manifest = stage_targeted_repair(plan=_plan(), databases=databases)
+
+    with pytest.raises(RepairIdConflict, match="no matching applied repair receipt"):
+        restore_targeted_repair(
+            manifest=manifest,
+            databases=databases,
+            expected_current_hash=manifest["preimage_hash"],
+        )
+
+
+@pytest.mark.parametrize("receipt_status", ["applying", "failed"])
+def test_restore_rejects_non_restorable_receipt_status(
+    receipt_status,
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    manifest_path = tmp_path / "repair.json"
+    execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+    databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents[0][
+        "status"
+    ] = receipt_status
+
+    with pytest.raises(RestoreStateMismatch, match="is not restorable"):
+        preview_targeted_restore(
+            manifest=load_repair_document(manifest_path),
+            databases=databases,
+        )
+
+
+def test_restore_revalidates_manifest_selector_scope():
+    databases = _databases()
+    manifest = stage_targeted_repair(plan=_plan(), databases=databases)
+    manifest["changes"][0]["selector"] = {"symbol": "600917"}
+    manifest["manifest_hash"] = targeted_ledger_module._manifest_hash(manifest)
+
+    with pytest.raises(InvalidRepairPlan, match="requires account_id"):
+        preview_targeted_restore(manifest=manifest, databases=databases)
+
+
+def test_restore_revalidates_manifest_document_scope():
+    databases = _databases()
+    manifest = stage_targeted_repair(plan=_plan(), databases=databases)
+    manifest["scope"]["symbols"] = ["600917"]
+    manifest["manifest_hash"] = targeted_ledger_module._manifest_hash(manifest)
+
+    with pytest.raises(InvalidRepairPlan, match="escapes declared scope field symbol"):
+        preview_targeted_restore(manifest=manifest, databases=databases)
+
 
 def test_apply_resumes_when_atomic_changes_are_individually_pre_or_post(tmp_path: Path):
     databases = _databases()
@@ -373,6 +877,77 @@ def test_apply_resumes_when_atomic_changes_are_individually_pre_or_post(tmp_path
     assert {
         item["symbol"] for item in databases["order"]["om_broker_orders"].documents
     } == {"600917", "688772"}
+
+
+def test_failed_apply_rolls_back_only_postimages_and_preserves_diverged_change(
+    monkeypatch,
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    original_write = targeted_ledger_module._write_change_documents
+    postimage_write_count = 0
+
+    def write_with_concurrent_divergence(
+        change,
+        *,
+        databases,
+        document_field,
+    ):
+        nonlocal postimage_write_count
+        if document_field == "postimage_documents":
+            postimage_write_count += 1
+            if postimage_write_count == 2:
+                databases["order"]["om_broker_orders"].replace_one(
+                    change["selector"],
+                    {
+                        "_id": REPAIRED_BROKER_ORDER_DOCUMENT_ID,
+                        "internal_order_id": "order-688772",
+                        "account_id": "acct-A",
+                        "trading_day": 20260804,
+                        "symbol": "688772",
+                        "broker_order_id": "1209008130",
+                        "side": "buy",
+                        "filled_quantity": 777,
+                        "filled_price": 99.0,
+                        "concurrent_marker": "preserve-me",
+                    },
+                    upsert=True,
+                )
+                raise RuntimeError("simulated concurrent divergence")
+        return original_write(
+            change,
+            databases=databases,
+            document_field=document_field,
+        )
+
+    monkeypatch.setattr(
+        targeted_ledger_module,
+        "_write_change_documents",
+        write_with_concurrent_divergence,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated concurrent divergence"):
+        execute_targeted_repair(
+            plan=plan,
+            databases=databases,
+            expected_preimage_hash=preview["preimage_hash"],
+            manifest_path=tmp_path / "repair.json",
+        )
+
+    documents_by_order_id = {
+        item["internal_order_id"]: item
+        for item in databases["order"]["om_broker_orders"].documents
+    }
+    assert documents_by_order_id["order-600917"]["filled_quantity"] == 48700
+    assert documents_by_order_id["order-600917"]["filled_price"] == 7.118932
+    assert documents_by_order_id["order-688772"]["filled_quantity"] == 777
+    assert documents_by_order_id["order-688772"]["filled_price"] == 99.0
+    assert documents_by_order_id["order-688772"]["concurrent_marker"] == "preserve-me"
+    receipt = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents[0]
+    assert receipt["status"] == "failed"
+    assert receipt["rollback_succeeded"] is False
 
 
 def test_restore_resumes_in_reverse_from_individual_pre_or_post_states(
@@ -418,6 +993,7 @@ def _databases():
             {
                 "om_broker_orders": [
                     {
+                        "_id": EXISTING_BROKER_ORDER_DOCUMENT_ID,
                         "internal_order_id": "order-600917",
                         "account_id": "acct-A",
                         "trading_day": 20260715,
@@ -434,6 +1010,7 @@ def _databases():
             {
                 "xt_trades": [
                     {
+                        "_id": BROKER_TRADE_DOCUMENT_ID,
                         "account_id": "acct-A",
                         "stock_code": "688772",
                         "side": "buy",
@@ -459,6 +1036,11 @@ def _plan():
             "broker_order_ids": ["1209008130"],
             "trading_days": [20260715, 20260804],
             "internal_order_ids": ["order-600917", "order-688772"],
+            "document_ids": [
+                EXISTING_BROKER_ORDER_DOCUMENT_ID,
+                REPAIRED_BROKER_ORDER_DOCUMENT_ID,
+                BROKER_TRADE_DOCUMENT_ID,
+            ],
         },
         "changes": [
             {
@@ -491,12 +1073,12 @@ def _plan():
                 "store": "order",
                 "collection": "om_broker_orders",
                 "selector": {
-                    "account_id": "acct-A",
-                    "internal_order_id": "order-688772",
+                    "_id": REPAIRED_BROKER_ORDER_DOCUMENT_ID,
                 },
                 "identity_fields": ["internal_order_id"],
                 "desired_documents": [
                     {
+                        "_id": REPAIRED_BROKER_ORDER_DOCUMENT_ID,
                         "internal_order_id": "order-688772",
                         "account_id": "acct-A",
                         "trading_day": 20260804,
@@ -542,8 +1124,26 @@ def _matches(document, query):
             if not any(_matches(document, item) for item in expected):
                 return False
             continue
+        if key == "$expr":
+            operands = expected.get("$eq") if isinstance(expected, dict) else None
+            if not isinstance(operands, list) or len(operands) != 2:
+                return False
+
+            def resolve_operand(value):
+                if value == "$$ROOT":
+                    return document
+                if isinstance(value, dict) and set(value) == {"$literal"}:
+                    return value["$literal"]
+                return value
+
+            if resolve_operand(operands[0]) != resolve_operand(operands[1]):
+                return False
+            continue
         actual = document.get(key)
         if isinstance(expected, dict):
+            if "$exists" in expected:
+                if bool(expected["$exists"]) != (key in document):
+                    return False
             if "$eq" in expected and actual != expected["$eq"]:
                 return False
             if "$in" in expected and actual not in expected["$in"]:

--- a/freshquant/tests/test_targeted_order_ledger_repair.py
+++ b/freshquant/tests/test_targeted_order_ledger_repair.py
@@ -1,0 +1,560 @@
+from __future__ import annotations
+
+import sys
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from bson import ObjectId
+
+from freshquant.order_management.repair.targeted_ledger import (
+    TARGETED_REPAIR_JOURNAL_COLLECTION,
+    AllowedDiffMismatch,
+    InvalidRepairPlan,
+    PreimageHashMismatch,
+    execute_targeted_repair,
+    load_repair_document,
+    preview_targeted_restore,
+    restore_targeted_repair,
+    stage_targeted_repair,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from script.maintenance.targeted_order_ledger_repair import run_repair_plan
+
+
+class MemoryCollection:
+    def __init__(self, documents=None):
+        self.documents = [_with_mongo_id(item) for item in list(documents or [])]
+
+    def create_index(self, *_args, **_kwargs):
+        return None
+
+    def find(self, query=None):
+        query = query or {}
+        return [deepcopy(item) for item in self.documents if _matches(item, query)]
+
+    def find_one(self, query=None):
+        rows = self.find(query)
+        return rows[0] if rows else None
+
+    def insert_one(self, document):
+        if self.find_one({"repair_id": document.get("repair_id")}) is not None:
+            raise AssertionError("duplicate repair_id")
+        document = _with_mongo_id(document)
+        self.documents.append(document)
+        return SimpleNamespace(inserted_id=document.get("repair_id"))
+
+    def insert_many(self, documents, ordered=False):
+        del ordered
+        rows = [_with_mongo_id(item) for item in documents]
+        self.documents.extend(rows)
+        return SimpleNamespace(inserted_ids=list(range(len(rows))))
+
+    def delete_many(self, query):
+        kept = [item for item in self.documents if not _matches(item, query)]
+        deleted = len(self.documents) - len(kept)
+        self.documents = kept
+        return SimpleNamespace(deleted_count=deleted)
+
+    def delete_one(self, query):
+        for index, item in enumerate(self.documents):
+            if _matches(item, query):
+                self.documents.pop(index)
+                return SimpleNamespace(deleted_count=1)
+        return SimpleNamespace(deleted_count=0)
+
+    def replace_one(self, query, document, upsert=False):
+        for index, item in enumerate(self.documents):
+            if not _matches(item, query):
+                continue
+            replacement = deepcopy(document)
+            replacement.setdefault("_id", item.get("_id"))
+            self.documents[index] = replacement
+            return SimpleNamespace(matched_count=1, upserted_id=None)
+        if not upsert:
+            return SimpleNamespace(matched_count=0, upserted_id=None)
+        replacement = _with_mongo_id(document)
+        self.documents.append(replacement)
+        return SimpleNamespace(matched_count=0, upserted_id=replacement["_id"])
+
+    def update_one(self, query, update, upsert=False):
+        for item in self.documents:
+            if not _matches(item, query):
+                continue
+            item.update(deepcopy(update.get("$set") or {}))
+            return SimpleNamespace(matched_count=1, upserted_id=None)
+        if not upsert:
+            return SimpleNamespace(matched_count=0, upserted_id=None)
+        document = deepcopy(query)
+        document.update(deepcopy(update.get("$setOnInsert") or {}))
+        document.update(deepcopy(update.get("$set") or {}))
+        document = _with_mongo_id(document)
+        self.documents.append(document)
+        return SimpleNamespace(matched_count=0, upserted_id=document.get("repair_id"))
+
+
+class MemoryDatabase:
+    def __init__(self, collections=None):
+        self.collections = {
+            name: MemoryCollection(documents)
+            for name, documents in dict(collections or {}).items()
+        }
+
+    def __getitem__(self, name):
+        return self.collections.setdefault(name, MemoryCollection())
+
+
+def test_dry_run_captures_688772_and_600917_preimage_without_mutating_database():
+    databases = _databases()
+    plan = _plan()
+    original = deepcopy(databases["order"]["om_broker_orders"].documents)
+
+    manifest = stage_targeted_repair(plan=plan, databases=databases)
+
+    assert databases["order"]["om_broker_orders"].documents == original
+    assert databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents == []
+    assert len(manifest["preimage_hash"]) == 64
+    assert len(manifest["postimage_hash"]) == 64
+    assert manifest["preimage_hash"] != manifest["postimage_hash"]
+    assert manifest["changes"][0]["preimage_documents"] == original
+    assert manifest["changes"][0]["diff"] == {
+        "inserted": [],
+        "updated": [{"internal_order_id": "order-600917"}],
+        "deleted": [],
+    }
+    assert manifest["changes"][1]["diff"] == {
+        "inserted": [{"internal_order_id": "order-688772"}],
+        "updated": [],
+        "deleted": [],
+    }
+    assert {
+        item["symbol"]
+        for change in manifest["changes"][:2]
+        for item in change["postimage_documents"]
+    } == {"600917", "688772"}
+    assert manifest["changes"][2]["mode"] == "snapshot"
+    assert manifest["changes"][2]["preimage_documents"][0]["stock_code"] == "688772"
+
+
+def test_cli_dry_run_summary_preserves_each_change_for_a_repeated_collection():
+    summary = run_repair_plan(
+        plan=_plan(),
+        databases=_databases(),
+    )
+
+    assert [
+        (item["index"], item["store"], item["collection"])
+        for item in summary["changes"]
+    ] == [
+        (0, "order", "om_broker_orders"),
+        (1, "order", "om_broker_orders"),
+        (2, "business", "xt_trades"),
+    ]
+    assert summary["changes"][0]["selector"] == {
+        "account_id": "acct-A",
+        "internal_order_id": "order-600917",
+    }
+    assert summary["changes"][0]["diff"]["updated"] == [
+        {"internal_order_id": "order-600917"}
+    ]
+    assert summary["changes"][1]["diff"]["inserted"] == [
+        {"internal_order_id": "order-688772"}
+    ]
+    assert summary["diff"]["order.om_broker_orders"] == {
+        "inserted": [{"internal_order_id": "order-688772"}],
+        "updated": [{"internal_order_id": "order-600917"}],
+        "deleted": [],
+    }
+
+
+def test_numeric_broker_order_id_is_preserved_for_broker_truth_snapshot():
+    numeric_order_id = 1209008130
+    databases = _databases()
+    plan = _plan()
+    plan["scope"]["broker_order_ids"] = [numeric_order_id]
+    for document in databases["order"]["om_broker_orders"].documents:
+        document["broker_order_id"] = numeric_order_id
+    for document in databases["business"]["xt_trades"].documents:
+        document["broker_order_id"] = numeric_order_id
+    for change in plan["changes"]:
+        for document in change.get("desired_documents", []):
+            document["broker_order_id"] = numeric_order_id
+    plan["changes"][2]["selector"]["broker_order_id"] = numeric_order_id
+
+    manifest = stage_targeted_repair(plan=plan, databases=databases)
+
+    assert manifest["scope"]["broker_order_ids"] == [numeric_order_id]
+    assert type(manifest["scope"]["broker_order_ids"][0]) is int
+    assert (
+        manifest["changes"][2]["preimage_documents"][0]["broker_order_id"]
+        == numeric_order_id
+    )
+
+
+def test_broker_order_id_string_variant_must_be_explicitly_scoped():
+    numeric_order_id = 1209008130
+    databases = _databases()
+    plan = _plan()
+    plan["scope"]["broker_order_ids"] = [numeric_order_id]
+    for document in databases["order"]["om_broker_orders"].documents:
+        document["broker_order_id"] = numeric_order_id
+    for change in plan["changes"][:2]:
+        for document in change["desired_documents"]:
+            document["broker_order_id"] = numeric_order_id
+
+    with pytest.raises(InvalidRepairPlan, match="escapes declared scope"):
+        stage_targeted_repair(plan=plan, databases=databases)
+
+    plan["scope"]["broker_order_ids"].append(str(numeric_order_id))
+    manifest = stage_targeted_repair(plan=plan, databases=databases)
+
+    assert manifest["scope"]["broker_order_ids"] == [
+        numeric_order_id,
+        str(numeric_order_id),
+    ]
+
+
+def test_execute_rejects_stale_preimage_hash_before_writing(tmp_path: Path):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    databases["order"]["om_broker_orders"].documents[0]["filled_price"] = 6.2
+
+    with pytest.raises(PreimageHashMismatch, match="preimage hash mismatch"):
+        execute_targeted_repair(
+            plan=plan,
+            databases=databases,
+            expected_preimage_hash=preview["preimage_hash"],
+            manifest_path=tmp_path / "repair.json",
+        )
+
+    assert databases["order"]["om_broker_orders"].documents[0]["filled_price"] == 6.2
+    assert databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents == []
+    assert not (tmp_path / "repair.json").exists()
+
+
+def test_allowed_diff_blocks_unplanned_delete():
+    databases = _databases()
+    plan = _plan()
+    plan["changes"][0]["allowed_diff"]["updated"] = []
+
+    with pytest.raises(AllowedDiffMismatch, match="allowed diff mismatch"):
+        stage_targeted_repair(plan=plan, databases=databases)
+
+
+def test_symbol_only_selector_is_rejected_before_database_read():
+    plan = _plan()
+    plan["changes"][0]["selector"] = {"symbol": "600917"}
+
+    with pytest.raises(InvalidRepairPlan, match="requires account_id"):
+        stage_targeted_repair(plan=plan, databases=_databases())
+
+
+def test_repair_id_is_idempotent_after_successful_apply(tmp_path: Path):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    manifest_path = tmp_path / "repair.json"
+
+    first = execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+    second = execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+
+    assert first["status"] == "applied"
+    assert first["idempotent"] is False
+    assert second["status"] == "already_applied"
+    assert second["idempotent"] is True
+    assert [item["index"] for item in first["changes"]] == [0, 1, 2]
+    assert first["diff_counts"]["order.om_broker_orders"] == {
+        "inserted": 1,
+        "updated": 1,
+        "deleted": 0,
+    }
+    assert first["changes"][0]["diff_counts"] == {
+        "inserted": 0,
+        "updated": 1,
+        "deleted": 0,
+    }
+    repaired_by_symbol = {
+        item["symbol"]: item
+        for item in databases["order"]["om_broker_orders"].documents
+    }
+    assert repaired_by_symbol["600917"]["filled_quantity"] == 38700
+    assert repaired_by_symbol["600917"]["filled_price"] == 5.16
+    assert repaired_by_symbol["688772"]["filled_quantity"] == 10000
+    assert repaired_by_symbol["688772"]["filled_price"] == 14.7
+    assert all("_id" in item for item in repaired_by_symbol.values())
+    assert "_id" not in preview["changes"][1]["postimage_documents"][0]
+    assert len(databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents) == 1
+    persisted = load_repair_document(manifest_path)
+    assert persisted["manifest_hash"] == preview["manifest_hash"]
+
+
+def test_restore_round_trip_requires_exact_postimage_and_is_idempotent(tmp_path: Path):
+    databases = _databases()
+    plan = _plan()
+    original = deepcopy(databases["order"]["om_broker_orders"].documents)
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    manifest_path = tmp_path / "repair.json"
+    execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+    manifest = load_repair_document(manifest_path)
+
+    restore_preview = preview_targeted_restore(
+        manifest=manifest,
+        databases=databases,
+    )
+    restored = restore_targeted_repair(
+        manifest=manifest,
+        databases=databases,
+        expected_current_hash=restore_preview["current_hash"],
+    )
+    restored_again = restore_targeted_repair(
+        manifest=manifest,
+        databases=databases,
+        expected_current_hash=restore_preview["current_hash"],
+    )
+
+    assert restore_preview["restorable"] is True
+    assert restored["status"] == "restored"
+    assert restored_again["status"] == "already_restored"
+    assert databases["order"]["om_broker_orders"].documents == original
+    assert databases["business"]["xt_trades"].documents[0]["price"] == 14.7
+    receipt = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents[0]
+    assert receipt["status"] == "restored"
+    assert receipt["restore_id"] == "restore:fix-504-688772-v1"
+
+
+def test_apply_resumes_when_atomic_changes_are_individually_pre_or_post(tmp_path: Path):
+    databases = _databases()
+    plan = _plan()
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    manifest_path = tmp_path / "repair.json"
+    execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+    databases["order"]["om_broker_orders"].delete_one(
+        {"account_id": "acct-A", "internal_order_id": "order-688772"}
+    )
+    databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents[0][
+        "status"
+    ] = "applying"
+
+    resumed = execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+
+    assert resumed["status"] == "applied"
+    assert resumed["idempotent"] is False
+    assert {
+        item["symbol"] for item in databases["order"]["om_broker_orders"].documents
+    } == {"600917", "688772"}
+
+
+def test_restore_resumes_in_reverse_from_individual_pre_or_post_states(
+    tmp_path: Path,
+):
+    databases = _databases()
+    plan = _plan()
+    original = deepcopy(databases["order"]["om_broker_orders"].documents)
+    preview = stage_targeted_repair(plan=plan, databases=databases)
+    manifest_path = tmp_path / "repair.json"
+    execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=preview["preimage_hash"],
+        manifest_path=manifest_path,
+    )
+    databases["order"]["om_broker_orders"].delete_one(
+        {"account_id": "acct-A", "internal_order_id": "order-688772"}
+    )
+    receipt = databases["order"][TARGETED_REPAIR_JOURNAL_COLLECTION].documents[0]
+    receipt["status"] = "restoring"
+    receipt["restore_id"] = "restore:fix-504-688772-v1"
+    manifest = load_repair_document(manifest_path)
+    restore_preview = preview_targeted_restore(
+        manifest=manifest,
+        databases=databases,
+    )
+
+    restored = restore_targeted_repair(
+        manifest=manifest,
+        databases=databases,
+        expected_current_hash=restore_preview["current_hash"],
+    )
+
+    assert restore_preview["restorable"] is True
+    assert restored["status"] == "restored"
+    assert databases["order"]["om_broker_orders"].documents == original
+
+
+def _databases():
+    return {
+        "order": MemoryDatabase(
+            {
+                "om_broker_orders": [
+                    {
+                        "internal_order_id": "order-600917",
+                        "account_id": "acct-A",
+                        "trading_day": 20260715,
+                        "symbol": "600917",
+                        "broker_order_id": "1209008130",
+                        "side": "buy",
+                        "filled_quantity": 48700,
+                        "filled_price": 7.118932,
+                    }
+                ]
+            }
+        ),
+        "business": MemoryDatabase(
+            {
+                "xt_trades": [
+                    {
+                        "account_id": "acct-A",
+                        "stock_code": "688772",
+                        "side": "buy",
+                        "broker_order_id": "1209008130",
+                        "broker_trade_id": "trade-1",
+                        "quantity": 10000,
+                        "price": 14.7,
+                    }
+                ]
+            }
+        ),
+    }
+
+
+def _plan():
+    return {
+        "schema_version": 1,
+        "repair_id": "fix-504-688772-v1",
+        "reason": "repair cross-symbol broker identity contamination",
+        "scope": {
+            "account_id": "acct-A",
+            "symbols": ["688772", "600917"],
+            "broker_order_ids": ["1209008130"],
+            "trading_days": [20260715, 20260804],
+            "internal_order_ids": ["order-600917", "order-688772"],
+        },
+        "changes": [
+            {
+                "store": "order",
+                "collection": "om_broker_orders",
+                "selector": {
+                    "account_id": "acct-A",
+                    "internal_order_id": "order-600917",
+                },
+                "identity_fields": ["internal_order_id"],
+                "desired_documents": [
+                    {
+                        "internal_order_id": "order-600917",
+                        "account_id": "acct-A",
+                        "trading_day": 20260715,
+                        "symbol": "600917",
+                        "broker_order_id": "1209008130",
+                        "side": "buy",
+                        "filled_quantity": 38700,
+                        "filled_price": 5.16,
+                    }
+                ],
+                "allowed_diff": {
+                    "inserted": [],
+                    "updated": [{"internal_order_id": "order-600917"}],
+                    "deleted": [],
+                },
+            },
+            {
+                "store": "order",
+                "collection": "om_broker_orders",
+                "selector": {
+                    "account_id": "acct-A",
+                    "internal_order_id": "order-688772",
+                },
+                "identity_fields": ["internal_order_id"],
+                "desired_documents": [
+                    {
+                        "internal_order_id": "order-688772",
+                        "account_id": "acct-A",
+                        "trading_day": 20260804,
+                        "symbol": "688772",
+                        "broker_order_id": "1209008130",
+                        "side": "buy",
+                        "filled_quantity": 10000,
+                        "filled_price": 14.7,
+                    },
+                ],
+                "allowed_diff": {
+                    "inserted": [{"internal_order_id": "order-688772"}],
+                    "updated": [],
+                    "deleted": [],
+                },
+            },
+            {
+                "mode": "snapshot",
+                "store": "business",
+                "collection": "xt_trades",
+                "selector": {
+                    "account_id": "acct-A",
+                    "broker_order_id": "1209008130",
+                },
+                "identity_fields": ["broker_trade_id"],
+                "allowed_diff": {
+                    "inserted": [],
+                    "updated": [],
+                    "deleted": [],
+                },
+            },
+        ],
+    }
+
+
+def _matches(document, query):
+    for key, expected in query.items():
+        if key == "$and":
+            if not all(_matches(document, item) for item in expected):
+                return False
+            continue
+        if key == "$or":
+            if not any(_matches(document, item) for item in expected):
+                return False
+            continue
+        actual = document.get(key)
+        if isinstance(expected, dict):
+            if "$eq" in expected and actual != expected["$eq"]:
+                return False
+            if "$in" in expected and actual not in expected["$in"]:
+                return False
+            continue
+        if actual != expected:
+            return False
+    return True
+
+
+def _with_mongo_id(document):
+    row = deepcopy(document)
+    row.setdefault("_id", ObjectId())
+    return row

--- a/freshquant/tests/test_tpsl_rearm.py
+++ b/freshquant/tests/test_tpsl_rearm.py
@@ -186,6 +186,8 @@ def test_xt_ingest_buy_trade_calls_tpsl_service_hook(monkeypatch):
             "quantity": 300,
             "source": "xt_trade_callback",
             "internal_order_id": "ord_xt_buy_1",
+            "account_id": "acct-1",
+            "trading_day": 20240102,
         }
     )
     tpsl_service = FakeTpslService()
@@ -206,6 +208,8 @@ def test_xt_ingest_buy_trade_calls_tpsl_service_hook(monkeypatch):
             "trade_time": 1710000000,
             "date": 20240102,
             "time": "09:31:00",
+            "account_id": "acct-1",
+            "trading_day": 20240102,
             "source": "xt_trade_callback",
         },
         lot_amount=3000,

--- a/freshquant/tests/test_xt_reports_runtime_observability.py
+++ b/freshquant/tests/test_xt_reports_runtime_observability.py
@@ -4,6 +4,8 @@ from freshquant.order_management.ingest.xt_reports import (
 )
 from freshquant.order_management.tracking.service import OrderTrackingService
 
+TEST_ACCOUNT_ID = "acct-test"
+
 
 class FakeRuntimeLogger:
     def __init__(self):
@@ -151,6 +153,8 @@ def test_ingest_trade_report_emits_runtime_events(monkeypatch):
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": TEST_ACCOUNT_ID,
+            "trading_day": 20240102,
             "symbol": "000001",
             "price": 10.0,
             "quantity": 300,
@@ -174,6 +178,7 @@ def test_ingest_trade_report_emits_runtime_events(monkeypatch):
     service.ingest_trade_report(
         {
             "internal_order_id": "ord_xt_1",
+            "account_id": TEST_ACCOUNT_ID,
             "broker_order_id": "90001",
             "broker_trade_id": "T-90001",
             "symbol": "000001",
@@ -208,6 +213,8 @@ def test_duplicate_trade_report_is_silent_in_runtime_observability(monkeypatch):
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": TEST_ACCOUNT_ID,
+            "trading_day": 20240102,
             "symbol": "000001",
             "price": 10.0,
             "quantity": 300,
@@ -229,6 +236,7 @@ def test_duplicate_trade_report_is_silent_in_runtime_observability(monkeypatch):
     )
     report = {
         "internal_order_id": "ord_xt_dup_1",
+        "account_id": TEST_ACCOUNT_ID,
         "broker_order_id": "90003",
         "broker_trade_id": "T-90003",
         "symbol": "000001",
@@ -267,6 +275,8 @@ def test_ingest_order_report_emits_runtime_events():
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": TEST_ACCOUNT_ID,
+            "trading_day": 20240310,
             "symbol": "000001",
             "price": 10.0,
             "quantity": 300,
@@ -289,8 +299,10 @@ def test_ingest_order_report_emits_runtime_events():
 
     service.ingest_order_report(
         {
+            "account_id": TEST_ACCOUNT_ID,
             "order_id": 90002,
             "stock_code": "000001.SZ",
+            "order_type": 23,
             "order_time": 1710000000,
             "order_status": 54,
         }
@@ -311,6 +323,8 @@ def test_duplicate_order_snapshot_is_silent_in_runtime_observability():
     tracking_service.submit_order(
         {
             "action": "buy",
+            "account_id": TEST_ACCOUNT_ID,
+            "trading_day": 20240310,
             "symbol": "000001",
             "price": 10.0,
             "quantity": 300,
@@ -331,8 +345,10 @@ def test_duplicate_order_snapshot_is_silent_in_runtime_observability():
         runtime_logger=runtime_logger,
     )
     report = {
+        "account_id": TEST_ACCOUNT_ID,
         "order_id": 90012,
         "stock_code": "000001.SZ",
+        "order_type": 23,
         "order_time": 1710000000,
         "order_status": 54,
     }
@@ -356,6 +372,7 @@ def test_unknown_order_snapshot_is_ignored_in_runtime_observability():
 
     result = service.ingest_order_report(
         {
+            "account_id": TEST_ACCOUNT_ID,
             "order_id": 99901,
             "stock_code": "000001.SZ",
             "order_time": 1710000000,

--- a/freshquant/tests/test_xtquant_runtime_observability.py
+++ b/freshquant/tests/test_xtquant_runtime_observability.py
@@ -1,5 +1,6 @@
 import contextlib
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -1048,6 +1049,59 @@ def test_broker_trading_loop_emits_success_heartbeat_after_connect(monkeypatch):
         "payload": {},
         "metrics": {"connected": 1, "retry_count": 0, "retry_delay_s": 0},
     }
+
+
+@pytest.mark.parametrize(("action", "remark_arg_index"), [("buy", 4), ("sell", 5)])
+def test_broker_gateway_passes_correlation_token_as_xt_order_remark(
+    monkeypatch,
+    action,
+    remark_arg_index,
+):
+    _install_broker_stubs(monkeypatch)
+    broker = _load_module(f"test_runtime_broker_{action}_remark", BROKER_PATH)
+    captured = {}
+    token = "FQOM0123456789abcdef0123"
+
+    def capture_submit(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return 90009
+
+    broker.puppet.buy = capture_submit
+    broker.puppet.sell = capture_submit
+    broker.connection_manager.connected = True
+    broker.resolve_broker_submit_mode = lambda settings_provider=None: "normal"
+    broker.random.shuffle = lambda _values: None
+    broker.tool_trade_date_seconds_to_start = lambda: 0
+    payload = {
+        "action": action,
+        "symbol": "688772",
+        "price": 14.7,
+        "quantity": 3400,
+        "source": "api",
+        "strategy_name": "takeprofit",
+        "remark": "human readable remark",
+        "broker_order_remark": token,
+        "internal_order_id": f"ord-{action}-remark",
+        "force": True,
+    }
+
+    class OneMessageRedis:
+        def __init__(self):
+            self.calls = 0
+
+        def brpop(self, _queues, _timeout):
+            self.calls += 1
+            if self.calls == 1:
+                return ("QUEUE:ORDER", json.dumps(payload))
+            raise KeyboardInterrupt()
+
+    broker.redis_db = OneMessageRedis()
+
+    broker.trading_main_loop()
+
+    assert captured["args"][remark_arg_index] == token
+    assert captured["args"][remark_arg_index] != payload["remark"]
 
 
 def test_broker_source_no_longer_contains_sync_maintenance_actions():

--- a/freshquant/tests/test_xtquant_runtime_observability.py
+++ b/freshquant/tests/test_xtquant_runtime_observability.py
@@ -619,6 +619,9 @@ def test_broker_trade_callback_emits_resolved_runtime_context(monkeypatch):
             "intent_id": "intent-broker-1",
             "request_id": "req-broker-1",
             "internal_order_id": "ord-broker-1",
+            "account_id": "acct-1",
+            "trading_day": 20260805,
+            "broker_order_id": "90001",
             "symbol": "600000",
             "side": "buy",
         }
@@ -630,6 +633,9 @@ def test_broker_trade_callback_emits_resolved_runtime_context(monkeypatch):
             order_id="90001",
             traded_id="T-90001",
             stock_code="600000.SH",
+            account_id="acct-1",
+            trading_day=20260805,
+            order_type=23,
         )
     )
 
@@ -659,6 +665,9 @@ def test_broker_trade_callback_disambiguates_reused_broker_order_id(monkeypatch)
                     "intent_id": "int_old",
                     "request_id": "req_old",
                     "internal_order_id": "ord_old_buy",
+                    "account_id": "acct-1",
+                    "trading_day": 20260413,
+                    "broker_order_id": "1477443585",
                     "symbol": "002262",
                     "side": "buy",
                     "broker_order_type": 27,
@@ -670,6 +679,9 @@ def test_broker_trade_callback_disambiguates_reused_broker_order_id(monkeypatch)
                     "intent_id": "int_new",
                     "request_id": "req_new",
                     "internal_order_id": "ord_new_sell",
+                    "account_id": "acct-1",
+                    "trading_day": 20260429,
+                    "broker_order_id": "1477443585",
                     "symbol": "002262",
                     "side": "sell",
                     "broker_order_type": 24,
@@ -688,6 +700,8 @@ def test_broker_trade_callback_disambiguates_reused_broker_order_id(monkeypatch)
             stock_code="002262.SZ",
             order_type=24,
             traded_time=1777428846,
+            account_id="acct-1",
+            trading_day=20260429,
         )
     )
 

--- a/morningglory/fqxtrade/fqxtrade/xtquant/broker.py
+++ b/morningglory/fqxtrade/fqxtrade/xtquant/broker.py
@@ -334,7 +334,11 @@ def trading_main_loop():
                                     resolved_order["price"],
                                     resolved_order["quantity"],
                                     pydash.get(resolved_order, "strategy_name", "N/A"),
-                                    pydash.get(resolved_order, "remark", "N/A"),
+                                    pydash.get(
+                                        resolved_order,
+                                        "broker_order_remark",
+                                        pydash.get(resolved_order, "remark", "N/A"),
+                                    ),
                                     pydash.get(resolved_order, "retry_count", 0),
                                     order_type=pydash.get(
                                         resolved_order, "broker_order_type"
@@ -369,7 +373,11 @@ def trading_main_loop():
                                     resolved_order["price"],
                                     resolved_order["quantity"],
                                     pydash.get(resolved_order, "strategy_name", "N/A"),
-                                    pydash.get(resolved_order, "remark", "N/A"),
+                                    pydash.get(
+                                        resolved_order,
+                                        "broker_order_remark",
+                                        pydash.get(resolved_order, "remark", "N/A"),
+                                    ),
                                     pydash.get(resolved_order, "retry_count", 0),
                                     order_type=pydash.get(
                                         resolved_order, "broker_order_type"

--- a/script/freshquant_deploy_plan.py
+++ b/script/freshquant_deploy_plan.py
@@ -108,6 +108,13 @@ FRESHQUANT_MESSAGE_SURFACES = ("market_data", "guardian")
 FRESHQUANT_TRADING_SURFACES = ("api", "dagster", "market_data", "guardian")
 FRESHQUANT_LEGACY_CONFIG_SURFACES = ("dagster", "market_data", "guardian")
 FQXTRADE_RUNTIME_SURFACES = ("order_management",)
+ORDER_LEDGER_SHARED_CONSUMER_SURFACES = (
+    "api",
+    "guardian",
+    "position_management",
+    "tpsl",
+    "order_management",
+)
 DOCKER_PARALLEL_ALL_SURFACES = ("api", "web", "dagster", "qa")
 DOCKER_PARALLEL_ALL_SERVICES = (
     "fq_mongodb",
@@ -229,6 +236,22 @@ PATH_RULES: tuple[PathRule, ...] = (
         surfaces=FRESHQUANT_LEGACY_CONFIG_SURFACES,
         notes=(
             "旧 `freshquant.yaml` 虽已降级，但当前仍随 `freshquant.config` 被部分宿主机链路读取。",
+        ),
+    ),
+    ExactRule(
+        label="order-ledger-shared-repository",
+        exact_path="freshquant/order_management/repository.py",
+        surfaces=ORDER_LEDGER_SHARED_CONSUMER_SURFACES,
+        notes=(
+            "订单账本 repository 被 Guardian、仓位同步、TPSL 与订单运行面共同加载，必须同步重启全部消费者。",
+        ),
+    ),
+    ExactRule(
+        label="order-ledger-shared-entry-adapter",
+        exact_path="freshquant/order_management/entry_adapter.py",
+        surfaces=ORDER_LEDGER_SHARED_CONSUMER_SURFACES,
+        notes=(
+            "entry adapter 是 Guardian、Position Management 与 TPSL 的共享 V2/compat 读取边界，必须同步重启全部消费者。",
         ),
     ),
     PrefixRule(

--- a/script/maintenance/targeted_order_ledger_repair.py
+++ b/script/maintenance/targeted_order_ledger_repair.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import click
+from bson import json_util
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from freshquant.order_management.db import (
+    get_order_management_db,
+    get_projection_db,
+)
+from freshquant.order_management.repair.targeted_ledger import (
+    execute_targeted_repair,
+    load_repair_document,
+    preview_targeted_restore,
+    restore_targeted_repair,
+    stage_targeted_repair,
+)
+
+
+def _get_databases():
+    return {
+        "order": get_order_management_db(),
+        "business": get_projection_db(),
+    }
+
+
+def run_repair_plan(
+    *,
+    plan,
+    execute=False,
+    expected_preimage_hash=None,
+    manifest_path=None,
+    databases=None,
+):
+    databases = databases if databases is not None else _get_databases()
+    if not execute:
+        manifest = stage_targeted_repair(plan=plan, databases=databases)
+        change_summaries = [
+            _change_summary(item, index=index)
+            for index, item in enumerate(manifest["changes"])
+        ]
+        return {
+            "repair_id": manifest["repair_id"],
+            "execute": False,
+            "status": "staged",
+            "plan_hash": manifest["plan_hash"],
+            "preimage_hash": manifest["preimage_hash"],
+            "postimage_hash": manifest["postimage_hash"],
+            "manifest_hash": manifest["manifest_hash"],
+            "scope": manifest["scope"],
+            "changes": change_summaries,
+            "diff": _aggregate_collection_diffs(manifest["changes"]),
+        }
+    if not str(expected_preimage_hash or "").strip():
+        raise click.UsageError("--execute requires --expected-preimage-hash")
+    if not str(manifest_path or "").strip():
+        raise click.UsageError("--execute requires --manifest-path")
+    return execute_targeted_repair(
+        plan=plan,
+        databases=databases,
+        expected_preimage_hash=str(expected_preimage_hash),
+        manifest_path=str(manifest_path),
+    )
+
+
+def _change_summary(change, *, index):
+    return {
+        "index": int(index),
+        "mode": change["mode"],
+        "store": change["store"],
+        "collection": change["collection"],
+        "selector": deepcopy(change["selector"]),
+        "identity_fields": list(change["identity_fields"]),
+        "diff": deepcopy(change["diff"]),
+    }
+
+
+def _aggregate_collection_diffs(changes):
+    aggregated = {}
+    for change in changes:
+        key = f"{change['store']}.{change['collection']}"
+        collection_diff = aggregated.setdefault(
+            key,
+            {"inserted": [], "updated": [], "deleted": []},
+        )
+        for action in ("inserted", "updated", "deleted"):
+            collection_diff[action].extend(deepcopy(change["diff"][action]))
+    return aggregated
+
+
+def run_restore(
+    *,
+    manifest,
+    execute=False,
+    expected_current_hash=None,
+    restore_id=None,
+    databases=None,
+):
+    databases = databases if databases is not None else _get_databases()
+    if not execute:
+        return preview_targeted_restore(manifest=manifest, databases=databases)
+    if not str(expected_current_hash or "").strip():
+        raise click.UsageError("restore --execute requires --expected-current-hash")
+    return restore_targeted_repair(
+        manifest=manifest,
+        databases=databases,
+        expected_current_hash=str(expected_current_hash),
+        restore_id=restore_id,
+    )
+
+
+@click.command(name="targeted-order-ledger-repair")
+@click.option("--plan-path", type=click.Path(exists=True, dir_okay=False))
+@click.option("--restore-manifest", type=click.Path(exists=True, dir_okay=False))
+@click.option("--dry-run", is_flag=True, help="Preview without writing (the default).")
+@click.option("--execute", is_flag=True, help="Apply the repair or restore.")
+@click.option("--expected-preimage-hash", default=None)
+@click.option("--expected-current-hash", default=None)
+@click.option(
+    "--manifest-path",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="Required output path for the complete preimage manifest during repair apply.",
+)
+@click.option("--restore-id", default=None)
+def targeted_order_ledger_repair_command(
+    plan_path,
+    restore_manifest,
+    dry_run,
+    execute,
+    expected_preimage_hash,
+    expected_current_hash,
+    manifest_path,
+    restore_id,
+):
+    if dry_run and execute:
+        raise click.UsageError("--dry-run and --execute cannot be used together")
+    if bool(plan_path) == bool(restore_manifest):
+        raise click.UsageError(
+            "provide exactly one of --plan-path or --restore-manifest"
+        )
+    if plan_path:
+        if expected_current_hash or restore_id:
+            raise click.UsageError(
+                "--expected-current-hash/--restore-id are only valid with --restore-manifest"
+            )
+        result = run_repair_plan(
+            plan=load_repair_document(plan_path),
+            execute=execute,
+            expected_preimage_hash=expected_preimage_hash,
+            manifest_path=manifest_path,
+        )
+    else:
+        if expected_preimage_hash or manifest_path:
+            raise click.UsageError(
+                "--expected-preimage-hash/--manifest-path are only valid with --plan-path"
+            )
+        result = run_restore(
+            manifest=load_repair_document(restore_manifest),
+            execute=execute,
+            expected_current_hash=expected_current_hash,
+            restore_id=restore_id,
+        )
+    click.echo(
+        json_util.dumps(
+            result,
+            json_options=json_util.RELAXED_JSON_OPTIONS,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+
+
+def main():
+    targeted_order_ledger_repair_command()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## ??

688772 ?????????????????????????entry/slice ??? allocation ????????????????? ID??????????????,????????????? ID ?????????????

## ?????

- ?? broker order ? execution identity,?????????? fail closed
- ? XT ingest?tracking?reconcile ? rebuild ???????????
- ? canonical fills ????? broker aggregate
- ?? entry/slice/allocation ???????????
- ???? partial unique indexes
- ??? BSON preimage?hash ???????? restore ????? repair ??
- ??????,??? repository ?????? API?Guardian?Position?TPSL ? Order Management
- ?? docs/current ?????

## ???

- ? PR ???????????
- ????? destructive rebuild
- ??? XT append-only archive ?????

## ??

- `script/fq_local_preflight.ps1 -Mode Ensure` ??
- docs-current-guard ??? pre-commit hooks ??
- ????:1869 passed, 1 skipped
- ????????:194 passed
- ?? Mongo ??:125 changes / 129 preimage documents ?? apply -> verify -> restore -> verify,preimage/postimage hash ??

## ????

???????????? main ?? formal deploy?FIX-504 ?????? API?Guardian?Position Management?TPSL ? Order Management;?? surface ? formal deploy `plan.json` ??????? repair ??????????,?? stage ??? preimage hash,????? health/runtime verify?

Refs #504
## ????

- ????:`99 passed`
- ????:`1944 passed, 1 skipped`
- ???? preflight:docs-current-guard?Black?pre-commit?mypy?isort?xdist pytest ????
- `compileall` ? `git diff --check` ??