### PR TITLE
fix: register clx_15_30 group in TDX blocknew.cfg so it is visible

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -101,6 +101,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 实时 CLX 只在 15/30 分钟 bar 上运行，生产模型为 `S0000-S0017`，对应 `model_opt=10000..10017`。
 正信号写库后会复用现有 DingTalk 私聊发送链做聚合通知；webhook 配置入口已存在，只有启用 CLX 实时模式且出现正信号时才发送，不在文档或日志中输出真实 webhook/token。
 consumer 还会把本批命中标的（带前缀代码，如 `sh600000`）去重追加到通达信自选股分组 `clx_15_30`（文件 `T0002/blocknew/CLX_15_30.blk`），复用 `freshquant/clx_daily_selection/tdx_export.py` 的编码与原子写实现；写入为 best-effort，失败只记 warning，不影响信号主链，无新增标的时不触碰旧文件。
+写入 `.blk` 后会幂等确保分组注册到通达信分组注册表 `T0002/blocknew/blocknew.cfg`（每条分组固定 120B = 显示名 50B + 键名 70B）；注册缺失时自动备份并追加，否则通达信界面不显示该分组。注册同样为 best-effort，注册文件缺失或写入失败不阻断信号主链。
 
 ## 配置
 

--- a/freshquant/clx_daily_selection/tdx_export.py
+++ b/freshquant/clx_daily_selection/tdx_export.py
@@ -14,6 +14,13 @@ CLX_15_30_TDX_GROUP_DISPLAY_NAME = "clx_15_30"
 CLX_15_30_TDX_BLOCK_KEY = "CLX_15_30"
 CLX_15_30_TDX_BLK_FILENAME = f"{CLX_15_30_TDX_BLOCK_KEY}.blk"
 
+# 通达信自定义分组注册表：T0002/blocknew/blocknew.cfg
+# 每条分组固定 120B = 名称1（50B，界面显示名）+ 名称2（70B，键名/文件名前缀）
+BLOCKNEW_CFG_NAME = "blocknew.cfg"
+BLOCKNEW_CFG_GROUP_SIZE = 120
+BLOCKNEW_CFG_NAME1_SIZE = 50
+BLOCKNEW_CFG_NAME2_SIZE = 70
+
 # consumer 的 fullcalc 回调来自线程池，读-合并-重写必须串行化
 _TDX_BLK_WRITE_LOCK = threading.Lock()
 
@@ -134,6 +141,75 @@ def read_tdx_blk_lines(
     return lines
 
 
+def _parse_blocknew_cfg_groups(data: bytes) -> list[tuple[str, str]]:
+    """解析 blocknew.cfg 为 [(名称1, 名称2), ...]，按固定 120B/组读取。"""
+    groups = []
+    offset = 0
+    while offset + BLOCKNEW_CFG_GROUP_SIZE <= len(data):
+        name1 = (
+            data[offset : offset + BLOCKNEW_CFG_NAME1_SIZE]
+            .split(b"\x00", 1)[0]
+            .decode("gbk", errors="replace")
+        )
+        name2 = (
+            data[offset + BLOCKNEW_CFG_NAME1_SIZE : offset + BLOCKNEW_CFG_GROUP_SIZE]
+            .split(b"\x00", 1)[0]
+            .decode("gbk", errors="replace")
+        )
+        groups.append((name1, name2))
+        offset += BLOCKNEW_CFG_GROUP_SIZE
+    return groups
+
+
+def _encode_blocknew_cfg_group(display_name: str, block_key: str) -> bytes:
+    def _encode(name: str, size: int) -> bytes:
+        raw = name.encode("gbk")
+        if len(raw) > size:
+            raise ValueError(f"通达信分组名过长：{name}")
+        return raw + b"\x00" * (size - len(raw))
+
+    return _encode(display_name, BLOCKNEW_CFG_NAME1_SIZE) + _encode(
+        block_key, BLOCKNEW_CFG_NAME2_SIZE
+    )
+
+
+def ensure_tdx_group_registered(
+    block_key: str,
+    display_name: str,
+    *,
+    tdx_home: str | Path | None = None,
+) -> bool:
+    """确保分组已注册到通达信 blocknew.cfg（120B/组）。
+
+    - 已注册返回 False；本次新增注册返回 True。
+    - best-effort：注册文件缺失、损坏或写入失败时返回 False，不抛错（不阻断信号主链）。
+    """
+    try:
+        root = Path(tdx_home) if tdx_home is not None else _require_tdx_home()
+    except Exception:
+        return False
+    cfg_path = root / "T0002" / "blocknew" / BLOCKNEW_CFG_NAME
+    with _TDX_BLK_WRITE_LOCK:
+        try:
+            if not cfg_path.exists():
+                return False
+            original = cfg_path.read_bytes()
+            for name1, name2 in _parse_blocknew_cfg_groups(original):
+                if (
+                    name1.strip().upper() == display_name.strip().upper()
+                    and name2.strip().upper() == block_key.strip().upper()
+                ):
+                    return False
+            backup = cfg_path.with_name(f"blocknew.cfg.{uuid4().hex}.bak")
+            backup.write_bytes(original)
+            cfg_path.write_bytes(
+                original + _encode_blocknew_cfg_group(display_name, block_key)
+            )
+            return True
+        except Exception:
+            return False
+
+
 def append_tdx_group_members(
     symbols: Sequence[object],
     *,
@@ -172,6 +248,8 @@ def append_tdx_group_members(
     target = root / "T0002" / "blocknew" / filename
     with _TDX_BLK_WRITE_LOCK:
         _atomic_write_blk(lines, target)
+    # 写入 .blk 后确保分组注册到 blocknew.cfg（best-effort，幂等）
+    ensure_tdx_group_registered(block_key, display_name, tdx_home=root)
     return result
 
 

--- a/freshquant/tests/test_clx_daily_selection_tdx_export.py
+++ b/freshquant/tests/test_clx_daily_selection_tdx_export.py
@@ -5,9 +5,12 @@ import os
 import pytest
 
 from freshquant.clx_daily_selection.tdx_export import (
+    BLOCKNEW_CFG_GROUP_SIZE,
+    BLOCKNEW_CFG_NAME,
     CLX_15_30_TDX_BLK_FILENAME,
     append_tdx_group_members,
     encode_tdx_blk_code,
+    ensure_tdx_group_registered,
     read_tdx_blk_lines,
     write_clx_tdx_group,
 )
@@ -170,3 +173,66 @@ def test_append_tdx_group_members_supports_custom_block_key(tmp_path):
         "appended_count": 1,
         "written_count": 1,
     }
+
+
+def _seed_blocknew_cfg(tmp_path, groups=("clx_18", "CLX_18")):
+    cfg = tmp_path / "T0002" / "blocknew" / BLOCKNEW_CFG_NAME
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    name1, name2 = groups
+    # 真实格式：名称1=50B + 名称2=70B
+    name1_bytes = name1.encode("gbk")
+    name2_bytes = name2.encode("gbk")
+    data = (
+        name1_bytes
+        + b"\x00" * (50 - len(name1_bytes))
+        + name2_bytes
+        + b"\x00" * (BLOCKNEW_CFG_GROUP_SIZE - 50 - len(name2_bytes))
+    )
+    cfg.write_bytes(data)
+    return cfg
+
+
+def test_ensure_tdx_group_registered_adds_standard_120b_group(tmp_path):
+    cfg = _seed_blocknew_cfg(tmp_path)
+
+    changed = ensure_tdx_group_registered("CLX_15_30", "clx_15_30", tdx_home=tmp_path)
+
+    assert changed is True
+    data = cfg.read_bytes()
+    assert len(data) == 2 * BLOCKNEW_CFG_GROUP_SIZE
+    # 第二组：名称1=clx_15_30(50B)，名称2=CLX_15_30(70B)
+    name1 = data[120:170].split(b"\x00", 1)[0].decode("gbk")
+    name2 = data[170:240].split(b"\x00", 1)[0].decode("gbk")
+    assert name1 == "clx_15_30"
+    assert name2 == "CLX_15_30"
+
+
+def test_ensure_tdx_group_registered_is_idempotent(tmp_path):
+    cfg = _seed_blocknew_cfg(tmp_path)
+    assert (
+        ensure_tdx_group_registered("CLX_15_30", "clx_15_30", tdx_home=tmp_path) is True
+    )
+    assert (
+        ensure_tdx_group_registered("CLX_15_30", "clx_15_30", tdx_home=tmp_path)
+        is False
+    )
+    assert len(cfg.read_bytes()) == 2 * BLOCKNEW_CFG_GROUP_SIZE
+
+
+def test_ensure_tdx_group_registered_missing_cfg_is_noop(tmp_path):
+    assert (
+        ensure_tdx_group_registered("CLX_15_30", "clx_15_30", tdx_home=tmp_path)
+        is False
+    )
+
+
+def test_append_tdx_group_members_registers_group_when_cfg_present(tmp_path):
+    cfg = _seed_blocknew_cfg(tmp_path)
+
+    append_tdx_group_members(["sh600000"], tdx_home=tmp_path)
+
+    data = cfg.read_bytes()
+    name1 = data[120:170].split(b"\x00", 1)[0].decode("gbk")
+    name2 = data[170:240].split(b"\x00", 1)[0].decode("gbk")
+    assert name1 == "clx_15_30"
+    assert name2 == "CLX_15_30"


### PR DESCRIPTION
背景：clx_15_30 监控命中已写入 T0002/blocknew/CLX_15_30.blk，但通达信界面看不到该分组。根因是通达信自定义分组以 T0002/blocknew/blocknew.cfg 为注册表（每条分组固定 120B = 显示名 50B + 键名 70B），只写 .blk 不注册该文件则界面不显示。此前 CLX_18 分组是人工注册，代码从未注册过 blocknew.cfg。

目标：写入 CLX_15_30.blk 后幂等注册分组到 blocknew.cfg，通达信界面可见；并对未来任意新分组自动生效。

范围：
- freshquant/clx_daily_selection/tdx_export.py：新增 BLOCKNEW_CFG_* 常量、_parse_blocknew_cfg_groups、_encode_blocknew_cfg_group、ensure_tdx_group_registered（幂等、best-effort）；append_tdx_group_members 写入 .blk 后自动注册。
- 测试：新增注册/幂等/缺失 cfg no-op/append 联动 4 用例（29 passed）。
- 文档：docs/current/modules/market-data-xtdata.md 补充注册说明。

非目标：不改动 CLX_18 导出；不改 stock_pools/must_pool 语义；不动通达信其他配置文件。

验收标准：
- pytest test_clx_daily_selection_tdx_export.py 全绿；pre-commit 全绿。
- 已手工完成本机 blocknew.cfg 注册（clx_15_30/CLX_15_30 已入注册表），通达信重启后界面可见。

部署影响：freshquant/clx_daily_selection/** → 重部署 API（fq_apiserver）与 Dagster；consumer 侧代码由宿主机 market_data 运行面加载，需重启 consumer 生效（宿主机 .py 源码直载，不依赖镜像）。