### PR TITLE
fix: add UTF-8 BOM to clx_eval_daily.ps1 for Windows PowerShell 5.1

### DIFF
--- a/script/clx_eval_daily.ps1
+++ b/script/clx_eval_daily.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [string]$TradeDate = (Get-Date -Format "yyyy-MM-dd"),
     [string]$RunDir = "",
     [switch]$SkipPhaseA,


### PR DESCRIPTION
clx_eval_daily.ps1 含中文但无 UTF-8 BOM，Windows PowerShell 5.1 按 ANSI 解码导致解析失败（pwsh 7 不受影响）。本 PR 添加 BOM，其余内容不变。