### PR TITLE
fix: harden external order identity ledger

### DIFF
--- a/docs/current/architecture.md
+++ b/docs/current/architecture.md
@@ -9,11 +9,11 @@
   2/3/4 倍率；`buy_active` 仅保留兼容审计，不参与买入准入。
 - Guardian 新买单提交前复用订单管理撤单链处理同标的内部活动买单；存在
   等待态、外部单或撤单请求时，本 Tick 不提交新单。
-- 当前 Guardian 与 `om_broker_orders` 运行面按单一已配置 XT 账户部署；
-  `om_broker_orders` 只有 `account_type`、没有可用于撤单隔离的 `account_id`，
-  因此活动买单查询在该单账户边界内按标的过滤。若未来同一运行实例承载多个
-  券商账户，必须先把 `account_id` 持久化到订单读模型并加入查询条件，不能直接
-  复用当前撤单编排。
+- 当前 Guardian 与 `om_broker_orders` 运行面按单一已配置 XT 账户部署；XT
+  回报会把 `account_id` 持久化到订单与 broker-order 读模型，并纳入 canonical
+  broker identity。Guardian 活动买单查询仍在该单账户部署边界内按标的过滤；
+  若未来同一运行实例承载多个券商账户，撤单查询与执行必须显式加入
+  `account_id` 过滤，不能直接复用当前单账户编排。
 - 三档止盈按触发时券商总仓位分别计算 1/3、1/2、全部，并受 open ledger
   与 `can_use_volume` 截断；来源分配先使用达价 Slice，不足部分从剩余数量
   最大的 Slice 补足。
@@ -168,7 +168,12 @@ finalizer 只在两侧 completed 后运行。sensor 先持久化 `finalization_a
   - 定义内部订单执行事实，并用于交叉核对 `xt_trades`
 - `om_broker_orders`
   - 定义券商订单聚合视图，不单独作为历史成交数量真值
-  - XT 回报进入订单账本时，`broker_order_id` 只作为候选检索键；重复券商订单号需要结合 `symbol`、`side/order_type` 与回报时间确定内部订单
+  - XT 回报归属优先使用严格 24 字符 `FQOM + 20 hex` correlation token；无
+    token 时只接受完整 canonical identity：
+    `account_id + trading_day + order_sysid`，或
+    `account_id + trading_day + symbol + side + broker_order_id`
+  - `broker_order_id`、`symbol/side` 或回报时间都不能单独证明内部订单归属；
+    无法证明时创建 deterministic broker-only 记录或 fail closed
 - `om_position_entries`
   - 定义系统可消费的持仓入口
 - `om_reconciliation_*`

--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -65,7 +65,10 @@
 - `om_broker_orders`
   - 券商订单聚合，维护 `requested_quantity / filled_quantity / avg_filled_price / fill_count`
 - `om_execution_fills`
-  - 真实券商成交 fill，`broker_trade_id` 去重
+  - 真实券商成交 fill，以 `execution_identity` 原子幂等写入
+  - XT canonical execution identity 固定包含
+    `account_id + trading_day + symbol + side + broker_trade_id`；
+    `broker_trade_id` 不能跨账户或跨交易日单独去重
 - `om_trade_facts`
   - 兼容期成交事实镜像，仍保留给旧读链和部分排障
 - `om_position_entries`
@@ -100,6 +103,12 @@
 ### 下单
 
 `submit_order -> credit mode resolve -> position gate -> om_order_requests / om_orders / om_broker_orders / om_order_events -> STOCK_ORDER_QUEUE -> broker`
+
+内部订单在受理时生成并持久化严格 24 字符 `FQOM + 20 hex` correlation token；
+broker 把该 token 放入既有 XT `order_remark` 参数槽。五档市价保护仍按买入
+`price × 1.008`、卖出 `price × 0.992` 传入，`order_stock()` 参数及顺序不变。
+XT 返回 `None/0/负订单号` 时订单标记为 `FAILED + submit_failed`，puppet 不
+sleep、不重新入队，也不自动重复提交相同券商委托。
 
 当前信用账户买单的运行期语义已经固定为：
 
@@ -136,6 +145,18 @@ Guardian 卖出请求当前会把本次卖量对应的来源入口计划一起�
 
 当前写链规则：
 
+- XT 回报归属优先按 FQOM token，其次按完整 canonical broker identity；
+  `broker_order_id`、价格、数量或时间邻近都不能作为猜测归属依据
+- 无法匹配内部订单、但 canonical identity 完整的 XT order/trade 使用稳定的
+  `ord_broker_*` broker-only owner；身份不完整则 fail closed
+- 首笔成交固定按 `claim/move -> execution fence -> trade fact/execution fill -> broker aggregate CAS`
+  写入；broker-only owner promotion 与首笔成交在同一
+  `om_broker_orders` fence/CAS 上竞争
+- existing-owner claim 的重领/合并只更新 owner 与不可变身份，不覆盖既有订单状态或
+  成交聚合；状态更新保持 owner 不变，成交聚合使用 `aggregate_revision`
+  compare-and-set，旧回报不能回滚新聚合
+- broker-order key move 的 source delete CAS 失败时会有界重读、合并并收敛到
+  单条 target；这里是数据库收敛重试，不是重复券商委托
 - 若 `broker_order_id` 已在 submit 成功阶段绑定到内部订单，trade callback 当前仍会继续进入 `ingest_trade_report()`；`ExternalOrderReconcileService` 只负责补齐 trace/request/internal order 上下文与 reconcile 侧 runtime event，不再把这类回报提前短路
 - buy fill 先按 `broker_order_key` 收口成 buy execution group，再按保守规则归并进 `buy_cluster` entry
 - `buy_cluster` 归并规则当前固定为：
@@ -209,10 +230,9 @@ py -3.12 script/maintenance/repair_guardian_sell_entry_allocations.py --execute 
 - 降级状态通过 `arrange_status / arrange_degraded / arrange_error_* / arrange_runtime_errors` 落在 entry 上
 - 降级时仍会写 compat mirror 与 holdings cache，避免真值已确认但视图长期滞后
 
-当前 external reconcile 对 XT 外部回报也支持部分匹配：
-
-- 若内部在途单的请求数量大于 XT 回报数量，但 symbol / side / 价格匹配，当前允许挂回同一 internal order
-- 这样 `intent=600`、`external_reported=300` 这类场景不会再一律 externalize
+当前 external reconcile 不按同价、同量、部分数量或时间邻近猜测 XT 回报归属。
+FQOM 或完整 canonical identity 能证明归属时才挂回内部订单；完整 canonical
+身份无法关联时进入 deterministic broker-only，身份不完整时 fail closed。
 自动平账与 XT 回报补录路径里，凡是由 `trade_time / confirmed_at` 回填 `date/time` 的订单域记录，当前统一按北京时间（`Asia/Shanghai`）落地，避免同一笔成交在不同读模型里出现跨日漂移。
 
 排障查看口径也保持同一套时间语义：`xt-order list`、`xt-trade list` 以及依赖成交 epoch 时间的 fill 查看命令，当前统一按北京时间展示；其中 `--date` 过滤使用北京时间自然日边界，而不是宿主机本地时区。
@@ -306,7 +326,8 @@ py -3.12 -m uv run script/maintenance/rebuild_order_ledger_v2.py --execute --bac
 - `/api/order-management/orders`
   - 订单列表与详情优先围绕 `internal_order_id` 展示
   - 对于 broker rebuild / broker-only 订单，列表和详情当前允许回退使用 `broker_order_id / broker_order_key` 作为详情查找键
-  - 缺失 `internal_order_id` 时，右侧详情仍可继续打开
+  - canonical broker-only 订单总是持久化 deterministic `ord_broker_*` `internal_order_id`；
+    `broker_order_id / broker_order_key` 回退只服务于历史 rebuild/legacy 记录
   - 详情中成交、券商订单聚合和运行态说明都来自 V2 账本
 - `/api/order-management/stoploss/bind`
   - 当前只绑定 `entry_id`

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -31,7 +31,10 @@
 
 - `ExternalOrderReconcileService` 对 buy gap 会同时记录 `initial/latest/chosen` 三组价格快照；运行面和排障口径里若看到 `chosen_price_policy=freeze_initial`，表示最终确认价按首次发现快照冻结，而不是跟随长时间观测漂移。
 - Guardian 遇到“持仓 entry 已确认但 arranged fills 不可用”的场景时，当前会显式区分 `arrangement_degraded` 与 `entry_without_slices`；这两种情况默认保守跳过，不再误记成“无持仓”。
-- XT 委托/成交回报匹配内部订单时，`broker_order_id` 不视为全局唯一键；同一 `broker_order_id` 命中多条 `om_orders` 时，会继续按 `symbol`、`side/order_type` 与回报时间选择候选。
+- XT 委托/成交回报匹配内部订单时，优先使用严格 24 字符 FQOM correlation
+  token，其次只接受完整 canonical broker identity。`broker_order_id`、
+  `symbol/side`、价格、数量或回报时间都不作为猜测归属依据；无法证明归属时，
+  完整外部身份进入 deterministic broker-only，身份不完整则 fail closed。
 
 ### Docker 并行环境承担
 

--- a/docs/current/storage.md
+++ b/docs/current/storage.md
@@ -30,9 +30,19 @@
 - `om_order_requests`
 - `om_orders`
 - `om_broker_orders`
+  - `broker_order_key` 使用账户与交易日隔离的 canonical identity：优先
+    `account_id + trading_day + order_sysid`，否则使用
+    `account_id + trading_day + symbol + side + broker_order_id`
+  - owner 固定为 `internal_order_id / request_id / broker_correlation_token`；
+    `execution_fence` 阻止首笔成交后继续 promotion，`aggregate_revision` 用于成交
+    聚合 compare-and-set
 - `om_order_events`
 - `om_execution_fills`
+  - `execution_identity` 对
+    `account_id + trading_day + symbol + side + broker_trade_id` 做稳定摘要并唯一
+    幂等写入
 - `om_trade_facts`
+  - 与 `om_execution_fills` 共用同一 `execution_identity` 幂等边界
 - `om_position_entries`
 - `om_entry_slices`
 - `om_exit_allocations`
@@ -162,6 +172,17 @@
   - 当前只做镜像/adapter，不再定义运行期仓位真值
 - `stock_fills`
   - 仅 raw 审计与最终兜底
+
+## 订单身份索引与并发边界
+
+- `om_orders.internal_order_id` 唯一
+- 非空 `om_orders.broker_correlation_token` 唯一，格式固定为
+  `FQOM + 20 hex` 共 24 字符
+- 非空 `om_broker_orders.broker_order_key` 唯一
+- 非空 `om_execution_fills.execution_identity` 与
+  `om_trade_facts.execution_identity` 分别唯一
+- existing broker owner claim 的重领/合并不覆盖既有订单状态或成交聚合；状态更新
+  保持 owner 不变，成交聚合以 fence/CAS 收敛，避免 stale 回报覆盖较新成交事实
 
 ## Redis 当前角色
 

--- a/docs/current/troubleshooting.md
+++ b/docs/current/troubleshooting.md
@@ -138,14 +138,44 @@ powershell -ExecutionPolicy Bypass -File script/fq_apply_deploy_plan.ps1 -FromGi
 - `@'
 from freshquant.order_management.db import DBOrderManagement
 broker_order_id = "<broker_order_id>"
-print(list(DBOrderManagement["om_orders"].find({"broker_order_id": str(broker_order_id)}, {"_id": 0, "internal_order_id": 1, "trace_id": 1, "symbol": 1, "side": 1, "broker_order_type": 1, "state": 1, "submitted_at": 1})))
+broker_order_key = "<broker_order_key>"
+print(list(DBOrderManagement["om_orders"].find({"broker_order_id": str(broker_order_id)}, {"_id": 0, "internal_order_id": 1, "request_id": 1, "broker_correlation_token": 1, "account_id": 1, "trading_day": 1, "order_sysid": 1, "trace_id": 1, "symbol": 1, "side": 1, "broker_order_type": 1, "state": 1, "submitted_at": 1})))
+print(list(DBOrderManagement["om_broker_orders"].find({"$or": [{"broker_order_key": broker_order_key}, {"broker_order_id": str(broker_order_id)}]}, {"_id": 0, "broker_order_key": 1, "internal_order_id": 1, "request_id": 1, "broker_correlation_token": 1, "account_id": 1, "trading_day": 1, "order_sysid": 1, "broker_order_id": 1, "symbol": 1, "side": 1, "source_type": 1, "execution_fence": 1, "aggregate_revision": 1, "filled_quantity": 1, "fill_count": 1, "avg_filled_price": 1, "state": 1})))
 '@ | py -3.12 -m uv run -`
 
 处理：
 
-- 当前 `broker_order_id` 不能单独当作全局唯一键；如果同号命中多条 `om_orders`，以 `symbol`、`side/order_type` 与回报时间确认真实内部订单。
-- 若重复券商订单号曾把回报挂到旧内部订单，需要同步核对 `om_execution_fills`、`om_trade_facts` 与 `om_position_entries` 是否已有错归属事实；必要时按券商真值 `xt_orders/xt_trades/xt_positions` 做账本修复。
+- 先核对 XT `order_remark` 是否为严格 24 字符 FQOM token；有效 token 必须唯一
+  命中对应内部订单，且账户、交易日、标的、方向等回报身份不能与订单冲突。
+- 没有 token 时，只能使用完整 canonical identity：
+  `account_id + trading_day + order_sysid`，或
+  `account_id + trading_day + symbol + side + broker_order_id`。
+  `broker_order_id`、价格、数量和回报时间都不能用于猜测真实内部订单。
+- 无法证明归属时，完整外部身份应保留为 deterministic broker-only；身份不完整
+  则 fail closed。若已出现错归属，继续核对 `execution_identity`、
+  `om_broker_orders.execution_fence/aggregate_revision`、`om_execution_fills`、
+  `om_trade_facts` 与 `om_position_entries`，再按券商真值
+  `xt_orders/xt_trades/xt_positions` 做定向账本修复。
 - 修复代码后需要重新部署 `order_management` host surface，并确认 broker / XT report ingest runtime event 已回到新内部订单对应的 trace。
+
+### 外部订单并发与提交失败排查
+
+- stale same-owner claim：对比 `om_broker_orders.aggregate_revision`、
+  `filled_quantity`、`fill_count` 与最近 `om_execution_fills`；existing-owner
+  claim 不应覆盖较新的成交聚合。若聚合已回退，不要从旧订单回报复制聚合字段；
+  应以 canonical fills 重算，并通过 aggregate CAS 做定向修复。
+- broker-only promotion：如果 broker-only 记录已有
+  `execution_fence=true` 或成交，promotion 必须停止并留下 targeted-repair
+  证据。保留 broker-only owner，不得强制 promotion 或静默改成内部订单。
+- broker-order key move：同时查询旧 `broker_order_key` 与新 key；source delete
+  CAS 竞争后最终只能保留一条 target。若仍有双记录，先停止写入面，核对两条
+  记录的 owner、canonical identity、execution fence 与聚合，再做定向修复；
+  在证据未收敛前不要直接删除任一记录。
+- `prepare_submit_execution` 返回 `missing_order`：broker 必须 fail closed，不得调用
+  XT、伪造提交成功或把消息重新入队。
+- XT 委托返回 `None/0/负订单号`：核对 `om_order_events.event_type=submit_failed`
+  和订单状态 `FAILED`。任何人工新发前先通过 XT 当日委托与柜台回报确认原请求是否
+  已实际受理；puppet 不得 sleep、Redis requeue 或自动重复提交相同券商委托。
 
 ## broker_gateway 健康摘要停留在旧 warning
 

--- a/freshquant/order_management/broker_correlation.py
+++ b/freshquant/order_management/broker_correlation.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+import re
+from hashlib import sha256
+
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityError,
+    normalize_identifier,
+)
+
+_TOKEN_PREFIX = "FQOM"
+_TOKEN_PATTERN = re.compile(r"^FQOM[0-9a-f]{20}$")
+
+
+def build_broker_correlation_token(internal_order_id):
+    normalized = normalize_identifier(internal_order_id)
+    if normalized is None:
+        raise BrokerIdentityError(
+            "internal_order_id is required for broker correlation"
+        )
+    token = f"{_TOKEN_PREFIX}{sha256(normalized.encode('utf-8')).hexdigest()[:20]}"
+    if len(token) != 24:  # pragma: no cover
+        raise BrokerIdentityError("broker correlation token length is invalid")
+    return token
+
+
+def normalize_broker_correlation_token(value):
+    normalized = normalize_identifier(value)
+    if normalized is None or _TOKEN_PATTERN.fullmatch(normalized) is None:
+        return None
+    return normalized
+
+
+def looks_like_broker_correlation_token(value):
+    normalized = normalize_identifier(value)
+    return bool(normalized and normalized.startswith(_TOKEN_PREFIX))

--- a/freshquant/order_management/broker_identity.py
+++ b/freshquant/order_management/broker_identity.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+from typing import Any, Mapping
+
+_BEIJING_TZ = timezone(timedelta(hours=8))
+
+
+class BrokerIdentityError(ValueError):
+    """Base error for broker identity normalization and validation failures."""
+
+
+class BrokerIdentityConflict(BrokerIdentityError):
+    """Raised when a broker report conflicts with a pinned internal order."""
+
+
+def normalize_identifier(value: Any) -> str | None:
+    if value in (None, "", "None"):
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def normalize_account_id(value: Any) -> str | None:
+    return normalize_identifier(value)
+
+
+def normalize_symbol(value: Any) -> str | None:
+    normalized = normalize_identifier(value)
+    if normalized is None:
+        return None
+    normalized = normalized.upper()
+    return normalized[:6] if len(normalized) >= 6 else normalized
+
+
+def normalize_side(value: Any) -> str | None:
+    normalized = normalize_identifier(value)
+    if normalized is None:
+        return None
+    normalized = normalized.lower()
+    return normalized if normalized in {"buy", "sell"} else None
+
+
+def normalize_trading_day(value: Any) -> int | None:
+    if value in (None, "", 0, "0"):
+        return None
+    if isinstance(value, datetime):
+        return int(_as_beijing(value).strftime("%Y%m%d"))
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError, OverflowError):
+        numeric = None
+    if numeric is not None and 19000101 <= numeric <= 29991231:
+        return numeric
+    parsed = _parse_datetime(value)
+    if parsed is None:
+        return None
+    return int(_as_beijing(parsed).strftime("%Y%m%d"))
+
+
+def resolve_trading_day(
+    payload: Mapping[str, Any] | None = None,
+    *,
+    trading_day: Any = None,
+    report_time: Any = None,
+) -> int | None:
+    payload = payload or {}
+    for value in (trading_day, payload.get("trading_day"), payload.get("date")):
+        normalized = normalize_trading_day(value)
+        if normalized is not None:
+            return normalized
+    for value in (
+        report_time,
+        payload.get("traded_time"),
+        payload.get("trade_time"),
+        payload.get("order_time"),
+        payload.get("submitted_at"),
+        payload.get("created_at"),
+    ):
+        normalized = normalize_trading_day(value)
+        if normalized is not None:
+            return normalized
+    return None
+
+
+def build_broker_order_key(
+    *,
+    account_id: Any = None,
+    order_sysid: Any = None,
+    trading_day: Any = None,
+    symbol: Any = None,
+    side: Any = None,
+    broker_order_id: Any = None,
+    strict: bool = True,
+) -> str | None:
+    account_id = normalize_account_id(account_id)
+    order_sysid = normalize_identifier(order_sysid)
+    trading_day = normalize_trading_day(trading_day)
+    if account_id and trading_day and order_sysid:
+        return f"account:{account_id}:day:{trading_day}:sysid:{order_sysid}"
+    symbol = normalize_symbol(symbol)
+    side = normalize_side(side)
+    broker_order_id = normalize_identifier(broker_order_id)
+    if all((account_id, trading_day, symbol, side, broker_order_id)):
+        return (
+            f"account:{account_id}:day:{trading_day}:symbol:{symbol}:"
+            f"side:{side}:order:{broker_order_id}"
+        )
+    if strict:
+        raise BrokerIdentityError(
+            "broker order identity requires account_id + trading_day + order_sysid, or "
+            "account_id + trading_day + symbol + side + broker_order_id"
+        )
+    return None
+
+
+def build_broker_only_internal_order_id(
+    *,
+    account_id: Any = None,
+    order_sysid: Any = None,
+    trading_day: Any = None,
+    symbol: Any = None,
+    side: Any = None,
+    broker_order_id: Any = None,
+) -> str:
+    broker_order_key = build_broker_order_key(
+        account_id=account_id,
+        order_sysid=order_sysid,
+        trading_day=trading_day,
+        symbol=symbol,
+        side=side,
+        broker_order_id=broker_order_id,
+    )
+    if broker_order_key is None:
+        raise BrokerIdentityError("cannot build broker-only order without identity")
+    digest = sha256(broker_order_key.encode("utf-8")).hexdigest()[:24]
+    return f"ord_broker_{digest}"
+
+
+def build_execution_identity(payload: Mapping[str, Any]) -> str:
+    broker_trade_id = normalize_identifier(
+        payload.get("broker_trade_id") or payload.get("traded_id")
+    )
+    symbol = normalize_symbol(payload.get("symbol") or payload.get("stock_code"))
+    side = normalize_side(payload.get("side"))
+    trading_day = resolve_trading_day(payload)
+    account_id = normalize_account_id(payload.get("account_id"))
+    if (
+        broker_trade_id is None
+        or symbol is None
+        or side is None
+        or trading_day is None
+        or account_id is None
+    ):
+        raise BrokerIdentityError(
+            "execution identity requires account_id, broker_trade_id, trading_day, symbol and side"
+        )
+    raw_identity = "|".join(
+        (account_id, str(trading_day), symbol, side, broker_trade_id)
+    )
+    return f"execution:{sha256(raw_identity.encode('utf-8')).hexdigest()}"
+
+
+def identity_conflicts(
+    candidate: Mapping[str, Any], report_identity: Mapping[str, Any]
+) -> dict[str, tuple[Any, Any]]:
+    normalizers = {
+        "account_id": normalize_account_id,
+        "order_sysid": normalize_identifier,
+        "trading_day": normalize_trading_day,
+        "symbol": normalize_symbol,
+        "side": normalize_side,
+        "broker_order_id": normalize_identifier,
+    }
+    conflicts = {}
+    for field, normalizer in normalizers.items():
+        left = normalizer(candidate.get(field))
+        right = normalizer(report_identity.get(field))
+        if left is not None and right is not None and left != right:
+            conflicts[field] = (left, right)
+    return conflicts
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    except (TypeError, ValueError, OverflowError, OSError):
+        pass
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _as_beijing(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=_BEIJING_TZ)
+    return value.astimezone(_BEIJING_TZ)

--- a/freshquant/order_management/broker_match.py
+++ b/freshquant/order_management/broker_match.py
@@ -1,21 +1,20 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
+from freshquant.order_management.broker_correlation import (
+    looks_like_broker_correlation_token,
+    normalize_broker_correlation_token,
+)
+from freshquant.order_management.broker_identity import (
+    build_broker_order_key,
+    normalize_account_id,
+    normalize_identifier,
+    normalize_side,
+    normalize_symbol,
+    resolve_trading_day,
+)
 
-_BEIJING_TZ = ZoneInfo("Asia/Shanghai")
 _BUY_ORDER_TYPES = {23, 27, 28, "23", "27", "28", "buy", "BUY"}
 _SELL_ORDER_TYPES = {24, 31, 32, "24", "31", "32", "sell", "SELL"}
-_NONTERMINAL_STATES = {
-    "ACCEPTED",
-    "VALIDATED",
-    "QUEUED",
-    "SUBMITTING",
-    "SUBMITTED",
-    "PARTIAL_FILLED",
-    "CANCEL_REQUESTED",
-    "INFERRED_PENDING",
-}
 
 
 def find_order_for_broker_report(
@@ -28,60 +27,136 @@ def find_order_for_broker_report(
     order_type=None,
     report_time=None,
 ):
-    if repository is None or broker_order_id in (None, "", "None"):
+    if repository is None:
         return None
-
-    candidates = _list_order_candidates(repository, broker_order_id)
-    if not candidates:
-        return None
-    if len(candidates) == 1:
-        return candidates[0]
-
     report = report or {}
-    symbol = _normalize_symbol(
+    raw_correlation_token = report.get("broker_correlation_token") or report.get(
+        "order_remark"
+    )
+    correlation_token = normalize_broker_correlation_token(raw_correlation_token)
+    if correlation_token is None and looks_like_broker_correlation_token(
+        raw_correlation_token
+    ):
+        return None
+    if correlation_token is not None:
+        finder = getattr(repository, "find_order_by_broker_correlation_token", None)
+        candidate = finder(correlation_token) if callable(finder) else None
+        if candidate is None:
+            return None
+        return (
+            candidate
+            if _candidate_matches_report(candidate, report, trust_correlation=True)
+            else None
+        )
+
+    symbol = normalize_symbol(
         symbol or report.get("symbol") or report.get("stock_code")
     )
     order_type = order_type if order_type is not None else report.get("order_type")
-    side = _normalize_side(side) or side_from_order_type(order_type)
-    report_time = _coalesce_report_time(report_time, report)
-
-    filtered = candidates
-    if symbol:
-        by_symbol = [
-            item for item in filtered if _normalize_symbol(item.get("symbol")) == symbol
-        ]
-        if by_symbol:
-            filtered = by_symbol
-
-    if side:
-        by_side = [item for item in filtered if _candidate_side(item) in (None, side)]
-        if by_side:
-            filtered = by_side
-
-    if order_type is not None and len(filtered) > 1:
-        report_side = side_from_order_type(order_type)
-        by_order_type = [
-            item
-            for item in filtered
-            if _order_type_equivalent(item.get("broker_order_type"), order_type)
-            or (
-                report_side is not None
-                and side_from_order_type(item.get("broker_order_type")) == report_side
-            )
-        ]
-        if by_order_type:
-            filtered = by_order_type
-
-    scored = sorted(
-        ((_candidate_score(item, report_time), item) for item in filtered),
-        key=lambda pair: pair[0],
-        reverse=True,
+    side = normalize_side(side) or side_from_order_type(order_type)
+    account_id = normalize_account_id(report.get("account_id"))
+    order_sysid = normalize_identifier(report.get("order_sysid"))
+    trading_day = resolve_trading_day(report, report_time=report_time)
+    broker_order_id = normalize_identifier(broker_order_id)
+    broker_order_key = build_broker_order_key(
+        account_id=account_id,
+        order_sysid=order_sysid,
+        trading_day=trading_day,
+        symbol=symbol,
+        side=side,
+        broker_order_id=broker_order_id,
+        strict=False,
     )
-    if not scored:
+    if broker_order_key is not None and hasattr(repository, "find_broker_order"):
+        broker_order = repository.find_broker_order(broker_order_key)
+        if broker_order is not None and _candidate_matches_report(broker_order, report):
+            return repository.find_order(broker_order.get("internal_order_id"))
+
+    if broker_order_id is None:
         return None
-    if len(scored) > 1 and scored[0][0] == scored[1][0]:
-        return None
-    return scored[0][1]
+    candidates = [
+        candidate
+        for candidate in _list_order_candidates(repository, broker_order_id)
+        if _candidate_proves_full_identity(
+            candidate,
+            account_id=account_id,
+            order_sysid=order_sysid,
+            trading_day=trading_day,
+            symbol=symbol,
+            side=side,
+            broker_order_id=broker_order_id,
+        )
+    ]
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _candidate_matches_report(candidate, report, *, trust_correlation=False):
+    for field, expected, normalizer in (
+        ("account_id", report.get("account_id"), normalize_account_id),
+        ("order_sysid", report.get("order_sysid"), normalize_identifier),
+        (
+            "trading_day",
+            resolve_trading_day(report),
+            lambda value: resolve_trading_day({"trading_day": value}),
+        ),
+        ("symbol", report.get("symbol") or report.get("stock_code"), normalize_symbol),
+        (
+            "side",
+            (
+                None
+                if trust_correlation
+                else report.get("side")
+                or side_from_order_type(report.get("order_type"))
+            ),
+            normalize_side,
+        ),
+        (
+            "broker_order_id",
+            report.get("broker_order_id") or report.get("order_id"),
+            normalize_identifier,
+        ),
+    ):
+        right = normalizer(expected)
+        left = normalizer(candidate.get(field))
+        if right is not None and left is not None and left != right:
+            return False
+    return True
+
+
+def _candidate_proves_full_identity(
+    candidate,
+    *,
+    account_id,
+    order_sysid,
+    trading_day,
+    symbol,
+    side,
+    broker_order_id,
+):
+    if account_id is None or trading_day is None:
+        return False
+    if order_sysid is None and None in (symbol, side, broker_order_id):
+        return False
+    candidate_order_sysid = normalize_identifier(candidate.get("order_sysid"))
+    if order_sysid is not None and candidate_order_sysid is not None:
+        if candidate_order_sysid != order_sysid:
+            return False
+    elif order_sysid is not None and None in (symbol, side, broker_order_id):
+        return False
+    return all(
+        (
+            normalize_account_id(candidate.get("account_id")) == account_id,
+            resolve_trading_day(candidate) == trading_day,
+            (
+                candidate_order_sysid == order_sysid
+                if order_sysid is not None and candidate_order_sysid is not None
+                else normalize_symbol(candidate.get("symbol")) == symbol
+                and normalize_side(candidate.get("side")) == side
+                and normalize_identifier(candidate.get("broker_order_id"))
+                == broker_order_id
+            ),
+        )
+    )
 
 
 def side_from_order_type(order_type):
@@ -106,93 +181,3 @@ def _list_order_candidates(repository, broker_order_id):
 
     order = repository.find_order_by_broker_order_id(broker_order_id)
     return [order] if order is not None else []
-
-
-def _candidate_side(order):
-    return _normalize_side(order.get("side")) or side_from_order_type(
-        order.get("broker_order_type")
-    )
-
-
-def _candidate_score(order, report_time):
-    state_score = 1 if order.get("state") in _NONTERMINAL_STATES else 0
-    submitted_at = _parse_order_datetime(
-        order.get("submitted_at") or order.get("updated_at") or order.get("created_at")
-    )
-    if report_time is None or submitted_at is None:
-        time_score = 0
-        distance_score = 0
-    else:
-        distance = abs((report_time - submitted_at).total_seconds())
-        time_score = 1
-        distance_score = -distance
-    recency = submitted_at.timestamp() if submitted_at is not None else 0
-    return (time_score, state_score, distance_score, recency)
-
-
-def _coalesce_report_time(report_time, report):
-    if report_time is not None:
-        return _parse_report_datetime(report_time)
-    for key in ("traded_time", "trade_time", "order_time"):
-        if report.get(key) is not None:
-            return _parse_report_datetime(report.get(key))
-    return None
-
-
-def _parse_report_datetime(value):
-    if value in (None, ""):
-        return None
-    if isinstance(value, datetime):
-        return _as_aware(value)
-    try:
-        return datetime.fromtimestamp(float(value), tz=timezone.utc)
-    except (TypeError, ValueError, OSError):
-        return _parse_order_datetime(value)
-
-
-def _parse_order_datetime(value):
-    if value in (None, ""):
-        return None
-    if isinstance(value, datetime):
-        return _as_aware(value)
-    text = str(value).strip()
-    if not text:
-        return None
-    if text.endswith("Z"):
-        text = f"{text[:-1]}+00:00"
-    try:
-        parsed = datetime.fromisoformat(text)
-    except ValueError:
-        return None
-    return _as_aware(parsed)
-
-
-def _as_aware(value):
-    if value.tzinfo is None:
-        return value.replace(tzinfo=_BEIJING_TZ).astimezone(timezone.utc)
-    return value.astimezone(timezone.utc)
-
-
-def _normalize_symbol(value):
-    if value in (None, ""):
-        return None
-    text = str(value).strip().upper()
-    return text[:6] if len(text) >= 6 else text
-
-
-def _normalize_side(value):
-    if value in (None, ""):
-        return None
-    text = str(value).strip().lower()
-    if text in {"buy", "sell"}:
-        return text
-    return None
-
-
-def _order_type_equivalent(left, right):
-    if left in (None, "") or right in (None, ""):
-        return False
-    try:
-        return int(left) == int(right)
-    except (TypeError, ValueError):
-        return str(left).strip().lower() == str(right).strip().lower()

--- a/freshquant/order_management/ingest/xt_reports.py
+++ b/freshquant/order_management/ingest/xt_reports.py
@@ -6,6 +6,20 @@ from uuid import uuid4
 from loguru import logger
 
 from freshquant.carnation import xtconstant
+from freshquant.order_management.broker_correlation import (
+    normalize_broker_correlation_token,
+)
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityError,
+    build_broker_only_internal_order_id,
+    build_broker_order_key,
+    build_execution_identity,
+    normalize_account_id,
+    normalize_identifier,
+    normalize_side,
+    normalize_symbol,
+    resolve_trading_day,
+)
 from freshquant.order_management.broker_match import find_order_for_broker_report
 from freshquant.order_management.entry_adapter import (
     list_open_entry_slices_compat,
@@ -90,15 +104,7 @@ class OrderManagementXtIngestService:
     def ingest_trade_report(self, report, lot_amount, grid_interval_lookup):
         current_node = "trade_match"
         try:
-            if hasattr(self.tracking_service, "ingest_trade_report_with_meta"):
-                ingest_result = self.tracking_service.ingest_trade_report_with_meta(
-                    report
-                )
-            else:
-                ingest_result = {
-                    "trade_fact": self.tracking_service.ingest_trade_report(report),
-                    "created": True,
-                }
+            ingest_result = self.tracking_service.ingest_trade_report_with_meta(report)
             trade_fact = ingest_result["trade_fact"]
             execution_fill = ingest_result.get("execution_fill")
             created = bool(ingest_result.get("created"))
@@ -358,13 +364,9 @@ class OrderManagementXtIngestService:
             return None
         current_node = "order_match"
         try:
-            if hasattr(self.tracking_service, "ingest_order_report_with_meta"):
-                ingest_result = self.tracking_service.ingest_order_report_with_meta(
-                    normalized_report
-                )
-            else:
-                self.tracking_service.ingest_order_report(normalized_report)
-                ingest_result = {"changed": True, "absorbed": False}
+            ingest_result = self.tracking_service.ingest_order_report_with_meta(
+                normalized_report
+            )
             if not ingest_result.get("changed"):
                 return normalized_report
             self._emit_runtime(
@@ -422,12 +424,12 @@ class OrderManagementXtIngestService:
 
 def normalize_xt_trade_report(report, repository=None):
     if "side" in report and "broker_trade_id" in report:
-        return report
+        return dict(report)
 
     traded_time = report["traded_time"]
     traded_datetime = _xt_timestamp_to_datetime(traded_time)
     stock_code = report.get("stock_code", "")
-    symbol = report.get("symbol") or stock_code[:6]
+    symbol = normalize_symbol(report.get("symbol") or stock_code)
     order_id = report.get("order_id")
     internal_order_id = report.get("internal_order_id")
     order = None
@@ -447,12 +449,42 @@ def normalize_xt_trade_report(report, repository=None):
             internal_order_id = order["internal_order_id"]
     if order is not None and order.get("broker_order_type") is not None:
         order_type = order.get("broker_order_type")
-    return {
-        "internal_order_id": internal_order_id or str(order_id),
-        "broker_order_id": str(order_id) if order_id is not None else None,
+    side = _map_xt_order_type_to_side(order_type)
+    identity = _normalize_xt_callback_identity(
+        report,
+        symbol=symbol,
+        side=side,
+        broker_order_id=order_id,
+        report_time=traded_time,
+    )
+    if internal_order_id is None:
+        if identity["broker_order_key"] is not None:
+            internal_order_id = build_broker_only_internal_order_id(
+                account_id=identity["account_id"],
+                order_sysid=identity["order_sysid"],
+                trading_day=identity["trading_day"],
+                symbol=identity["symbol"],
+                side=identity["side"],
+                broker_order_id=identity["broker_order_id"],
+            )
+        elif repository is not None:
+            raise BrokerIdentityError("XT trade report lacks canonical broker identity")
+        else:
+            internal_order_id = str(order_id)
+    normalized = {
+        "internal_order_id": internal_order_id,
+        "broker_order_key": identity["broker_order_key"]
+        or (order or {}).get("broker_order_key")
+        or internal_order_id,
+        "broker_order_id": identity["broker_order_id"],
         "broker_trade_id": str(report["traded_id"]),
-        "symbol": symbol,
-        "side": _map_xt_order_type_to_side(order_type),
+        "account_type": report.get("account_type") or (order or {}).get("account_type"),
+        "account_id": identity["account_id"],
+        "order_sysid": identity["order_sysid"],
+        "trading_day": identity["trading_day"],
+        "broker_correlation_token": identity["broker_correlation_token"],
+        "symbol": identity["symbol"],
+        "side": identity["side"],
         "quantity": report["traded_volume"],
         "price": report["traded_price"],
         "trade_time": traded_time,
@@ -464,6 +496,9 @@ def normalize_xt_trade_report(report, repository=None):
         "trace_id": report.get("trace_id") or (order or {}).get("trace_id"),
         "intent_id": report.get("intent_id") or (order or {}).get("intent_id"),
     }
+    if identity["broker_order_key"] is not None:
+        normalized["execution_identity"] = build_execution_identity(normalized)
+    return normalized
 
 
 def normalize_xt_order_report(report, repository=None):
@@ -490,15 +525,47 @@ def normalize_xt_order_report(report, repository=None):
         order = (
             repository.find_order(internal_order_id) if repository is not None else None
         )
+    side = _map_xt_order_type_to_side(report.get("order_type"))
+    symbol = normalize_symbol(report.get("symbol") or report.get("stock_code"))
+    identity = _normalize_xt_callback_identity(
+        report,
+        symbol=symbol,
+        side=side,
+        broker_order_id=broker_order_id,
+        report_time=report.get("order_time"),
+    )
     if internal_order_id is None:
-        if repository is not None:
+        if identity["broker_order_key"] is not None:
+            internal_order_id = build_broker_only_internal_order_id(
+                account_id=identity["account_id"],
+                order_sysid=identity["order_sysid"],
+                trading_day=identity["trading_day"],
+                symbol=identity["symbol"],
+                side=identity["side"],
+                broker_order_id=identity["broker_order_id"],
+            )
+        elif repository is not None:
             return None
-        internal_order_id = str(broker_order_id)
+        else:
+            internal_order_id = str(broker_order_id)
         order = None
 
     return {
         "internal_order_id": internal_order_id,
-        "broker_order_id": str(broker_order_id),
+        "broker_order_key": identity["broker_order_key"]
+        or (order or {}).get("broker_order_key")
+        or internal_order_id,
+        "broker_order_id": identity["broker_order_id"],
+        "broker_order_type": report.get("order_type"),
+        "account_type": report.get("account_type") or (order or {}).get("account_type"),
+        "account_id": identity["account_id"],
+        "order_sysid": identity["order_sysid"],
+        "trading_day": identity["trading_day"],
+        "broker_correlation_token": identity["broker_correlation_token"],
+        "symbol": identity["symbol"],
+        "side": identity["side"],
+        "requested_quantity": report.get("order_volume"),
+        "source": report.get("source", "xt_order_callback"),
         "state": _map_xt_order_status_to_state(report.get("order_status")),
         "event_type": "xt_order_reported",
         "request_id": report.get("request_id") or (order or {}).get("request_id"),
@@ -508,6 +575,43 @@ def normalize_xt_order_report(report, repository=None):
             _xt_timestamp_to_datetime(report["order_time"]).isoformat()
             if report.get("order_time") is not None
             else None
+        ),
+    }
+
+
+def _normalize_xt_callback_identity(
+    report,
+    *,
+    symbol,
+    side,
+    broker_order_id,
+    report_time,
+):
+    account_id = normalize_account_id(report.get("account_id"))
+    order_sysid = normalize_identifier(report.get("order_sysid"))
+    trading_day = resolve_trading_day(report, report_time=report_time)
+    symbol = normalize_symbol(symbol)
+    side = normalize_side(side)
+    broker_order_id = normalize_identifier(broker_order_id)
+    broker_order_key = build_broker_order_key(
+        account_id=account_id,
+        order_sysid=order_sysid,
+        trading_day=trading_day,
+        symbol=symbol,
+        side=side,
+        broker_order_id=broker_order_id,
+        strict=False,
+    )
+    return {
+        "account_id": account_id,
+        "order_sysid": order_sysid,
+        "trading_day": trading_day,
+        "symbol": symbol,
+        "side": side,
+        "broker_order_id": broker_order_id,
+        "broker_order_key": broker_order_key,
+        "broker_correlation_token": normalize_broker_correlation_token(
+            report.get("broker_correlation_token") or report.get("order_remark")
         ),
     }
 
@@ -773,7 +877,7 @@ def _map_xt_order_type_to_side(order_type):
         return "buy"
     if order_type in _SELL_ORDER_TYPES:
         return "sell"
-    return "sell"
+    return None
 
 
 def _xt_timestamp_to_datetime(timestamp):

--- a/freshquant/order_management/reconcile/service.py
+++ b/freshquant/order_management/reconcile/service.py
@@ -5,6 +5,10 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityError,
+    build_broker_only_internal_order_id,
+)
 from freshquant.order_management.broker_match import find_order_for_broker_report
 from freshquant.order_management.entry_aggregation import (
     build_clustered_position_entry,
@@ -23,12 +27,9 @@ from freshquant.order_management.guardian.sell_semantics import (
 from freshquant.order_management.ids import (
     new_allocation_id,
     new_entry_slice_id,
-    new_event_id,
-    new_internal_order_id,
     new_position_entry_id,
     new_reconciliation_gap_id,
     new_reconciliation_resolution_id,
-    new_request_id,
 )
 from freshquant.order_management.ingest.xt_reports import (
     OrderManagementXtIngestService,
@@ -63,6 +64,21 @@ class TradeReportReconcileOutcome:
     result: dict | None = None
     normalized: dict | None = None
     ingested: bool = False
+
+
+def _is_deterministic_broker_only_trade(normalized):
+    try:
+        expected_internal_order_id = build_broker_only_internal_order_id(
+            account_id=normalized.get("account_id"),
+            order_sysid=normalized.get("order_sysid"),
+            trading_day=normalized.get("trading_day"),
+            symbol=normalized.get("symbol"),
+            side=normalized.get("side"),
+            broker_order_id=normalized.get("broker_order_id"),
+        )
+    except BrokerIdentityError:
+        return False
+    return normalized.get("internal_order_id") == expected_internal_order_id
 
 
 class ExternalOrderReconcileService:
@@ -329,58 +345,10 @@ class ExternalOrderReconcileService:
                     ingested=True,
                 )
 
-            match_status, matched_order = self._match_inflight_internal_order(
-                normalized
-            )
-            if match_status == "matched":
-                ids.update(
-                    {
-                        "trace_id": matched_order.get("trace_id"),
-                        "intent_id": matched_order.get("intent_id"),
-                        "request_id": matched_order.get("request_id"),
-                        "internal_order_id": matched_order["internal_order_id"],
-                        "symbol": normalized["symbol"],
-                    }
-                )
-                self._emit_runtime(
-                    "internal_match",
-                    ids,
-                    payload={"broker_order_id": normalized.get("broker_order_id")},
-                )
-                normalized["internal_order_id"] = matched_order["internal_order_id"]
-                if normalized.get("broker_order_id") and not matched_order.get(
-                    "broker_order_id"
-                ):
-                    self.repository.update_order(
-                        matched_order["internal_order_id"],
-                        {
-                            "broker_order_id": normalized.get("broker_order_id"),
-                            "updated_at": datetime.now(timezone.utc).isoformat(),
-                        },
-                    )
-                current_node = "projection_update"
-                result = self.ingest_service.ingest_trade_report(
-                    normalized,
-                    lot_amount=_safe_resolve_lot_amount(normalized["symbol"]),
-                    grid_interval_lookup=_safe_grid_interval_lookup,
-                )
-                self._emit_runtime(
-                    "projection_update",
-                    ids,
-                    payload={"source": "internal_match"},
-                )
-                return TradeReportReconcileOutcome(
-                    handled=True,
-                    action="matched_internal_order",
-                    result=result,
-                    normalized=normalized,
-                    ingested=True,
-                )
-            if match_status == "defer":
-                return TradeReportReconcileOutcome(
-                    handled=True,
-                    action="deferred_ambiguous_internal_match",
-                    normalized=normalized,
+            deterministic_broker_only = _is_deterministic_broker_only_trade(normalized)
+            if not deterministic_broker_only:
+                raise BrokerIdentityError(
+                    "XT trade report lacks canonical broker identity"
                 )
 
             if pending_candidates is None:
@@ -389,33 +357,26 @@ class ExternalOrderReconcileService:
                 )
             candidate = _find_trade_gap(pending_candidates, normalized)
             current_node = "externalize"
-            order = self._create_external_order(
-                symbol=normalized["symbol"],
-                side=normalized["side"],
-                quantity=normalized["quantity"],
-                price=normalized["price"],
-                source_type="external_reported",
-                state="FILLED",
-                broker_order_id=normalized.get("broker_order_id"),
-            )
+            source_type = "broker_only"
             ids = {
-                "request_id": order["request_id"],
-                "internal_order_id": order["internal_order_id"],
+                "request_id": normalized.get("request_id"),
+                "internal_order_id": normalized["internal_order_id"],
                 "symbol": normalized["symbol"],
             }
             self._emit_runtime(
                 "externalize",
                 ids,
-                payload={"source_type": "external_reported"},
+                payload={"source_type": source_type},
             )
-            normalized["internal_order_id"] = order["internal_order_id"]
-            normalized["source"] = "external_reported"
             current_node = "projection_update"
             result = self.ingest_service.ingest_trade_report(
                 normalized,
                 lot_amount=_safe_resolve_lot_amount(normalized["symbol"]),
                 grid_interval_lookup=_safe_grid_interval_lookup,
             )
+            order = self.repository.find_order(normalized["internal_order_id"])
+            if order is None:
+                raise RuntimeError("broker-only order was not persisted")
             if candidate is not None:
                 candidate_updates = _build_gap_trade_updates(
                     candidate,
@@ -444,7 +405,7 @@ class ExternalOrderReconcileService:
             self._emit_runtime(
                 "projection_update",
                 ids,
-                payload={"source": "external_reported"},
+                payload={"source": source_type},
             )
             return TradeReportReconcileOutcome(
                 handled=True,
@@ -463,46 +424,6 @@ class ExternalOrderReconcileService:
             )
             mark_exception_emitted(exc)
             raise
-
-    def _match_inflight_internal_order(self, normalized_trade):
-        exact_candidates = []
-        partial_candidates = []
-        for order in self.repository.list_orders(
-            symbol=normalized_trade["symbol"],
-            states={"ACCEPTED", "QUEUED", "SUBMITTING"},
-            missing_broker_only=True,
-        ):
-            if order.get("side") != normalized_trade["side"]:
-                continue
-            if order.get("source_type") in {"external_reported", "external_inferred"}:
-                continue
-            request = self.repository.find_order_request(order["request_id"])
-            if request is None:
-                continue
-            request_quantity = int(request.get("quantity") or 0)
-            trade_quantity = int(normalized_trade["quantity"] or 0)
-            if request_quantity < trade_quantity:
-                continue
-            request_price = request.get("price")
-            if (
-                request_price is not None
-                and abs(float(request_price) - float(normalized_trade["price"])) > 1e-6
-            ):
-                continue
-            if request_quantity == trade_quantity:
-                exact_candidates.append(order)
-            else:
-                partial_candidates.append(order)
-
-        if len(exact_candidates) == 1:
-            return "matched", exact_candidates[0]
-        if len(exact_candidates) > 1:
-            return "defer", None
-        if len(partial_candidates) == 1:
-            return "matched", partial_candidates[0]
-        if len(partial_candidates) > 1:
-            return "defer", None
-        return "missing", None
 
     def confirm_expired_candidates(self, now):
         confirmed = []
@@ -754,64 +675,6 @@ class ExternalOrderReconcileService:
         )
         _after_holdings_reconciled(gap["symbol"], repository=self.repository)
         return updated_gap
-
-    def _create_external_order(
-        self,
-        symbol,
-        side,
-        quantity,
-        price,
-        source_type,
-        state,
-        broker_order_id,
-    ):
-        request_id = new_request_id()
-        internal_order_id = new_internal_order_id()
-        now_iso = datetime.now(timezone.utc).isoformat()
-        self.repository.insert_order_request(
-            {
-                "request_id": request_id,
-                "action": side,
-                "source": source_type,
-                "symbol": symbol,
-                "price": price,
-                "quantity": quantity,
-                "strategy_name": None,
-                "remark": source_type,
-                "scope_type": None,
-                "scope_ref_id": None,
-                "req_id": request_id,
-                "state": state,
-                "created_at": now_iso,
-            }
-        )
-        order = {
-            "internal_order_id": internal_order_id,
-            "request_id": request_id,
-            "broker_order_id": (
-                str(broker_order_id) if broker_order_id is not None else None
-            ),
-            "symbol": symbol,
-            "side": side,
-            "state": state,
-            "source_type": source_type,
-            "submitted_at": now_iso,
-            "filled_quantity": quantity,
-            "avg_filled_price": price,
-            "updated_at": now_iso,
-        }
-        self.repository.insert_order(order)
-        self.repository.insert_order_event(
-            {
-                "event_id": new_event_id(),
-                "request_id": request_id,
-                "internal_order_id": internal_order_id,
-                "event_type": "external_reconciled",
-                "state": state,
-                "created_at": now_iso,
-            }
-        )
-        return order
 
     def _emit_runtime(self, node, ids, *, status="info", reason_code="", payload=None):
         event = {

--- a/freshquant/order_management/repository.py
+++ b/freshquant/order_management/repository.py
@@ -1,11 +1,94 @@
 # -*- coding: utf-8 -*-
 
+from pymongo.errors import DuplicateKeyError
+
+from freshquant.order_management.broker_correlation import (
+    build_broker_correlation_token,
+    normalize_broker_correlation_token,
+)
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityConflict,
+    BrokerIdentityError,
+    build_broker_only_internal_order_id,
+    identity_conflicts,
+    normalize_identifier,
+    resolve_trading_day,
+)
 from freshquant.order_management.db import DBOrderManagement
+
+_BROKER_ORDER_OWNER_FIELDS = (
+    "internal_order_id",
+    "request_id",
+    "broker_correlation_token",
+)
+_BROKER_ORDER_IDENTITY_FIELDS = (
+    "broker_order_key",
+    "account_id",
+    "trading_day",
+    "order_sysid",
+    "broker_order_id",
+    "symbol",
+    "side",
+)
+_BROKER_ORDER_CLAIM_FIELDS = (
+    *_BROKER_ORDER_OWNER_FIELDS,
+    *_BROKER_ORDER_IDENTITY_FIELDS,
+    "source_type",
+)
+_BROKER_ORDER_AGGREGATE_FIELDS = (
+    "filled_quantity",
+    "fill_count",
+    "avg_filled_price",
+    "fill_set_fingerprint",
+    "aggregate_revision",
+    "first_fill_time",
+    "last_fill_time",
+)
+_BROKER_ORDER_CLAIM_ATTEMPTS = 16
+_BROKER_ORDER_MOVE_ATTEMPTS = 16
+_MISSING = object()
 
 
 class OrderManagementRepository:
     def __init__(self, database=None):
         self.database = database if database is not None else DBOrderManagement
+        self._canonical_indexes_ready = False
+
+    def _ensure_canonical_indexes(self):
+        if self._canonical_indexes_ready:
+            return
+        for collection, field, name in (
+            (self.orders, "internal_order_id", "uq_om_orders_internal_order_id"),
+            (
+                self.orders,
+                "broker_correlation_token",
+                "uq_om_orders_broker_correlation_token",
+            ),
+            (
+                self.broker_orders,
+                "broker_order_key",
+                "uq_om_broker_orders_broker_order_key",
+            ),
+            (
+                self.trade_facts,
+                "execution_identity",
+                "uq_om_trade_facts_execution_identity",
+            ),
+            (
+                self.execution_fills,
+                "execution_identity",
+                "uq_om_execution_fills_execution_identity",
+            ),
+        ):
+            create_index = getattr(collection, "create_index", None)
+            if callable(create_index):
+                create_index(
+                    [(field, 1)],
+                    unique=True,
+                    partialFilterExpression={field: {"$type": "string"}},
+                    name=name,
+                )
+        self._canonical_indexes_ready = True
 
     @property
     def order_requests(self):
@@ -133,23 +216,301 @@ class OrderManagementRepository:
         return list(cursor)
 
     def insert_order(self, document):
-        self.orders.insert_one(document)
-        return document
+        self._ensure_canonical_indexes()
+        payload = _without_mongo_id(document)
+        internal_order_id = normalize_identifier(payload.get("internal_order_id"))
+        if internal_order_id is None:
+            raise BrokerIdentityConflict("internal_order_id is required")
+        payload["internal_order_id"] = internal_order_id
+        try:
+            self.orders.update_one(
+                {"internal_order_id": internal_order_id},
+                {"$setOnInsert": payload},
+                upsert=True,
+            )
+        except DuplicateKeyError:
+            pass
+        saved = self.find_order(internal_order_id)
+        if saved is None:
+            raise BrokerIdentityConflict("canonical order insert did not persist")
+        _assert_broker_order_identity_consistent(saved, payload)
+        for field in ("request_id", "broker_correlation_token"):
+            if (
+                normalize_identifier(saved.get(field)) is not None
+                and normalize_identifier(payload.get(field)) is not None
+                and normalize_identifier(saved.get(field))
+                != normalize_identifier(payload.get(field))
+            ):
+                raise BrokerIdentityConflict(
+                    f"order conflicts with canonical {field} ownership"
+                )
+        return saved
 
     def upsert_broker_order(self, document, unique_keys):
-        query = {key: document[key] for key in unique_keys}
-        existing = self.broker_orders.find_one(query)
-        if existing is not None:
-            self.broker_orders.update_one(query, {"$set": document})
-            return self.broker_orders.find_one(query), False
-        self.broker_orders.insert_one(document)
-        return document, True
+        if list(unique_keys or []) != ["broker_order_key"]:
+            raise BrokerIdentityConflict(
+                "broker order upsert requires broker_order_key identity"
+            )
+        return self.claim_broker_order_owner(document)
+
+    def claim_broker_order_owner(self, document):
+        self._ensure_canonical_indexes()
+        payload = _without_mongo_id(document)
+        broker_order_key = normalize_identifier(payload.get("broker_order_key"))
+        if broker_order_key is None:
+            raise BrokerIdentityConflict("broker_order_key is required")
+        payload["broker_order_key"] = broker_order_key
+        incoming_owner_kind = _classify_broker_order_owner(payload)
+        if incoming_owner_kind == "real":
+            self._assert_canonical_real_broker_order_owner(payload)
+
+        for _attempt in range(_BROKER_ORDER_CLAIM_ATTEMPTS):
+            existing = self.find_broker_order(broker_order_key)
+            if existing is None:
+                if incoming_owner_kind == "real_partial":
+                    raise BrokerIdentityConflict(
+                        "new broker order requires complete canonical owner"
+                    )
+                try:
+                    result = self.broker_orders.update_one(
+                        {"broker_order_key": broker_order_key},
+                        {"$setOnInsert": payload},
+                        upsert=True,
+                    )
+                except DuplicateKeyError:
+                    continue
+                saved = self.find_broker_order(broker_order_key)
+                if saved is None:
+                    continue
+                if result.upserted_id is not None:
+                    return saved, True
+                existing = saved
+
+            self._assert_broker_order_owner_claim_allowed(
+                existing,
+                payload,
+                incoming_owner_kind=incoming_owner_kind,
+            )
+            next_payload = _merge_broker_order_claim(existing, payload)
+            if _without_mongo_id(existing) == next_payload:
+                return existing, False
+            result = self.broker_orders.replace_one(
+                _exact_document_selector(existing, identity_field="broker_order_key"),
+                next_payload,
+                upsert=False,
+            )
+            if not result.matched_count:
+                continue
+            saved = self.find_broker_order(broker_order_key)
+            if saved is not None:
+                return saved, False
+        raise BrokerIdentityConflict(
+            "broker order owner claim could not converge after concurrent updates"
+        )
+
+    def _assert_canonical_real_broker_order_owner(self, incoming):
+        internal_order = self.find_order(
+            normalize_identifier(incoming.get("internal_order_id"))
+        )
+        if internal_order is None:
+            raise BrokerIdentityConflict(
+                "canonical broker order owner requires an existing internal order"
+            )
+        if str(internal_order.get("source_type") or "").lower() == "broker_only":
+            raise BrokerIdentityConflict(
+                "canonical broker order owner cannot reference a broker-only order"
+            )
+        _assert_broker_order_identity_consistent(internal_order, incoming)
+        for field in ("request_id", "broker_correlation_token"):
+            if normalize_identifier(internal_order.get(field)) != normalize_identifier(
+                incoming.get(field)
+            ):
+                raise BrokerIdentityConflict(
+                    f"canonical broker order owner conflicts with internal {field}"
+                )
+
+    def _assert_broker_order_owner_claim_allowed(
+        self, existing, incoming, *, incoming_owner_kind
+    ):
+        _assert_broker_order_owner_transition(existing, incoming)
+        if incoming_owner_kind == "real_partial":
+            if not _is_complete_real_broker_order_owner(existing):
+                raise BrokerIdentityConflict(
+                    "partial broker order owner requires an existing canonical owner"
+                )
+        elif incoming_owner_kind == "real":
+            self._assert_canonical_real_broker_order_owner(incoming)
+        if not _broker_order_internal_owner_changes(existing, incoming):
+            return
+        if not _is_strict_broker_only_owner(existing):
+            return
+        if incoming_owner_kind != "real":
+            raise BrokerIdentityConflict(
+                "broker-only owner promotion requires complete canonical owner"
+            )
+        if (
+            existing.get("execution_fence") is True
+            or int(existing.get("fill_count") or 0) > 0
+        ):
+            raise BrokerIdentityConflict(
+                "broker-only owner with executions requires targeted repair"
+            )
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        self._ensure_canonical_indexes()
+        normalized_key = normalize_identifier(broker_order_key)
+        current = self.find_broker_order(normalized_key)
+        if current is None:
+            return None
+        payload = _without_mongo_id(updates)
+        if any(field in payload for field in _BROKER_ORDER_AGGREGATE_FIELDS):
+            raise BrokerIdentityConflict(
+                "broker aggregate fields require compare-and-set"
+            )
+        candidate = {**_without_mongo_id(current), **payload}
+        _assert_broker_order_identity_consistent(current, candidate)
+        _assert_broker_order_owner_unchanged(current, candidate)
+        update_fields = {
+            key: value
+            for key, value in payload.items()
+            if key not in _BROKER_ORDER_OWNER_FIELDS
+            and key != "broker_order_key"
+            and current.get(key) != value
+        }
+        if not update_fields:
+            return current
+        selector = {"broker_order_key": normalized_key}
+        for field in (*_BROKER_ORDER_OWNER_FIELDS, *_BROKER_ORDER_IDENTITY_FIELDS):
+            if field != "broker_order_key":
+                selector[field] = current.get(field)
+        result = self.broker_orders.update_one(selector, {"$set": update_fields})
+        saved = self.find_broker_order(normalized_key)
+        if result.matched_count or (
+            saved is not None
+            and all(saved.get(key) == value for key, value in update_fields.items())
+        ):
+            return saved
+        raise BrokerIdentityConflict("broker order field update lost canonical owner")
+
+    def fence_broker_order_execution(self, document):
+        self._ensure_canonical_indexes()
+        broker_order_key = normalize_identifier(document.get("broker_order_key"))
+        internal_order_id = normalize_identifier(document.get("internal_order_id"))
+        if broker_order_key is None or internal_order_id is None:
+            raise BrokerIdentityConflict(
+                "execution fence requires broker_order_key and internal_order_id"
+            )
+        for _attempt in range(_BROKER_ORDER_CLAIM_ATTEMPTS):
+            current = self.find_broker_order(broker_order_key)
+            if current is None:
+                raise BrokerIdentityConflict(
+                    "execution fence requires an existing broker order"
+                )
+            _assert_broker_order_identity_consistent(current, document)
+            if (
+                normalize_identifier(current.get("internal_order_id"))
+                != internal_order_id
+            ):
+                raise BrokerIdentityConflict(
+                    "broker order execution owner changed; targeted repair required"
+                )
+            if current.get("execution_fence") is True:
+                return current
+            result = self.broker_orders.update_one(
+                _exact_document_selector(current, identity_field="broker_order_key"),
+                {"$set": {"execution_fence": True}},
+            )
+            if result.matched_count:
+                return self.find_broker_order(broker_order_key)
+        raise BrokerIdentityConflict(
+            "broker order execution fence could not converge after concurrent updates"
+        )
+
+    def compare_and_set_broker_order(self, *, before, after):
+        self._ensure_canonical_indexes()
+        before_payload = _without_mongo_id(before)
+        after_payload = _without_mongo_id(after)
+        broker_order_key = normalize_identifier(
+            after_payload.get("broker_order_key")
+            or before_payload.get("broker_order_key")
+        )
+        if broker_order_key is None:
+            raise BrokerIdentityConflict("broker_order_key is required")
+        before_payload["broker_order_key"] = broker_order_key
+        after_payload["broker_order_key"] = broker_order_key
+        _assert_broker_order_identity_consistent(before_payload, after_payload)
+        _assert_broker_order_owner_unchanged(before_payload, after_payload)
+        result = self.broker_orders.replace_one(
+            _exact_document_selector(before_payload, identity_field="broker_order_key"),
+            after_payload,
+        )
+        if result.matched_count:
+            return self.find_broker_order(broker_order_key)
+        current = self.find_broker_order(broker_order_key)
+        return current if _without_mongo_id(current) == after_payload else None
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        self._ensure_canonical_indexes()
+        old_key = normalize_identifier(old_key)
+        new_key = normalize_identifier(new_key)
+        if new_key is None:
+            raise BrokerIdentityConflict("new broker_order_key is required")
+        payload = _without_mongo_id({**document, "broker_order_key": new_key})
+        if old_key is None or old_key == new_key:
+            return self.claim_broker_order_owner(payload)[0]
+        initial_source = self.find_broker_order(old_key)
+        for _attempt in range(_BROKER_ORDER_MOVE_ATTEMPTS):
+            source = self.find_broker_order(old_key)
+            if source is None:
+                return self.claim_broker_order_owner(payload)[0]
+            if initial_source is None:
+                initial_source = source
+            _assert_broker_order_identity_consistent(source, payload)
+            _assert_broker_order_owner_transition(source, payload)
+            _assert_broker_order_owner_unchanged(initial_source, source)
+            candidate = _merge_broker_order_move_candidate(
+                initial_source=initial_source,
+                current_source=source,
+                incoming=payload,
+                new_key=new_key,
+            )
+            self.claim_broker_order_owner(candidate)
+            saved = self._converge_broker_order_move_target(new_key, candidate)
+            result = self.broker_orders.delete_one(
+                _exact_document_selector(source, identity_field="broker_order_key")
+            )
+            if result.deleted_count:
+                return saved
+        raise BrokerIdentityConflict(
+            "broker order key move could not converge after concurrent source updates"
+        )
+
+    def _converge_broker_order_move_target(self, broker_order_key, candidate):
+        for _attempt in range(_BROKER_ORDER_MOVE_ATTEMPTS):
+            current = self.find_broker_order(broker_order_key)
+            if current is None:
+                return self.claim_broker_order_owner(candidate)[0]
+            merged = _merge_broker_order_move_target(current, candidate)
+            if _without_mongo_id(current) == merged:
+                return current
+            saved = self.compare_and_set_broker_order(before=current, after=merged)
+            if saved is not None:
+                return saved
+        raise BrokerIdentityConflict(
+            "broker order key move target could not converge after concurrent updates"
+        )
 
     def insert_order_event(self, document):
         self.order_events.insert_one(document)
         return document
 
     def upsert_trade_fact(self, document, unique_keys):
+        if list(unique_keys or []) == ["execution_identity"]:
+            return self._upsert_execution_record(
+                self.trade_facts,
+                document,
+                identity_field="execution_identity",
+            )
         query = {key: document[key] for key in unique_keys}
         existing = self.trade_facts.find_one(query)
         if existing is not None:
@@ -169,6 +530,12 @@ class OrderManagementRepository:
     def find_order_by_request_id(self, request_id):
         return self.orders.find_one({"request_id": request_id})
 
+    def find_order_by_broker_correlation_token(self, broker_correlation_token):
+        token = normalize_broker_correlation_token(broker_correlation_token)
+        if token is None:
+            return None
+        return self.orders.find_one({"broker_correlation_token": token})
+
     def find_order_by_broker_order_id(self, broker_order_id):
         return self.orders.find_one({"broker_order_id": str(broker_order_id)})
 
@@ -185,12 +552,38 @@ class OrderManagementRepository:
         return self.find_order(internal_order_id)
 
     def upsert_execution_fill(self, document, unique_keys):
+        if list(unique_keys or []) == ["execution_identity"]:
+            return self._upsert_execution_record(
+                self.execution_fills,
+                document,
+                identity_field="execution_identity",
+            )
         query = {key: document[key] for key in unique_keys}
         existing = self.execution_fills.find_one(query)
         if existing is not None:
             return existing, False
         self.execution_fills.insert_one(document)
         return document, True
+
+    def _upsert_execution_record(self, collection, document, *, identity_field):
+        self._ensure_canonical_indexes()
+        payload = _without_mongo_id(document)
+        identity = normalize_identifier(payload.get(identity_field))
+        if identity is None:
+            raise BrokerIdentityConflict(f"{identity_field} is required")
+        payload[identity_field] = identity
+        try:
+            result = collection.update_one(
+                {identity_field: identity},
+                {"$setOnInsert": payload},
+                upsert=True,
+            )
+        except DuplicateKeyError:
+            result = None
+        saved = collection.find_one({identity_field: identity})
+        if saved is None:
+            raise BrokerIdentityConflict(f"{identity_field} insert did not persist")
+        return saved, bool(result is not None and result.upserted_id is not None)
 
     def find_buy_lot_by_origin_trade_fact_id(self, origin_trade_fact_id):
         return self.buy_lots.find_one({"origin_trade_fact_id": origin_trade_fact_id})
@@ -456,3 +849,233 @@ class OrderManagementRepository:
         if reason_code is not None:
             query["reason_code"] = reason_code
         return list(self.ingest_rejections.find(query))
+
+
+def _without_mongo_id(document):
+    return {key: value for key, value in dict(document or {}).items() if key != "_id"}
+
+
+def _exact_document_selector(document, *, identity_field):
+    payload = _without_mongo_id(document)
+    return {
+        identity_field: payload[identity_field],
+        "$expr": {
+            "$eq": [
+                {"$unsetField": {"field": "_id", "input": "$$ROOT"}},
+                payload,
+            ]
+        },
+    }
+
+
+def _assert_broker_order_identity_consistent(existing, incoming):
+    conflicts = identity_conflicts(existing, incoming)
+    if conflicts:
+        raise BrokerIdentityConflict(
+            "broker order conflicts with canonical identity: "
+            + ", ".join(sorted(conflicts))
+        )
+
+
+def _broker_order_owner(document):
+    return {
+        field: normalize_identifier((document or {}).get(field))
+        for field in _BROKER_ORDER_OWNER_FIELDS
+    }
+
+
+def _assert_broker_order_owner_transition(existing, incoming):
+    existing_owner = _broker_order_owner(existing)
+    incoming_owner = _broker_order_owner(incoming)
+    if (
+        existing_owner["internal_order_id"] is not None
+        and incoming_owner["internal_order_id"] is not None
+        and existing_owner["internal_order_id"] != incoming_owner["internal_order_id"]
+        and not (
+            _is_strict_broker_only_owner(existing)
+            and not _is_strict_broker_only_owner(incoming)
+        )
+    ):
+        raise BrokerIdentityConflict(
+            "broker order owner conflicts with canonical internal_order_id"
+        )
+    for field in ("request_id", "broker_correlation_token"):
+        if (
+            existing_owner[field] is not None
+            and incoming_owner[field] is not None
+            and existing_owner[field] != incoming_owner[field]
+        ):
+            raise BrokerIdentityConflict(
+                f"broker order owner conflicts with canonical {field}"
+            )
+
+
+def _assert_broker_order_owner_unchanged(existing, incoming):
+    if _broker_order_owner(existing) != _broker_order_owner(incoming):
+        raise BrokerIdentityConflict(
+            "broker order owner cannot change through aggregate compare-and-set"
+        )
+
+
+def _classify_broker_order_owner(document):
+    owner = _broker_order_owner(document)
+    internal_order_id = owner["internal_order_id"]
+    request_id = owner["request_id"]
+    raw_token = normalize_identifier((document or {}).get("broker_correlation_token"))
+    token = normalize_broker_correlation_token(raw_token)
+    if raw_token is not None and token is None:
+        raise BrokerIdentityConflict(
+            "broker order owner correlation token is malformed"
+        )
+    if internal_order_id is None:
+        if request_id is not None or raw_token is not None:
+            raise BrokerIdentityConflict(
+                "broker order owner request/token requires internal_order_id"
+            )
+        return "empty"
+    if str((document or {}).get("source_type") or "").lower() == "broker_only":
+        if request_id is not None or raw_token is not None:
+            raise BrokerIdentityConflict(
+                "broker-only owner cannot carry request or correlation ownership"
+            )
+        if not _is_strict_broker_only_owner(document):
+            raise BrokerIdentityConflict(
+                "broker-only owner identity cannot be proven; targeted repair required"
+            )
+        return "broker_only"
+    if token is not None and token != build_broker_correlation_token(internal_order_id):
+        raise BrokerIdentityConflict(
+            "broker order owner correlation token conflicts with internal_order_id"
+        )
+    if request_id is None or token is None:
+        return "real_partial"
+    return "real"
+
+
+def _is_complete_real_broker_order_owner(document):
+    try:
+        return _classify_broker_order_owner(document) == "real"
+    except BrokerIdentityConflict:
+        return False
+
+
+def _broker_order_internal_owner_changes(existing, incoming):
+    return (
+        normalize_identifier((existing or {}).get("internal_order_id")) is not None
+        and normalize_identifier((incoming or {}).get("internal_order_id")) is not None
+        and normalize_identifier((existing or {}).get("internal_order_id"))
+        != normalize_identifier((incoming or {}).get("internal_order_id"))
+    )
+
+
+def _is_strict_broker_only_owner(document):
+    if str((document or {}).get("source_type") or "").lower() != "broker_only":
+        return False
+    owner = _broker_order_owner(document)
+    if (
+        owner["internal_order_id"] is None
+        or owner["request_id"] is not None
+        or owner["broker_correlation_token"] is not None
+    ):
+        return False
+    expected_ids = []
+    identity = {
+        "account_id": (document or {}).get("account_id"),
+        "order_sysid": (document or {}).get("order_sysid"),
+        "trading_day": resolve_trading_day(document or {}),
+        "symbol": (document or {}).get("symbol"),
+        "side": (document or {}).get("side"),
+        "broker_order_id": (document or {}).get("broker_order_id"),
+    }
+    for order_sysid in (identity["order_sysid"], None):
+        try:
+            expected_ids.append(
+                build_broker_only_internal_order_id(
+                    account_id=identity["account_id"],
+                    order_sysid=order_sysid,
+                    trading_day=identity["trading_day"],
+                    symbol=identity["symbol"],
+                    side=identity["side"],
+                    broker_order_id=identity["broker_order_id"],
+                )
+            )
+        except BrokerIdentityError:
+            continue
+    return owner["internal_order_id"] in set(expected_ids)
+
+
+def _merge_broker_order_claim(existing, incoming):
+    _assert_broker_order_identity_consistent(existing, incoming)
+    _assert_broker_order_owner_transition(existing, incoming)
+    merged = _without_mongo_id(existing)
+    owner_changes = _broker_order_internal_owner_changes(existing, incoming)
+    for field in _BROKER_ORDER_CLAIM_FIELDS:
+        if field not in incoming:
+            continue
+        value = incoming.get(field)
+        if field == "source_type":
+            if owner_changes or merged.get(field) in (None, ""):
+                merged[field] = value
+            continue
+        if value is None and merged.get(field) is not None:
+            continue
+        merged[field] = value
+    return merged
+
+
+def _merge_broker_order_move_candidate(
+    *, initial_source, current_source, incoming, new_key
+):
+    initial_payload = _without_mongo_id(initial_source)
+    current_payload = _without_mongo_id(current_source)
+    merged = {
+        **initial_payload,
+        **_without_mongo_id(incoming),
+        "broker_order_key": new_key,
+    }
+    for field in set(initial_payload) | set(current_payload):
+        if field == "broker_order_key":
+            continue
+        initial_value = initial_payload.get(field, _MISSING)
+        current_value = current_payload.get(field, _MISSING)
+        if current_value == initial_value:
+            continue
+        if current_value is _MISSING:
+            merged.pop(field, None)
+        else:
+            merged[field] = current_value
+    _preserve_newer_broker_order_aggregate(merged, current_payload)
+    if current_payload.get("execution_fence") is True:
+        merged["execution_fence"] = True
+    return merged
+
+
+def _merge_broker_order_move_target(existing, candidate):
+    _assert_broker_order_identity_consistent(existing, candidate)
+    _assert_broker_order_owner_unchanged(existing, candidate)
+    merged = {**_without_mongo_id(existing), **_without_mongo_id(candidate)}
+    _preserve_newer_broker_order_aggregate(merged, existing)
+    if existing.get("execution_fence") is True:
+        merged["execution_fence"] = True
+    return merged
+
+
+def _preserve_newer_broker_order_aggregate(merged, source):
+    source_revision = _broker_order_aggregate_revision(source)
+    merged_revision = _broker_order_aggregate_revision(merged)
+    if source_revision <= merged_revision:
+        return
+    for field in _BROKER_ORDER_AGGREGATE_FIELDS:
+        if field in source:
+            merged[field] = source.get(field)
+        else:
+            merged.pop(field, None)
+    if "state" in source:
+        merged["state"] = source.get("state")
+
+
+def _broker_order_aggregate_revision(document):
+    try:
+        return int((document or {}).get("aggregate_revision") or 0)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise BrokerIdentityConflict("broker aggregate revision is invalid") from exc

--- a/freshquant/order_management/submit/execution_bridge.py
+++ b/freshquant/order_management/submit/execution_bridge.py
@@ -5,6 +5,10 @@ from datetime import time as dt_time
 from datetime import timezone
 
 from freshquant.carnation import xtconstant
+from freshquant.order_management.broker_correlation import (
+    build_broker_correlation_token,
+    normalize_broker_correlation_token,
+)
 from freshquant.order_management.repository import OrderManagementRepository
 from freshquant.order_management.tracking.service import OrderTrackingService
 
@@ -40,6 +44,24 @@ def prepare_submit_execution(
         )
         return {"status": "skipped", "reason": "already_canceled"}
 
+    message_correlation_token = normalize_broker_correlation_token(
+        order_message.get("broker_correlation_token")
+    )
+    order_correlation_token = normalize_broker_correlation_token(
+        order.get("broker_correlation_token")
+    )
+    if (
+        message_correlation_token is not None
+        and order_correlation_token is not None
+        and message_correlation_token != order_correlation_token
+    ):
+        raise ValueError("broker correlation token conflicts with internal order")
+    broker_correlation_token = (
+        order_correlation_token
+        or message_correlation_token
+        or build_broker_correlation_token(internal_order_id)
+    )
+
     runtime_resolution = _resolve_runtime_execution(
         order_message,
         order,
@@ -55,6 +77,7 @@ def prepare_submit_execution(
             "broker_order_type": runtime_resolution.get("broker_order_type"),
             "price_mode_resolved": runtime_resolution.get("price_mode_resolved"),
             "broker_price_type": runtime_resolution.get("broker_price_type"),
+            "broker_correlation_token": broker_correlation_token,
             "updated_at": _utc_now_iso(),
         },
     )
@@ -85,6 +108,8 @@ def prepare_submit_execution(
             "credit_available_amount": runtime_resolution.get(
                 "credit_available_amount"
             ),
+            "broker_correlation_token": broker_correlation_token,
+            "broker_order_remark": broker_correlation_token,
         }
     )
     return {"status": "execute", "order_message": resolved_message}

--- a/freshquant/order_management/tracking/service.py
+++ b/freshquant/order_management/tracking/service.py
@@ -1,7 +1,26 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime, timezone
+from hashlib import sha256
 
+from freshquant.order_management.broker_correlation import (
+    build_broker_correlation_token,
+    looks_like_broker_correlation_token,
+    normalize_broker_correlation_token,
+)
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityConflict,
+    BrokerIdentityError,
+    build_broker_only_internal_order_id,
+    build_broker_order_key,
+    build_execution_identity,
+    identity_conflicts,
+    normalize_account_id,
+    normalize_identifier,
+    normalize_side,
+    normalize_symbol,
+    resolve_trading_day,
+)
 from freshquant.order_management.ids import (
     new_event_id,
     new_execution_fill_id,
@@ -21,7 +40,25 @@ class OrderTrackingService:
     def submit_order(self, payload):
         request_id = payload.get("request_id") or new_request_id()
         internal_order_id = payload.get("internal_order_id") or new_internal_order_id()
+        raw_correlation_token = payload.get("broker_correlation_token")
+        broker_correlation_token = normalize_broker_correlation_token(
+            raw_correlation_token
+        )
+        if raw_correlation_token not in (None, "", "None"):
+            if broker_correlation_token is None:
+                raise BrokerIdentityError("broker correlation token is invalid")
+        else:
+            broker_correlation_token = build_broker_correlation_token(internal_order_id)
         now = _utc_now_iso()
+        trading_day = resolve_trading_day(payload)
+        broker_order_key = _resolve_broker_order_key(
+            {
+                **payload,
+                "internal_order_id": internal_order_id,
+                "broker_correlation_token": broker_correlation_token,
+                "trading_day": trading_day,
+            }
+        )
 
         request_document = {
             "request_id": request_id,
@@ -30,6 +67,8 @@ class OrderTrackingService:
             "trace_id": payload.get("trace_id"),
             "intent_id": payload.get("intent_id"),
             "account_type": payload.get("account_type"),
+            "account_id": normalize_account_id(payload.get("account_id")),
+            "trading_day": trading_day,
             "symbol": payload.get("symbol"),
             "price": payload.get("price"),
             "quantity": payload.get("quantity"),
@@ -41,6 +80,7 @@ class OrderTrackingService:
             "scope_type": payload.get("scope_type"),
             "scope_ref_id": payload.get("scope_ref_id"),
             "req_id": payload.get("req_id") or request_id,
+            "broker_correlation_token": broker_correlation_token,
             "state": "ACCEPTED",
             "created_at": now,
         }
@@ -48,9 +88,14 @@ class OrderTrackingService:
             "internal_order_id": internal_order_id,
             "request_id": request_id,
             "broker_order_id": payload.get("broker_order_id"),
+            "broker_order_key": broker_order_key,
             "broker_order_type": payload.get("broker_order_type"),
             "broker_price_type": payload.get("broker_price_type"),
+            "broker_correlation_token": broker_correlation_token,
             "account_type": payload.get("account_type"),
+            "account_id": normalize_account_id(payload.get("account_id")),
+            "order_sysid": normalize_identifier(payload.get("order_sysid")),
+            "trading_day": trading_day,
             "trace_id": payload.get("trace_id"),
             "intent_id": payload.get("intent_id"),
             "symbol": payload.get("symbol"),
@@ -77,39 +122,27 @@ class OrderTrackingService:
 
         self.repository.insert_order_request(request_document)
         self.repository.insert_order(order_document)
-        if hasattr(self.repository, "upsert_broker_order"):
-            self.repository.upsert_broker_order(
-                {
-                    "broker_order_key": internal_order_id,
-                    "internal_order_id": internal_order_id,
-                    "request_id": request_id,
-                    "broker_order_id": payload.get("broker_order_id"),
-                    "broker_order_type": payload.get("broker_order_type"),
-                    "broker_price_type": payload.get("broker_price_type"),
-                    "account_type": payload.get("account_type"),
-                    "trace_id": payload.get("trace_id"),
-                    "intent_id": payload.get("intent_id"),
-                    "symbol": payload.get("symbol"),
-                    "side": payload["action"],
-                    "credit_trade_mode_requested": payload.get("credit_trade_mode"),
-                    "credit_trade_mode_resolved": payload.get(
-                        "credit_trade_mode_resolved"
-                    ),
-                    "price_mode_requested": payload.get("price_mode"),
-                    "price_mode_resolved": payload.get("price_mode_resolved"),
-                    "state": "ACCEPTED",
-                    "source_type": payload.get("source", "unknown"),
-                    "submitted_at": None,
-                    "requested_quantity": payload.get("quantity"),
-                    "filled_quantity": 0,
-                    "avg_filled_price": None,
-                    "fill_count": 0,
-                    "first_fill_time": None,
-                    "last_fill_time": None,
-                    "updated_at": now,
-                },
-                unique_keys=["broker_order_key"],
-            )
+        self.repository.claim_broker_order_owner(
+            _broker_order_owner_claim(order_document)
+        )
+        self.repository.update_broker_order_fields(
+            broker_order_key,
+            {
+                "broker_order_type": payload.get("broker_order_type"),
+                "broker_price_type": payload.get("broker_price_type"),
+                "account_type": payload.get("account_type"),
+                "trace_id": payload.get("trace_id"),
+                "intent_id": payload.get("intent_id"),
+                "credit_trade_mode_requested": payload.get("credit_trade_mode"),
+                "credit_trade_mode_resolved": payload.get("credit_trade_mode_resolved"),
+                "price_mode_requested": payload.get("price_mode"),
+                "price_mode_resolved": payload.get("price_mode_resolved"),
+                "state": "ACCEPTED",
+                "submitted_at": None,
+                "requested_quantity": payload.get("quantity"),
+                "updated_at": now,
+            },
+        )
         self.repository.insert_order_event(event_document)
         return request_id
 
@@ -152,10 +185,11 @@ class OrderTrackingService:
             {"state": next_state, "updated_at": now},
         )
         self._sync_broker_order_report(
-            internal_order_id,
+            current_order.get("broker_order_key") or internal_order_id,
             {
                 "state": next_state,
             },
+            current_order=current_order,
         )
         self.repository.insert_order_event(event_document)
         return request_id
@@ -170,10 +204,11 @@ class OrderTrackingService:
             {"state": next_state, "updated_at": now},
         )
         self._sync_broker_order_report(
-            internal_order_id,
+            order.get("broker_order_key") or internal_order_id,
             {
                 "state": next_state,
             },
+            current_order=order,
         )
         self.repository.insert_order_event(
             {
@@ -191,54 +226,95 @@ class OrderTrackingService:
         return self.ingest_order_report_with_meta(report)["order"]
 
     def ingest_order_report_with_meta(self, report):
+        report = dict(report)
         internal_order_id = report["internal_order_id"]
         current_order = self.repository.find_order(internal_order_id)
+        created_broker_only = current_order is None
+        if current_order is None:
+            current_order = self._build_broker_only_order(report)
+            internal_order_id = current_order["internal_order_id"]
+            report["internal_order_id"] = internal_order_id
+            self.repository.insert_order(current_order)
+        else:
+            _assert_order_report_identity(current_order, report)
+
+        placeholder_key = (
+            current_order.get("broker_order_key") or current_order["internal_order_id"]
+        )
+        identity_updates = {
+            key: value
+            for key, value in _non_empty_identity_fields(report).items()
+            if current_order.get(key) != value
+        }
+        broker_order_key = _resolve_broker_order_key(
+            report, current_order=current_order
+        )
+        if current_order.get("broker_order_key") != broker_order_key:
+            identity_updates["broker_order_key"] = broker_order_key
+        effective_order = {**current_order, **identity_updates}
+        if created_broker_only:
+            self._sync_broker_order_report(
+                broker_order_key,
+                report,
+                current_order=effective_order,
+                placeholder_key=placeholder_key,
+            )
+            self.repository.insert_order_event(
+                {
+                    "event_id": new_event_id(),
+                    "request_id": None,
+                    "internal_order_id": internal_order_id,
+                    "event_type": report.get(
+                        "event_type", "broker_only_order_reported"
+                    ),
+                    "state": current_order["state"],
+                    "created_at": _utc_now_iso(),
+                }
+            )
+            return {"order": current_order, "changed": True, "absorbed": False}
+
         current_state = current_order["state"]
         updates = {}
-        if report.get("broker_order_id") and not current_order.get("broker_order_id"):
-            updates["broker_order_id"] = report.get("broker_order_id")
+        updates.update(identity_updates)
         if report.get("submitted_at") and not current_order.get("submitted_at"):
             updates["submitted_at"] = report.get("submitted_at")
+        absorbed = False
+        if current_state == report["state"]:
+            next_state = current_state
+        elif _should_absorb_terminal_replay(current_state, report["state"]):
+            next_state = current_state
+            absorbed = True
+        else:
+            next_state = self.state_machine.transition(current_state, report["state"])
+
+        self._sync_broker_order_report(
+            broker_order_key,
+            {**report, "state": next_state},
+            current_order=effective_order,
+            placeholder_key=placeholder_key,
+        )
         if current_state == report["state"]:
             if updates:
                 updates["updated_at"] = _utc_now_iso()
                 updated_order = self.repository.update_order(internal_order_id, updates)
-                self._sync_broker_order_report(
-                    internal_order_id,
-                    {
-                        "broker_order_id": report.get("broker_order_id"),
-                        "submitted_at": report.get("submitted_at"),
-                        "state": current_state,
-                    },
-                )
                 return {
                     "order": updated_order,
                     "changed": True,
                     "absorbed": False,
                 }
             return {"order": current_order, "changed": False, "absorbed": False}
-        if _should_absorb_terminal_replay(current_state, report["state"]):
+        if absorbed:
             if updates:
                 updates["updated_at"] = _utc_now_iso()
                 current_order = self.repository.update_order(internal_order_id, updates)
-                self._sync_broker_order_report(
-                    internal_order_id,
-                    {
-                        "broker_order_id": report.get("broker_order_id"),
-                        "submitted_at": report.get("submitted_at"),
-                        "state": current_order.get("state"),
-                    },
-                )
             return {"order": current_order, "changed": False, "absorbed": True}
-        next_state = self.state_machine.transition(current_state, report["state"])
         now = _utc_now_iso()
 
         updated_order = self.repository.update_order(
             internal_order_id,
             {
                 "state": next_state,
-                "broker_order_id": report.get("broker_order_id"),
-                "submitted_at": report.get("submitted_at"),
+                **updates,
                 "updated_at": now,
             },
         )
@@ -252,33 +328,52 @@ class OrderTrackingService:
                 "created_at": now,
             }
         )
-        self._sync_broker_order_report(
-            internal_order_id,
-            {
-                "broker_order_id": report.get("broker_order_id"),
-                "submitted_at": report.get("submitted_at"),
-                "state": next_state,
-            },
-        )
         return {"order": updated_order, "changed": True, "absorbed": False}
 
     def ingest_trade_report(self, report):
         return self.ingest_trade_report_with_meta(report)["trade_fact"]
 
     def ingest_trade_report_with_meta(self, report):
+        report = _normalize_trade_report_identity(report)
         current_order = self.repository.find_order(report["internal_order_id"])
+        created_broker_only = current_order is None
+        if current_order is None:
+            current_order = self._build_broker_only_order(
+                {**report, "state": "PARTIAL_FILLED"}
+            )
+        else:
+            _assert_order_report_identity(current_order, report)
+
+        placeholder_key = (
+            current_order.get("broker_order_key") or current_order["internal_order_id"]
+        )
+        identity_updates = {
+            key: value
+            for key, value in _non_empty_identity_fields(report).items()
+            if current_order.get(key) != value
+        }
         broker_order_key = _resolve_broker_order_key(
             report, current_order=current_order
+        )
+        if current_order.get("broker_order_key") != broker_order_key:
+            identity_updates["broker_order_key"] = broker_order_key
+        effective_order = {**current_order, **identity_updates}
+        execution_identity = _resolve_execution_identity(
+            report, current_order=effective_order
         )
         execution_fill = {
             "execution_fill_id": report.get("execution_fill_id")
             or new_execution_fill_id(),
             "broker_order_key": broker_order_key,
             "internal_order_id": report["internal_order_id"],
-            "request_id": current_order.get("request_id") if current_order else None,
+            "request_id": effective_order.get("request_id"),
             "broker_order_id": report.get("broker_order_id")
-            or (current_order.get("broker_order_id") if current_order else None),
+            or effective_order.get("broker_order_id"),
             "broker_trade_id": report["broker_trade_id"],
+            "execution_identity": execution_identity,
+            "account_id": report.get("account_id"),
+            "order_sysid": report.get("order_sysid"),
+            "trading_day": report.get("trading_day"),
             "symbol": report["symbol"],
             "side": report["side"],
             "quantity": report["quantity"],
@@ -291,8 +386,14 @@ class OrderTrackingService:
         }
         trade_fact = {
             "trade_fact_id": report.get("trade_fact_id") or new_trade_fact_id(),
+            "broker_order_key": broker_order_key,
             "internal_order_id": report["internal_order_id"],
+            "broker_order_id": report.get("broker_order_id"),
             "broker_trade_id": report["broker_trade_id"],
+            "execution_identity": execution_identity,
+            "account_id": report.get("account_id"),
+            "order_sysid": report.get("order_sysid"),
+            "trading_day": report.get("trading_day"),
             "symbol": report["symbol"],
             "side": report["side"],
             "quantity": report["quantity"],
@@ -303,20 +404,36 @@ class OrderTrackingService:
             "source": report.get("source", "unknown"),
             "provisional": report.get("provisional", False),
         }
+        if created_broker_only:
+            self.repository.insert_order(effective_order)
+        self._sync_broker_order_report(
+            broker_order_key,
+            {**report, "state": "PARTIAL_FILLED"},
+            current_order=effective_order,
+            placeholder_key=placeholder_key,
+        )
+        self.repository.fence_broker_order_execution(execution_fill)
         saved_trade_fact, created = self.repository.upsert_trade_fact(
             trade_fact,
-            unique_keys=["broker_trade_id"],
+            unique_keys=["execution_identity"],
         )
-        if hasattr(self.repository, "upsert_execution_fill"):
-            saved_execution_fill, created_execution_fill = (
-                self.repository.upsert_execution_fill(
-                    execution_fill,
-                    unique_keys=["broker_trade_id"],
-                )
+        saved_execution_fill, created_execution_fill = (
+            self.repository.upsert_execution_fill(
+                execution_fill,
+                unique_keys=["execution_identity"],
+            )
+        )
+        _assert_execution_replay_consistent(saved_trade_fact, trade_fact)
+        _assert_execution_replay_consistent(saved_execution_fill, execution_fill)
+        if not created_broker_only and identity_updates:
+            current_order = self.repository.update_order(
+                report["internal_order_id"],
+                {**identity_updates, "updated_at": _utc_now_iso()},
             )
         else:
-            saved_execution_fill = dict(execution_fill)
-            created_execution_fill = created
+            current_order = effective_order
+        created = bool(created_execution_fill)
+        broker_order = None
         if created:
             broker_order = self._apply_fill_to_broker_order(
                 broker_order_key,
@@ -339,115 +456,161 @@ class OrderTrackingService:
             "created": created,
         }
 
-    def _sync_broker_order_report(self, broker_order_key, report):
-        if not hasattr(self.repository, "find_broker_order") or not hasattr(
-            self.repository, "upsert_broker_order"
+    def _build_broker_only_order(self, report):
+        expected_internal_order_id = build_broker_only_internal_order_id(
+            account_id=report.get("account_id"),
+            order_sysid=report.get("order_sysid"),
+            trading_day=resolve_trading_day(report),
+            symbol=report.get("symbol"),
+            side=report.get("side"),
+            broker_order_id=report.get("broker_order_id"),
+        )
+        reported_internal_order_id = normalize_identifier(
+            report.get("internal_order_id")
+        )
+        if (
+            reported_internal_order_id is not None
+            and reported_internal_order_id != expected_internal_order_id
         ):
-            return None
+            raise BrokerIdentityConflict(
+                "broker-only internal_order_id is not deterministic"
+            )
+        now = _utc_now_iso()
+        return {
+            "internal_order_id": expected_internal_order_id,
+            "request_id": None,
+            "broker_order_key": _resolve_broker_order_key(report),
+            "broker_order_id": normalize_identifier(report.get("broker_order_id")),
+            "broker_order_type": report.get("broker_order_type")
+            or report.get("order_type"),
+            "account_type": report.get("account_type"),
+            "account_id": normalize_account_id(report.get("account_id")),
+            "order_sysid": normalize_identifier(report.get("order_sysid")),
+            "trading_day": resolve_trading_day(report),
+            "trace_id": report.get("trace_id"),
+            "intent_id": report.get("intent_id"),
+            "symbol": normalize_symbol(report.get("symbol")),
+            "side": normalize_side(report.get("side")),
+            "state": report.get("state") or "PARTIAL_FILLED",
+            "source_type": "broker_only",
+            "submitted_at": report.get("submitted_at"),
+            "requested_quantity": report.get("requested_quantity")
+            or report.get("order_volume"),
+            "filled_quantity": 0,
+            "avg_filled_price": None,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+    def _sync_broker_order_report(
+        self,
+        broker_order_key,
+        report,
+        *,
+        current_order=None,
+        placeholder_key=None,
+    ):
+        current_order = current_order or self.repository.find_order(
+            report.get("internal_order_id") or broker_order_key
+        )
+        if current_order is None:
+            raise BrokerIdentityConflict("broker order owner is required")
+        claim = _broker_order_owner_claim(
+            {**current_order, "broker_order_key": broker_order_key}
+        )
+        placeholder_key = normalize_identifier(
+            placeholder_key
+            or current_order.get("broker_order_key")
+            or current_order.get("internal_order_id")
+        )
+        if placeholder_key and placeholder_key != broker_order_key:
+            self.repository.move_broker_order_key(
+                placeholder_key,
+                broker_order_key,
+                claim,
+            )
+        else:
+            self.repository.claim_broker_order_owner(claim)
         broker_order = self.repository.find_broker_order(broker_order_key)
         if broker_order is None:
-            return None
+            raise BrokerIdentityConflict("broker order claim did not persist")
         updates = {
-            "updated_at": _utc_now_iso(),
             "state": report.get("state") or broker_order.get("state"),
             "broker_order_id": report.get("broker_order_id")
             or broker_order.get("broker_order_id"),
             "submitted_at": report.get("submitted_at")
             or broker_order.get("submitted_at"),
+            "requested_quantity": report.get("requested_quantity")
+            or report.get("order_volume")
+            or broker_order.get("requested_quantity"),
         }
-        next_document = {
-            **broker_order,
-            **{key: value for key, value in updates.items() if value is not None},
+        update_fields = {
+            key: value
+            for key, value in updates.items()
+            if value is not None and broker_order.get(key) != value
         }
-        saved_broker_order, _ = self.repository.upsert_broker_order(
-            next_document,
-            unique_keys=["broker_order_key"],
+        if not update_fields:
+            return broker_order
+        update_fields["updated_at"] = _utc_now_iso()
+        return self.repository.update_broker_order_fields(
+            broker_order_key,
+            update_fields,
         )
-        return saved_broker_order
 
     def _apply_fill_to_broker_order(
         self, broker_order_key, execution_fill, *, current_order
     ):
-        if not hasattr(self.repository, "find_broker_order") or not hasattr(
-            self.repository, "upsert_broker_order"
-        ):
-            return None
-        broker_order = self.repository.find_broker_order(broker_order_key)
-        if broker_order is None:
-            broker_order = {
-                "broker_order_key": broker_order_key,
-                "internal_order_id": (
-                    current_order.get("internal_order_id")
-                    if current_order
-                    else broker_order_key
-                ),
-                "request_id": (
-                    current_order.get("request_id") if current_order else None
-                ),
-                "broker_order_id": execution_fill.get("broker_order_id"),
-                "account_type": (
-                    current_order.get("account_type") if current_order else None
-                ),
-                "trace_id": current_order.get("trace_id") if current_order else None,
-                "intent_id": current_order.get("intent_id") if current_order else None,
-                "symbol": execution_fill.get("symbol"),
-                "side": execution_fill.get("side"),
-                "state": "PARTIAL_FILLED",
-                "source_type": execution_fill.get("source"),
-                "submitted_at": (
-                    current_order.get("submitted_at") if current_order else None
-                ),
-                "requested_quantity": None,
-                "filled_quantity": 0,
-                "avg_filled_price": None,
-                "fill_count": 0,
-                "first_fill_time": None,
-                "last_fill_time": None,
+        for _attempt in range(8):
+            broker_order = self.repository.find_broker_order(broker_order_key)
+            if broker_order is None:
+                raise BrokerIdentityConflict("execution fence has no broker order")
+            conflicts = identity_conflicts(broker_order, execution_fill)
+            if conflicts:
+                raise BrokerIdentityConflict(
+                    "execution fill conflicts with broker aggregate: "
+                    + ", ".join(sorted(conflicts))
+                )
+            fills = _list_broker_execution_fills(
+                self.repository,
+                broker_order_key=broker_order_key,
+            )
+            next_quantity = sum(int(fill.get("quantity") or 0) for fill in fills)
+            next_fill_count = len(fills)
+            next_notional = sum(
+                int(fill.get("quantity") or 0) * float(fill.get("price") or 0)
+                for fill in fills
+            )
+            next_avg_price = (
+                round(next_notional / next_quantity, 6) if next_quantity > 0 else None
+            )
+            first_fill_time, last_fill_time = _fill_time_bounds(fills)
+            requested_quantity = broker_order.get("requested_quantity")
+            next_state = "PARTIAL_FILLED"
+            if requested_quantity not in (None, "") and next_quantity >= int(
+                requested_quantity
+            ):
+                next_state = "FILLED"
+            next_document = {
+                **broker_order,
+                "filled_quantity": next_quantity,
+                "avg_filled_price": next_avg_price,
+                "fill_count": next_fill_count,
+                "aggregate_revision": int(broker_order.get("aggregate_revision") or 0)
+                + 1,
+                "first_fill_time": first_fill_time,
+                "last_fill_time": last_fill_time,
+                "state": next_state,
                 "updated_at": _utc_now_iso(),
             }
-        previous_quantity = int(broker_order.get("filled_quantity") or 0)
-        previous_fill_count = int(broker_order.get("fill_count") or 0)
-        previous_notional = previous_quantity * float(
-            broker_order.get("avg_filled_price") or 0
+            saved_broker_order = self.repository.compare_and_set_broker_order(
+                before=broker_order,
+                after=next_document,
+            )
+            if saved_broker_order is not None:
+                return saved_broker_order
+        raise BrokerIdentityConflict(
+            "broker aggregate could not converge after concurrent updates"
         )
-        fill_quantity = int(execution_fill.get("quantity") or 0)
-        fill_price = float(execution_fill.get("price") or 0)
-        next_quantity = previous_quantity + fill_quantity
-        next_fill_count = previous_fill_count + 1
-        next_avg_price = (
-            round((previous_notional + fill_quantity * fill_price) / next_quantity, 6)
-            if next_quantity > 0
-            else None
-        )
-        requested_quantity = broker_order.get("requested_quantity")
-        next_state = "PARTIAL_FILLED"
-        if requested_quantity not in (None, "") and next_quantity >= int(
-            requested_quantity
-        ):
-            next_state = "FILLED"
-        next_document = {
-            **broker_order,
-            "broker_order_id": execution_fill.get("broker_order_id")
-            or broker_order.get("broker_order_id"),
-            "filled_quantity": next_quantity,
-            "avg_filled_price": next_avg_price,
-            "fill_count": next_fill_count,
-            "first_fill_time": _pick_first_time(
-                broker_order.get("first_fill_time"),
-                execution_fill.get("trade_time"),
-            ),
-            "last_fill_time": _pick_last_time(
-                broker_order.get("last_fill_time"),
-                execution_fill.get("trade_time"),
-            ),
-            "state": next_state,
-            "updated_at": _utc_now_iso(),
-        }
-        saved_broker_order, _ = self.repository.upsert_broker_order(
-            next_document,
-            unique_keys=["broker_order_key"],
-        )
-        return saved_broker_order
 
 
 def _utc_now_iso():
@@ -455,32 +618,203 @@ def _utc_now_iso():
 
 
 def _resolve_broker_order_key(report, *, current_order=None):
-    broker_order_key = ""
-    if current_order and current_order.get("internal_order_id"):
-        broker_order_key = str(current_order.get("internal_order_id") or "").strip()
-    if not broker_order_key:
-        broker_order_key = str(
-            report.get("broker_order_key") or report.get("internal_order_id") or ""
-        ).strip()
-    if not broker_order_key:
-        raise ValueError("broker_order_key is required")
-    return broker_order_key
+    identity = dict(current_order or {})
+    identity.update(_non_empty_identity_fields(report))
+    broker_order_key = build_broker_order_key(
+        account_id=identity.get("account_id"),
+        order_sysid=identity.get("order_sysid"),
+        trading_day=resolve_trading_day(identity),
+        symbol=identity.get("symbol"),
+        side=identity.get("side"),
+        broker_order_id=identity.get("broker_order_id"),
+        strict=False,
+    )
+    if broker_order_key is not None:
+        return broker_order_key
+    fallback_key = normalize_identifier(
+        (current_order or {}).get("broker_order_key")
+        or report.get("broker_order_key")
+        or (current_order or {}).get("internal_order_id")
+        or report.get("internal_order_id")
+    )
+    if fallback_key is None:
+        raise BrokerIdentityError("broker_order_key is required")
+    return fallback_key
 
 
-def _pick_first_time(previous, current):
-    if previous in (None, ""):
-        return current
-    if current in (None, ""):
-        return previous
-    return min(previous, current)
+def _normalize_trade_report_identity(report):
+    normalized = dict(report)
+    normalized["account_id"] = normalize_account_id(report.get("account_id"))
+    normalized["order_sysid"] = normalize_identifier(report.get("order_sysid"))
+    normalized["broker_order_id"] = normalize_identifier(
+        report.get("broker_order_id") or report.get("order_id")
+    )
+    normalized["broker_trade_id"] = normalize_identifier(
+        report.get("broker_trade_id") or report.get("traded_id")
+    )
+    normalized["symbol"] = normalize_symbol(
+        report.get("symbol") or report.get("stock_code")
+    )
+    normalized["side"] = normalize_side(report.get("side"))
+    normalized["trading_day"] = resolve_trading_day(report)
+    if normalized["broker_trade_id"] is None:
+        raise BrokerIdentityError("broker_trade_id is required")
+    if normalized["symbol"] is None:
+        raise BrokerIdentityError("trade symbol is required")
+    if normalized["side"] is None:
+        raise BrokerIdentityError("unknown broker order side")
+    try:
+        quantity = int(report.get("quantity"))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise BrokerIdentityError(
+            "execution quantity must be a positive integer"
+        ) from exc
+    if quantity <= 0 or quantity != float(report.get("quantity")):
+        raise BrokerIdentityError("execution quantity must be a positive integer")
+    normalized["quantity"] = quantity
+    internal_order_id = normalize_identifier(report.get("internal_order_id"))
+    if internal_order_id is None:
+        internal_order_id = build_broker_only_internal_order_id(
+            account_id=normalized["account_id"],
+            order_sysid=normalized["order_sysid"],
+            trading_day=normalized["trading_day"],
+            symbol=normalized["symbol"],
+            side=normalized["side"],
+            broker_order_id=normalized["broker_order_id"],
+        )
+    normalized["internal_order_id"] = internal_order_id
+    normalized["broker_order_key"] = _resolve_broker_order_key(normalized)
+    return normalized
 
 
-def _pick_last_time(previous, current):
-    if previous in (None, ""):
-        return current
-    if current in (None, ""):
-        return previous
-    return max(previous, current)
+def _resolve_execution_identity(report, *, current_order):
+    existing = normalize_identifier(report.get("execution_identity"))
+    if existing is not None:
+        return existing
+    try:
+        return build_execution_identity(report)
+    except BrokerIdentityError:
+        internal_order_id = normalize_identifier(
+            (current_order or {}).get("internal_order_id")
+            or report.get("internal_order_id")
+        )
+        broker_trade_id = normalize_identifier(report.get("broker_trade_id"))
+        if (
+            internal_order_id is None
+            or broker_trade_id is None
+            or str((current_order or {}).get("source_type") or "").lower()
+            == "broker_only"
+        ):
+            raise
+        raw = f"{internal_order_id}|{broker_trade_id}"
+        return f"internal-execution:{sha256(raw.encode('utf-8')).hexdigest()}"
+
+
+def _non_empty_identity_fields(payload):
+    raw_correlation_token = payload.get("broker_correlation_token") or payload.get(
+        "order_remark"
+    )
+    broker_correlation_token = normalize_broker_correlation_token(raw_correlation_token)
+    if broker_correlation_token is None and looks_like_broker_correlation_token(
+        raw_correlation_token
+    ):
+        raise BrokerIdentityConflict("broker correlation token is malformed")
+    normalized = {
+        "account_id": normalize_account_id(payload.get("account_id")),
+        "order_sysid": normalize_identifier(payload.get("order_sysid")),
+        "trading_day": resolve_trading_day(payload),
+        "symbol": normalize_symbol(payload.get("symbol") or payload.get("stock_code")),
+        "side": normalize_side(payload.get("side")),
+        "broker_order_id": normalize_identifier(
+            payload.get("broker_order_id") or payload.get("order_id")
+        ),
+        "broker_correlation_token": broker_correlation_token,
+    }
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _broker_order_owner_claim(order):
+    source_type = str(order.get("source_type") or "").strip() or "unknown"
+    broker_only = source_type.lower() == "broker_only"
+    return {
+        "broker_order_key": normalize_identifier(order.get("broker_order_key")),
+        "internal_order_id": normalize_identifier(order.get("internal_order_id")),
+        "request_id": (
+            None if broker_only else normalize_identifier(order.get("request_id"))
+        ),
+        "broker_correlation_token": (
+            None
+            if broker_only
+            else normalize_broker_correlation_token(
+                order.get("broker_correlation_token")
+            )
+        ),
+        "account_id": normalize_account_id(order.get("account_id")),
+        "trading_day": resolve_trading_day(order),
+        "order_sysid": normalize_identifier(order.get("order_sysid")),
+        "broker_order_id": normalize_identifier(order.get("broker_order_id")),
+        "symbol": normalize_symbol(order.get("symbol")),
+        "side": normalize_side(order.get("side")),
+        "source_type": source_type,
+    }
+
+
+def _assert_order_report_identity(current_order, report):
+    report_identity = _non_empty_identity_fields(report)
+    conflicts = identity_conflicts(current_order, report_identity)
+    current_token = normalize_broker_correlation_token(
+        current_order.get("broker_correlation_token")
+    )
+    report_token = normalize_broker_correlation_token(
+        report_identity.get("broker_correlation_token")
+    )
+    if current_token and report_token and current_token != report_token:
+        conflicts["broker_correlation_token"] = (current_token, report_token)
+    if conflicts:
+        raise BrokerIdentityConflict(
+            "broker report conflicts with internal order: "
+            + ", ".join(sorted(conflicts))
+        )
+
+
+def _assert_execution_replay_consistent(existing, incoming):
+    conflicts = identity_conflicts(existing, incoming)
+    for field in (
+        "execution_identity",
+        "broker_trade_id",
+        "broker_order_key",
+        "internal_order_id",
+        "quantity",
+        "price",
+        "trade_time",
+    ):
+        left = existing.get(field)
+        right = incoming.get(field)
+        if left is not None and right is not None and left != right:
+            conflicts[field] = (left, right)
+    if conflicts:
+        raise BrokerIdentityConflict(
+            "execution replay conflicts with canonical fill: "
+            + ", ".join(sorted(conflicts))
+        )
+
+
+def _list_broker_execution_fills(repository, *, broker_order_key):
+    fills = repository.list_execution_fills(broker_order_keys=[broker_order_key])
+    deduplicated = {}
+    for fill in fills:
+        key = fill.get("execution_identity") or fill.get("execution_fill_id")
+        deduplicated[key] = fill
+    return list(deduplicated.values())
+
+
+def _fill_time_bounds(fills):
+    values = [
+        fill.get("trade_time") for fill in fills if fill.get("trade_time") is not None
+    ]
+    if not values:
+        return None, None
+    return min(values), max(values)
 
 
 def _should_absorb_terminal_replay(current_state: str, next_state: str) -> bool:

--- a/freshquant/tests/test_external_order_identity_p1.py
+++ b/freshquant/tests/test_external_order_identity_p1.py
@@ -1,0 +1,552 @@
+from types import SimpleNamespace
+
+import pytest
+
+from freshquant.order_management.broker_correlation import (
+    build_broker_correlation_token,
+)
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityConflict,
+    build_broker_only_internal_order_id,
+    build_broker_order_key,
+)
+from freshquant.order_management.ingest.xt_reports import (
+    OrderManagementXtIngestService,
+    normalize_xt_order_report,
+    normalize_xt_trade_report,
+)
+from freshquant.order_management.repository import OrderManagementRepository
+from freshquant.order_management.tracking.service import OrderTrackingService
+
+
+class _FakeCollection:
+    def __init__(self):
+        self.rows = []
+
+    def create_index(self, *_args, **_kwargs):
+        return None
+
+    def find_one(self, query):
+        for document in self.find(query):
+            return document
+        return None
+
+    def find(self, query):
+        return [item for item in self.rows if _matches(item, query or {})]
+
+    def update_one(self, query, update, upsert=False):
+        for index, document in enumerate(self.rows):
+            if not _matches(document, query or {}):
+                continue
+            saved = dict(document)
+            saved.update(dict((update or {}).get("$set") or {}))
+            self.rows[index] = saved
+            return SimpleNamespace(matched_count=1, upserted_id=None)
+        if upsert:
+            saved = dict(query or {})
+            saved.update(dict((update or {}).get("$setOnInsert") or {}))
+            saved.update(dict((update or {}).get("$set") or {}))
+            self.rows.append(saved)
+            return SimpleNamespace(matched_count=0, upserted_id=len(self.rows))
+        return SimpleNamespace(matched_count=0, upserted_id=None)
+
+    def replace_one(self, query, document, upsert=False):
+        for index, current in enumerate(self.rows):
+            if _matches(current, query or {}):
+                self.rows[index] = dict(document)
+                return SimpleNamespace(matched_count=1, upserted_id=None)
+        if upsert:
+            self.rows.append(dict(document))
+            return SimpleNamespace(matched_count=0, upserted_id=len(self.rows))
+        return SimpleNamespace(matched_count=0, upserted_id=None)
+
+    def delete_one(self, query):
+        for index, document in enumerate(self.rows):
+            if _matches(document, query or {}):
+                del self.rows[index]
+                return SimpleNamespace(deleted_count=1)
+        return SimpleNamespace(deleted_count=0)
+
+    def insert_one(self, document):
+        self.rows.append(dict(document))
+        return SimpleNamespace(inserted_id=len(self.rows))
+
+
+class _PromotionRaceCollection(_FakeCollection):
+    def __init__(self, broker_order_key):
+        super().__init__()
+        self.broker_order_key = broker_order_key
+        self.before_replace = None
+        self.triggered = False
+
+    def replace_one(self, query, document, upsert=False):
+        current = self.find_one({"broker_order_key": self.broker_order_key})
+        is_promotion = (
+            current is not None
+            and current.get("source_type") == "broker_only"
+            and document.get("source_type") != "broker_only"
+        )
+        if is_promotion and not self.triggered:
+            self.triggered = True
+            self.before_replace()
+        return super().replace_one(query, document, upsert=upsert)
+
+
+class _MutateBeforeDeleteCollection(_FakeCollection):
+    def __init__(self, source_key):
+        super().__init__()
+        self.source_key = source_key
+        self.triggered = False
+
+    def delete_one(self, query):
+        if not self.triggered:
+            self.triggered = True
+            source = self.find_one({"broker_order_key": self.source_key})
+            source.update(
+                {
+                    "state": "FILLED",
+                    "filled_quantity": 100,
+                    "fill_count": 1,
+                    "aggregate_revision": 1,
+                }
+            )
+        return super().delete_one(query)
+
+
+class _FakeDatabase(dict):
+    def __getitem__(self, name):
+        if name not in self:
+            self[name] = _FakeCollection()
+        return dict.__getitem__(self, name)
+
+
+def _matches(document, query):
+    for key, expected in dict(query or {}).items():
+        if key == "$expr":
+            operands = list((expected or {}).get("$eq") or [])
+            expected_document = operands[1] if len(operands) == 2 else None
+            actual_document = {
+                field: value for field, value in document.items() if field != "_id"
+            }
+            if actual_document != expected_document:
+                return False
+            continue
+        if isinstance(expected, dict) and "$in" in expected:
+            if document.get(key) not in list(expected.get("$in") or []):
+                return False
+            continue
+        if document.get(key) != expected:
+            return False
+    return True
+
+
+def _real_owner(internal_order_id="ord-real"):
+    return {
+        "broker_order_key": build_broker_order_key(
+            account_id="acct-1",
+            trading_day=20260805,
+            symbol="688772",
+            side="buy",
+            broker_order_id="557",
+        ),
+        "internal_order_id": internal_order_id,
+        "request_id": f"request-{internal_order_id}",
+        "broker_correlation_token": build_broker_correlation_token(internal_order_id),
+        "account_id": "acct-1",
+        "trading_day": 20260805,
+        "broker_order_id": "557",
+        "symbol": "688772",
+        "side": "buy",
+        "source_type": "strategy",
+        "state": "SUBMITTED",
+        "filled_quantity": 0,
+        "fill_count": 0,
+        "aggregate_revision": 0,
+    }
+
+
+def _seed_internal_order(database, owner):
+    database["om_orders"].rows.append(
+        {
+            "internal_order_id": owner["internal_order_id"],
+            "request_id": owner["request_id"],
+            "broker_correlation_token": owner["broker_correlation_token"],
+            "account_id": owner["account_id"],
+            "trading_day": owner["trading_day"],
+            "broker_order_id": owner["broker_order_id"],
+            "symbol": owner["symbol"],
+            "side": owner["side"],
+            "source_type": "strategy",
+        }
+    )
+
+
+def test_external_identity_is_deterministic_and_account_scoped():
+    key = build_broker_order_key(
+        account_id="acct-1",
+        trading_day=20260805,
+        symbol="688772.SH",
+        side="BUY",
+        broker_order_id=557,
+    )
+    assert key == ("account:acct-1:day:20260805:symbol:688772:side:buy:order:557")
+    assert build_broker_only_internal_order_id(
+        account_id="acct-1",
+        trading_day=20260805,
+        symbol="688772",
+        side="buy",
+        broker_order_id="557",
+    ).startswith("ord_broker_")
+
+
+def test_same_owner_claim_never_rolls_back_newer_fill_aggregate():
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    owner = _real_owner()
+    _seed_internal_order(database, owner)
+    repository.claim_broker_order_owner(owner)
+    database["om_broker_orders"].rows[0].update(
+        {
+            "state": "FILLED",
+            "filled_quantity": 100,
+            "fill_count": 1,
+            "avg_filled_price": 14.8,
+            "aggregate_revision": 1,
+        }
+    )
+
+    saved, created = repository.claim_broker_order_owner(
+        {
+            **owner,
+            "state": "CANCELED",
+            "filled_quantity": 0,
+            "fill_count": 0,
+            "avg_filled_price": None,
+            "aggregate_revision": 0,
+        }
+    )
+
+    assert created is False
+    assert saved["state"] == "FILLED"
+    assert saved["filled_quantity"] == 100
+    assert saved["fill_count"] == 1
+    assert saved["avg_filled_price"] == 14.8
+    assert saved["aggregate_revision"] == 1
+
+
+def test_broker_only_promotion_loses_race_with_first_execution_fence():
+    real_owner = _real_owner()
+    key = real_owner["broker_order_key"]
+    broker_only_id = build_broker_only_internal_order_id(
+        account_id="acct-1",
+        trading_day=20260805,
+        symbol="688772",
+        side="buy",
+        broker_order_id="557",
+    )
+    broker_only = {
+        **real_owner,
+        "internal_order_id": broker_only_id,
+        "request_id": None,
+        "broker_correlation_token": None,
+        "source_type": "broker_only",
+    }
+    database = _FakeDatabase()
+    collection = _PromotionRaceCollection(key)
+    collection.rows.append(broker_only)
+    database["om_broker_orders"] = collection
+    _seed_internal_order(database, real_owner)
+    repository = OrderManagementRepository(database=database)
+
+    collection.before_replace = lambda: repository.fence_broker_order_execution(
+        {
+            "broker_order_key": key,
+            "internal_order_id": broker_only_id,
+            "account_id": "acct-1",
+            "trading_day": 20260805,
+            "broker_order_id": "557",
+            "symbol": "688772",
+            "side": "buy",
+        }
+    )
+
+    with pytest.raises(BrokerIdentityConflict, match="targeted repair"):
+        repository.claim_broker_order_owner(real_owner)
+
+    saved = repository.find_broker_order(key)
+    assert saved["internal_order_id"] == broker_only_id
+    assert saved["execution_fence"] is True
+
+
+def test_internal_state_update_does_not_move_canonical_broker_key_back_to_placeholder():
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    owner = _real_owner()
+    database["om_orders"].rows.append(
+        {
+            **owner,
+            "state": "ACCEPTED",
+        }
+    )
+    repository.claim_broker_order_owner(owner)
+    tracking_service = OrderTrackingService(repository=repository)
+
+    tracking_service.mark_order_queued(owner["internal_order_id"])
+
+    assert len(database["om_broker_orders"].rows) == 1
+    saved = repository.find_broker_order(owner["broker_order_key"])
+    assert saved["state"] == "QUEUED"
+    assert repository.find_broker_order(owner["internal_order_id"]) is None
+
+
+def test_terminal_order_replay_does_not_downgrade_broker_aggregate_state():
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    owner = _real_owner()
+    database["om_orders"].rows.append(
+        {
+            **owner,
+            "state": "FILLED",
+        }
+    )
+    repository.claim_broker_order_owner(
+        {
+            **owner,
+            "state": "FILLED",
+            "filled_quantity": 100,
+            "fill_count": 1,
+            "aggregate_revision": 1,
+        }
+    )
+    tracking_service = OrderTrackingService(repository=repository)
+
+    result = tracking_service.ingest_order_report_with_meta(
+        {
+            "internal_order_id": owner["internal_order_id"],
+            "broker_order_key": owner["broker_order_key"],
+            "broker_order_id": owner["broker_order_id"],
+            "state": "CANCELED",
+            "event_type": "stale_cancel_replay",
+        }
+    )
+
+    assert result["absorbed"] is True
+    assert repository.find_order(owner["internal_order_id"])["state"] == "FILLED"
+    assert repository.find_broker_order(owner["broker_order_key"])["state"] == "FILLED"
+
+
+def test_move_missing_source_cannot_silently_accept_fenced_target():
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    owner = _real_owner()
+    broker_only_id = build_broker_only_internal_order_id(
+        account_id="acct-1",
+        trading_day=20260805,
+        symbol="688772",
+        side="buy",
+        broker_order_id="557",
+    )
+    database["om_orders"].rows.append(
+        {
+            **owner,
+            "state": "SUBMITTED",
+        }
+    )
+    target = {
+        **owner,
+        "internal_order_id": broker_only_id,
+        "request_id": None,
+        "broker_correlation_token": None,
+        "source_type": "broker_only",
+        "execution_fence": True,
+    }
+    database["om_broker_orders"].rows.append(target)
+
+    with pytest.raises(BrokerIdentityConflict, match="targeted repair"):
+        repository.move_broker_order_key(
+            "missing-placeholder", owner["broker_order_key"], owner
+        )
+
+    saved = repository.find_broker_order(owner["broker_order_key"])
+    assert saved["internal_order_id"] == broker_only_id
+    assert saved["execution_fence"] is True
+
+
+def test_late_order_sysid_promotes_existing_fallback_broker_order_without_duplication():
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    tracking_service = OrderTrackingService(repository=repository)
+    ingest_service = OrderManagementXtIngestService(
+        repository=repository,
+        tracking_service=tracking_service,
+    )
+
+    first = ingest_service.ingest_order_report(_xt_order_callback(order_sysid=None))
+    fallback_key = first["broker_order_key"]
+    second = ingest_service.ingest_order_report(_xt_order_callback())
+    canonical_key = build_broker_order_key(
+        account_id="acct-xt-1",
+        order_sysid="SYS-557",
+        trading_day=20260805,
+    )
+
+    assert second["internal_order_id"] == first["internal_order_id"]
+    assert len(database["om_orders"].rows) == 1
+    assert len(database["om_broker_orders"].rows) == 1
+    assert repository.find_broker_order(fallback_key) is None
+    assert repository.find_broker_order(canonical_key)["internal_order_id"] == (
+        first["internal_order_id"]
+    )
+    assert repository.find_order(first["internal_order_id"])["order_sysid"] == "SYS-557"
+
+
+def test_move_retries_source_delete_cas_and_keeps_concurrent_aggregate():
+    owner = _real_owner()
+    old_key = owner["internal_order_id"]
+    new_key = owner["broker_order_key"]
+    source = {**owner, "broker_order_key": old_key}
+    database = _FakeDatabase()
+    collection = _MutateBeforeDeleteCollection(old_key)
+    collection.rows.append(source)
+    database["om_broker_orders"] = collection
+    _seed_internal_order(database, owner)
+    repository = OrderManagementRepository(database=database)
+
+    saved = repository.move_broker_order_key(old_key, new_key, owner)
+
+    assert repository.find_broker_order(old_key) is None
+    assert saved == repository.find_broker_order(new_key)
+    assert saved["state"] == "FILLED"
+    assert saved["filled_quantity"] == 100
+    assert saved["fill_count"] == 1
+    assert saved["aggregate_revision"] == 1
+    assert len(database["om_broker_orders"].rows) == 1
+
+
+def _xt_order_callback(*, account_id="acct-xt-1", order_id="557", **overrides):
+    return {
+        "account_id": account_id,
+        "order_id": order_id,
+        "order_sysid": "SYS-557",
+        "order_time": 1785947400,
+        "date": 20260805,
+        "stock_code": "688772.SH",
+        "order_type": 23,
+        "order_volume": 100,
+        "order_status": 50,
+        "source": "xtquant",
+        **overrides,
+    }
+
+
+def _xt_trade_callback(*, account_id="acct-xt-1", order_id="557", **overrides):
+    return {
+        "account_id": account_id,
+        "order_id": order_id,
+        "order_sysid": "SYS-557",
+        "traded_id": "TRADE-557-1",
+        "traded_time": 1785947460,
+        "date": 20260805,
+        "stock_code": "688772.SH",
+        "order_type": 23,
+        "traded_volume": 100,
+        "traded_price": 14.8,
+        "source": "xtquant",
+        **overrides,
+    }
+
+
+def test_unknown_xt_order_callback_creates_deterministic_broker_only_owner():
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    tracking_service = OrderTrackingService(repository=repository)
+    ingest_service = OrderManagementXtIngestService(
+        repository=repository,
+        tracking_service=tracking_service,
+    )
+    callback = _xt_order_callback()
+
+    normalized = normalize_xt_order_report(callback, repository=repository)
+    expected_key = build_broker_order_key(
+        account_id="acct-xt-1",
+        order_sysid="SYS-557",
+        trading_day=20260805,
+    )
+    expected_order_id = build_broker_only_internal_order_id(
+        account_id="acct-xt-1",
+        order_sysid="SYS-557",
+        trading_day=20260805,
+    )
+
+    assert normalized["internal_order_id"] == expected_order_id
+    assert normalized["broker_order_key"] == expected_key
+
+    result = ingest_service.ingest_order_report(callback)
+
+    assert result["internal_order_id"] == expected_order_id
+    assert repository.find_order(expected_order_id)["source_type"] == "broker_only"
+    broker_order = repository.find_broker_order(expected_key)
+    assert broker_order["internal_order_id"] == expected_order_id
+    assert broker_order["source_type"] == "broker_only"
+
+
+def test_unknown_xt_trade_callback_fences_owner_before_idempotent_execution_write():
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    tracking_service = OrderTrackingService(repository=repository)
+    ingest_service = OrderManagementXtIngestService(
+        repository=repository,
+        tracking_service=tracking_service,
+    )
+    order_callback = _xt_order_callback()
+    trade_callback = _xt_trade_callback()
+    ingest_service.ingest_order_report(order_callback)
+
+    normalized_trade = normalize_xt_trade_report(
+        trade_callback,
+        repository=repository,
+    )
+    first = tracking_service.ingest_trade_report_with_meta(normalized_trade)
+    second = tracking_service.ingest_trade_report_with_meta(normalized_trade)
+
+    broker_order = repository.find_broker_order(normalized_trade["broker_order_key"])
+    assert broker_order["execution_fence"] is True
+    assert broker_order["filled_quantity"] == 100
+    assert first["execution_fill"]["execution_identity"]
+    assert second["created"] is False
+    assert len(database["om_trade_facts"].rows) == 1
+    assert len(database["om_execution_fills"].rows) == 1
+
+
+def test_real_internal_order_promotes_unfilled_broker_only_owner_only_once():
+    database = _FakeDatabase()
+    repository = OrderManagementRepository(database=database)
+    tracking_service = OrderTrackingService(repository=repository)
+    ingest_service = OrderManagementXtIngestService(
+        repository=repository,
+        tracking_service=tracking_service,
+    )
+    callback = _xt_order_callback()
+    normalized = ingest_service.ingest_order_report(callback)
+
+    tracking_service.submit_order(
+        {
+            "internal_order_id": "ord-real-557",
+            "request_id": "req-real-557",
+            "action": "buy",
+            "symbol": "688772",
+            "price": 14.8,
+            "quantity": 100,
+            "source": "strategy",
+            "account_id": "acct-xt-1",
+            "order_sysid": "SYS-557",
+            "trading_day": 20260805,
+            "broker_order_id": "557",
+        }
+    )
+
+    broker_order = repository.find_broker_order(normalized["broker_order_key"])
+    assert broker_order["internal_order_id"] == "ord-real-557"
+    assert broker_order["request_id"] == "req-real-557"
+    assert broker_order["source_type"] == "strategy"
+    assert broker_order.get("execution_fence") is not True

--- a/freshquant/tests/test_external_order_identity_real_mongo.py
+++ b/freshquant/tests/test_external_order_identity_real_mongo.py
@@ -1,0 +1,377 @@
+import os
+import threading
+from uuid import uuid4
+
+import pytest
+from pymongo import MongoClient
+
+from freshquant.order_management.broker_correlation import (
+    build_broker_correlation_token,
+)
+from freshquant.order_management.broker_identity import (
+    BrokerIdentityConflict,
+    build_broker_only_internal_order_id,
+    build_broker_order_key,
+)
+from freshquant.order_management.repository import OrderManagementRepository
+
+_RUN_REAL_MONGO = os.getenv("FQ_FIX_504_REAL_MONGO") == "1"
+_REAL_MONGO_URI = os.getenv(
+    "FQ_REAL_MONGO_URI",
+    "mongodb://127.0.0.1:27027",
+)
+_TEST_DATABASE_PREFIX = "fq_test_fix_504_"
+_GATE_TIMEOUT_SECONDS = 10
+
+pytestmark = pytest.mark.skipif(
+    not _RUN_REAL_MONGO,
+    reason="set FQ_FIX_504_REAL_MONGO=1 to run FIX-504 real Mongo tests",
+)
+
+
+class _OneShotGate:
+    def __init__(self):
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self._lock = threading.Lock()
+        self._triggered = False
+
+    def pause_once(self):
+        with self._lock:
+            if self._triggered:
+                return
+            self._triggered = True
+        self.entered.set()
+        if not self.release.wait(_GATE_TIMEOUT_SECONDS):
+            raise AssertionError("timed out waiting to release Mongo race gate")
+
+
+class _GatedCollection:
+    def __init__(
+        self,
+        collection,
+        *,
+        gate,
+        replace_when=None,
+        delete_when=None,
+    ):
+        self._collection = collection
+        self._gate = gate
+        self._replace_when = replace_when
+        self._delete_when = delete_when
+
+    def __getattr__(self, name):
+        return getattr(self._collection, name)
+
+    def replace_one(self, query, document, *args, **kwargs):
+        if self._replace_when is not None and self._replace_when(query, document):
+            self._gate.pause_once()
+        return self._collection.replace_one(query, document, *args, **kwargs)
+
+    def delete_one(self, query, *args, **kwargs):
+        if self._delete_when is not None and self._delete_when(query):
+            self._gate.pause_once()
+        return self._collection.delete_one(query, *args, **kwargs)
+
+
+class _DatabaseWithBrokerOrderOverride:
+    def __init__(self, database, broker_orders):
+        self._database = database
+        self._broker_orders = broker_orders
+
+    def __getitem__(self, name):
+        if name == "om_broker_orders":
+            return self._broker_orders
+        return self._database[name]
+
+
+@pytest.fixture
+def real_mongo_database():
+    client = MongoClient(
+        _REAL_MONGO_URI,
+        connectTimeoutMS=5_000,
+        serverSelectionTimeoutMS=5_000,
+        tz_aware=True,
+    )
+    database_name = f"{_TEST_DATABASE_PREFIX}{uuid4().hex}"
+    try:
+        client.admin.command("ping")
+        yield client[database_name]
+    finally:
+        if database_name.startswith(_TEST_DATABASE_PREFIX):
+            client.drop_database(database_name)
+        client.close()
+
+
+def _real_owner(internal_order_id="ord-real"):
+    return {
+        "broker_order_key": build_broker_order_key(
+            account_id="acct-1",
+            trading_day=20260805,
+            symbol="688772",
+            side="buy",
+            broker_order_id="557",
+        ),
+        "internal_order_id": internal_order_id,
+        "request_id": f"request-{internal_order_id}",
+        "broker_correlation_token": build_broker_correlation_token(internal_order_id),
+        "account_id": "acct-1",
+        "trading_day": 20260805,
+        "broker_order_id": "557",
+        "symbol": "688772",
+        "side": "buy",
+        "source_type": "strategy",
+        "state": "SUBMITTED",
+        "filled_quantity": 0,
+        "fill_count": 0,
+        "aggregate_revision": 0,
+    }
+
+
+def _insert_internal_order(repository, owner):
+    return repository.insert_order(
+        {
+            "internal_order_id": owner["internal_order_id"],
+            "request_id": owner["request_id"],
+            "broker_correlation_token": owner["broker_correlation_token"],
+            "account_id": owner["account_id"],
+            "trading_day": owner["trading_day"],
+            "broker_order_id": owner["broker_order_id"],
+            "symbol": owner["symbol"],
+            "side": owner["side"],
+            "source_type": "strategy",
+        }
+    )
+
+
+def _start_thread(call):
+    outcome = {}
+
+    def invoke():
+        try:
+            outcome["value"] = call()
+        except BaseException as exc:  # noqa: BLE001 - asserted by the test thread
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=invoke, daemon=True)
+    thread.start()
+    return thread, outcome
+
+
+def _release_and_join(gate, thread):
+    gate.release.set()
+    thread.join(_GATE_TIMEOUT_SECONDS)
+    assert not thread.is_alive(), "Mongo race worker did not finish"
+
+
+def test_real_mongo_same_owner_stale_claim_preserves_newer_aggregate(
+    real_mongo_database,
+):
+    writer_repository = OrderManagementRepository(database=real_mongo_database)
+    owner = _real_owner()
+    key = owner["broker_order_key"]
+    _insert_internal_order(writer_repository, owner)
+    writer_repository.claim_broker_order_owner({**owner, "source_type": None})
+
+    gate = _OneShotGate()
+    gated_collection = _GatedCollection(
+        real_mongo_database["om_broker_orders"],
+        gate=gate,
+        replace_when=lambda query, document: (
+            query.get("broker_order_key") == key
+            and document.get("source_type") == "strategy"
+        ),
+    )
+    claimant_repository = OrderManagementRepository(
+        database=_DatabaseWithBrokerOrderOverride(
+            real_mongo_database,
+            gated_collection,
+        )
+    )
+    stale_claim = {
+        **owner,
+        "state": "CANCELED",
+        "filled_quantity": 0,
+        "fill_count": 0,
+        "avg_filled_price": None,
+        "aggregate_revision": 0,
+    }
+    thread, outcome = _start_thread(
+        lambda: claimant_repository.claim_broker_order_owner(stale_claim)
+    )
+
+    try:
+        assert gate.entered.wait(
+            _GATE_TIMEOUT_SECONDS
+        ), "stale owner claim did not reach the replace CAS gate"
+        before = writer_repository.find_broker_order(key)
+        concurrent = writer_repository.compare_and_set_broker_order(
+            before=before,
+            after={
+                **before,
+                "state": "FILLED",
+                "filled_quantity": 100,
+                "fill_count": 1,
+                "avg_filled_price": 14.8,
+                "aggregate_revision": 1,
+            },
+        )
+        assert concurrent is not None
+    finally:
+        _release_and_join(gate, thread)
+
+    assert "error" not in outcome, repr(outcome.get("error"))
+    saved = writer_repository.find_broker_order(key)
+    assert saved["source_type"] == "strategy"
+    assert saved["state"] == "FILLED"
+    assert saved["filled_quantity"] == 100
+    assert saved["fill_count"] == 1
+    assert saved["avg_filled_price"] == 14.8
+    assert saved["aggregate_revision"] == 1
+
+
+def test_real_mongo_broker_only_promotion_loses_to_execution_fence(
+    real_mongo_database,
+):
+    writer_repository = OrderManagementRepository(database=real_mongo_database)
+    real_owner = _real_owner()
+    key = real_owner["broker_order_key"]
+    broker_only_id = build_broker_only_internal_order_id(
+        account_id="acct-1",
+        trading_day=20260805,
+        symbol="688772",
+        side="buy",
+        broker_order_id="557",
+    )
+    broker_only = {
+        **real_owner,
+        "internal_order_id": broker_only_id,
+        "request_id": None,
+        "broker_correlation_token": None,
+        "source_type": "broker_only",
+    }
+    _insert_internal_order(writer_repository, real_owner)
+    writer_repository.claim_broker_order_owner(broker_only)
+
+    gate = _OneShotGate()
+    gated_collection = _GatedCollection(
+        real_mongo_database["om_broker_orders"],
+        gate=gate,
+        replace_when=lambda query, document: (
+            query.get("broker_order_key") == key
+            and document.get("internal_order_id") == real_owner["internal_order_id"]
+        ),
+    )
+    promotion_repository = OrderManagementRepository(
+        database=_DatabaseWithBrokerOrderOverride(
+            real_mongo_database,
+            gated_collection,
+        )
+    )
+    thread, outcome = _start_thread(
+        lambda: promotion_repository.claim_broker_order_owner(real_owner)
+    )
+
+    try:
+        assert gate.entered.wait(
+            _GATE_TIMEOUT_SECONDS
+        ), "broker-only promotion did not reach the replace CAS gate"
+        fenced = writer_repository.fence_broker_order_execution(
+            {
+                "broker_order_key": key,
+                "internal_order_id": broker_only_id,
+                "account_id": "acct-1",
+                "trading_day": 20260805,
+                "broker_order_id": "557",
+                "symbol": "688772",
+                "side": "buy",
+            }
+        )
+        assert fenced["execution_fence"] is True
+    finally:
+        _release_and_join(gate, thread)
+
+    error = outcome.get("error")
+    assert isinstance(error, BrokerIdentityConflict)
+    assert "targeted repair" in str(error)
+    saved = writer_repository.find_broker_order(key)
+    assert saved["internal_order_id"] == broker_only_id
+    assert saved["source_type"] == "broker_only"
+    assert saved["execution_fence"] is True
+    assert (
+        real_mongo_database["om_broker_orders"].count_documents(
+            {"broker_order_key": key}
+        )
+        == 1
+    )
+    assert (
+        real_mongo_database["om_orders"].count_documents(
+            {"internal_order_id": real_owner["internal_order_id"]}
+        )
+        == 1
+    )
+
+
+def test_real_mongo_move_retries_delete_cas_and_converges_to_one_target(
+    real_mongo_database,
+):
+    writer_repository = OrderManagementRepository(database=real_mongo_database)
+    owner = _real_owner()
+    old_key = owner["internal_order_id"]
+    new_key = owner["broker_order_key"]
+    source = {**owner, "broker_order_key": old_key}
+    _insert_internal_order(writer_repository, owner)
+    writer_repository.claim_broker_order_owner(source)
+
+    gate = _OneShotGate()
+    gated_collection = _GatedCollection(
+        real_mongo_database["om_broker_orders"],
+        gate=gate,
+        delete_when=lambda query: query.get("broker_order_key") == old_key,
+    )
+    mover_repository = OrderManagementRepository(
+        database=_DatabaseWithBrokerOrderOverride(
+            real_mongo_database,
+            gated_collection,
+        )
+    )
+    thread, outcome = _start_thread(
+        lambda: mover_repository.move_broker_order_key(old_key, new_key, owner)
+    )
+
+    try:
+        assert gate.entered.wait(
+            _GATE_TIMEOUT_SECONDS
+        ), "broker-order move did not reach the source delete CAS gate"
+        before = writer_repository.find_broker_order(old_key)
+        concurrent = writer_repository.compare_and_set_broker_order(
+            before=before,
+            after={
+                **before,
+                "state": "FILLED",
+                "filled_quantity": 100,
+                "fill_count": 1,
+                "avg_filled_price": 14.8,
+                "aggregate_revision": 1,
+            },
+        )
+        assert concurrent is not None
+    finally:
+        _release_and_join(gate, thread)
+
+    assert "error" not in outcome, repr(outcome.get("error"))
+    saved = writer_repository.find_broker_order(new_key)
+    assert writer_repository.find_broker_order(old_key) is None
+    assert saved == outcome["value"]
+    assert saved["state"] == "FILLED"
+    assert saved["filled_quantity"] == 100
+    assert saved["fill_count"] == 1
+    assert saved["avg_filled_price"] == 14.8
+    assert saved["aggregate_revision"] == 1
+    assert (
+        real_mongo_database["om_broker_orders"].count_documents(
+            {"broker_order_key": {"$in": [old_key, new_key]}}
+        )
+        == 1
+    )
+    assert real_mongo_database["om_broker_orders"].count_documents({}) == 1

--- a/freshquant/tests/test_order_management_db.py
+++ b/freshquant/tests/test_order_management_db.py
@@ -90,11 +90,15 @@ class _FakeCollection:
         for index, item in enumerate(self.rows):
             if _matches_query(item, query):
                 self.rows[index] = dict(document)
-                return
+                return type("Result", (), {"matched_count": 1, "upserted_id": None})()
         if upsert:
             self.rows.append(dict(document))
+            return type(
+                "Result", (), {"matched_count": 0, "upserted_id": len(self.rows)}
+            )()
+        return type("Result", (), {"matched_count": 0, "upserted_id": None})()
 
-    def update_one(self, query, update):
+    def update_one(self, query, update, upsert=False):
         query = dict(query or {})
         updates = dict((update or {}).get("$set") or {})
         for index, item in enumerate(self.rows):
@@ -102,7 +106,16 @@ class _FakeCollection:
                 next_item = dict(item)
                 next_item.update(updates)
                 self.rows[index] = next_item
-                return
+                return type("Result", (), {"matched_count": 1, "upserted_id": None})()
+        if upsert:
+            inserted = dict(query)
+            inserted.update(dict((update or {}).get("$setOnInsert") or {}))
+            inserted.update(updates)
+            self.rows.append(inserted)
+            return type(
+                "Result", (), {"matched_count": 0, "upserted_id": len(self.rows)}
+            )()
+        return type("Result", (), {"matched_count": 0, "upserted_id": None})()
 
     def delete_many(self, query):
         query = dict(query or {})
@@ -118,6 +131,15 @@ class _FakeDatabase(dict):
 
 def _matches_query(document, query):
     for key, expected in query.items():
+        if key == "$expr":
+            operands = list((expected or {}).get("$eq") or [])
+            expected_document = operands[1] if len(operands) == 2 else None
+            actual_document = {
+                field: value for field, value in document.items() if field != "_id"
+            }
+            if actual_document != expected_document:
+                return False
+            continue
         actual = document.get(key)
         if isinstance(expected, dict):
             if "$in" in expected and actual not in set(expected["$in"]):
@@ -161,6 +183,15 @@ def test_order_management_repository_supports_v2_collections_and_basic_crud():
         unique_keys=["broker_order_key"],
     )
     assert created_order is False
+    assert saved_order == broker_order
+    saved_order = repository.update_broker_order_fields(
+        "border_1",
+        {"state": "FILLED"},
+    )
+    saved_order = repository.compare_and_set_broker_order(
+        before=saved_order,
+        after={**saved_order, "fill_count": 2},
+    )
     assert saved_order == updated_broker_order
     assert repository.list_broker_orders(symbol="000001") == [updated_broker_order]
 

--- a/freshquant/tests/test_order_management_execution_bridge.py
+++ b/freshquant/tests/test_order_management_execution_bridge.py
@@ -17,6 +17,7 @@ class InMemoryRepository:
     def __init__(self):
         self.order_requests = []
         self.orders = []
+        self.broker_orders = []
         self.order_events = []
         self.trade_facts = []
 
@@ -57,6 +58,38 @@ class InMemoryRepository:
             return None
         order.update(updates)
         return order
+
+    def claim_broker_order_owner(self, document):
+        broker_order_key = document["broker_order_key"]
+        broker_order = self.find_broker_order(broker_order_key)
+        if broker_order is None:
+            broker_order = dict(document)
+            self.broker_orders.append(broker_order)
+            return broker_order, True
+        broker_order.update(document)
+        return broker_order, False
+
+    def find_broker_order(self, broker_order_key):
+        for broker_order in self.broker_orders:
+            if broker_order["broker_order_key"] == broker_order_key:
+                return broker_order
+        return None
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        broker_order = self.find_broker_order(broker_order_key)
+        if broker_order is None:
+            return None
+        broker_order.update(updates)
+        return broker_order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        broker_order = self.find_broker_order(old_key)
+        if broker_order is None:
+            broker_order = dict(document)
+            self.broker_orders.append(broker_order)
+        broker_order.update(document)
+        broker_order["broker_order_key"] = new_key
+        return broker_order
 
 
 def test_prepare_submit_execution_skips_canceled_order_before_submit():
@@ -109,6 +142,35 @@ def test_finalize_submit_execution_marks_order_submitted_with_broker_order_id():
     order = repository.find_order("ord_submit_1")
     assert order["state"] == "SUBMITTED"
     assert order["broker_order_id"] == "123456"
+
+
+@pytest.mark.parametrize("broker_order_id", [None, 0, -7])
+def test_finalize_submit_execution_marks_nonpositive_result_failed(broker_order_id):
+    repository = InMemoryRepository()
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "000001",
+            "price": 10.0,
+            "quantity": 100,
+            "source": "strategy",
+            "internal_order_id": "ord_submit_failed_1",
+        }
+    )
+    repository.update_order("ord_submit_failed_1", {"state": "SUBMITTING"})
+
+    result = finalize_submit_execution(
+        {"internal_order_id": "ord_submit_failed_1"},
+        broker_order_id=broker_order_id,
+        repository=repository,
+        tracking_service=tracking_service,
+    )
+
+    order = repository.find_order("ord_submit_failed_1")
+    assert result == {"status": "failed"}
+    assert order["state"] == "FAILED"
+    assert order["broker_order_id"] is None
 
 
 def test_finalize_submit_execution_marks_order_broker_bypassed_in_observe_only_mode():
@@ -285,6 +347,12 @@ def test_prepare_submit_execution_resolves_credit_sell_order_before_submit():
         == xtconstant.MARKET_SH_CONVERT_5_CANCEL
     )
     assert result["order_message"]["price"] == 9.92
+    correlation_token = result["order_message"]["broker_correlation_token"]
+    assert correlation_token == result["order_message"]["broker_order_remark"]
+    assert correlation_token.startswith("FQOM")
+    assert len(correlation_token) == 24
+    assert set(correlation_token[4:]) <= set("0123456789abcdef")
+    assert order["broker_correlation_token"] == correlation_token
     assert order["broker_order_type"] == xtconstant.CREDIT_SELL_SECU_REPAY
     assert order["broker_price_type"] == xtconstant.MARKET_SH_CONVERT_5_CANCEL
 

--- a/freshquant/tests/test_order_management_reconcile.py
+++ b/freshquant/tests/test_order_management_reconcile.py
@@ -6,6 +6,7 @@ import pytest
 
 import freshquant.order_management.ingest.xt_reports as xt_reports_module
 import freshquant.order_management.reconcile.service as reconcile_service_module
+from freshquant.order_management.broker_identity import BrokerIdentityError
 from freshquant.order_management.guardian.arranger import (
     arrange_buy_lot,
     build_buy_lot_from_trade_fact,
@@ -102,13 +103,74 @@ class InMemoryRepository:
         return document
 
     def upsert_broker_order(self, document, unique_keys):
-        for existing in self.broker_orders:
-            if all(existing.get(key) == document.get(key) for key in unique_keys):
-                existing.update(document)
-                return existing, False
-        saved = dict(document)
-        self.broker_orders.append(saved)
-        return saved, True
+        assert unique_keys == ["broker_order_key"]
+        return self.claim_broker_order_owner(document)
+
+    def claim_broker_order_owner(self, document):
+        existing = self.find_broker_order(document["broker_order_key"])
+        if existing is None:
+            saved = dict(document)
+            self.broker_orders.append(saved)
+            return saved, True
+        owner_changed = existing.get("internal_order_id") != document.get(
+            "internal_order_id"
+        )
+        for field in (
+            "internal_order_id",
+            "request_id",
+            "broker_correlation_token",
+            "broker_order_key",
+            "account_id",
+            "trading_day",
+            "order_sysid",
+            "broker_order_id",
+            "symbol",
+            "side",
+        ):
+            if field in document and (
+                document.get(field) is not None or existing.get(field) is None
+            ):
+                existing[field] = document.get(field)
+        if owner_changed or not existing.get("source_type"):
+            existing["source_type"] = document.get("source_type")
+        return existing, False
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def fence_broker_order_execution(self, document):
+        order = self.find_broker_order(document["broker_order_key"])
+        assert order["internal_order_id"] == document["internal_order_id"]
+        order["execution_fence"] = True
+        return order
+
+    def compare_and_set_broker_order(self, *, before, after):
+        order = self.find_broker_order(before["broker_order_key"])
+        if order != before:
+            return order if order == after else None
+        order.clear()
+        order.update(after)
+        return order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        source = self.find_broker_order(old_key)
+        target = self.find_broker_order(new_key)
+        merged = {**(source or {}), **dict(document), "broker_order_key": new_key}
+        if target is None:
+            self.broker_orders.append(merged)
+            target = merged
+        else:
+            target.update(merged)
+        self.broker_orders = [
+            item
+            for item in self.broker_orders
+            if item.get("broker_order_key") != old_key
+        ]
+        return target
 
     def upsert_trade_fact(self, document, unique_keys):
         for existing in self.trade_facts:
@@ -129,6 +191,12 @@ class InMemoryRepository:
     def find_order(self, internal_order_id):
         for order in self.orders:
             if order["internal_order_id"] == internal_order_id:
+                return order
+        return None
+
+    def find_order_by_broker_correlation_token(self, token):
+        for order in self.orders:
+            if order.get("broker_correlation_token") == token:
                 return order
         return None
 
@@ -764,13 +832,16 @@ def test_reconcile_matches_external_trade_report_to_existing_candidate(monkeypat
     results = service.reconcile_trade_reports(
         [
             {
+                "account_id": "acct-reconcile-1",
                 "order_id": 90001,
+                "order_sysid": "SYS-90001",
                 "traded_id": "T90001",
                 "stock_code": "000001.SZ",
                 "order_type": 23,
                 "traded_volume": 200,
                 "traded_price": 10.5,
                 "traded_time": 1_030,
+                "date": 20260805,
             }
         ]
     )
@@ -784,11 +855,94 @@ def test_reconcile_matches_external_trade_report_to_existing_candidate(monkeypat
         == "matched_execution_fill"
     )
     assert len(repository.buy_lots) == 1
-    assert repository.orders[0]["source_type"] == "external_reported"
+    assert repository.orders[0]["source_type"] == "broker_only"
+    assert repository.orders[0]["internal_order_id"].startswith("ord_broker_")
+    assert repository.broker_orders[0]["execution_fence"] is True
     assert marks == ["matched"]
 
 
-def test_reconcile_matches_inflight_internal_order_before_creating_external_order(
+def test_reconcile_canonical_external_trade_does_not_guess_inflight_owner(monkeypatch):
+    repository, service = _build_service(monkeypatch)
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "000001",
+            "price": 10.5,
+            "quantity": 200,
+            "source": "strategy",
+            "internal_order_id": "ord_inflight_same_shape",
+        }
+    )
+    tracking_service.mark_order_queued("ord_inflight_same_shape")
+
+    outcome = service.reconcile_trade_report(
+        {
+            "account_id": "acct-external-owner",
+            "order_id": 90009,
+            "order_sysid": "SYS-90009",
+            "traded_id": "T90009",
+            "stock_code": "000001.SZ",
+            "order_type": 23,
+            "traded_volume": 200,
+            "traded_price": 10.5,
+            "traded_time": 1_030,
+            "date": 20260805,
+        }
+    )
+
+    assert outcome.ingested is True
+    assert len(repository.orders) == 2
+    assert repository.find_order("ord_inflight_same_shape")["source_type"] == "strategy"
+    external_order = next(
+        order for order in repository.orders if order["source_type"] == "broker_only"
+    )
+    assert external_order["internal_order_id"].startswith("ord_broker_")
+    assert (
+        outcome.result["trade_fact"]["internal_order_id"]
+        == external_order["internal_order_id"]
+    )
+
+
+def test_reconcile_identity_incomplete_trade_fails_closed_without_shape_guess(
+    monkeypatch,
+):
+    repository, service = _build_service(monkeypatch)
+    tracking_service = OrderTrackingService(repository=repository)
+    tracking_service.submit_order(
+        {
+            "action": "buy",
+            "symbol": "000001",
+            "price": 10.5,
+            "quantity": 200,
+            "source": "strategy",
+            "internal_order_id": "ord_inflight_same_shape_incomplete",
+        }
+    )
+    tracking_service.mark_order_queued("ord_inflight_same_shape_incomplete")
+
+    with pytest.raises(BrokerIdentityError, match="canonical broker identity"):
+        service.reconcile_trade_report(
+            {
+                "broker_order_id": "90010",
+                "broker_trade_id": "T90010",
+                "symbol": "000001",
+                "side": "buy",
+                "quantity": 200,
+                "price": 10.5,
+                "trade_time": 1_030,
+            }
+        )
+
+    assert len(repository.orders) == 1
+    assert repository.orders[0]["internal_order_id"] == (
+        "ord_inflight_same_shape_incomplete"
+    )
+    assert repository.trade_facts == []
+    assert repository.execution_fills == []
+
+
+def test_reconcile_matches_inflight_internal_order_by_correlation_token(
     monkeypatch,
 ):
     repository, service = _build_service(monkeypatch)
@@ -812,6 +966,9 @@ def test_reconcile_matches_inflight_internal_order_before_creating_external_orde
             "broker_order_id": None,
         }
     )
+    correlation_token = repository.find_order("ord_internal_1")[
+        "broker_correlation_token"
+    ]
 
     results = service.reconcile_trade_reports(
         [
@@ -823,6 +980,7 @@ def test_reconcile_matches_inflight_internal_order_before_creating_external_orde
                 "traded_volume": 200,
                 "traded_price": 10.5,
                 "traded_time": 1_030,
+                "order_remark": correlation_token,
             }
         ]
     )
@@ -835,7 +993,7 @@ def test_reconcile_matches_inflight_internal_order_before_creating_external_orde
     assert repository.trade_facts[0]["internal_order_id"] == "ord_internal_1"
 
 
-def test_reconcile_matches_partial_inflight_internal_order_without_externalizing(
+def test_reconcile_matches_partial_inflight_internal_order_by_correlation_token(
     monkeypatch,
 ):
     repository, service = _build_service(monkeypatch)
@@ -859,6 +1017,9 @@ def test_reconcile_matches_partial_inflight_internal_order_without_externalizing
             "broker_order_id": None,
         }
     )
+    correlation_token = repository.find_order("ord_internal_partial_1")[
+        "broker_correlation_token"
+    ]
 
     results = service.reconcile_trade_reports(
         [
@@ -870,6 +1031,7 @@ def test_reconcile_matches_partial_inflight_internal_order_without_externalizing
                 "traded_volume": 300,
                 "traded_price": 10.5,
                 "traded_time": 1_030,
+                "order_remark": correlation_token,
             }
         ]
     )
@@ -919,6 +1081,9 @@ def test_reconcile_trade_report_ingests_known_internal_sell_order(monkeypatch):
         "ord_internal_known_1",
         {"broker_order_id": "90011", "state": "SUBMITTED"},
     )
+    correlation_token = repository.find_order("ord_internal_known_1")[
+        "broker_correlation_token"
+    ]
 
     outcome = service.reconcile_trade_report(
         {
@@ -929,6 +1094,7 @@ def test_reconcile_trade_report_ingests_known_internal_sell_order(monkeypatch):
             "traded_volume": 200,
             "traded_price": 10.5,
             "traded_time": 1_030,
+            "order_remark": correlation_token,
         }
     )
 
@@ -950,7 +1116,7 @@ def test_reconcile_trade_report_ingests_known_internal_sell_order(monkeypatch):
     assert len(repository.sell_allocations) == 1
 
 
-def test_reconcile_trade_report_uses_matching_duplicate_broker_order_candidate(
+def test_reconcile_trade_report_uses_correlation_token_with_duplicate_broker_id(
     monkeypatch,
 ):
     repository, service = _build_service(monkeypatch)
@@ -1016,6 +1182,9 @@ def test_reconcile_trade_report_uses_matching_duplicate_broker_order_candidate(
             "submitted_at": "2026-04-29T10:14:06+08:00",
         },
     )
+    correlation_token = repository.find_order("ord_new_sell_duplicate")[
+        "broker_correlation_token"
+    ]
 
     outcome = service.reconcile_trade_report(
         {
@@ -1026,6 +1195,7 @@ def test_reconcile_trade_report_uses_matching_duplicate_broker_order_candidate(
             "traded_volume": 2300,
             "traded_price": 22.41,
             "traded_time": 1777428846,
+            "order_remark": correlation_token,
         }
     )
 
@@ -1399,13 +1569,16 @@ def test_partial_trade_shrinks_pending_gap_before_auto_close(monkeypatch):
     results = service.reconcile_trade_reports(
         [
             {
+                "account_id": "acct-reconcile-2",
                 "order_id": 90003,
+                "order_sysid": "SYS-90003",
                 "traded_id": "T90003",
                 "stock_code": "000001.SZ",
                 "order_type": 24,
                 "traded_volume": 200,
                 "traded_price": 10.5,
                 "traded_time": 1_030,
+                "date": 20260805,
             }
         ]
     )

--- a/freshquant/tests/test_order_management_submit_service.py
+++ b/freshquant/tests/test_order_management_submit_service.py
@@ -18,6 +18,7 @@ class InMemoryRepository:
     def __init__(self):
         self.order_requests = []
         self.orders = []
+        self.broker_orders = []
         self.order_events = []
         self.trade_facts = []
 
@@ -57,6 +58,50 @@ class InMemoryRepository:
             if str(order.get("broker_order_id")) == str(broker_order_id):
                 return order
         return None
+
+    def find_broker_order(self, broker_order_key):
+        for order in self.broker_orders:
+            if order["broker_order_key"] == broker_order_key:
+                return order
+        return None
+
+    def claim_broker_order_owner(self, document):
+        existing = self.find_broker_order(document["broker_order_key"])
+        if existing is None:
+            saved = dict(document)
+            self.broker_orders.append(saved)
+            return saved, True
+        for field in (
+            "internal_order_id",
+            "request_id",
+            "broker_correlation_token",
+            "account_id",
+            "trading_day",
+            "order_sysid",
+            "broker_order_id",
+            "symbol",
+            "side",
+            "source_type",
+        ):
+            if field in document:
+                existing[field] = document.get(field)
+        return existing, False
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        order = self.find_broker_order(old_key)
+        if order is None:
+            order = dict(document)
+            self.broker_orders.append(order)
+        order.update(document)
+        order["broker_order_key"] = new_key
+        return order
 
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)

--- a/freshquant/tests/test_order_management_tracking_service.py
+++ b/freshquant/tests/test_order_management_tracking_service.py
@@ -23,13 +23,74 @@ class InMemoryRepository:
         return document
 
     def upsert_broker_order(self, document, unique_keys):
-        for existing in self.broker_orders:
-            if all(existing.get(key) == document.get(key) for key in unique_keys):
-                existing.update(document)
-                return existing, False
-        saved = dict(document)
-        self.broker_orders.append(saved)
-        return saved, True
+        assert unique_keys == ["broker_order_key"]
+        return self.claim_broker_order_owner(document)
+
+    def claim_broker_order_owner(self, document):
+        existing = self.find_broker_order(document["broker_order_key"])
+        if existing is None:
+            saved = dict(document)
+            self.broker_orders.append(saved)
+            return saved, True
+        owner_changed = existing.get("internal_order_id") != document.get(
+            "internal_order_id"
+        )
+        for field in (
+            "internal_order_id",
+            "request_id",
+            "broker_correlation_token",
+            "broker_order_key",
+            "account_id",
+            "trading_day",
+            "order_sysid",
+            "broker_order_id",
+            "symbol",
+            "side",
+        ):
+            if field in document and (
+                document.get(field) is not None or existing.get(field) is None
+            ):
+                existing[field] = document.get(field)
+        if owner_changed or not existing.get("source_type"):
+            existing["source_type"] = document.get("source_type")
+        return existing, False
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def fence_broker_order_execution(self, document):
+        order = self.find_broker_order(document["broker_order_key"])
+        assert order["internal_order_id"] == document["internal_order_id"]
+        order["execution_fence"] = True
+        return order
+
+    def compare_and_set_broker_order(self, *, before, after):
+        order = self.find_broker_order(before["broker_order_key"])
+        if order != before:
+            return order if order == after else None
+        order.clear()
+        order.update(after)
+        return order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        source = self.find_broker_order(old_key)
+        target = self.find_broker_order(new_key)
+        merged = {**(source or {}), **dict(document), "broker_order_key": new_key}
+        if target is None:
+            self.broker_orders.append(merged)
+            target = merged
+        else:
+            target.update(merged)
+        self.broker_orders = [
+            item
+            for item in self.broker_orders
+            if item.get("broker_order_key") != old_key
+        ]
+        return target
 
     def insert_order_event(self, document):
         self.order_events.append(document)
@@ -61,6 +122,19 @@ class InMemoryRepository:
             if order["broker_order_key"] == broker_order_key:
                 return order
         return None
+
+    def find_order_by_broker_correlation_token(self, token):
+        for order in self.orders:
+            if order.get("broker_correlation_token") == token:
+                return order
+        return None
+
+    def list_execution_fills(self, *, broker_order_keys=None, **_kwargs):
+        rows = list(self.execution_fills)
+        if broker_order_keys is not None:
+            allowed = set(broker_order_keys)
+            rows = [item for item in rows if item.get("broker_order_key") in allowed]
+        return rows
 
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)

--- a/freshquant/tests/test_order_management_xt_ingest.py
+++ b/freshquant/tests/test_order_management_xt_ingest.py
@@ -1,3 +1,5 @@
+import pytest
+
 import freshquant.order_management.ingest.xt_reports as xt_reports_module
 from freshquant.order_management.ingest.xt_reports import (
     OrderManagementXtIngestService,
@@ -35,13 +37,74 @@ class InMemoryRepository:
         return document
 
     def upsert_broker_order(self, document, unique_keys):
-        for existing in self.broker_orders:
-            if all(existing.get(key) == document.get(key) for key in unique_keys):
-                existing.update(document)
-                return existing, False
-        saved = dict(document)
-        self.broker_orders.append(saved)
-        return saved, True
+        assert unique_keys == ["broker_order_key"]
+        return self.claim_broker_order_owner(document)
+
+    def claim_broker_order_owner(self, document):
+        existing = self.find_broker_order(document["broker_order_key"])
+        if existing is None:
+            saved = dict(document)
+            self.broker_orders.append(saved)
+            return saved, True
+        owner_changed = existing.get("internal_order_id") != document.get(
+            "internal_order_id"
+        )
+        for field in (
+            "internal_order_id",
+            "request_id",
+            "broker_correlation_token",
+            "broker_order_key",
+            "account_id",
+            "trading_day",
+            "order_sysid",
+            "broker_order_id",
+            "symbol",
+            "side",
+        ):
+            if field in document and (
+                document.get(field) is not None or existing.get(field) is None
+            ):
+                existing[field] = document.get(field)
+        if owner_changed or not existing.get("source_type"):
+            existing["source_type"] = document.get("source_type")
+        return existing, False
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def fence_broker_order_execution(self, document):
+        order = self.find_broker_order(document["broker_order_key"])
+        assert order["internal_order_id"] == document["internal_order_id"]
+        order["execution_fence"] = True
+        return order
+
+    def compare_and_set_broker_order(self, *, before, after):
+        order = self.find_broker_order(before["broker_order_key"])
+        if order != before:
+            return order if order == after else None
+        order.clear()
+        order.update(after)
+        return order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        source = self.find_broker_order(old_key)
+        target = self.find_broker_order(new_key)
+        merged = {**(source or {}), **dict(document), "broker_order_key": new_key}
+        if target is None:
+            self.broker_orders.append(merged)
+            target = merged
+        else:
+            target.update(merged)
+        self.broker_orders = [
+            item
+            for item in self.broker_orders
+            if item.get("broker_order_key") != old_key
+        ]
+        return target
 
     def insert_order_event(self, document):
         self.order_events.append(document)
@@ -79,6 +142,19 @@ class InMemoryRepository:
             if order["broker_order_key"] == broker_order_key:
                 return order
         return None
+
+    def find_order_by_broker_correlation_token(self, token):
+        for order in self.orders:
+            if order.get("broker_correlation_token") == token:
+                return order
+        return None
+
+    def list_execution_fills(self, *, broker_order_keys=None, **_kwargs):
+        rows = list(self.execution_fills)
+        if broker_order_keys is not None:
+            allowed = set(broker_order_keys)
+            rows = [item for item in rows if item.get("broker_order_key") in allowed]
+        return rows
 
     def find_order_by_broker_order_id(self, broker_order_id):
         for order in self.orders:
@@ -206,6 +282,16 @@ def _bootstrap_service():
             "internal_order_id": "ord_test_1",
         }
     )
+    tracking_service.submit_order(
+        {
+            "action": "sell",
+            "symbol": "000001",
+            "price": 10.8,
+            "quantity": 500,
+            "source": "xt_trade_callback",
+            "internal_order_id": "ord_test_sell_1",
+        }
+    )
     ingest_service = OrderManagementXtIngestService(
         repository=repository,
         tracking_service=tracking_service,
@@ -265,7 +351,7 @@ def _buy_report(broker_trade_id="T-100", **overrides):
 
 def _sell_report(broker_trade_id="T-101", **overrides):
     payload = {
-        "internal_order_id": "ord_test_1",
+        "internal_order_id": "ord_test_sell_1",
         "broker_trade_id": broker_trade_id,
         "symbol": "000001",
         "side": "sell",
@@ -365,6 +451,9 @@ def test_normalize_xt_trade_report_prefers_order_domain_broker_order_type():
             "traded_volume": 100,
             "traded_price": 10.0,
             "traded_time": 1710000000,
+            "order_remark": repository.find_order("ord_credit_ingest_1")[
+                "broker_correlation_token"
+            ],
         },
         repository=repository,
     )
@@ -430,6 +519,9 @@ def test_normalize_xt_trade_report_disambiguates_reused_broker_order_id():
             "traded_volume": 2300,
             "traded_price": 22.41,
             "traded_time": 1777428846,
+            "order_remark": repository.find_order("ord_new_sell")[
+                "broker_correlation_token"
+            ],
         },
         repository=repository,
     )
@@ -495,6 +587,9 @@ def test_normalize_xt_order_report_disambiguates_reused_broker_order_id():
             "order_type": 24,
             "order_time": 1777428846,
             "order_status": 50,
+            "order_remark": repository.find_order("ord_new_sell")[
+                "broker_correlation_token"
+            ],
         },
         repository=repository,
     )
@@ -576,6 +671,9 @@ def test_normalize_xt_order_report_maps_broker_order_back_to_internal_order():
             "stock_code": "000001.SZ",
             "order_time": 1710000000,
             "order_status": 54,
+            "order_remark": repository.find_order("ord_test_order_report")[
+                "broker_correlation_token"
+            ],
         },
         repository=repository,
     )
@@ -1235,7 +1333,60 @@ def test_order_report_updates_existing_order_state():
             "stock_code": "000001.SZ",
             "order_time": 1710000000,
             "order_status": 54,
+            "order_remark": repository.find_order("ord_order_state_1")[
+                "broker_correlation_token"
+            ],
         }
     )
 
     assert repository.find_order("ord_order_state_1")["state"] == "CANCELED"
+
+
+def test_trade_ingest_requires_meta_tracking_contract():
+    class LegacyOnlyTrackingService:
+        def ingest_trade_report(self, _report):
+            raise AssertionError("legacy trade ingest must not be used")
+
+    service = OrderManagementXtIngestService(
+        repository=InMemoryRepository(),
+        tracking_service=LegacyOnlyTrackingService(),
+        tpsl_service=object(),
+        runtime_logger=object(),
+    )
+
+    with pytest.raises(AttributeError, match="ingest_trade_report_with_meta"):
+        service.ingest_trade_report(
+            {
+                "internal_order_id": "ord_contract_trade",
+                "symbol": "000001",
+                "side": "buy",
+                "broker_trade_id": "trade-contract",
+            },
+            lot_amount=100,
+            grid_interval_lookup=lambda *_args: 1,
+        )
+
+
+def test_order_ingest_requires_meta_tracking_contract():
+    class LegacyOnlyTrackingService:
+        def ingest_order_report(self, _report):
+            raise AssertionError("legacy order ingest must not be used")
+
+    service = OrderManagementXtIngestService(
+        repository=InMemoryRepository(),
+        tracking_service=LegacyOnlyTrackingService(),
+        tpsl_service=object(),
+        runtime_logger=object(),
+    )
+
+    with pytest.raises(AttributeError, match="ingest_order_report_with_meta"):
+        service.ingest_order_report(
+            {
+                "internal_order_id": "ord_contract_order",
+                "broker_order_key": "acct|20260806|sys-contract",
+                "broker_order_id": "order-contract",
+                "symbol": "000001",
+                "side": "buy",
+                "state": "SUBMITTED",
+            }
+        )

--- a/freshquant/tests/test_order_reconcile_runtime_observability.py
+++ b/freshquant/tests/test_order_reconcile_runtime_observability.py
@@ -50,12 +50,71 @@ class InMemoryRepository:
         return document
 
     def upsert_broker_order(self, document, unique_keys):
-        for existing in self.broker_orders:
-            if all(existing.get(key) == document.get(key) for key in unique_keys):
-                existing.update(document)
-                return existing, False
-        self.broker_orders.append(dict(document))
-        return document, True
+        assert unique_keys == ["broker_order_key"]
+        return self.claim_broker_order_owner(document)
+
+    def claim_broker_order_owner(self, document):
+        existing = self.find_broker_order(document["broker_order_key"])
+        if existing is None:
+            saved = dict(document)
+            self.broker_orders.append(saved)
+            return saved, True
+        owner_changed = existing.get("internal_order_id") != document.get(
+            "internal_order_id"
+        )
+        for field in (
+            "internal_order_id",
+            "request_id",
+            "broker_correlation_token",
+            "account_id",
+            "trading_day",
+            "order_sysid",
+            "broker_order_id",
+            "symbol",
+            "side",
+        ):
+            if field in document and (
+                document.get(field) is not None or existing.get(field) is None
+            ):
+                existing[field] = document.get(field)
+        if owner_changed or not existing.get("source_type"):
+            existing["source_type"] = document.get("source_type")
+        return existing, False
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def fence_broker_order_execution(self, document):
+        order = self.find_broker_order(document["broker_order_key"])
+        assert order["internal_order_id"] == document["internal_order_id"]
+        order["execution_fence"] = True
+        return order
+
+    def compare_and_set_broker_order(self, *, before, after):
+        order = self.find_broker_order(before["broker_order_key"])
+        if order != before:
+            return order if order == after else None
+        order.clear()
+        order.update(after)
+        return order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        source = self.find_broker_order(old_key)
+        target = self.find_broker_order(new_key)
+        merged = {**(source or {}), **dict(document), "broker_order_key": new_key}
+        if target is None:
+            self.broker_orders.append(merged)
+            target = merged
+        else:
+            target.update(merged)
+        self.broker_orders = [
+            item for item in self.broker_orders if item["broker_order_key"] != old_key
+        ]
+        return target
 
     def upsert_trade_fact(self, document, unique_keys):
         for existing in self.trade_facts:
@@ -89,11 +148,24 @@ class InMemoryRepository:
                 return order
         return None
 
+    def find_order_by_broker_correlation_token(self, token):
+        for order in self.orders:
+            if order.get("broker_correlation_token") == token:
+                return order
+        return None
+
     def find_broker_order(self, broker_order_key):
         for order in self.broker_orders:
             if order["broker_order_key"] == broker_order_key:
                 return order
         return None
+
+    def list_execution_fills(self, *, broker_order_keys=None, **_kwargs):
+        rows = list(self.execution_fills)
+        if broker_order_keys is not None:
+            allowed = set(broker_order_keys)
+            rows = [item for item in rows if item.get("broker_order_key") in allowed]
+        return rows
 
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)
@@ -273,6 +345,7 @@ def test_reconcile_trade_reports_emits_runtime_events(monkeypatch):
             "broker_order_id": None,
         }
     )
+    correlation_token = repository.find_order("ord_recon_1")["broker_correlation_token"]
     runtime_logger = FakeRuntimeLogger()
     service = ExternalOrderReconcileService(
         repository=repository,
@@ -290,6 +363,7 @@ def test_reconcile_trade_reports_emits_runtime_events(monkeypatch):
                 "traded_volume": 200,
                 "traded_price": 10.5,
                 "traded_time": 1030,
+                "order_remark": correlation_token,
             }
         ]
     )
@@ -346,6 +420,9 @@ def test_known_internal_trade_report_still_emits_xt_ingest_events(monkeypatch):
         "ord_recon_known_1",
         {"broker_order_id": "90012", "state": "SUBMITTED"},
     )
+    correlation_token = repository.find_order("ord_recon_known_1")[
+        "broker_correlation_token"
+    ]
     reconcile_runtime_logger = FakeRuntimeLogger()
     ingest_runtime_logger = FakeRuntimeLogger()
     ingest_service = OrderManagementXtIngestService(
@@ -369,6 +446,7 @@ def test_known_internal_trade_report_still_emits_xt_ingest_events(monkeypatch):
             "traded_volume": 200,
             "traded_price": 10.5,
             "traded_time": 1030,
+            "order_remark": correlation_token,
         }
     )
 
@@ -472,6 +550,9 @@ def test_known_internal_sell_trade_report_ignores_missing_legacy_slices(
         "ord_recon_known_sell_1",
         {"broker_order_id": "90021", "state": "SUBMITTED"},
     )
+    correlation_token = repository.find_order("ord_recon_known_sell_1")[
+        "broker_correlation_token"
+    ]
     reconcile_runtime_logger = FakeRuntimeLogger()
     service = ExternalOrderReconcileService(
         repository=repository,
@@ -489,6 +570,7 @@ def test_known_internal_sell_trade_report_ignores_missing_legacy_slices(
             "traded_volume": 500,
             "traded_price": 10.8,
             "traded_time": 1710003600,
+            "order_remark": correlation_token,
         }
     )
 

--- a/freshquant/tests/test_order_submit_runtime_observability.py
+++ b/freshquant/tests/test_order_submit_runtime_observability.py
@@ -33,6 +33,7 @@ class InMemoryRepository:
     def __init__(self):
         self.order_requests = []
         self.orders = []
+        self.broker_orders = []
         self.order_events = []
         self.trade_facts = []
 
@@ -72,6 +73,50 @@ class InMemoryRepository:
             if str(order.get("broker_order_id")) == str(broker_order_id):
                 return order
         return None
+
+    def find_broker_order(self, broker_order_key):
+        for order in self.broker_orders:
+            if order["broker_order_key"] == broker_order_key:
+                return order
+        return None
+
+    def claim_broker_order_owner(self, document):
+        existing = self.find_broker_order(document["broker_order_key"])
+        if existing is None:
+            saved = dict(document)
+            self.broker_orders.append(saved)
+            return saved, True
+        for field in (
+            "internal_order_id",
+            "request_id",
+            "broker_correlation_token",
+            "account_id",
+            "trading_day",
+            "order_sysid",
+            "broker_order_id",
+            "symbol",
+            "side",
+            "source_type",
+        ):
+            if field in document:
+                existing[field] = document.get(field)
+        return existing, False
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        order = self.find_broker_order(old_key)
+        if order is None:
+            order = dict(document)
+            self.broker_orders.append(order)
+        order.update(document)
+        order["broker_order_key"] = new_key
+        return order
 
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)

--- a/freshquant/tests/test_position_management_guardian_placeholder.py
+++ b/freshquant/tests/test_position_management_guardian_placeholder.py
@@ -33,6 +33,7 @@ class InMemoryRepository:
     def __init__(self):
         self.order_requests = []
         self.orders = []
+        self.broker_orders = []
         self.order_events = []
         self.trade_facts = []
 
@@ -72,6 +73,50 @@ class InMemoryRepository:
             if str(order.get("broker_order_id")) == str(broker_order_id):
                 return order
         return None
+
+    def find_broker_order(self, broker_order_key):
+        for order in self.broker_orders:
+            if order["broker_order_key"] == broker_order_key:
+                return order
+        return None
+
+    def claim_broker_order_owner(self, document):
+        existing = self.find_broker_order(document["broker_order_key"])
+        if existing is None:
+            saved = dict(document)
+            self.broker_orders.append(saved)
+            return saved, True
+        for field in (
+            "internal_order_id",
+            "request_id",
+            "broker_correlation_token",
+            "account_id",
+            "trading_day",
+            "order_sysid",
+            "broker_order_id",
+            "symbol",
+            "side",
+            "source_type",
+        ):
+            if field in document:
+                existing[field] = document.get(field)
+        return existing, False
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        order = self.find_broker_order(old_key)
+        if order is None:
+            order = dict(document)
+            self.broker_orders.append(order)
+        order.update(document)
+        order["broker_order_key"] = new_key
+        return order
 
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)

--- a/freshquant/tests/test_position_management_submit_gate.py
+++ b/freshquant/tests/test_position_management_submit_gate.py
@@ -26,6 +26,7 @@ class InMemoryRepository:
     def __init__(self):
         self.order_requests = []
         self.orders = []
+        self.broker_orders = []
         self.order_events = []
         self.trade_facts = []
 
@@ -65,6 +66,50 @@ class InMemoryRepository:
             if str(order.get("broker_order_id")) == str(broker_order_id):
                 return order
         return None
+
+    def find_broker_order(self, broker_order_key):
+        for order in self.broker_orders:
+            if order["broker_order_key"] == broker_order_key:
+                return order
+        return None
+
+    def claim_broker_order_owner(self, document):
+        existing = self.find_broker_order(document["broker_order_key"])
+        if existing is None:
+            saved = dict(document)
+            self.broker_orders.append(saved)
+            return saved, True
+        for field in (
+            "internal_order_id",
+            "request_id",
+            "broker_correlation_token",
+            "account_id",
+            "trading_day",
+            "order_sysid",
+            "broker_order_id",
+            "symbol",
+            "side",
+            "source_type",
+        ):
+            if field in document:
+                existing[field] = document.get(field)
+        return existing, False
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        order = self.find_broker_order(old_key)
+        if order is None:
+            order = dict(document)
+            self.broker_orders.append(order)
+        order.update(document)
+        order["broker_order_key"] = new_key
+        return order
 
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)

--- a/freshquant/tests/test_tpsl_rearm.py
+++ b/freshquant/tests/test_tpsl_rearm.py
@@ -40,8 +40,10 @@ class InMemoryOrderRepository:
     def __init__(self):
         self.order_requests = []
         self.orders = []
+        self.broker_orders = []
         self.order_events = []
         self.trade_facts = []
+        self.execution_fills = []
         self.buy_lots = []
         self.lot_slices = []
         self.sell_allocations = []
@@ -65,6 +67,14 @@ class InMemoryOrderRepository:
         self.trade_facts.append(document)
         return document, True
 
+    def upsert_execution_fill(self, document, unique_keys):
+        for existing in self.execution_fills:
+            if all(existing.get(key) == document.get(key) for key in unique_keys):
+                return existing, False
+        saved = dict(document)
+        self.execution_fills.append(saved)
+        return saved, True
+
     def find_order(self, internal_order_id):
         for order in self.orders:
             if order["internal_order_id"] == internal_order_id:
@@ -76,6 +86,82 @@ class InMemoryOrderRepository:
             if str(order.get("broker_order_id")) == str(broker_order_id):
                 return order
         return None
+
+    def find_order_by_broker_correlation_token(self, token):
+        for order in self.orders:
+            if order.get("broker_correlation_token") == token:
+                return order
+        return None
+
+    def find_broker_order(self, broker_order_key):
+        for order in self.broker_orders:
+            if order["broker_order_key"] == broker_order_key:
+                return order
+        return None
+
+    def claim_broker_order_owner(self, document):
+        existing = self.find_broker_order(document["broker_order_key"])
+        if existing is None:
+            saved = dict(document)
+            self.broker_orders.append(saved)
+            return saved, True
+        for field in (
+            "internal_order_id",
+            "request_id",
+            "broker_correlation_token",
+            "account_id",
+            "trading_day",
+            "order_sysid",
+            "broker_order_id",
+            "symbol",
+            "side",
+            "source_type",
+        ):
+            if field in document:
+                existing[field] = document.get(field)
+        return existing, False
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def fence_broker_order_execution(self, document):
+        order = self.find_broker_order(document["broker_order_key"])
+        assert order["internal_order_id"] == document["internal_order_id"]
+        order["execution_fence"] = True
+        return order
+
+    def compare_and_set_broker_order(self, *, before, after):
+        order = self.find_broker_order(before["broker_order_key"])
+        if order != before:
+            return order if order == after else None
+        order.clear()
+        order.update(after)
+        return order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        source = self.find_broker_order(old_key)
+        target = self.find_broker_order(new_key)
+        merged = {**(source or {}), **dict(document), "broker_order_key": new_key}
+        if target is None:
+            self.broker_orders.append(merged)
+            target = merged
+        else:
+            target.update(merged)
+        self.broker_orders = [
+            item for item in self.broker_orders if item["broker_order_key"] != old_key
+        ]
+        return target
+
+    def list_execution_fills(self, *, broker_order_keys=None, **_kwargs):
+        rows = list(self.execution_fills)
+        if broker_order_keys is not None:
+            allowed = set(broker_order_keys)
+            rows = [item for item in rows if item.get("broker_order_key") in allowed]
+        return rows
 
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)

--- a/freshquant/tests/test_xt_reports_runtime_observability.py
+++ b/freshquant/tests/test_xt_reports_runtime_observability.py
@@ -18,8 +18,10 @@ class InMemoryRepository:
     def __init__(self):
         self.order_requests = []
         self.orders = []
+        self.broker_orders = []
         self.order_events = []
         self.trade_facts = []
+        self.execution_fills = []
         self.buy_lots = []
         self.lot_slices = []
         self.sell_allocations = []
@@ -43,6 +45,14 @@ class InMemoryRepository:
         self.trade_facts.append(document)
         return document, True
 
+    def upsert_execution_fill(self, document, unique_keys):
+        for existing in self.execution_fills:
+            if all(existing.get(key) == document.get(key) for key in unique_keys):
+                return existing, False
+        saved = dict(document)
+        self.execution_fills.append(saved)
+        return saved, True
+
     def find_order(self, internal_order_id):
         for order in self.orders:
             if order["internal_order_id"] == internal_order_id:
@@ -60,6 +70,82 @@ class InMemoryRepository:
             if str(order.get("broker_order_id")) == str(broker_order_id):
                 return order
         return None
+
+    def find_order_by_broker_correlation_token(self, token):
+        for order in self.orders:
+            if order.get("broker_correlation_token") == token:
+                return order
+        return None
+
+    def find_broker_order(self, broker_order_key):
+        for order in self.broker_orders:
+            if order["broker_order_key"] == broker_order_key:
+                return order
+        return None
+
+    def claim_broker_order_owner(self, document):
+        existing = self.find_broker_order(document["broker_order_key"])
+        if existing is None:
+            saved = dict(document)
+            self.broker_orders.append(saved)
+            return saved, True
+        for field in (
+            "internal_order_id",
+            "request_id",
+            "broker_correlation_token",
+            "account_id",
+            "trading_day",
+            "order_sysid",
+            "broker_order_id",
+            "symbol",
+            "side",
+            "source_type",
+        ):
+            if field in document:
+                existing[field] = document.get(field)
+        return existing, False
+
+    def update_broker_order_fields(self, broker_order_key, updates):
+        order = self.find_broker_order(broker_order_key)
+        if order is None:
+            return None
+        order.update(updates)
+        return order
+
+    def fence_broker_order_execution(self, document):
+        order = self.find_broker_order(document["broker_order_key"])
+        assert order["internal_order_id"] == document["internal_order_id"]
+        order["execution_fence"] = True
+        return order
+
+    def compare_and_set_broker_order(self, *, before, after):
+        order = self.find_broker_order(before["broker_order_key"])
+        if order != before:
+            return order if order == after else None
+        order.clear()
+        order.update(after)
+        return order
+
+    def move_broker_order_key(self, old_key, new_key, document):
+        source = self.find_broker_order(old_key)
+        target = self.find_broker_order(new_key)
+        merged = {**(source or {}), **dict(document), "broker_order_key": new_key}
+        if target is None:
+            self.broker_orders.append(merged)
+            target = merged
+        else:
+            target.update(merged)
+        self.broker_orders = [
+            item for item in self.broker_orders if item["broker_order_key"] != old_key
+        ]
+        return target
+
+    def list_execution_fills(self, *, broker_order_keys=None, **_kwargs):
+        rows = list(self.execution_fills)
+        if broker_order_keys is not None:
+            allowed = set(broker_order_keys)
+            rows = [item for item in rows if item.get("broker_order_key") in allowed]
+        return rows
 
     def update_order(self, internal_order_id, updates):
         order = self.find_order(internal_order_id)
@@ -281,6 +367,7 @@ def test_ingest_order_report_emits_runtime_events():
         "ord_xt_2",
         {"broker_order_id": "90002", "state": "SUBMITTED"},
     )
+    correlation_token = repository.find_order("ord_xt_2")["broker_correlation_token"]
     service = OrderManagementXtIngestService(
         repository=repository,
         tracking_service=tracking_service,
@@ -293,6 +380,7 @@ def test_ingest_order_report_emits_runtime_events():
             "stock_code": "000001.SZ",
             "order_time": 1710000000,
             "order_status": 54,
+            "order_remark": correlation_token,
         }
     )
 
@@ -325,6 +413,9 @@ def test_duplicate_order_snapshot_is_silent_in_runtime_observability():
         "ord_xt_dup_order_1",
         {"broker_order_id": "90012", "state": "SUBMITTED"},
     )
+    correlation_token = repository.find_order("ord_xt_dup_order_1")[
+        "broker_correlation_token"
+    ]
     service = OrderManagementXtIngestService(
         repository=repository,
         tracking_service=tracking_service,
@@ -335,6 +426,7 @@ def test_duplicate_order_snapshot_is_silent_in_runtime_observability():
         "stock_code": "000001.SZ",
         "order_time": 1710000000,
         "order_status": 54,
+        "order_remark": correlation_token,
     }
 
     service.ingest_order_report(report)

--- a/freshquant/tests/test_xtquant_runtime_observability.py
+++ b/freshquant/tests/test_xtquant_runtime_observability.py
@@ -1,5 +1,6 @@
 import contextlib
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -481,6 +482,135 @@ def test_puppet_buy_emits_runtime_error_when_order_submit_raises(monkeypatch):
     assert collector.events[-1]["payload"]["error_message"] == "xt submit failed"
 
 
+@pytest.mark.parametrize("action", ["buy", "sell"])
+@pytest.mark.parametrize("submit_result", [None, 0, -1])
+def test_puppet_failed_submit_result_does_not_sleep_or_requeue(
+    monkeypatch,
+    action,
+    submit_result,
+):
+    class FakeTrader:
+        def query_stock_asset(self, acc):
+            return types.SimpleNamespace(cash=100000.0, frozen_cash=0.0)
+
+        def query_stock_positions(self, acc):
+            return [types.SimpleNamespace(stock_code="600000.SH", can_use_volume=500)]
+
+        def order_stock(self, *args, **kwargs):
+            return submit_result
+
+    _install_puppet_stubs(monkeypatch, xt_trader=FakeTrader())
+    puppet = _load_module(
+        f"test_runtime_puppet_{action}_{submit_result}",
+        PUPPET_PATH,
+    )
+    collector = EventCollector()
+    puppet._runtime_logger = collector
+
+    class ForbiddenRedis:
+        def lpush(self, *args, **kwargs):
+            raise AssertionError("failed XT submit must not be requeued")
+
+    puppet.redis_db = ForbiddenRedis()
+    puppet.time = types.SimpleNamespace(
+        sleep=lambda _delay: (_ for _ in ()).throw(
+            AssertionError("failed XT submit must not sleep before retry")
+        ),
+        time=lambda: 0,
+    )
+
+    if action == "buy":
+        result = puppet.buy(
+            "600000",
+            10.08,
+            300,
+            retryCount=0,
+            internal_order_id="ord-puppet-failed-buy",
+        )
+    else:
+        result = puppet.sell(
+            "600000",
+            11,
+            9.92,
+            300,
+            retryCount=0,
+            internal_order_id="ord-puppet-failed-sell",
+        )
+
+    assert result == submit_result
+    assert collector.events[-1]["node"] == "submit_result"
+    assert collector.events[-1]["status"] == "failed"
+
+
+@pytest.mark.parametrize("action", ["buy", "sell"])
+def test_puppet_preserves_xt_order_stock_signature_and_correlation_remark(
+    monkeypatch,
+    action,
+):
+    captured = {}
+    token = "FQOM0123456789abcdef0123"
+
+    class FakeTrader:
+        def query_stock_asset(self, acc):
+            return types.SimpleNamespace(cash=100000.0, frozen_cash=0.0)
+
+        def query_stock_positions(self, acc):
+            return [types.SimpleNamespace(stock_code="600000.SH", can_use_volume=500)]
+
+        def order_stock(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return 90009
+
+    _install_puppet_stubs(monkeypatch, xt_trader=FakeTrader())
+    puppet = _load_module(f"test_runtime_puppet_{action}_signature", PUPPET_PATH)
+
+    if action == "buy":
+        result = puppet.buy(
+            "600000",
+            10.08,
+            300,
+            strategyName="takeprofit",
+            remark=token,
+            order_type=27,
+            price_type=11,
+        )
+        assert captured["args"][1:] == (
+            "600000.SH",
+            27,
+            300,
+            11,
+            10.08,
+        )
+        assert captured["kwargs"] == {
+            "strategy_name": "takeprofit",
+            "order_remark": token,
+        }
+    else:
+        result = puppet.sell(
+            "600000",
+            11,
+            9.92,
+            300,
+            strategyName="takeprofit",
+            remark=token,
+            order_type=32,
+        )
+        assert captured["args"][1:] == (
+            "600000.SH",
+            32,
+            300,
+            11,
+            9.92,
+            "takeprofit",
+            token,
+        )
+        assert captured["kwargs"] == {}
+
+    assert captured["args"][0].account_id == "acct-1"
+    assert result == 90009
+
+
 def test_puppet_buy_keeps_duplicate_check_and_submit_inside_trading_lock(
     monkeypatch,
 ):
@@ -613,8 +743,9 @@ def test_broker_trade_callback_emits_resolved_runtime_context(monkeypatch):
     broker = _load_module("test_runtime_broker", BROKER_PATH)
     collector = EventCollector()
     broker._runtime_logger = collector
+    correlation_token = "FQOM0123456789abcdef0123"
     broker.order_management_repository = types.SimpleNamespace(
-        find_order_by_broker_order_id=lambda broker_order_id: {
+        find_order_by_broker_correlation_token=lambda token: {
             "trace_id": "trace-broker-1",
             "intent_id": "intent-broker-1",
             "request_id": "req-broker-1",
@@ -630,6 +761,7 @@ def test_broker_trade_callback_emits_resolved_runtime_context(monkeypatch):
             order_id="90001",
             traded_id="T-90001",
             stock_code="600000.SH",
+            order_remark=correlation_token,
         )
     )
 
@@ -651,6 +783,21 @@ def test_broker_trade_callback_disambiguates_reused_broker_order_id(monkeypatch)
     broker._runtime_logger = collector
 
     class DuplicateBrokerOrderRepository:
+        def find_order_by_broker_correlation_token(self, token):
+            assert token == "FQOM0123456789abcdef0123"
+            return {
+                "trace_id": "trc_new",
+                "intent_id": "int_new",
+                "request_id": "req_new",
+                "internal_order_id": "ord_new_sell",
+                "symbol": "002262",
+                "side": "sell",
+                "broker_order_id": "1477443585",
+                "broker_order_type": 24,
+                "state": "SUBMITTED",
+                "submitted_at": "2026-04-29T10:14:06+08:00",
+            }
+
         def list_orders_by_broker_order_id(self, broker_order_id):
             assert str(broker_order_id) == "1477443585"
             return [
@@ -688,6 +835,7 @@ def test_broker_trade_callback_disambiguates_reused_broker_order_id(monkeypatch)
             stock_code="002262.SZ",
             order_type=24,
             traded_time=1777428846,
+            order_remark="FQOM0123456789abcdef0123",
         )
     )
 
@@ -745,6 +893,34 @@ def test_broker_observe_only_submit_emits_bypass_event_without_calling_executor(
     assert collector.events[-1]["node"] == "execution_bypassed"
     assert collector.events[-1]["action"] == "buy"
     assert collector.events[-1]["payload"]["reason"] == "observe_only"
+
+
+def test_broker_missing_internal_order_fails_closed(monkeypatch):
+    _install_broker_stubs(monkeypatch)
+    broker = _load_module("test_runtime_broker_missing_order", BROKER_PATH)
+    broker.prepare_submit_execution = lambda order, **kwargs: {
+        "status": "missing_order"
+    }
+    broker.finalize_submit_execution = lambda *args, **kwargs: (_ for _ in ()).throw(
+        AssertionError("missing order must not be finalized after broker submission")
+    )
+
+    result = broker._handle_submit_action(
+        {
+            "action": "buy",
+            "symbol": "600000",
+            "price": 10.0,
+            "quantity": 100,
+            "internal_order_id": "ord-missing-1",
+        },
+        action="buy",
+        submit_executor=lambda _resolved_order: (_ for _ in ()).throw(
+            AssertionError("missing order must not reach XT submit executor")
+        ),
+        broker_submit_mode="normal",
+    )
+
+    assert result == {"status": "missing_order"}
 
 
 def test_broker_submit_emits_runtime_error_when_executor_raises(monkeypatch):
@@ -820,6 +996,47 @@ def test_broker_failed_strategy_buy_clears_guardian_buy_cooldown(monkeypatch):
 
     assert result["status"] == "failed"
     assert fake_redis.deleted == ["buy:002123"]
+
+
+def test_broker_finalize_receives_same_resolved_order_as_submit(monkeypatch):
+    _install_broker_stubs(monkeypatch)
+    broker = _load_module("test_runtime_broker_finalize_resolved_order", BROKER_PATH)
+    original = {
+        "action": "buy",
+        "symbol": "002123",
+        "source": "strategy",
+        "price": 10.0,
+        "quantity": 5000,
+        "internal_order_id": "ord-broker-resolved-order-1",
+    }
+    resolved = {
+        **original,
+        "price": 10.08,
+        "broker_order_remark": "FQOM0123456789abcdef01",
+    }
+    observed = {}
+    broker.prepare_submit_execution = lambda order, **kwargs: {
+        "status": "execute",
+        "order_message": resolved,
+    }
+
+    def finalize(order, **kwargs):
+        observed["finalize_order"] = order
+        return {"status": "submitted", "broker_order_id": "123"}
+
+    broker.finalize_submit_execution = finalize
+
+    result = broker._handle_submit_action(
+        original,
+        action="buy",
+        submit_executor=lambda order: observed.setdefault("submit_order", order)
+        and 123,
+        broker_submit_mode="normal",
+    )
+
+    assert result["status"] == "submitted"
+    assert observed["submit_order"] is resolved
+    assert observed["finalize_order"] is resolved
 
 
 def test_broker_does_not_clear_buy_cooldown_when_finalize_raises_after_submit(
@@ -1034,6 +1251,59 @@ def test_broker_trading_loop_emits_success_heartbeat_after_connect(monkeypatch):
         "payload": {},
         "metrics": {"connected": 1, "retry_count": 0, "retry_delay_s": 0},
     }
+
+
+@pytest.mark.parametrize(("action", "remark_arg_index"), [("buy", 4), ("sell", 5)])
+def test_broker_gateway_passes_correlation_token_as_xt_order_remark(
+    monkeypatch,
+    action,
+    remark_arg_index,
+):
+    _install_broker_stubs(monkeypatch)
+    broker = _load_module(f"test_runtime_broker_{action}_remark", BROKER_PATH)
+    captured = {}
+    token = "FQOM0123456789abcdef0123"
+
+    def capture_submit(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return 90009
+
+    broker.puppet.buy = capture_submit
+    broker.puppet.sell = capture_submit
+    broker.connection_manager.connected = True
+    broker.resolve_broker_submit_mode = lambda settings_provider=None: "normal"
+    broker.random.shuffle = lambda _values: None
+    broker.tool_trade_date_seconds_to_start = lambda: 0
+    payload = {
+        "action": action,
+        "symbol": "688772",
+        "price": 14.7,
+        "quantity": 3400,
+        "source": "api",
+        "strategy_name": "takeprofit",
+        "remark": "human readable remark",
+        "broker_order_remark": token,
+        "internal_order_id": f"ord-{action}-remark",
+        "force": True,
+    }
+
+    class OneMessageRedis:
+        def __init__(self):
+            self.calls = 0
+
+        def brpop(self, _queues, _timeout):
+            self.calls += 1
+            if self.calls == 1:
+                return ("QUEUE:ORDER", json.dumps(payload))
+            raise KeyboardInterrupt()
+
+    broker.redis_db = OneMessageRedis()
+
+    broker.trading_main_loop()
+
+    assert captured["args"][remark_arg_index] == token
+    assert captured["args"][remark_arg_index] != payload["remark"]
 
 
 def test_broker_source_no_longer_contains_sync_maintenance_actions():

--- a/morningglory/fqxtrade/fqxtrade/xtquant/broker.py
+++ b/morningglory/fqxtrade/fqxtrade/xtquant/broker.py
@@ -334,7 +334,11 @@ def trading_main_loop():
                                     resolved_order["price"],
                                     resolved_order["quantity"],
                                     pydash.get(resolved_order, "strategy_name", "N/A"),
-                                    pydash.get(resolved_order, "remark", "N/A"),
+                                    pydash.get(
+                                        resolved_order,
+                                        "broker_order_remark",
+                                        pydash.get(resolved_order, "remark", "N/A"),
+                                    ),
                                     pydash.get(resolved_order, "retry_count", 0),
                                     order_type=pydash.get(
                                         resolved_order, "broker_order_type"
@@ -369,7 +373,11 @@ def trading_main_loop():
                                     resolved_order["price"],
                                     resolved_order["quantity"],
                                     pydash.get(resolved_order, "strategy_name", "N/A"),
-                                    pydash.get(resolved_order, "remark", "N/A"),
+                                    pydash.get(
+                                        resolved_order,
+                                        "broker_order_remark",
+                                        pydash.get(resolved_order, "remark", "N/A"),
+                                    ),
                                     pydash.get(resolved_order, "retry_count", 0),
                                     order_type=pydash.get(
                                         resolved_order, "broker_order_type"
@@ -482,14 +490,14 @@ def _handle_submit_action(order, *, action, submit_executor, broker_submit_mode)
             repository=order_management_repository,
             tracking_service=order_tracking_service,
         )
-        if execution.get("status") == "skipped":
+        if execution.get("status") in {"skipped", "missing_order"}:
             return execution
         resolved_order = execution.get("order_message", order)
 
         broker_order_id = submit_executor(resolved_order)
         logger.info(broker_order_id)
         finalize_result = finalize_submit_execution(
-            order,
+            resolved_order,
             broker_order_id=broker_order_id,
             repository=order_management_repository,
             tracking_service=order_tracking_service,

--- a/morningglory/fqxtrade/fqxtrade/xtquant/puppet.py
+++ b/morningglory/fqxtrade/fqxtrade/xtquant/puppet.py
@@ -1,9 +1,7 @@
-import json
 import time
 
 import pendulum
 import pydash
-from fqxtrade import ORDER_QUEUE
 from fqxtrade.database.mongodb import DBfreshquant
 from fqxtrade.database.redis import redis_db
 from fqxtrade.xtquant.fqtype import FqXtAsset, FqXtOrder, FqXtPosition, FqXtTrade
@@ -749,25 +747,6 @@ def buy(
                 ),
                 payload={"broker_order_id": fix_result_order_id},
             )
-            if fix_result_order_id < 0 and retryCount < 3:
-                # Exponential backoff delay: 2^retryCount seconds
-                delay = 2**retryCount
-                time.sleep(delay)
-                redis_db.lpush(
-                    ORDER_QUEUE,
-                    json.dumps(
-                        {
-                            "action": "buy",
-                            "symbol": symbol,
-                            "price": float(price),
-                            "quantity": quantity,
-                            "fire_time": pendulum.now().format("YYYY-MM-DD hh:mm:ss"),
-                            "strategy_name": strategyName,
-                            "remark": remark,
-                            "retry_count": retryCount + 1,
-                        }
-                    ),
-                )
             return fix_result_order_id
     except Exception as exc:
         _emit_puppet_event(
@@ -964,25 +943,6 @@ def sell(
                 ),
                 payload={"broker_order_id": fix_result_order_id},
             )
-            if fix_result_order_id < 0 and retryCount < 3:
-                # Exponential backoff delay: 2^retryCount seconds
-                delay = 2**retryCount
-                time.sleep(delay)
-                redis_db.lpush(
-                    ORDER_QUEUE,
-                    json.dumps(
-                        {
-                            "action": "sell",
-                            "symbol": symbol,
-                            "price": float(price),
-                            "quantity": quantity,
-                            "fire_time": pendulum.now().format("YYYY-MM-DD hh:mm:ss"),
-                            "strategy_name": strategyName,
-                            "remark": remark,
-                            "retry_count": retryCount + 1,
-                        }
-                    ),
-                )
             return fix_result_order_id
     except Exception as exc:
         _emit_puppet_event(


### PR DESCRIPTION
## ?????

FIX-504 ??? XT order/trade ???????????? canonical identity,?? Mongo ?? owner claim?broker-only promotion?broker-order key move ???????,??????????? owner ???????

## ????

- ???? 24 ?? `FQOM + 20 hex` correlation token,????? XT `order_remark` ????
- canonical broker order identity ??? `account_id + trading_day + order_sysid`,??? fallback `account_id + trading_day + symbol + side + broker_order_id`?
- execution identity ?? `account_id + trading_day + symbol + side + broker_trade_id` ???
- ?? stale same-owner claim ?????broker-only promotion ????? TOCTOU?move delete CAS ????????
- ?? reconcile ???????????????;????? fail closed?
- ?? XT ingest ? legacy `hasattr()` ??;?? `*_with_meta` ??????????
- XT ?? `None/0/????` ?? sleep?? Redis requeue???????????

## ????

- ?? `1.008`??? `0.992` ???????
- XT `order_stock()` ????????
- ????????????
- ????? Redis/projection lock?pending drain ? crash-recovery ???

## ???????

- `docs-current-guard`: OK
- pre-commit(Black / mypy / isort / ?? hooks): ??
- ????????????: `173 passed`
- ?? Mongo ?? P1 ????: `3 passed`
- ??????: `1856 passed, 3 skipped`,?? 2 ????????????(memory ?????TDX ????)
- ?? pre-push xdist ?? deploy-mirror / docs-check / memory ????????;? PR ??? GitHub Actions ??? CI gate?

## ????

???????????? `main` ???????? order-management / broker host surface,??? health/runtime ??;?????? `688772` ?????dry-run????????????