### PR TITLE
feat: add must-pool 5m guardian new opens

### DIFF
--- a/docs/current/architecture.md
+++ b/docs/current/architecture.md
@@ -1,5 +1,22 @@
 # 当前架构
 
+## Guardian 5 分钟首开与 1 分钟持仓路由
+
+- 正式 XTData consumer 模式为 `guardian_and_clx_15_30`；Guardian 复用同一个
+  `BarEventListener` 监听 `1min / 5min`，listener filter 使用 `sh600000 /
+  sz000001` 形式的 prefixed code，scope 与策略门禁使用 6 位 base code。
+- listener 范围为当前持仓与 enabled `must_pool` 的并集，每 30 秒刷新。1 分钟
+  事件只处理当前持仓，继续沿用既有买入、卖出与 `buy_zs_huila` 过滤语义。
+- 5 分钟事件只处理 enabled `must_pool` 中的当前非持仓标的，只接受
+  `buy_v_reverse / macd_bullish_divergence`，忽略 `buy_zs_huila` 和全部卖点；
+  入库前追加 `must_pool_5m_new_open` tag。
+- `StrategyGuardian.on_signal` 是最终交易资格门禁：带首开 tag 的买点只有在
+  `in_must_pool && !in_holding` 时进入 `_handle_new_open_buy`；普通买点只有当前
+  持仓才能进入 `_handle_holding_buy`；`SELL_SHORT` 仍只对当前持仓生效。
+- enabled `must_pool` base-code reader 的进程缓存 TTL 为 60 秒。信号顺序幂等、
+  下单冷却和活动买单门禁继续分别复用 `stock_signals` upsert、Redis cooldown
+  与 Order Management 活动单检查；CLX 15/30 分钟链保持独立。
+
 ## Guardian Grid 与三档止盈
 
 - Guardian 买入 Grid 使用三条 BUY 价格与三档累计仓位上限

--- a/docs/current/modules/strategy-guardian.md
+++ b/docs/current/modules/strategy-guardian.md
@@ -17,7 +17,7 @@ Guardian 当前会把“本次卖量实际由哪些 entry 贡献出来”一起�
 
 ## 依赖
 
-- XTData consumer 推送的 1 分钟 bar 更新
+- XTData consumer 推送的 1 分钟与 5 分钟 bar 更新
 - `must_pool`
 - `xt_positions`
 - Guardian buy grid 状态
@@ -29,7 +29,12 @@ Guardian 当前会把“本次卖量实际由哪些 entry 贡献出来”一起�
 
 `bar update -> calculate_guardian_signals_latest -> save_a_stock_signal -> stock_signals -> StrategyGuardian.on_signal -> buy/sell decision -> submit_guardian_order -> OrderSubmitService`
 
-当前正式 Guardian 事件链会在入口直接过滤 `buy_zs_huila`。该信号底层仍可被 `calculate_guardian_signals_latest` 计算，但不会继续写入 `stock_signals`、页面展示或 `guardian_strategy` runtime trace。
+当前正式 Guardian 事件链复用一个 `BarEventListener` 监听 `1min / 5min`，listener filter 使用 prefixed code，scope 判断与 `StrategyGuardian` 使用 base code。监听范围是当前持仓与 enabled `must_pool` 的并集，每 30 秒刷新。
+
+- 1 分钟只处理当前持仓，沿用既有 Guardian 买卖行为，不附加首开 tag。
+- 1 分钟入口继续过滤 `buy_zs_huila`。该信号底层仍可被 `calculate_guardian_signals_latest` 计算，但不会继续写入 `stock_signals`、页面展示或 `guardian_strategy` runtime trace。
+- 5 分钟只处理 enabled `must_pool` 中的当前非持仓标的，只接受 `buy_v_reverse` 与 `macd_bullish_divergence`；`buy_zs_huila` 和全部卖点直接忽略。
+- 5 分钟允许信号会在原 tags 后追加 `must_pool_5m_new_open`，再复用 `save_a_stock_signal -> StrategyGuardian.on_signal`。
 
 买入路径分为两类：
 
@@ -40,6 +45,8 @@ Guardian 当前会把“本次卖量实际由哪些 entry 贡献出来”一起�
 - 若当前 symbol 缺失 execution fill，`_handle_holding_buy` 会回退到最低 open Guardian slice 作为价格基准，并按该 slice 的 `grid_interval` 推导“下一档”价格作为买入阈值；Trace 会在 `decision_context.threshold.fill_reference_source / threshold_rule_source / grid_interval` 标明来源与规则
 - must_pool 新开仓
   - `_handle_new_open_buy`
+  - 只有带 `must_pool_5m_new_open` tag、仍在 enabled `must_pool` 且当前非持仓的买点才能进入该分支
+- `StrategyGuardian.on_signal` 的最终 scope gate 会跳过：带首开 tag 但已经持仓、带首开 tag 但已经移出/禁用 `must_pool`、以及未带首开 tag 的 must-pool-only 买点
 
 卖出路径：
 
@@ -54,6 +61,7 @@ Guardian 当前会把“本次卖量实际由哪些 entry 贡献出来”一起�
 Guardian 自身不维护订单账本，但依赖以下状态：
 
 - `must_pool`
+  - enabled base-code 查询使用 60 秒进程缓存 TTL
 - `xt_positions`
 - `stock_signals`
 - Guardian buy grid 集合
@@ -119,6 +127,13 @@ Guardian 会把关键判断路径写入 `guardian_strategy` runtime event，不�
 - `submit_intent`
 - `finish`
 
+首次开仓 scope 的关键 `decision_branch / reason_code` 为：
+
+- 允许首开：`decision_branch=must_pool_5m_new_open_buy`，reason 为空
+- 已经持仓：`must_pool_5m_new_open_already_holding`
+- 已移出或禁用池：`must_pool_5m_new_open_not_in_pool`
+- must-pool-only 买点缺少来源 tag：`must_pool_5m_new_open_tag_missing`
+
 `finish` 用于表达 Guardian 自身未继续提交策略单时的终止结论；成功进入下单链时，以 `submit_intent` 作为 Guardian 侧最终节点。
 
 如果 Guardian 在顶层 scope/timing 判断、buy/sell 具体分支或 `submit_intent` 后续执行中出现 unexpected exception，当前会直接在真实失败节点发 `status=error`、`reason_code=unexpected_exception` 的 runtime event，并保留 `payload.error_type/error_message`。不会再补一个兜底 `finish` 去掩盖异常出口节点。
@@ -142,7 +157,8 @@ python -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event
 
 ### BUY_LONG 信号没有下单
 
-- 检查目标 code 是否在 `must_pool` 或 `xt_positions`
+- 普通买点检查目标 code 是否在 `xt_positions`；must-pool-only 首开检查信号是否为 5 分钟允许类型并带 `must_pool_5m_new_open`
+- 检查目标 code 当前是否仍在 enabled `must_pool`，或是否已成为持仓；对应 scope skip reason 会写入 `guardian_strategy`
 - 检查 `buy:<code>` 冷却键
 - 检查 Position Management 是否拒绝
 - 检查 `guardian_buy_grid_states`
@@ -152,6 +168,7 @@ python -m freshquant.signal.astock.job.monitor_stock_zh_a_min --mode event
 
 ### 新开仓长期不生效
 
+- 检查 `queryMustPoolCodes` 60 秒 TTL 到期后的 enabled 池结果
 - 检查 `fq:xtrade:last_new_order_time` 是否还在冷却窗口
 - 检查 buy grid 计算出的 `quantity` 是否为 0
 

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -2,6 +2,18 @@
 
 ## Guardian / TPSL 交易运行规则
 
+- Guardian monitor 在正式 `monitor.xtdata.mode=guardian_and_clx_15_30` 下使用
+  一个 listener 监听 `1min / 5min`。listener 范围是当前持仓与 enabled
+  `must_pool` 的并集，每 30 秒刷新；`queryMustPoolCodes` 的进程缓存 TTL 为
+  60 秒。
+- 1 分钟只处理当前持仓并沿用既有 Guardian 买卖规则。5 分钟只处理
+  must-pool-only 标的，并且只把 `buy_v_reverse`、
+  `macd_bullish_divergence` 作为带 `must_pool_5m_new_open` tag 的首次开仓信号；
+  5 分钟 `buy_zs_huila` 与全部卖点不进入保存/策略链。
+- Guardian 最终 scope gate 会再次读取当前持仓与 enabled `must_pool`：首开 tag
+  遇到已持仓或已移出池时跳过，未带 tag 的 must-pool-only 买点也跳过；
+  普通持仓买点与持仓卖点继续走既有分支。CLX 15/30 分钟消费与落库行为不受
+  该 listener 路由影响。
 - Guardian 买入以 Position Management 的 `pm_symbol_position_snapshots.market_value`
   计算阶段剩余容量，容量真值不可读取时本次 Grid 买入退出。
 - Guardian 与最终提交门禁都优先读取持久化的单标的仓位快照；快照缺失时才

--- a/freshquant/pool/general.py
+++ b/freshquant/pool/general.py
@@ -10,7 +10,7 @@ from freshquant.util.code import (
 )
 
 
-@in_memory_cache.memoize(expiration=3600)
+@in_memory_cache.memoize(expiration=60)
 def queryMustPoolCodes(
     instrumentTypes: List[str] = ["stock_cn", "etf_cn"]
 ) -> List[str]:

--- a/freshquant/signal/astock/job/monitor_stock_zh_a_min.py
+++ b/freshquant/signal/astock/job/monitor_stock_zh_a_min.py
@@ -5,31 +5,41 @@ from time import sleep
 import click
 from loguru import logger
 
+from freshquant.data.astock.holding import get_stock_holding_codes
 from freshquant.market_data.xtdata.pools import (
-    load_guardian_monitor_codes,
     normalize_xtdata_mode,
     xtdata_mode_enables_guardian,
 )
+from freshquant.market_data.xtdata.schema import normalize_prefixed_code
+from freshquant.pool.general import queryMustPoolCodes
 from freshquant.runtime_constants import TZ
 from freshquant.signal.a_stock_common import save_a_stock_signal
 from freshquant.signal.astock.job.bar_event_listener import BarEventListener
 from freshquant.signal.astock.job.monitor_helpers_event import (
     calculate_guardian_signals_latest,
 )
-from freshquant.strategy.guardian import StrategyGuardian
+from freshquant.strategy.guardian import (
+    MUST_POOL_5M_NEW_OPEN_TAG,
+    StrategyGuardian,
+)
 from freshquant.system_settings import system_settings
 from freshquant.util.code import normalize_to_base_code
 from freshquant.util.period import to_backend_period, to_frontend_period
 
 strategy = StrategyGuardian()
 DISABLED_GUARDIAN_SIGNAL_TYPES = {"buy_zs_huila"}
+MUST_POOL_5M_NEW_OPEN_SIGNAL_TYPES = {
+    "buy_v_reverse",
+    "macd_bullish_divergence",
+}
 
 
 def monitor_stock_zh_a_min_event_driven() -> None:
     """
-    Mode A: Guardian-1m
+    Mode A: Guardian event monitor.
 
-    Subscribe `CHANNEL:BAR_UPDATE` and calculate Guardian signals on 1min updates.
+    Subscribe `CHANNEL:BAR_UPDATE` and calculate Guardian signals for current
+    holdings on 1-minute bars and enabled must-pool new opens on 5-minute bars.
     """
     xt_mode = normalize_xtdata_mode(system_settings.monitor.xtdata_mode)
     if not xtdata_mode_enables_guardian(xt_mode):
@@ -37,8 +47,6 @@ def monitor_stock_zh_a_min_event_driven() -> None:
             f"[Event] monitor.xtdata.mode={xt_mode}; guardian capability disabled. Exiting."
         )
         return
-
-    max_symbols = int(system_settings.monitor.xtdata_max_symbols or 50)
 
     signal_map = {
         "buy_zs_huila": "回拉中枢上涨",
@@ -57,20 +65,41 @@ def monitor_stock_zh_a_min_event_driven() -> None:
         "macd_bearish_divergence": "SELL_SHORT",
     }
 
-    filter_periods = {to_backend_period("1m")}
+    filter_periods = {
+        to_backend_period("1m"),
+        to_backend_period("5m"),
+    }
 
-    def _load_codes() -> set[str]:
-        codes = load_guardian_monitor_codes(max_symbols=max_symbols)
-        return {c.lower() for c in codes if c}
+    def _load_scope() -> dict[str, set[str]]:
+        holding_codes = {
+            normalize_to_base_code(code) for code in get_stock_holding_codes() if code
+        }
+        must_pool_codes = {
+            normalize_to_base_code(code) for code in queryMustPoolCodes() if code
+        }
+        return {
+            "holding_codes": {code for code in holding_codes if code.isdigit()},
+            "must_pool_codes": {code for code in must_pool_codes if code.isdigit()},
+        }
 
-    codes_lock = {"codes": _load_codes()}
+    def _load_codes(scope: dict[str, set[str]]) -> set[str]:
+        base_codes = (scope.get("holding_codes") or set()) | (
+            scope.get("must_pool_codes") or set()
+        )
+        return {normalize_prefixed_code(code).lower() for code in base_codes}
+
+    initial_scope = _load_scope()
+    codes_lock = {"codes": _load_codes(initial_scope)}
+    scope_lock = {"scope": initial_scope}
 
     def _refresh_codes_loop(listener: BarEventListener) -> None:
         while True:
             try:
                 sleep(30)
-                new_codes = _load_codes()
+                new_scope = _load_scope()
+                new_codes = _load_codes(new_scope)
                 old_codes = codes_lock.get("codes") or set()
+                scope_lock["scope"] = new_scope
                 if new_codes != old_codes:
                     codes_lock["codes"] = new_codes
                     listener.update_filter_codes(new_codes)
@@ -83,7 +112,7 @@ def monitor_stock_zh_a_min_event_driven() -> None:
     def on_bar_update(code: str, period_backend: str, data: dict) -> None:
         try:
             period_backend = to_backend_period(period_backend)
-            if period_backend != "1min":
+            if period_backend not in filter_periods:
                 return
 
             bar_ts = int(data.get("_bar_time") or 0)
@@ -96,13 +125,28 @@ def monitor_stock_zh_a_min_event_driven() -> None:
             if not base_code or not base_code.isdigit():
                 return
 
+            scope = scope_lock.get("scope") or {}
+            in_holding = base_code in (scope.get("holding_codes") or set())
+            in_must_pool = base_code in (scope.get("must_pool_codes") or set())
+            if period_backend == "1min" and not in_holding:
+                return
+            if period_backend == "5min" and (in_holding or not in_must_pool):
+                return
+
             signals = calculate_guardian_signals_latest(data=data, fire_time=fire_time)
             if not signals:
                 return
 
             for s in signals:
-                if s.signal_type in DISABLED_GUARDIAN_SIGNAL_TYPES:
-                    continue
+                tags = list(s.tags or [])
+                if period_backend == "1min":
+                    if s.signal_type in DISABLED_GUARDIAN_SIGNAL_TYPES:
+                        continue
+                else:
+                    if s.signal_type not in MUST_POOL_5M_NEW_OPEN_SIGNAL_TYPES:
+                        continue
+                    if MUST_POOL_5M_NEW_OPEN_TAG not in tags:
+                        tags.append(MUST_POOL_5M_NEW_OPEN_TAG)
                 save_a_stock_signal(
                     code,
                     base_code,
@@ -112,7 +156,7 @@ def monitor_stock_zh_a_min_event_driven() -> None:
                     s.price,
                     s.stop_lose_price,
                     position=signal_dir_map.get(s.signal_type, ""),
-                    tags=s.tags,
+                    tags=tags,
                     strategy=strategy,
                     zsdata=data.get("zsdata"),
                     fills=None,

--- a/freshquant/strategy/guardian.py
+++ b/freshquant/strategy/guardian.py
@@ -41,6 +41,7 @@ from freshquant.util.code import fq_util_code_append_market_code_suffix
 from freshquant.util.datetime_helper import fq_util_datetime_localize
 
 order_alert = signal("order_alert")
+MUST_POOL_5M_NEW_OPEN_TAG = "must_pool_5m_new_open"
 
 
 class StrategyGuardian(metaclass=SingletonType):
@@ -64,6 +65,7 @@ class StrategyGuardian(metaclass=SingletonType):
             period = signal["period"]
             remark = signal["remark"]
             tags = signal["tags"] or []
+            has_must_pool_5m_new_open_tag = MUST_POOL_5M_NEW_OPEN_TAG in tags
             zsdata = signal["zsdata"]
             fills = signal["fills"]
             action = self._resolve_action(position)
@@ -107,20 +109,37 @@ class StrategyGuardian(metaclass=SingletonType):
                     "position": position,
                     "in_holding": in_holding,
                     "in_must_pool": in_must_pool,
+                    "has_must_pool_5m_new_open_tag": (has_must_pool_5m_new_open_tag),
                 }
             }
+            scope_decision_expr = (
+                "(position == BUY_LONG and ((has_must_pool_5m_new_open_tag and "
+                "in_must_pool and not in_holding) or "
+                "(not has_must_pool_5m_new_open_tag and in_holding))) or "
+                "(position == SELL_SHORT and in_holding)"
+            )
             eligible = False
             scope_branch = "unsupported_position"
             scope_reason_code = "unsupported_position"
             if position == "BUY_LONG":
-                if in_holding:
+                if has_must_pool_5m_new_open_tag:
+                    if in_holding:
+                        scope_branch = "must_pool_5m_new_open_already_holding"
+                        scope_reason_code = "must_pool_5m_new_open_already_holding"
+                    elif not in_must_pool:
+                        scope_branch = "must_pool_5m_new_open_not_in_pool"
+                        scope_reason_code = "must_pool_5m_new_open_not_in_pool"
+                    else:
+                        eligible = True
+                        scope_branch = "must_pool_5m_new_open_buy"
+                        scope_reason_code = ""
+                elif in_holding:
                     eligible = True
                     scope_branch = "holding_buy"
                     scope_reason_code = ""
                 elif in_must_pool:
-                    eligible = True
-                    scope_branch = "new_open_buy"
-                    scope_reason_code = ""
+                    scope_branch = "must_pool_5m_new_open_tag_missing"
+                    scope_reason_code = "must_pool_5m_new_open_tag_missing"
                 else:
                     scope_branch = "buy_out_of_scope"
                     scope_reason_code = "buy_out_of_scope"
@@ -140,9 +159,7 @@ class StrategyGuardian(metaclass=SingletonType):
                 status="success" if eligible else "skipped",
                 reason_code=scope_reason_code,
                 decision_branch=scope_branch,
-                decision_expr=(
-                    "position == BUY_LONG ? (in_holding or in_must_pool) : in_holding"
-                ),
+                decision_expr=scope_decision_expr,
                 decision_context=scope_context,
                 decision_outcome={"outcome": "pass" if eligible else "skip"},
                 payload={"in_holding": in_holding, "in_must_pool": in_must_pool},
@@ -156,9 +173,7 @@ class StrategyGuardian(metaclass=SingletonType):
                     reason_code=scope_reason_code,
                     outcome="skip",
                     decision_branch=scope_branch,
-                    decision_expr=(
-                        "position == BUY_LONG ? (in_holding or in_must_pool) : in_holding"
-                    ),
+                    decision_expr=scope_decision_expr,
                     decision_context=scope_context,
                 )
             else:
@@ -213,7 +228,15 @@ class StrategyGuardian(metaclass=SingletonType):
                 )
 
                 if position == "BUY_LONG":
-                    if in_holding:
+                    if has_must_pool_5m_new_open_tag:
+                        self._handle_new_open_buy(
+                            signal=signal,
+                            code=code,
+                            name=name,
+                            price=price,
+                            remark=remark,
+                        )
+                    elif in_holding:
                         self._handle_holding_buy(
                             signal=signal,
                             code=code,
@@ -223,14 +246,6 @@ class StrategyGuardian(metaclass=SingletonType):
                             remark=remark,
                             zsdata=zsdata,
                             fills=fills,
-                        )
-                    elif in_must_pool:
-                        self._handle_new_open_buy(
-                            signal=signal,
-                            code=code,
-                            name=name,
-                            price=price,
-                            remark=remark,
                         )
                 elif position == "SELL_SHORT" and in_holding:
                     self._handle_sell(

--- a/freshquant/tests/test_a_stock_common.py
+++ b/freshquant/tests/test_a_stock_common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import sys
 import types
+from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 
@@ -75,10 +76,29 @@ class FakeStockPoolCollection:
         return SimpleNamespace(acknowledged=True)
 
 
+class FakeSignalCollection:
+    def __init__(self) -> None:
+        self.docs: list[dict] = []
+
+    def find_one_and_update(self, query: dict, update: dict, upsert: bool = False):
+        for doc in self.docs:
+            if all(doc.get(key) == value for key, value in query.items()):
+                previous = dict(doc)
+                doc.update(update.get("$set", {}))
+                return previous
+        if upsert:
+            self.docs.append({**query, **update.get("$set", {})})
+        return None
+
+
 class FakeDB:
     def __init__(self) -> None:
         self.stock_pre_pools = FakePrePoolCollection()
         self.stock_pools = FakeStockPoolCollection()
+        self.stock_signals = FakeSignalCollection()
+
+    def __getitem__(self, name: str):
+        return getattr(self, name)
 
 
 def _import_a_stock_common_with_stubs(monkeypatch, fake_db: FakeDB):
@@ -137,6 +157,32 @@ def test_save_a_stock_pre_pools_writes_top_level_remark(monkeypatch):
         2026, 3, 17, tz=pendulum.now().timezone
     )
     assert saved["expire_at"].date() == pendulum.now().add(days=89).date()
+
+
+def test_save_a_stock_signal_reuses_upsert_for_duplicate_bar(monkeypatch):
+    fake_db = FakeDB()
+    a_stock_common = _import_a_stock_common_with_stubs(monkeypatch, fake_db)
+    calls = []
+    strategy = SimpleNamespace(on_signal=lambda signal: calls.append(signal))
+    fire_time = datetime.now()
+
+    for _ in range(2):
+        a_stock_common.save_a_stock_signal(
+            "sz000001",
+            "000001",
+            "5m",
+            "V反上涨",
+            fire_time,
+            10.0,
+            9.0,
+            "BUY_LONG",
+            tags=["must_pool_5m_new_open"],
+            strategy=strategy,
+        )
+
+    assert len(fake_db.stock_signals.docs) == 1
+    assert len(calls) == 1
+    assert calls[0]["tags"] == ["must_pool_5m_new_open"]
 
 
 def test_save_a_stock_pre_pools_keeps_rows_isolated_by_remark(monkeypatch):

--- a/freshquant/tests/test_guardian_monitor_cli.py
+++ b/freshquant/tests/test_guardian_monitor_cli.py
@@ -1,3 +1,6 @@
+import importlib.util
+import sys
+import types
 from pathlib import Path
 
 
@@ -26,3 +29,73 @@ def test_guardian_monitor_disables_buy_zs_huila_signal():
 
     assert 'DISABLED_GUARDIAN_SIGNAL_TYPES = {"buy_zs_huila"}' in content
     assert "if s.signal_type in DISABLED_GUARDIAN_SIGNAL_TYPES:" in content
+
+
+def test_query_must_pool_codes_cache_expires_after_one_minute(monkeypatch):
+    records = [
+        {
+            "code": "000001",
+            "instrument_type": "stock_cn",
+            "disabled": False,
+        }
+    ]
+    find_calls = []
+
+    class FakeMemoizer:
+        def __init__(self):
+            self.now = 0
+
+        def memoize(self, expiration):
+            def decorator(func):
+                cache = {}
+
+                def wrapper(*args, **kwargs):
+                    key = repr((args, sorted(kwargs.items())))
+                    item = cache.get(key)
+                    if item is None or self.now >= item[0]:
+                        value = func(*args, **kwargs)
+                        cache[key] = (self.now + expiration, value)
+                        return value
+                    return item[1]
+
+                wrapper._test_expiration = expiration
+                return wrapper
+
+            return decorator
+
+    class FakeCollection:
+        def find(self, query):
+            find_calls.append(query)
+            return [dict(item) for item in records if not item.get("disabled")]
+
+    class FakeDb:
+        def __getitem__(self, _name):
+            return FakeCollection()
+
+    memoizer = FakeMemoizer()
+    cache_stub = types.ModuleType("freshquant.database.cache")
+    cache_stub.in_memory_cache = memoizer
+    db_stub = types.ModuleType("freshquant.db")
+    db_stub.DBfreshquant = FakeDb()
+    code_stub = types.ModuleType("freshquant.util.code")
+    code_stub.fq_util_code_append_market_code = lambda code: code
+    code_stub.fq_util_code_append_market_code_suffix = lambda code: code
+    monkeypatch.setitem(sys.modules, "freshquant.database.cache", cache_stub)
+    monkeypatch.setitem(sys.modules, "freshquant.db", db_stub)
+    monkeypatch.setitem(sys.modules, "freshquant.util.code", code_stub)
+
+    module_path = Path("freshquant/pool/general.py").resolve()
+    spec = importlib.util.spec_from_file_location("test_pool_general_ttl", module_path)
+    assert spec is not None and spec.loader is not None
+    pool_general = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(pool_general)
+
+    assert pool_general.queryMustPoolCodes() == ["000001"]
+    records[0]["disabled"] = True
+    memoizer.now = 59
+    assert pool_general.queryMustPoolCodes() == ["000001"]
+    memoizer.now = 60
+    assert pool_general.queryMustPoolCodes() == []
+
+    assert len(find_calls) == 2
+    assert pool_general.queryMustPoolCodes._test_expiration == 60

--- a/freshquant/tests/test_guardian_monitor_event_routing.py
+++ b/freshquant/tests/test_guardian_monitor_event_routing.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pendulum
+
+from freshquant.signal.astock.job.monitor_helpers_event import GuardianSignal
+
+
+def _signal(signal_type: str, *, tags: list[str] | None = None) -> GuardianSignal:
+    return GuardianSignal(
+        signal_type=signal_type,
+        fire_time=pendulum.now(),
+        price=10.0,
+        stop_lose_price=9.0,
+        tags=list(tags or []),
+    )
+
+
+def test_guardian_monitor_routes_holding_1m_and_must_pool_new_open_5m(monkeypatch):
+    import freshquant.signal.astock.job.monitor_stock_zh_a_min as monitor
+
+    saved: list[dict] = []
+    listeners = []
+    bar_time = pendulum.now().int_timestamp
+    tag = "must_pool_5m_new_open"
+
+    updates = [
+        (
+            "sz000001",
+            "1min",
+            {
+                "_bar_time": bar_time,
+                "_signals": [
+                    _signal("buy_v_reverse", tags=["existing"]),
+                    _signal("sell_v_reverse"),
+                    _signal("buy_zs_huila"),
+                ],
+            },
+        ),
+        (
+            "sh600000",
+            "1min",
+            {"_bar_time": bar_time, "_signals": [_signal("buy_v_reverse")]},
+        ),
+        (
+            "sh600000",
+            "5min",
+            {
+                "_bar_time": bar_time,
+                "_signals": [
+                    _signal("buy_v_reverse", tags=["existing"]),
+                    _signal("macd_bullish_divergence", tags=[tag]),
+                    _signal("buy_zs_huila"),
+                    _signal("sell_v_reverse"),
+                ],
+            },
+        ),
+        (
+            "sz000001",
+            "5min",
+            {"_bar_time": bar_time, "_signals": [_signal("buy_v_reverse")]},
+        ),
+        (
+            "sz000002",
+            "5min",
+            {"_bar_time": bar_time, "_signals": [_signal("buy_v_reverse")]},
+        ),
+    ]
+
+    class FakeListener:
+        def __init__(self, callback, **kwargs):
+            self.callback = callback
+            self.filter_codes = kwargs["filter_codes"]
+            self.filter_periods = kwargs["filter_periods"]
+            self.stopped = False
+            listeners.append(self)
+
+        def start(self):
+            for code, period, data in updates:
+                self.callback(code, period, data)
+
+        def update_filter_codes(self, _codes):
+            raise AssertionError("refresh thread should not run in this unit test")
+
+        def get_stats(self):
+            raise KeyboardInterrupt
+
+        def stop(self):
+            self.stopped = True
+
+    class FakeThread:
+        def __init__(self, **_kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    def fake_save(*args, **kwargs):
+        saved.append(
+            {
+                "symbol": args[0],
+                "code": args[1],
+                "period": args[2],
+                "remark": args[3],
+                "position": kwargs["position"],
+                "tags": kwargs["tags"],
+            }
+        )
+
+    monkeypatch.setattr(
+        monitor,
+        "system_settings",
+        SimpleNamespace(
+            monitor=SimpleNamespace(
+                xtdata_mode="guardian_and_clx_15_30",
+                xtdata_max_symbols=1,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        monitor, "get_stock_holding_codes", lambda: ["000001"], raising=False
+    )
+    monkeypatch.setattr(
+        monitor, "queryMustPoolCodes", lambda: ["600000"], raising=False
+    )
+    monkeypatch.setattr(
+        monitor,
+        "calculate_guardian_signals_latest",
+        lambda *, data, fire_time: data["_signals"],
+    )
+    monkeypatch.setattr(monitor, "save_a_stock_signal", fake_save)
+    monkeypatch.setattr(monitor, "BarEventListener", FakeListener)
+    monkeypatch.setattr(monitor, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(threading, "Thread", FakeThread)
+
+    monitor.monitor_stock_zh_a_min_event_driven()
+
+    assert len(listeners) == 1
+    assert listeners[0].filter_codes == {"sz000001", "sh600000"}
+    assert listeners[0].filter_periods == {"1min", "5min"}
+    assert listeners[0].stopped is True
+    assert saved == [
+        {
+            "symbol": "sz000001",
+            "code": "000001",
+            "period": "1m",
+            "remark": "V反上涨",
+            "position": "BUY_LONG",
+            "tags": ["existing"],
+        },
+        {
+            "symbol": "sz000001",
+            "code": "000001",
+            "period": "1m",
+            "remark": "V反下跌",
+            "position": "SELL_SHORT",
+            "tags": [],
+        },
+        {
+            "symbol": "sh600000",
+            "code": "600000",
+            "period": "5m",
+            "remark": "V反上涨",
+            "position": "BUY_LONG",
+            "tags": ["existing", tag],
+        },
+        {
+            "symbol": "sh600000",
+            "code": "600000",
+            "period": "5m",
+            "remark": "看涨背驰",
+            "position": "BUY_LONG",
+            "tags": [tag],
+        },
+    ]

--- a/freshquant/tests/test_guardian_runtime_observability.py
+++ b/freshquant/tests/test_guardian_runtime_observability.py
@@ -535,6 +535,7 @@ def test_guardian_new_open_buy_cooldown_emits_structured_skip_finish(monkeypatch
     guardian = StrategyGuardian()
     guardian.runtime_logger = runtime_logger
     signal = _make_signal()
+    signal["tags"] = [guardian_module.MUST_POOL_5M_NEW_OPEN_TAG]
 
     fake_redis = FakeRedis()
     fake_redis.data["fq:xtrade:last_new_order_time"] = "2026-03-09 10:00:00"
@@ -567,6 +568,11 @@ def test_guardian_new_open_buy_cooldown_emits_structured_skip_finish(monkeypatch
 
     guardian.on_signal(signal)
 
+    scope_event = next(
+        event
+        for event in runtime_logger.events
+        if event["node"] == "holding_scope_resolve"
+    )
     cooldown_event = next(
         event for event in runtime_logger.events if event["node"] == "cooldown_check"
     )
@@ -574,6 +580,11 @@ def test_guardian_new_open_buy_cooldown_emits_structured_skip_finish(monkeypatch
         event for event in runtime_logger.events if event["node"] == "finish"
     )
 
+    assert scope_event["decision_branch"] == "must_pool_5m_new_open_buy"
+    assert (
+        scope_event["decision_context"]["scope"]["has_must_pool_5m_new_open_tag"]
+        is True
+    )
     assert cooldown_event["signal_summary"]["code"] == signal["code"]
     assert (
         cooldown_event["decision_context"]["cooldown"]["key"]
@@ -586,6 +597,134 @@ def test_guardian_new_open_buy_cooldown_emits_structured_skip_finish(monkeypatch
     assert finish_event["decision_outcome"]["outcome"] == "skip"
     assert finish_event["reason_code"] == "new_open_cooldown_active"
     assert finish_event["status"] == "skipped"
+
+
+@pytest.mark.parametrize(
+    ("tags", "holding_codes", "must_pool_codes", "branch", "reason_code"),
+    [
+        (
+            ["must_pool_5m_new_open"],
+            ["000001"],
+            ["000001"],
+            "must_pool_5m_new_open_already_holding",
+            "must_pool_5m_new_open_already_holding",
+        ),
+        (
+            ["must_pool_5m_new_open"],
+            [],
+            [],
+            "must_pool_5m_new_open_not_in_pool",
+            "must_pool_5m_new_open_not_in_pool",
+        ),
+        (
+            [],
+            [],
+            ["000001"],
+            "must_pool_5m_new_open_tag_missing",
+            "must_pool_5m_new_open_tag_missing",
+        ),
+    ],
+)
+def test_guardian_buy_scope_gate_rejects_ineligible_new_open_sources(
+    monkeypatch,
+    tags,
+    holding_codes,
+    must_pool_codes,
+    branch,
+    reason_code,
+):
+    runtime_logger = FakeRuntimeLogger()
+    guardian = StrategyGuardian()
+    guardian.runtime_logger = runtime_logger
+    signal = _make_signal()
+    signal["period"] = "5m" if tags else "1m"
+    signal["tags"] = tags
+    handler_calls = []
+
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.get_stock_holding_codes",
+        lambda: holding_codes,
+    )
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.queryMustPoolCodes",
+        lambda: must_pool_codes,
+    )
+    monkeypatch.setattr(
+        guardian,
+        "_handle_holding_buy",
+        lambda **_kwargs: handler_calls.append("holding_buy"),
+    )
+    monkeypatch.setattr(
+        guardian,
+        "_handle_new_open_buy",
+        lambda **_kwargs: handler_calls.append("new_open_buy"),
+    )
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.order_alert",
+        types.SimpleNamespace(send=lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.logger",
+        types.SimpleNamespace(info=lambda *args, **kwargs: None),
+    )
+
+    guardian.on_signal(signal)
+
+    scope_event = next(
+        event
+        for event in runtime_logger.events
+        if event["node"] == "holding_scope_resolve"
+    )
+    finish_event = next(
+        event for event in runtime_logger.events if event["node"] == "finish"
+    )
+    assert handler_calls == []
+    assert scope_event["status"] == "skipped"
+    assert scope_event["decision_branch"] == branch
+    assert scope_event["reason_code"] == reason_code
+    assert finish_event["decision_branch"] == branch
+    assert finish_event["reason_code"] == reason_code
+    assert not any(event["node"] == "timing_check" for event in runtime_logger.events)
+
+
+def test_guardian_stale_must_pool_5m_signal_stops_at_freshness_gate(monkeypatch):
+    runtime_logger = FakeRuntimeLogger()
+    guardian = StrategyGuardian()
+    guardian.runtime_logger = runtime_logger
+    signal = _make_signal()
+    signal["period"] = "5m"
+    signal["fire_time"] = pendulum.now().subtract(minutes=31)
+    signal["tags"] = [guardian_module.MUST_POOL_5M_NEW_OPEN_TAG]
+    handler_calls = []
+
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.get_stock_holding_codes", lambda: []
+    )
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.queryMustPoolCodes", lambda: ["000001"]
+    )
+    monkeypatch.setattr(
+        guardian,
+        "_handle_new_open_buy",
+        lambda **_kwargs: handler_calls.append("new_open_buy"),
+    )
+    monkeypatch.setattr(
+        "freshquant.strategy.guardian.logger",
+        types.SimpleNamespace(info=lambda *args, **kwargs: None),
+    )
+
+    guardian.on_signal(signal)
+
+    timing_event = next(
+        event for event in runtime_logger.events if event["node"] == "timing_check"
+    )
+    finish_event = next(
+        event for event in runtime_logger.events if event["node"] == "finish"
+    )
+    assert handler_calls == []
+    assert timing_event["status"] == "skipped"
+    assert timing_event["reason_code"] == "signal_too_old"
+    assert finish_event["reason_code"] == "signal_too_old"
 
 
 def test_guardian_scope_exception_emits_error_at_scope_node(monkeypatch):
@@ -694,6 +833,7 @@ def test_guardian_new_open_buy_unexpected_exception_emits_error_at_quantity_chec
     guardian = StrategyGuardian()
     guardian.runtime_logger = runtime_logger
     signal = _make_signal()
+    signal["tags"] = [guardian_module.MUST_POOL_5M_NEW_OPEN_TAG]
 
     monkeypatch.setattr(
         "freshquant.strategy.guardian.get_guardian_buy_grid_service",

--- a/freshquant/tests/test_guardian_strategy.py
+++ b/freshquant/tests/test_guardian_strategy.py
@@ -830,6 +830,7 @@ def test_new_open_for_must_pool_uses_new_open_decision_without_auto_open_gate(
         }
     )
     signal = _make_signal(price=10.0)
+    signal["tags"] = [guardian_module.MUST_POOL_5M_NEW_OPEN_TAG]
 
     monkeypatch.setattr(
         "freshquant.strategy.guardian.get_guardian_buy_grid_service",


### PR DESCRIPTION
## 背景

人工维护的 enabled `must_pool` 需要在尚未持仓时通过 Guardian 5 分钟买点完成首次开仓；成为持仓后继续由既有 1 分钟 Guardian 管理买卖。

## 目标

- 复用现有 `fqnext_guardian_event + BarEventListener`，在不改 producer/consumer 与 CLX 15/30 链的前提下补齐 must_pool 5 分钟首次开仓。
- 在 `StrategyGuardian.on_signal` 增加最终来源与 scope 门禁，封闭 5 分钟加仓、1 分钟误首开和移出池后的误开仓。

## 范围

- 单 listener 监听 `1min / 5min`；filter 使用 prefixed code，scope 使用 base code。
- 1 分钟仅处理当前持仓，保留既有 Guardian 买卖与 `buy_zs_huila` 过滤行为。
- 5 分钟仅处理 enabled must_pool 且当前非持仓，只接受 `buy_v_reverse`、`macd_bullish_divergence`，追加 `must_pool_5m_new_open`。
- Guardian 最终门禁：
  - tagged + `in_must_pool && !in_holding` -> new open
  - tagged + holding / not in pool -> skip
  - untagged + holding -> existing holding buy
  - untagged + must-pool-only -> skip
  - SELL 仍只对持仓生效
- `queryMustPoolCodes` in-memory TTL 从 3600 秒调整为 60 秒。
- 同步 Guardian 架构、运行与模块文档，并补齐路由、门禁、TTL、upsert、freshness 测试。

## 非目标

- 不改 XTData producer/consumer。
- 不改 CLX 15/30 分钟模型与落库。
- 不新增 supervisor program、配置开关、独立 listener、Redis lock 或新幂等机制。
- 不改变现有下单冷却、活动单门禁和 Position Management gate。

## 验收

- 两种允许的 5 分钟买点可进入首次开仓链。
- must-pool-only 的 1 分钟买点、5 分钟 `buy_zs_huila`、5 分钟卖点均被过滤。
- tagged 已持仓、tagged 已离池、untagged must-pool-only 均有明确 `decision_branch/reason_code` 并跳过。
- 普通持仓买卖、30 分钟 freshness、同 bar upsert、冷却/活动单行为保持。
- combined mode 的 CLX 15/30 行为测试保持通过。

## 验证

- `script/ci/check_current_docs.py`: passed
- pre-commit 全 hooks: passed
- 定向 Guardian/XTData 回归: `85 passed`
- 正式本地预检：`1871 passed, 4 skipped`
  - 使用临时 bootstrap 指向本机隔离空库，避免正式 `stock_realtime` 数据污染两个既有 Order Reconcile 单测；`origin/main` 在正式库连接下复现同签名。

## 部署影响

- 代码部署解析：仅 `guardian` surface，宿主机 program 为 `fqnext_guardian_event`。
- 当前运行配置只读核验为 `monitor.xtdata.mode=clx_15_30_only`，与正式冻结值冲突。合并后通过既有 System Settings 入口收敛为 `guardian_and_clx_15_30`，并重启 `market_data + guardian` 使 producer、consumer 与 Guardian 重新读取配置。
- 部署后执行 Guardian/market-data 健康与 runtime ops verify；不自动添加任何 must_pool 标的。