### PR TITLE
feat: import TDX 待买 group into must_pool

### DIFF
--- a/docs/current/interfaces.md
+++ b/docs/current/interfaces.md
@@ -64,11 +64,12 @@ python -m freshquant.rear.api_server --port 5000
 - `/api/stock_data`
 - `/api/stock_data_v2`
 - `/api/stock_data_chanlun_structure`
-- `/api/guardian_buy_grid_state`
-- `/api/get_stock_pools_list`
+  - `/api/guardian_buy_grid_state`
+  - `/api/get_stock_pools_list`
 - `POST /api/sync_stock_pools_from_tdx_self_select`
-- `/api/get_stock_pre_pools_list`
-- `/api/get_stock_must_pools_list`
+  - `POST /api/sync_must_pool_from_tdx_self_select`
+  - `/api/get_stock_pre_pools_list`
+  - `/api/get_stock_must_pools_list`
 - `/api/add_to_stock_pools_by_code`
 - `/api/add_to_must_pool_by_code`
 
@@ -178,6 +179,12 @@ python -m freshquant.rear.api_server --port 5000
   - 不在当前 TDX 标的池中的旧 `stock_pools` 记录会被删除；当前 TDX 标的按 `tdx_self_select` 来源 upsert
   - 查询参数 `days` 控制新增记录有效期，默认 `30`
   - 返回 `synced_count / removed_count / skipped_holding_count / skipped_invalid_count` 及对应代码列表；兼容保留 `appended_count / skipped_existing_count` 字段；只写 `stock_pools`，不写 `must_pool`，不触发交易动作
+- `POST /api/sync_must_pool_from_tdx_self_select`
+  - 复用与 `sync_stock_pools_from_tdx_self_select` 相同的 TDX `.blk` 读取/解码链路，从当前 TDX home 的 `T0002/blocknew/待买.blk` 读取「待买」自选股分组，解码为 6 位标的代码，排除当前 `xt_positions` 持仓后导入 `freshquant.must_pool`
+  - 导入为增量合并：已存在于 `must_pool` 的记录保留其 `stop_loss_price / initial_lot_amount / lot_amount` 交易参数，仅合并 `tdx_must_pool` 来源的 provenance；不在「待买」分组中的既有 `must_pool` 记录不会被删除
+  - 新增记录 `stop_loss_price` 保持未配置（`None`），`lot_amount / initial_lot_amount` 走 `get_trade_amount` 默认值
+  - 查询参数 `days` 控制 membership 有效期，默认 `30`
+  - 返回 `synced_count / appended_count / skipped_holding_count / skipped_invalid_count` 及对应代码列表；只写 `must_pool`，不写 `stock_pools`，不触发交易动作
 - `/api/stock_fills`
   - 仍保留旧名称
   - 底层优先读 `entry ledger`

--- a/docs/current/modules/kline-webui.md
+++ b/docs/current/modules/kline-webui.md
@@ -48,7 +48,7 @@
 ## 当前页面结构
 
 - 三栏统一布局
-  - 左栏：持仓、`stock_pools`、`must_pool`、预选池和 CLX 批次/scope、完整筛选条件、cursor 结果列表；分组标题点击即展开/收起，不再额外展示“展开/收起”文字；`stock_pools` 分组提供 `同步自选股` 按钮，可从当前 TDX home 的 `T0002/blocknew/ZXG.blk` 去重追加到 `freshquant.stock_pools`，并在左栏展示时与持仓股去重
+  - 左栏：持仓、`stock_pools`、`must_pool`、预选池和 CLX 批次/scope、完整筛选条件、cursor 结果列表；分组标题点击即展开/收起，不再额外展示“展开/收起”文字；`stock_pools` 分组提供 `同步自选股` 按钮，可从当前 TDX home 的 `T0002/blocknew/ZXG.blk` 去重追加到 `freshquant.stock_pools`，`must_pool` 分组提供 `同步待买` 按钮，可从 `T0002/blocknew/待买.blk` 导入到 `freshquant.must_pool`，并在左栏展示时与持仓股去重
   - 中栏：当前标的主图与多周期结构
   - 右栏：CLX 信号显示控制、时间轴和证据详情
 - 标的设置浮层
@@ -97,6 +97,9 @@
 - `stock_pools` 左栏
   - 列表来自 `/api/get_stock_pools_list`，前端会按 6 位代码过滤掉已在“持仓股”分组展示的标的；点击任一标的后使用同一 K 线加载链路，因此 `15min / 30min` 兼容别名与实时缓存 QFQ 未就绪回退对所有左侧列表标的生效
   - `同步自选股` 调用 `POST /api/sync_stock_pools_from_tdx_self_select?days=30`，以后端读取的 TDX `ZXG.blk` 有效标的减去当前持仓作为唯一集合，覆盖 `stock_pools`；旧集合外记录会删除，同步完成后刷新列表并提示同步、移除旧标的和持仓去重数量
+- `must_pool` 左栏
+  - 列表来自 `/api/get_stock_must_pools_list`，点击任一标的后使用同一 K 线加载链路
+  - `同步待买` 调用 `POST /api/sync_must_pool_from_tdx_self_select?days=30`，以后端读取的 TDX `待买.blk` 有效标的减去当前持仓作为增量导入 `must_pool`；已存在记录保留交易参数并合并 `tdx_must_pool` provenance，分组外既有记录不删除，同步完成后刷新列表并提示导入、持仓去重和忽略无效数量
 - `CLX 信号工作台`
   - 按当前 symbol、asset type、日线 endDate（缺省时由服务端解析最新交易日）、barCount、模型/条件请求 `/api/clx-daily-selection/history/signals`
   - 只在 `profile=production_v1`、`switch_opt=1` 且 `future_function_guard.passed=true` 时把 marker 交给 chart renderer

--- a/docs/current/reference/stock-pools-and-positions.md
+++ b/docs/current/reference/stock-pools-and-positions.md
@@ -99,6 +99,12 @@
   - 后端读取当前 TDX home 下的 `T0002/blocknew/ZXG.blk`，解码通达信前缀代码，排除当前 `xt_positions` 持仓后，以该集合覆盖 `stock_pools`
   - 不在当前 TDX 标的池中的旧 `stock_pools` 记录会被删除；当前 TDX 标的会按 `tdx_self_select` 来源更新，默认有效期 30 天
   - 同步只写 `stock_pools`，不写 `must_pool`，不触发下单；左侧 `stock_pools` 分组仍会过滤已在“持仓股”分组出现的标的
+- KlineSlim 从通达信「待买」分组导入 `must_pool`
+  - `/kline-slim` 左侧 `must_pool` 分组的 `同步待买` 按钮调用 `POST /api/sync_must_pool_from_tdx_self_select?days=30`
+  - 后端读取当前 TDX home 下的 `T0002/blocknew/待买.blk`，解码通达信前缀代码，排除当前 `xt_positions` 持仓后，增量导入 `must_pool`
+  - 导入为增量合并：已存在 `must_pool` 记录保留 `stop_loss_price / initial_lot_amount / lot_amount` 交易参数，仅合并 `tdx_must_pool` 来源 provenance；不在「待买」分组中的既有 `must_pool` 记录不会被删除
+  - 新增记录 `stop_loss_price` 保持未配置（`None`），`lot_amount / initial_lot_amount` 走 `get_trade_amount` 默认值；`forever` 固定为 `true`
+  - 导入只写 `must_pool`，不写 `stock_pools`，不触发下单
 - 代码加入 `must_pool`
   - `/api/add_to_must_pool_by_code`
   - 当前显式加入后统一固定写 `forever=true`

--- a/freshquant/data/astock/must_pool.py
+++ b/freshquant/data/astock/must_pool.py
@@ -270,7 +270,7 @@ def remove(id=None, category=None, codes=None):
 def import_pool(
     code: str,
     category: str,
-    stop_loss_price: float,
+    stop_loss_price: float | None = None,
     initial_lot_amount: float = None,
     lot_amount: float = None,
     forever: bool = True,
@@ -282,7 +282,7 @@ def import_pool(
         code: 股票代码
         lot_amount: 每次买入金额
         category: 分类名称
-        stop_loss_price: 止损价格
+        stop_loss_price: 止损价格（可为 None，表示尚未配置）
         initial_lot_amount: 首次买入金额 (可选，默认等于lot_amount)
     """
 
@@ -292,8 +292,8 @@ def import_pool(
         lot_amount = get_trade_amount(code)
     if initial_lot_amount is None:
         initial_lot_amount = lot_amount
-    if not code or stop_loss_price is None:
-        raise ValueError("code, stop_loss_price 参数必须提供")
+    if not code:
+        raise ValueError("code 参数必须提供")
 
     # 检查是否已存在相同code和category的记录
     existing = DBfreshquant.must_pool.find_one({"code": code})

--- a/freshquant/rear/stock/routes.py
+++ b/freshquant/rear/stock/routes.py
@@ -442,6 +442,29 @@ def sync_stock_pools_from_tdx_self_select():
     return jsonify({"code": "0", "msg": "操作成功", "data": result})
 
 
+@stock_bp.route("/sync_must_pool_from_tdx_self_select", methods=["POST"])
+def sync_must_pool_from_tdx_self_select():
+    try:
+        days = int(request.args.get("days", "30"))
+        result = _get_stock_service().sync_must_pool_from_tdx_self_select(days=days)
+    except Exception as exc:
+        logging.error(
+            "sync must_pool from TDX 待买 group failed: %s\n%s",
+            exc,
+            traceback.format_exc(),
+        )
+        return (
+            jsonify(
+                {
+                    "code": "1",
+                    "msg": f"同步待买分组失败: {exc}",
+                }
+            ),
+            500,
+        )
+    return jsonify({"code": "0", "msg": "操作成功", "data": result})
+
+
 # 计算股票网格交易计划
 @stock_bp.route("/plan_grid_trade")
 def plan_grid_trade():

--- a/freshquant/stock_service.py
+++ b/freshquant/stock_service.py
@@ -39,6 +39,9 @@ TDX_SELF_SELECT_SUPPORTED_INSTRUMENT_TYPES = {
     InstrumentType.STOCK_CN,
     InstrumentType.ETF_CN,
 }
+TDX_MUST_POOL_FILENAME = "待买.blk"
+TDX_MUST_POOL_CATEGORY = "待买"
+TDX_MUST_POOL_SOURCE = "tdx_must_pool"
 
 
 def _normalize_stock_code6(value):
@@ -256,6 +259,89 @@ def sync_stock_pools_from_tdx_self_select(
         "removed_codes": removed_codes,
         "skipped_holding_codes": skipped_holding_codes,
         "skipped_existing_codes": [],
+        "skipped_invalid_codes": skipped_invalid_codes,
+    }
+
+
+def sync_must_pool_from_tdx_self_select(
+    days=30,
+    *,
+    tdx_home=None,
+    filename=TDX_MUST_POOL_FILENAME,
+    category=TDX_MUST_POOL_CATEGORY,
+    source=TDX_MUST_POOL_SOURCE,
+):
+    """Import freshquant.must_pool from the TDX ``待买`` self-select group.
+
+    Reuses the same TDX ``.blk`` reading/decoding chain as
+    ``sync_stock_pools_from_tdx_self_select``: it reads the group file
+    (default ``T0002/blocknew/待买.blk``), decodes prefixed codes, skips
+    current ``xt_positions`` holdings, and upserts every valid code into
+    ``must_pool`` with a ``tdx_must_pool`` membership.
+
+    Unlike the stock_pools overwrite sync, this is an additive import:
+    existing ``must_pool`` records keep their trading parameters
+    (``stop_loss_price`` / ``initial_lot_amount`` / ``lot_amount``) and are
+    never deleted when they are absent from the TDX group.
+    """
+    codes = read_tdx_self_select_codes(tdx_home=tdx_home, filename=filename)
+    now = pendulum.now()
+    expire_at = now.add(days=int(days or 30))
+    synced_codes = []
+    skipped_holding_codes = []
+    skipped_invalid_codes = []
+    holding_codes = get_current_stock_holding_codes()
+
+    for code in codes:
+        if not _is_supported_tdx_stock_pool_code(code):
+            skipped_invalid_codes.append(code)
+            continue
+        if code in holding_codes:
+            skipped_holding_codes.append(code)
+            continue
+
+        existing = DBfreshquant["must_pool"].find_one({"code": code}) or {}
+        provenance = {
+            "sources": [source],
+            "categories": [category],
+            "memberships": [
+                {
+                    "source": source,
+                    "category": category,
+                    "added_at": now,
+                    "expire_at": expire_at,
+                    "extra": {
+                        "entrypoint": "tdx_must_pool",
+                        "file_name": filename,
+                    },
+                }
+            ],
+        }
+        must_pool.import_pool(
+            code=code,
+            category=category,
+            stop_loss_price=existing.get("stop_loss_price"),
+            initial_lot_amount=existing.get("initial_lot_amount"),
+            lot_amount=existing.get("lot_amount"),
+            forever=True,
+            provenance=provenance,
+        )
+        synced_codes.append(code)
+
+    return {
+        "file_name": filename,
+        "file_path": str(_tdx_self_select_path(tdx_home=tdx_home, filename=filename)),
+        "category": category,
+        "source": source,
+        "read_count": len(codes),
+        "unique_count": len(codes),
+        "synced_count": len(synced_codes),
+        "appended_count": len(synced_codes),
+        "skipped_holding_count": len(skipped_holding_codes),
+        "skipped_invalid_count": len(skipped_invalid_codes),
+        "synced_codes": synced_codes,
+        "appended_codes": synced_codes,
+        "skipped_holding_codes": skipped_holding_codes,
         "skipped_invalid_codes": skipped_invalid_codes,
     }
 

--- a/freshquant/tests/test_must_pool_data.py
+++ b/freshquant/tests/test_must_pool_data.py
@@ -243,3 +243,29 @@ def test_import_pool_persists_provenance_for_new_doc(monkeypatch):
     assert collection.inserted["sources"] == ["daily-screening", "shouban30"]
     assert collection.inserted["categories"] == ["CLXS_10008", "plate:11"]
     assert collection.inserted["workspace_order_hint"] == 7
+
+
+def test_import_pool_accepts_none_stop_loss_price(monkeypatch):
+    collection = FakeMustPoolCollection()
+    must_pool = _import_must_pool_with_stubs(monkeypatch, collection=collection)
+
+    must_pool.import_pool(
+        code="000001",
+        category="待买",
+        stop_loss_price=None,
+        initial_lot_amount=None,
+        lot_amount=None,
+        forever=True,
+        provenance={
+            "sources": ["tdx_must_pool"],
+            "categories": ["待买"],
+            "memberships": [],
+        },
+    )
+
+    assert collection.inserted is not None
+    assert collection.inserted["code"] == "000001"
+    assert collection.inserted["category"] == "待买"
+    assert collection.inserted["stop_loss_price"] is None
+    assert collection.inserted["initial_lot_amount"] == 50000
+    assert collection.inserted["lot_amount"] == 50000

--- a/freshquant/tests/test_stock_service_tdx_self_select.py
+++ b/freshquant/tests/test_stock_service_tdx_self_select.py
@@ -146,3 +146,139 @@ def test_sync_stock_pools_from_tdx_self_select_skips_unsupported_securities(
 
     assert result["synced_codes"] == ["300127"]
     assert result["skipped_invalid_codes"] == ["113000", "123456", "900901"]
+
+
+def test_sync_must_pool_from_tdx_self_select_reads_dai_mai_group(monkeypatch, tmp_path):
+    target = Path(tmp_path) / "T0002" / "blocknew" / "待买.blk"
+    target.parent.mkdir(parents=True)
+    target.write_text("0300127\n000001\n000002\n113000\n", encoding="gbk")
+    fake_db = {
+        "stock_pools": FakeStockPoolsCollection(),
+        "must_pool": FakeStockPoolsCollection(),
+        "xt_positions": FakeStockPoolsCollection(),
+    }
+    monkeypatch.setattr(stock_service, "DBfreshquant", fake_db)
+
+    calls = []
+    monkeypatch.setattr(
+        stock_service.must_pool,
+        "import_pool",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    result = stock_service.sync_must_pool_from_tdx_self_select(tdx_home=tmp_path)
+
+    assert result["file_name"] == "待买.blk"
+    assert result["category"] == "待买"
+    assert result["source"] == "tdx_must_pool"
+    assert result["synced_codes"] == ["300127", "000001", "000002"]
+    assert result["skipped_invalid_codes"] == ["113000"]
+    assert [call["code"] for call in calls] == ["300127", "000001", "000002"]
+    assert all(call["category"] == "待买" for call in calls)
+    assert calls[0]["provenance"]["sources"] == ["tdx_must_pool"]
+    assert calls[0]["provenance"]["categories"] == ["待买"]
+    assert calls[0]["provenance"]["memberships"][0]["source"] == "tdx_must_pool"
+    assert calls[0]["provenance"]["memberships"][0]["category"] == "待买"
+    assert calls[0]["provenance"]["memberships"][0]["extra"]["file_name"] == "待买.blk"
+
+
+def test_sync_must_pool_from_tdx_self_select_preserves_existing_params(
+    monkeypatch, tmp_path
+):
+    target = Path(tmp_path) / "T0002" / "blocknew" / "待买.blk"
+    target.parent.mkdir(parents=True)
+    target.write_text("0300127\n", encoding="gbk")
+    fake_db = {
+        "stock_pools": FakeStockPoolsCollection(),
+        "must_pool": FakeStockPoolsCollection(
+            [
+                {
+                    "code": "300127",
+                    "category": "人工",
+                    "stop_loss_price": 9.8,
+                    "initial_lot_amount": 80000,
+                    "lot_amount": 50000,
+                }
+            ]
+        ),
+        "xt_positions": FakeStockPoolsCollection(),
+    }
+    monkeypatch.setattr(stock_service, "DBfreshquant", fake_db)
+
+    calls = []
+    monkeypatch.setattr(
+        stock_service.must_pool,
+        "import_pool",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    result = stock_service.sync_must_pool_from_tdx_self_select(tdx_home=tmp_path)
+
+    assert result["synced_codes"] == ["300127"]
+    call = calls[0]
+    assert call["code"] == "300127"
+    assert call["stop_loss_price"] == 9.8
+    assert call["initial_lot_amount"] == 80000
+    assert call["lot_amount"] == 50000
+
+
+def test_sync_must_pool_from_tdx_self_select_keeps_records_outside_group(
+    monkeypatch, tmp_path
+):
+    target = Path(tmp_path) / "T0002" / "blocknew" / "待买.blk"
+    target.parent.mkdir(parents=True)
+    target.write_text("0300127\n", encoding="gbk")
+    collection = FakeStockPoolsCollection(
+        [
+            {"code": "600999", "category": "人工"},
+        ]
+    )
+    fake_db = {
+        "stock_pools": FakeStockPoolsCollection(),
+        "must_pool": collection,
+        "xt_positions": FakeStockPoolsCollection(),
+    }
+    monkeypatch.setattr(stock_service, "DBfreshquant", fake_db)
+
+    calls = []
+    monkeypatch.setattr(
+        stock_service.must_pool,
+        "import_pool",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    result = stock_service.sync_must_pool_from_tdx_self_select(tdx_home=tmp_path)
+
+    assert result["synced_codes"] == ["300127"]
+    assert collection.find_one({"code": "600999"}) is not None
+
+
+def test_sync_must_pool_from_tdx_self_select_skips_current_holdings(
+    monkeypatch, tmp_path
+):
+    target = Path(tmp_path) / "T0002" / "blocknew" / "待买.blk"
+    target.parent.mkdir(parents=True)
+    target.write_text("0300127\n000002\n", encoding="gbk")
+    fake_db = {
+        "stock_pools": FakeStockPoolsCollection(),
+        "must_pool": FakeStockPoolsCollection(),
+        "xt_positions": FakeStockPoolsCollection(
+            [
+                {"symbol": "sz300127"},
+            ]
+        ),
+    }
+    monkeypatch.setattr(stock_service, "DBfreshquant", fake_db)
+
+    calls = []
+    monkeypatch.setattr(
+        stock_service.must_pool,
+        "import_pool",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    result = stock_service.sync_must_pool_from_tdx_self_select(tdx_home=tmp_path)
+
+    assert result["synced_codes"] == ["000002"]
+    assert result["skipped_holding_codes"] == ["300127"]
+    assert [call["code"] for call in calls] == ["000002"]

--- a/morningglory/fqwebui/src/api/stockApi.js
+++ b/morningglory/fqwebui/src/api/stockApi.js
@@ -56,6 +56,13 @@ export const stockApi = {
       params: { days }
     })
   },
+  syncMustPoolFromTdxSelfSelect ({ days = 30 } = {}) {
+    return http({
+      url: '/api/sync_must_pool_from_tdx_self_select',
+      method: 'post',
+      params: { days }
+    })
+  },
   getStockPrePoolsCategory () {
     return http({
       url: '/api/get_stock_pre_pools_category',

--- a/morningglory/fqwebui/src/api/stockApi.test.mjs
+++ b/morningglory/fqwebui/src/api/stockApi.test.mjs
@@ -13,3 +13,10 @@ test('stockApi sends add_to_stock_pools_by_code through params with direct CLX o
   assert.match(source, /params\.source = options\.source/)
   assert.match(source, /params\.remark = options\.remark/)
 })
+
+test('stockApi exposes must_pool TDX 待买 group sync endpoint', () => {
+  assert.match(source, /syncMustPoolFromTdxSelfSelect \(\{ days = 30 \} = \{\}\)/)
+  assert.match(source, /url: '\/api\/sync_must_pool_from_tdx_self_select'/)
+  assert.match(source, /method: 'post'/)
+  assert.match(source, /params: \{ days \}/)
+})

--- a/morningglory/fqwebui/src/views/KlineSlim.vue
+++ b/morningglory/fqwebui/src/views/KlineSlim.vue
@@ -129,6 +129,15 @@
             >
               {{ stockPoolsTdxSyncing ? '同步中' : '同步自选股' }}
             </button>
+            <button
+              v-if="section.key === 'must_pool'"
+              type="button"
+              class="sidebar-section-sync"
+              :disabled="mustPoolTdxSyncing"
+              @click.stop="syncMustPoolFromTdxSelfSelect"
+            >
+              {{ mustPoolTdxSyncing ? '同步中' : '同步待买' }}
+            </button>
           </header>
           <transition name="sidebar-section-collapse">
             <div v-show="section.expanded" class="sidebar-section-body">

--- a/morningglory/fqwebui/src/views/js/kline-slim.js
+++ b/morningglory/fqwebui/src/views/js/kline-slim.js
@@ -398,6 +398,7 @@ export default {
       mustPools: [],
       stockPools: [],
       stockPoolsTdxSyncing: false,
+      mustPoolTdxSyncing: false,
       prePools: [],
       sidebarLoading: {
         holding: false,
@@ -1031,6 +1032,32 @@ export default {
         this.$message?.error?.('同步自选股失败')
       } finally {
         this.stockPoolsTdxSyncing = false
+      }
+    },
+    async syncMustPoolFromTdxSelfSelect() {
+      if (this.mustPoolTdxSyncing) {
+        return
+      }
+      this.mustPoolTdxSyncing = true
+      try {
+        const result = await stockApi.syncMustPoolFromTdxSelfSelect({ days: 30 })
+        if (result && String(result.code ?? '0') !== '0') {
+          throw new Error(result.msg || 'sync_must_pool_from_tdx_self_select failed')
+        }
+        await this.loadMustPools()
+        const summary = result?.data || {}
+        this.$message?.success?.(
+          '待买分组已导入：新增 ' +
+            (summary.synced_count ?? summary.appended_count ?? 0) +
+            '，持仓去重 ' +
+            (summary.skipped_holding_count || 0) +
+            '，忽略无效 ' +
+            (summary.skipped_invalid_count || 0)
+        )
+      } catch (error) {
+        this.$message?.error?.('同步待买分组失败')
+      } finally {
+        this.mustPoolTdxSyncing = false
       }
     },
     async addCurrentSymbolToClx15Monitor() {

--- a/morningglory/fqwebui/src/views/klineSlim.test.mjs
+++ b/morningglory/fqwebui/src/views/klineSlim.test.mjs
@@ -97,6 +97,22 @@ test('KlineSlim stock_pools sidebar can sync TDX self-select symbols', () => {
   assert.match(apiSource, /\/api\/sync_stock_pools_from_tdx_self_select/)
 })
 
+test('KlineSlim must_pool sidebar can import TDX 待买 group', () => {
+  const viewSource = fs.readFileSync(new URL('./KlineSlim.vue', import.meta.url), 'utf8')
+  const scriptSource = fs.readFileSync(new URL('./js/kline-slim.js', import.meta.url), 'utf8')
+  const apiSource = fs.readFileSync(new URL('../api/stockApi.js', import.meta.url), 'utf8')
+
+  assert.match(viewSource, /同步待买/)
+  assert.match(viewSource, /section\.key === 'must_pool'/)
+  assert.match(viewSource, /@click\.stop="syncMustPoolFromTdxSelfSelect"/)
+  assert.match(scriptSource, /mustPoolTdxSyncing: false/)
+  assert.match(scriptSource, /async syncMustPoolFromTdxSelfSelect\(\)/)
+  assert.match(scriptSource, /stockApi\.syncMustPoolFromTdxSelfSelect\(\{ days: 30 \}\)/)
+  assert.match(scriptSource, /await this\.loadMustPools\(\)/)
+  assert.match(apiSource, /syncMustPoolFromTdxSelfSelect/)
+  assert.match(apiSource, /\/api\/sync_must_pool_from_tdx_self_select/)
+})
+
 test('KlineSlim page script delegates lifecycle hooks and orchestration to a dedicated controller module', () => {
   const viewSource = fs.readFileSync(new URL('./KlineSlim.vue', import.meta.url), 'utf8')
   const scriptSource = fs.readFileSync(new URL('./js/kline-slim.js', import.meta.url), 'utf8')


### PR DESCRIPTION
## 背景

系统需要把通达信「待买」自选股分组作为 must_pool 的增量来源，让用户在主图/待买池看到 TDX 侧维护的候选标的，同时保留 must_pool 上已配置的交易参数（止损价、买卖金额）。

## 目标

- 读取 TDX `T0002/blocknew/待买.blk`，将有效代码增量导入 `must_pool`（`tdx_must_pool` membership）
- 跳过当前 `xt_positions` 持仓标的与不支持的代码
- 提供 API 触发入口与 WebUI 展示

## 范围

- `freshquant/stock_service.py`：新增 `sync_must_pool_from_tdx_self_select`
- `freshquant/data/astock/must_pool.py`：`import_pool` 允许 `stop_loss_price=None`
- `freshquant/rear/stock/routes.py`：同步入口路由
- `morningglory/fqwebui/**`：KlineSlim 待买导入入口与展示
- `docs/current/**`：同步接口与运行文档
- 测试：`test_must_pool_data.py`、`test_stock_service_tdx_self_select.py`、前端 `stockApi.test.mjs` / `klineSlim.test.mjs`

## 非目标

- 不改变 stock_pools 的覆盖式同步语义
- 不删除 must_pool 中不在 TDX 分组的既有记录
- 不触碰交易下单逻辑

## 验收标准

- pytest：`test_must_pool_data.py`、`test_stock_service_tdx_self_select.py` 全绿
- 前端：lint / unit / browser-smoke / build 全绿
- CI 全绿（docs-current-guard / pre-commit / pytest）

## 部署影响

- `freshquant/rear/**` + `freshquant/stock_service.py`：重建 `fq_apiserver`
- `morningglory/fqwebui/**`：重建 `fq_webui`
- `must_pool` 数据为增量写入，不影响存量交易参数
