### PR TITLE
fix: tolerate source invalid close in QFQ bootstrap exclusions

### DIFF
--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -88,6 +88,7 @@
 - `stock_postclose_ready` 在股票日线、分钟线和质量股票池快照完成后发布；`etf_postclose_ready` 在 ETF 日线与分钟线完成后发布。正常 schedule 不再选择旧 `stock_xdxr`、`etf_xdxr`、`etf_adj` asset。
 - A/B 快照与发布 marker 写在 QuantAxis Mongo：数据集合为 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`，marker 集合为 `qfq_ready`；`qfq_writer_locks` 以 scope 唯一后台 heartbeat lease 强制 worker、人工 build 与 rollback 串行，单次 XTData 下载或 Mongo `$out` 阻塞期间也会持续续租，发布前再次核对 owner。
 - QFQ coverage 排除 `vol/amount` 同时命中 QASU 浮点哨兵的 BFQ 占位行；XTData 多出的真实交易日仍参与完整递推，之后才投影到有效 BFQ 日期。bootstrap、update 与 audit JSON 的 `coverage` 字段记录 sentinel 和无有效历史标的计数。
+- bootstrap/update 遇到单只标的的 XTData 日线数据不可用（close 或 used preClose 全为 0/NaN）时，按 `source_invalid_close` 排除项记录到 `qfq_ready` 的 `source_exclusions` 并继续，不让整批构建失败；`duplicate XTData trading dates` 仍保持硬失败，视为真实异常。
 - Stock / ETF 在线 reader 每次请求从 `qfq_ready` 解析 active slot；marker、coverage、factor 或 snapshot-bound override 不满足合同时 fail closed 为 `QFQ_DATA_NOT_READY`。Redis Kline 与 StrategyConsumer 常驻窗口按 effective adjustment version 隔离，marker/override 版本变化会 miss/reload。
 - `/api/stock_data?realtimeCache=1` 且未显式传 `endDate` 时，若只有当前交易日缺 snapshot-bound intraday override，Kline 读取会按交易日历最多回退最近 5 个已完成交易日取分钟历史；显式 `endDate` 或非当前交易日缺口仍保持 `QFQ_DATA_NOT_READY`。
 - 旧 `stock_xdxr`、`etf_xdxr`、`etf_adj` asset 仅保留为人工 legacy 运维入口；`stock_adj` / `etf_adj` 集合至少保留 7 个交易日且不再作为在线真值。

--- a/freshquant/market_data/xtdata/qfq.py
+++ b/freshquant/market_data/xtdata/qfq.py
@@ -63,6 +63,7 @@ SOURCE_EXCLUSION_REASONS = frozenset(
         "source_empty_bars",
         "source_adjustment_gap_unproven",
         "source_prefix_unavailable",
+        "source_invalid_close",
     }
 )
 
@@ -816,6 +817,8 @@ def _new_bfq_coverage_summary() -> dict[str, Any]:
         "source_adjustment_gap_unproven": [],
         "source_prefix_unavailable_excluded": 0,
         "source_prefix_unavailable": [],
+        "source_invalid_close_excluded": 0,
+        "source_invalid_close": [],
         "skipped_codes": 0,
         "skipped": [],
     }

--- a/freshquant/market_data/xtdata/qfq.py
+++ b/freshquant/market_data/xtdata/qfq.py
@@ -376,13 +376,19 @@ def normalize_xtdata_bars(payload: Any, *, code: str | None = None) -> pd.DataFr
         lambda value: math.isfinite(float(value)) and float(value) > 0
     )
     if not valid_close.all():
-        raise QFQSyncError(f"invalid close values for code={code}")
+        raise QFQSyncError(
+            f"invalid close values for code={code}",
+            stats={"failure": "source_invalid_close"},
+        )
     used_preclose = frame["preClose"].iloc[1:]
     valid_used_preclose = used_preclose.map(
         lambda value: math.isfinite(float(value)) and float(value) > 0
     )
     if not valid_used_preclose.all():
-        raise QFQSyncError(f"invalid used preClose values for code={code}")
+        raise QFQSyncError(
+            f"invalid used preClose values for code={code}",
+            stats={"failure": "source_invalid_close"},
+        )
     return frame
 
 
@@ -2028,6 +2034,8 @@ def _source_exclusion_reason(error: QFQSyncError) -> str | None:
         return "source_prefix_unavailable"
     if error.stats.get("failure") == "source_adjustment_gap_unproven":
         return "source_adjustment_gap_unproven"
+    if error.stats.get("failure") == "source_invalid_close":
+        return "source_invalid_close"
     return None
 
 

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -2817,3 +2817,43 @@ def test_source_exclusion_reason_recognizes_invalid_close():
         stats={"failure": "source_invalid_close"},
     )
     assert qfq._source_exclusion_reason(error) == "source_invalid_close"
+
+
+def test_bootstrap_excludes_source_invalid_close_and_publishes_marker():
+    target = "2026-01-05"
+    db = _DB(
+        stock_list=[
+            {"code": code, "name": "Stock"}
+            for code in ("000001", "000004", "000005")
+        ],
+        stock_day=[
+            {"code": code, "date": target}
+            for code in ("000001", "000004", "000005")
+        ],
+    )
+
+    def loader(code, **_kwargs):
+        if code == "000004":
+            return _bars([(target, 0.0, 0.0)])
+        if code == "000005":
+            return _bars([("2026-01-02", 5.0, 0.0), (target, 4.0, 5.0)])
+        return _bars([(target, 10.0, 0.0)])
+
+    result = qfq.sync_stock_adj_all(target_date=target, db=db, bars_loader=loader)
+
+    scope = result["by_scope"]["stock"]
+    exclusions = [{"code": "000004", "reason": "source_invalid_close"}]
+    assert scope["codes"] == 2
+    assert scope["coverage"]["source_invalid_close_excluded"] == 1
+    assert scope["coverage"]["source_invalid_close"] == exclusions
+    assert {row["code"] for row in db["stock_adj_qfq_a"].rows} == {
+        "000001",
+        "000005",
+    }
+    assert {row["code"] for row in db["stock_adj_qfq_b"].rows} == {
+        "000001",
+        "000005",
+    }
+    marker = db["qfq_ready"].rows[0]
+    assert marker["slots"]["a"]["source_exclusions"] == exclusions
+    assert marker["slots"]["b"]["source_exclusions"] == exclusions

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -2783,3 +2783,37 @@ def test_real_xtdata_stock_and_etf_action_fixtures():
             sample["front_reference_normalized_close"],
             abs=sample["front_tolerance"],
         )
+
+
+def test_normalize_xtdata_bars_marks_invalid_close_as_source_exclusion():
+    bars = _bars(
+        [
+            ("2026-01-02", 0.0, 0.0),
+            ("2026-01-05", 0.0, 0.0),
+            ("2026-01-06", 0.0, 0.0),
+        ]
+    )
+    with pytest.raises(qfq.QFQSyncError, match="invalid close") as caught:
+        qfq.normalize_xtdata_bars(bars, code="000004.SZ")
+    assert caught.value.stats["failure"] == "source_invalid_close"
+
+
+def test_normalize_xtdata_bars_marks_invalid_used_preclose_as_source_exclusion():
+    bars = _bars(
+        [
+            ("2026-01-02", 10.0, 0.0),
+            ("2026-01-05", 9.0, 0.0),
+            ("2026-01-06", 9.1, 9.0),
+        ]
+    )
+    with pytest.raises(qfq.QFQSyncError, match="invalid used preClose") as caught:
+        qfq.normalize_xtdata_bars(bars, code="000004.SZ")
+    assert caught.value.stats["failure"] == "source_invalid_close"
+
+
+def test_source_exclusion_reason_recognizes_invalid_close():
+    error = qfq.QFQSyncError(
+        "invalid close values for code=000004.SZ",
+        stats={"failure": "source_invalid_close"},
+    )
+    assert qfq._source_exclusion_reason(error) == "source_invalid_close"

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -2823,12 +2823,10 @@ def test_bootstrap_excludes_source_invalid_close_and_publishes_marker():
     target = "2026-01-05"
     db = _DB(
         stock_list=[
-            {"code": code, "name": "Stock"}
-            for code in ("000001", "000004", "000005")
+            {"code": code, "name": "Stock"} for code in ("000001", "000004", "000005")
         ],
         stock_day=[
-            {"code": code, "date": target}
-            for code in ("000001", "000004", "000005")
+            {"code": code, "date": target} for code in ("000001", "000004", "000005")
         ],
     )
 


### PR DESCRIPTION
## 背景

116 机器首次 QFQ bootstrap（`qfq_worker build --scope stock --full`）因 `000004.SZ` 崩溃：该股在 XTData 中 close 全为 0（已退市/无行情），`normalize_xtdata_bars` 抛 `invalid close values`，而 `_source_exclusion_reason` 不识别该错误 → bootstrap 整体失败。

对照：101 的 `stock_day` 无 000004 数据故未触发；116 的 legacy `stock_day` 保留了该股历史行（含有效 vol/amount），导致候选清单包含它。

## 目标

让 QFQ bootstrap 对单只"源数据无效"的股票容错：标记为 `source_invalid_close` 排除项并继续，而不是让整个 bootstrap 崩溃。

## 范围

- `freshquant/market_data/xtdata/qfq.py`：
  - `normalize_xtdata_bars` 的 `invalid close values` / `invalid used preClose values` 抛错时附带 `stats={"failure": "source_invalid_close"}`
  - `_source_exclusion_reason` 识别 `source_invalid_close` 为可排除项
- `freshquant/tests/test_xtdata_qfq.py`：新增 3 个测试（invalid close、invalid used preClose、exclusion reason 识别）

## 非目标

- 不改 QFQ 递推/因子计算逻辑
- 不处理 `duplicate XTData trading dates`（保持硬失败，属真异常）
- 不删除任何 Mongo 数据

## 验收标准

- `test_xtdata_qfq.py` 106 项全绿（含新增 3 项）
- `test_xtdata_qfq_worker.py` 13 项全绿
- CI 全绿

## 部署影响

- `freshquant/market_data/**`：重启 producer / consumer / reference-data worker
- 116 首次 QFQ bootstrap 需重跑 `qfq_worker build --scope stock --target-date 2026-08-06 --full`
