### PR TITLE
fix: skip QASU sentinel placeholder bars in QFQ K-line reads

### DIFF
--- a/docs/current/architecture.md
+++ b/docs/current/architecture.md
@@ -102,7 +102,7 @@ finalizer 只在两侧 completed 后运行。sensor 先持久化 `finalization_a
   - ETF：`etf_adj_qfq_a` / `etf_adj_qfq_b`
   - `quantaxis.qfq_ready` 以每个 `scope` 的单文档保存 `active_slot` 与两个槽位的快照元数据。
 - writer 只构建 inactive slot，审计通过后再原子切换 `active_slot`；`worker`、人工 `build` 与 `rollback` 共用 `qfq_writer_locks` 的 scope 唯一 lease。回滚会先将仍需生效的 intraday override 重新绑定到目标 snapshot，再以 CAS 切换 marker；factor A/B 集合本身不改写。
-- reader 要求 active slot 为 `ready`，并严格校验请求 bar 的日期覆盖、正因子、重复键、source exclusion 和 snapshot-bound intraday override；证明失败统一抛出 `QFQ_DATA_NOT_READY`，三条 Stock Kline API 统一返回 HTTP 503。
+- reader 要求 active slot 为 `ready`，并严格校验请求 bar 的日期覆盖、正因子、重复键、source exclusion 和 snapshot-bound intraday override；证明失败统一抛出 `QFQ_DATA_NOT_READY`，三条 Stock Kline API 统一返回 HTTP 503。K 线读取路径（`quote/etf.py`、`quote/stock.py`、`data/stock.py`）对源 bar 中与快照构建同一语义的 QASU sentinel 占位行（`vol/volume` 与 `amount` 均为 `5.877471754e-39`）按可跳过处理：缺失因子日期若全部可证明为占位行，则剔除这些行后继续返回，不回退 `adj=1.0`；其余日期缺口仍 fail closed。
 - Redis Kline key/payload 与 StrategyConsumer 常驻窗口绑定 effective adjustment version（active `snapshot_id` 加匹配的 override version）；版本变化时旧 cache miss、常驻窗口重载。
 - 旧 `stock_adj` / `etf_adj` 不再是线上 reader 真值。
 - 真实 Index 的日线、分钟线和实时合并固定使用 BFQ；Index 路径不读取 Stock / ETF 因子，实时数据读取 `freshquant.index_realtime`。

--- a/docs/current/interfaces.md
+++ b/docs/current/interfaces.md
@@ -172,7 +172,7 @@ python -m freshquant.rear.api_server --port 5000
   - `events[].signal` 只在存在 `request_id / internal_order_id / trace_id / intent_id` 等明确关联键时返回；不以时间邻近规则伪造信号与订单关联
 - `/api/stock_data`、`/api/stock_data_v2`、`/api/stock_data_chanlun_structure`
   - 当前分钟周期参数兼容 `1min / 5min / 15min / 30min` 与 `1m / 5m / 15m / 30m`，进入服务前统一归一到前端/缠论服务使用的 `1m / 5m / 15m / 30m`
-  - `/api/stock_data?realtimeCache=1` 优先读取实时 K 线缓存；若仅实时 QFQ 当日覆盖未就绪，则记录 warning 并回退历史 K 线读取，避免行情图表左侧列表标的出现主图空白
+  - `/api/stock_data?realtimeCache=1` 优先读取实时 K 线缓存；若 QFQ 覆盖缺口（含历史无效/占位缺口，不再限定为当日）未就绪，则记录 warning 并回退历史 K 线读取，避免行情图表左侧列表标的出现主图空白
   - 非实时历史读取或结构读取遇到 QFQ 未就绪时仍返回 `QFQ_DATA_NOT_READY` 对应 HTTP 状态
 - `POST /api/sync_stock_pools_from_tdx_self_select`
   - 从当前 TDX home 的 `T0002/blocknew/ZXG.blk` 读取通达信自选股，解码为 6 位标的代码，排除当前 `xt_positions` 持仓后，以结果覆盖 `freshquant.stock_pools`

--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -80,7 +80,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - 完整 source 区间下载后仍无 `none` bars 的 code 同样不生成空因子或 `1.0`，并记录 `{code, reason=source_empty_bars}`。A/B 各自保留自己的 `source_exclusions[]`，rollback 随 slot 一起恢复。tail 请求为空必须先用完整 BFQ 区间复核；`front_ratio` proof 为空不属于该分类，继续 fail closed。
 - primary `none` loader 完成单调前缀分页后仍报告 `history_prefix_no_progress` 时，该 code 记录 `{code, reason=source_prefix_unavailable}` 并从本轮 slot 隔离；同一错误来自 `front_ratio` proof loader 时仍中止 scope。普通 unbounded prefix/suffix、proof 缺失和日期轴不一致不进入该分类。
 - XTData 长区间下载只返回近期后缀时，QFQ client 会以当前最早缓存日的前一日为边界继续向前分页，直至覆盖请求起点；任一页未把最早日期向前推进时立即报错，不发布不完整快照。
-- Stock / ETF 在线 reader 统一使用 `freshquant.data.qfq_reader`：每个请求重新解析 marker 指向的 active slot，严格验证 snapshot、请求日期覆盖、正因子、重复键、source exclusion 与 snapshot-bound override；失败统一为 `QFQ_DATA_NOT_READY`，Stock Kline API 映射 HTTP 503。
+- Stock / ETF 在线 reader 统一使用 `freshquant.data.qfq_reader`：每个请求重新解析 marker 指向的 active slot，严格验证 snapshot、请求日期覆盖、正因子、重复键、source exclusion 与 snapshot-bound override；失败统一为 `QFQ_DATA_NOT_READY`，Stock Kline API 映射 HTTP 503。K 线读取路径对源 bar 中的 QASU sentinel 占位行（`vol/volume` 与 `amount` 均为 `5.877471754e-39`）按快照构建同一语义跳过：缺失因子日期全部可证明为占位行时剔除这些行后继续返回，不回退 `adj=1.0`。
 - StrategyConsumer 先落 raw realtime bar，再执行严格 QFQ 派生；Redis Kline key/payload 和常驻窗口绑定 effective adjustment version，版本变化后旧缓存 miss、窗口 reload。
 - 旧 `stock_xdxr`、`etf_xdxr`、`etf_adj` asset 不在正常 schedule，仅保留为人工 legacy 运维入口；`stock_adj` / `etf_adj` 至少保留 7 个交易日但不再作为在线读取真值。
 - 真实 Index 走 BFQ 日线/分钟线和 `index_realtime`，不读取 ETF/Stock 因子，也不进入 QFQ scope。
@@ -185,4 +185,4 @@ consumer 还会把本批命中标的（带前缀代码，如 `sh600000`）去重
 - 执行 `python -m freshquant.market_data.xtdata.qfq_worker worker --once`，区分 `waiting_for_bfq`、`current`、`published` 与错误结果。
 - 执行 `status --strict` 核对 active 截止日与盘后 marker，执行 `audit --scope stock|etf --mode full` 对 active slot 做 XTData source-aware 审计；快速排查可先用 `--mode structure`。
 - 若 active slot 已更新但页面仍是旧结果，核对响应/Redis payload 的 `adjustment_version` 与 marker `snapshot_id`；旧 version key 不应被新 reader 命中。
-- `QFQ_DATA_NOT_READY/503` 时先核对 active slot `status=ready`、请求 code/date coverage、`source_exclusions[]` 和 intraday override 的 `base_snapshot_id`，不回退到 BFQ 或 `1.0`。
+- `QFQ_DATA_NOT_READY/503` 时先核对 active slot `status=ready`、请求 code/date coverage、`source_exclusions[]` 和 intraday override 的 `base_snapshot_id`，不回退到 BFQ 或 `1.0`。历史缺口若全部对应源 bar 的 sentinel 占位行（如 ETF 512600 的 QASU 占位日期），属 reader 可跳过场景，检查 `quote/etf.py` / `quote/stock.py` / `data/stock.py` 是否带 `skip_sentinel_placeholder_bars=True` 读取。

--- a/docs/current/reference/etf-data.md
+++ b/docs/current/reference/etf-data.md
@@ -36,7 +36,7 @@ ETF 当前前复权链路：
 
 - `ETF BFQ ready -> XTData preClose -> etf_adj_qfq_a/b inactive slot -> full audit -> qfq_ready active_slot -> freshquant.data.qfq_reader`
 - 页面、策略与共享 QuantAxis 适配层每次读取 active marker，严格校验 snapshot、coverage、正因子、重复键、source exclusion 与 snapshot-bound intraday override
-- 合同不满足时返回 `QFQ_DATA_NOT_READY`；Stock/ETF Kline HTTP 路由映射为 503，不回退 `adj=1.0` 或 legacy 集合
+- 合同不满足时返回 `QFQ_DATA_NOT_READY`；Stock/ETF Kline HTTP 路由映射为 503，不回退 `adj=1.0` 或 legacy 集合。源 bar 中的 QASU sentinel 占位行（`vol/volume` 与 `amount` 均为 `5.877471754e-39`）与快照构建同一语义：K 线读取路径在缺失因子日期全部可证明为占位行时剔除这些行后继续返回（如 512600 历史占位日期），不整体 503
 - `quantaxis.etf_xdxr` / `quantaxis.etf_adj` 不在正常 schedule，也不是在线 reader 真值；相关 CLI/asset 仅用于 legacy 人工诊断
 
 ## 当前排查

--- a/docs/current/reference/market-data.md
+++ b/docs/current/reference/market-data.md
@@ -47,7 +47,7 @@ FreshQuant 当前同时使用三类行情来源：
 - TDX 股票日线对未上市/暂无源数据代码返回空结果时按 no-op 处理，不执行空批量写入；连接、抓取或真实写库异常仍由 Dagster 标记为失败
 - 股票除权除息复权计算使用显式列赋值与 `DataFrame.ffill()`，避免 Pandas 3.0 链式 `inplace`/`fillna(method=...)` 兼容性问题，计算口径不变
 - CLX 日线选股按 Stock / ETF 各自 active marker 冻结 QFQ snapshot pair，并通过共享 strict reader 构造 effective universe；marker `source_exclusions` 与逐标的 `QFQ_DATA_NOT_READY` 会在 attempt 前通用隔离并记录，其他异常直接阻断规划，不回退为 `adj=1` 或 BFQ
-- Stock / ETF 在线读取统一使用 `freshquant.data.qfq_reader`，按 `quantaxis.qfq_ready` 指向的 active slot 读取 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`
+- Stock / ETF 在线读取统一使用 `freshquant.data.qfq_reader`，按 `quantaxis.qfq_ready` 指向的 active slot 读取 `stock_adj_qfq_a/b`、`etf_adj_qfq_a/b`；K 线读取路径对源 bar 中的 QASU sentinel 占位行（`vol/volume` 与 `amount` 均为 `5.877471754e-39`）按快照构建同一语义跳过，缺失因子日期全部可证明为占位行时剔除后继续返回，不回退 `adj=1.0`
 - XTData `preClose` QFQ writer 只在 inactive slot 构建并审计，审计成功且 writer lease owner 仍匹配后原子切换 marker；reader 每次请求重新解析 marker，并对 snapshot、coverage、source exclusion 与 override fail closed
 - Redis Kline 与 StrategyConsumer 常驻窗口绑定 effective adjustment version；旧 `stock_adj` / `etf_adj` 不再是 reader 真值，旧 writer 在切换健康检查后停止，旧集合保留至少 7 个交易日
 - 完整历史请求后仍无 source bars、有界内部 source gap 两端 adjustment proof 不一致，或 primary source 前缀分页稳定报告 `history_prefix_no_progress` 的 code，不写推断因子或 `1.0`，从当前 snapshot 隔离，并在对应 slot `source_exclusions[]` 分别记录 `source_empty_bars`、`source_adjustment_gap_unproven` 或 `source_prefix_unavailable`；A/B 与 rollback 各自保留该审计边界

--- a/freshquant/data/qfq_reader.py
+++ b/freshquant/data/qfq_reader.py
@@ -14,6 +14,39 @@ from freshquant.util.code import normalize_to_base_code
 
 QFQ_DATA_NOT_READY = "QFQ_DATA_NOT_READY"
 QFQ_DATA_NOT_READY_HTTP_STATUS = 503
+BFQ_SENTINEL_VALUE = 5.877471754e-39
+
+
+def _is_sentinel_placeholder_row(row: Mapping[str, Any]) -> bool:
+    """Mirror the snapshot-builder sentinel semantics for source placeholder bars."""
+
+    volume = row.get("vol", row.get("volume"))
+    amount = row.get("amount")
+    if volume is None or amount is None:
+        return False
+    try:
+        values = (float(volume), float(amount))
+    except (TypeError, ValueError):
+        return False
+    return all(
+        math.isfinite(value)
+        and math.isclose(value, BFQ_SENTINEL_VALUE, rel_tol=1e-9, abs_tol=0.0)
+        for value in values
+    )
+
+
+def _all_sentinel_placeholder_dates(
+    bars: pd.DataFrame,
+    dates: pd.Series,
+    missing_dates: Iterable[str],
+) -> bool:
+    """True when every requested bar at a missing factor date is a placeholder."""
+
+    missing = set(missing_dates)
+    for (_, row), date_value in zip(bars.iterrows(), dates):
+        if date_value in missing and not _is_sentinel_placeholder_row(row):
+            return False
+    return True
 
 
 class QFQDataNotReadyError(RuntimeError):
@@ -365,6 +398,7 @@ def _read_factor_series(
     code: str,
     dates: pd.Series,
     db,
+    bars: pd.DataFrame | None = None,
 ) -> tuple[pd.Series, QFQReadMetadata]:
     unique_dates = sorted(set(dates.tolist()))
     trade_date = unique_dates[-1]
@@ -431,13 +465,19 @@ def _read_factor_series(
         )
 
     missing_dates = [value for value in canonical_dates if value not in factors_by_date]
+    tolerated_sentinel_dates: set[str] = set()
     if missing_dates:
-        raise QFQDataNotReadyError(
-            "active QFQ snapshot does not cover the requested bars",
-            scope=scope,
-            code=code,
-            missing_dates=missing_dates,
-        )
+        if bars is not None and _all_sentinel_placeholder_dates(
+            bars, dates, missing_dates
+        ):
+            tolerated_sentinel_dates.update(missing_dates)
+        else:
+            raise QFQDataNotReadyError(
+                "active QFQ snapshot does not cover the requested bars",
+                scope=scope,
+                code=code,
+                missing_dates=missing_dates,
+            )
 
     factor = dates.map(factors_by_date).astype(float)
     if uncovered_dates:
@@ -458,9 +498,15 @@ def _read_factor_series(
         )
         factor.loc[dates == override_date] = 1.0
     if factor.isna().any():
-        raise QFQDataNotReadyError(
-            "active QFQ factor result is incomplete", scope=scope, code=code
-        )
+        if tolerated_sentinel_dates:
+            tolerated_mask = dates.isin(tolerated_sentinel_dates)
+            unresolved = factor.isna() & ~tolerated_mask
+        else:
+            unresolved = factor.isna()
+        if unresolved.any():
+            raise QFQDataNotReadyError(
+                "active QFQ factor result is incomplete", scope=scope, code=code
+            )
     return factor, metadata
 
 
@@ -473,6 +519,7 @@ def apply_qfq_to_bars(
     date_col: str | None = None,
     datetime_col: str = "datetime",
     ohlc_cols: Iterable[str] = ("open", "high", "low", "close"),
+    skip_sentinel_placeholder_bars: bool = False,
 ) -> tuple[pd.DataFrame, QFQReadMetadata]:
     if bars is None or len(bars) == 0:
         raise QFQDataNotReadyError(
@@ -482,9 +529,18 @@ def apply_qfq_to_bars(
     code = normalize_to_base_code(code)
     dates = _extract_bar_dates(bars, date_col=date_col, datetime_col=datetime_col)
     factor, metadata = _read_factor_series(
-        scope=scope, code=code, dates=dates, db=database
+        scope=scope,
+        code=code,
+        dates=dates,
+        db=database,
+        bars=bars if skip_sentinel_placeholder_bars else None,
     )
     result = bars.copy()
+    if skip_sentinel_placeholder_bars:
+        kept = ~factor.isna().to_numpy(dtype=bool)
+        if not kept.all():
+            result = result.loc[kept].copy()
+            factor = factor.loc[kept]
     factor_values = factor.to_numpy(dtype=float)
     for column in ohlc_cols:
         if column in result.columns:

--- a/freshquant/data/stock.py
+++ b/freshquant/data/stock.py
@@ -45,6 +45,7 @@ def _apply_stock_qfq(
         scope="stock",
         code=base_code,
         datetime_col="datetime",
+        skip_sentinel_placeholder_bars=True,
     )
     return adjusted
 

--- a/freshquant/quote/etf.py
+++ b/freshquant/quote/etf.py
@@ -180,6 +180,7 @@ def queryEtfCandleSticksDay(code, start=None, end=None):
         scope="etf",
         code=normalize_to_base_code(code),
         datetime_col="datetime",
+        skip_sentinel_placeholder_bars=True,
     )
 
     data = data.round(
@@ -259,6 +260,7 @@ def queryEtfCandleSticksMin(code, frequence, start=None, end=None):
         scope="etf",
         code=normalize_to_base_code(code),
         datetime_col="datetime",
+        skip_sentinel_placeholder_bars=True,
     )
 
     data = data.round(

--- a/freshquant/quote/stock.py
+++ b/freshquant/quote/stock.py
@@ -14,6 +14,7 @@ def fq_quote_QA_fetch_stock_day_adv(code, start, end):
             scope="stock",
             code=normalize_to_base_code(code),
             date_col="date",
+            skip_sentinel_placeholder_bars=True,
         )
         return adjusted
     return

--- a/freshquant/rear/stock/routes.py
+++ b/freshquant/rear/stock/routes.py
@@ -218,7 +218,9 @@ def _recent_previous_trade_dates(
     return sorted(set(keys), reverse=True)[:limit]
 
 
-def _is_current_date_qfq_gap(error):
+def _has_qfq_gap(error):
+    """Any missing factor date is treated as a realtime-cache gap to retry."""
+
     missing_dates = [
         value
         for value in (
@@ -227,14 +229,11 @@ def _is_current_date_qfq_gap(error):
         )
         if value
     ]
-    if not missing_dates:
-        return False
-    today = datetime.now().strftime("%Y-%m-%d")
-    return set(missing_dates) == {today}
+    return bool(missing_dates)
 
 
 def _get_realtime_history_fallback(symbol, period, bar_count, error):
-    if not _is_current_date_qfq_gap(error):
+    if not _has_qfq_gap(error):
         raise error
 
     for fallback_end_date in _recent_previous_trade_dates():

--- a/freshquant/tests/test_qfq_reader.py
+++ b/freshquant/tests/test_qfq_reader.py
@@ -125,6 +125,22 @@ def _bars(*dates):
     )
 
 
+def _bars_with_sentinel(*dates, sentinel_dates=()):
+    sentinel = qfq_reader.BFQ_SENTINEL_VALUE
+    sentinel_set = set(sentinel_dates)
+    return pd.DataFrame(
+        {
+            "datetime": [pd.Timestamp(f"{value} 10:00:00") for value in dates],
+            "open": [10.0] * len(dates),
+            "high": [11.0] * len(dates),
+            "low": [9.0] * len(dates),
+            "close": [10.5] * len(dates),
+            "volume": [sentinel if value in sentinel_set else 100.0 for value in dates],
+            "amount": [sentinel if value in sentinel_set else 200.0 for value in dates],
+        }
+    )
+
+
 def test_reader_uses_only_marker_selected_active_slot():
     db = _Database(
         qfq_ready=[
@@ -323,6 +339,106 @@ def test_reader_fails_closed_on_factor_coverage_gap():
         )
 
     assert exc_info.value.missing_dates == ("2026-07-30", "2026-07-31")
+
+
+def test_reader_skips_sentinel_placeholder_bars_when_opt_in():
+    db = _Database(
+        qfq_ready=[_marker()],
+        stock_adj_qfq_a=[
+            {"code": "000001", "date": "2026-07-29", "adj": 0.5},
+            {"code": "000001", "date": "2026-07-31", "adj": 1.0},
+        ],
+    )
+
+    result, metadata = apply_qfq_to_bars(
+        _bars_with_sentinel(
+            "2026-07-29",
+            "2026-07-30",
+            "2026-07-31",
+            sentinel_dates=["2026-07-30"],
+        ),
+        scope="stock",
+        code="000001",
+        db=db,
+        skip_sentinel_placeholder_bars=True,
+    )
+
+    assert len(result) == 2
+    assert result["datetime"].dt.strftime("%Y-%m-%d").tolist() == [
+        "2026-07-29",
+        "2026-07-31",
+    ]
+    assert result["open"].tolist() == [5.0, 10.0]
+    assert result["close"].tolist() == [5.25, 10.5]
+    assert metadata.collection == "stock_adj_qfq_a"
+    assert metadata.snapshot_id == "snapshot-a"
+
+
+def test_reader_fails_closed_on_sentinel_gap_without_opt_in():
+    db = _Database(
+        qfq_ready=[_marker()],
+        stock_adj_qfq_a=[
+            {"code": "000001", "date": "2026-07-29", "adj": 0.5},
+            {"code": "000001", "date": "2026-07-31", "adj": 1.0},
+        ],
+    )
+
+    with pytest.raises(QFQDataNotReadyError) as exc_info:
+        apply_qfq_to_bars(
+            _bars_with_sentinel(
+                "2026-07-29",
+                "2026-07-30",
+                "2026-07-31",
+                sentinel_dates=["2026-07-30"],
+            ),
+            scope="stock",
+            code="000001",
+            db=db,
+        )
+
+    assert exc_info.value.missing_dates == ("2026-07-30",)
+
+
+def test_reader_fails_closed_when_missing_date_bar_is_not_sentinel():
+    db = _Database(
+        qfq_ready=[_marker()],
+        stock_adj_qfq_a=[
+            {"code": "000001", "date": "2026-07-29", "adj": 0.5},
+            {"code": "000001", "date": "2026-07-31", "adj": 1.0},
+        ],
+    )
+
+    with pytest.raises(QFQDataNotReadyError) as exc_info:
+        apply_qfq_to_bars(
+            _bars("2026-07-29", "2026-07-30", "2026-07-31"),
+            scope="stock",
+            code="000001",
+            db=db,
+            skip_sentinel_placeholder_bars=True,
+        )
+
+    assert exc_info.value.missing_dates == ("2026-07-30",)
+
+
+def test_reader_sentinel_opt_in_keeps_fully_covered_bars_unchanged():
+    db = _Database(
+        qfq_ready=[_marker()],
+        stock_adj_qfq_a=[
+            {"code": "000001", "date": "2026-07-30", "adj": 0.5},
+            {"code": "000001", "date": "2026-07-31", "adj": 1.0},
+        ],
+    )
+
+    result, _metadata = apply_qfq_to_bars(
+        _bars_with_sentinel("2026-07-30", "2026-07-31"),
+        scope="stock",
+        code="000001",
+        db=db,
+        skip_sentinel_placeholder_bars=True,
+    )
+
+    assert len(result) == 2
+    assert result["open"].tolist() == [5.0, 10.0]
 
 
 def test_reader_fails_closed_for_active_source_exclusion():

--- a/freshquant/tests/test_quantaxis_qfq_reader_routing.py
+++ b/freshquant/tests/test_quantaxis_qfq_reader_routing.py
@@ -43,7 +43,7 @@ TEMPORARY_DIRECT_ADJUSTMENT_COLLECTION_ALLOWLIST = {
     ("freshquant/data/etf_adj_sync.py", 683, "attribute:etf_adj"): (
         "PR2a transitional legacy ETF writer"
     ),
-    ("freshquant/data/qfq_reader.py", 129, "fragment:_adj_intraday"): (
+    ("freshquant/data/qfq_reader.py", 162, "fragment:_adj_intraday"): (
         "shared strict QFQ reader"
     ),
     (

--- a/freshquant/tests/test_stock_data_route_cache.py
+++ b/freshquant/tests/test_stock_data_route_cache.py
@@ -287,6 +287,98 @@ def test_stock_data_realtime_today_qfq_gap_uses_previous_trade_date(
     ]
 
 
+def test_stock_data_realtime_historical_qfq_gap_falls_back_to_history(
+    monkeypatch, stock_routes
+):
+    class FakeDatetime:
+        @staticmethod
+        def now():
+            return real_datetime(2026, 8, 3, 10, 30)
+
+    calls = []
+
+    def fake_get_data_v2(symbol, period, end_date, bar_count=0):
+        calls.append((symbol, period, end_date, bar_count))
+        if end_date is None:
+            raise stock_routes.QFQDataNotReadyError(
+                "active QFQ snapshot does not cover the requested bars",
+                scope="etf",
+                code="512600",
+                missing_dates=["2016-04-26", "2016-04-27"],
+            )
+        return {"source": "history", "endDate": end_date, "barCount": bar_count}
+
+    monkeypatch.setattr(stock_routes, "datetime", FakeDatetime)
+    monkeypatch.setattr(
+        stock_routes, "_get_realtime_stock_data_from_cache", lambda *args: None
+    )
+    monkeypatch.setattr(
+        stock_routes,
+        "fq_trading_fetch_trade_dates",
+        lambda *args, **kwargs: ["2026-07-30", "2026-07-31", "2026-08-03"],
+    )
+    monkeypatch.setattr(stock_routes, "get_data_v2", fake_get_data_v2)
+
+    response = call_stock_data(
+        stock_routes,
+        symbol="sh512600",
+        period="1d",
+        realtimeCache="1",
+        barCount="20000",
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "source": "history",
+        "endDate": "2026-07-31",
+        "barCount": 20000,
+    }
+    assert calls == [
+        ("sh512600", "1d", None, 20000),
+        ("sh512600", "1d", "2026-07-31", 20000),
+    ]
+
+
+def test_stock_data_realtime_historical_qfq_gap_stays_503_when_fallback_fails(
+    monkeypatch, stock_routes
+):
+    class FakeDatetime:
+        @staticmethod
+        def now():
+            return real_datetime(2026, 8, 3, 10, 30)
+
+    def fail(*_args, **_kwargs):
+        raise stock_routes.QFQDataNotReadyError(
+            "active QFQ snapshot does not cover the requested bars",
+            scope="etf",
+            code="512600",
+            missing_dates=["2016-04-26", "2016-04-27"],
+        )
+
+    monkeypatch.setattr(stock_routes, "datetime", FakeDatetime)
+    monkeypatch.setattr(
+        stock_routes, "_get_realtime_stock_data_from_cache", lambda *args: None
+    )
+    monkeypatch.setattr(
+        stock_routes,
+        "fq_trading_fetch_trade_dates",
+        lambda *args, **kwargs: ["2026-07-30", "2026-07-31", "2026-08-03"],
+    )
+    monkeypatch.setattr(stock_routes, "get_data_v2", fail)
+
+    response = call_stock_data(
+        stock_routes,
+        symbol="sh512600",
+        period="1d",
+        realtimeCache="1",
+        barCount="20000",
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error_code"] == "QFQ_DATA_NOT_READY"
+    assert response.get_json()["missing_dates"] == ["2016-04-26", "2016-04-27"]
+
+
 def test_stock_data_explicit_end_date_qfq_gap_stays_503(monkeypatch, stock_routes):
     def fail(*_args, **_kwargs):
         raise stock_routes.QFQDataNotReadyError(

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -2855,3 +2855,132 @@ def test_bootstrap_excludes_source_invalid_close_and_publishes_marker():
     marker = db["qfq_ready"].rows[0]
     assert marker["slots"]["a"]["source_exclusions"] == exclusions
     assert marker["slots"]["b"]["source_exclusions"] == exclusions
+
+
+def test_etf_sentinel_history_is_excluded_by_builder_and_skipped_by_reader():
+    sentinel = 5.877471754e-39
+    db = _DB(
+        etf_list=[
+            {"code": "512600", "name": "Dividend ETF"},
+            {"code": "510050", "name": "Tradable ETF"},
+        ],
+        index_day=[
+            {
+                "code": "512600",
+                "date": "2015-12-03",
+                "open": 1.4,
+                "high": 1.4,
+                "low": 1.4,
+                "close": 1.4,
+                "vol": sentinel,
+                "amount": sentinel,
+            },
+            {
+                "code": "512600",
+                "date": "2016-04-26",
+                "open": 1.3,
+                "high": 1.3,
+                "low": 1.3,
+                "close": 1.3,
+                "vol": sentinel,
+                "amount": sentinel,
+            },
+            {
+                "code": "512600",
+                "date": "2026-07-30",
+                "vol": 100.0,
+                "amount": 200.0,
+            },
+            {
+                "code": "512600",
+                "date": "2026-07-31",
+                "vol": 100.0,
+                "amount": 200.0,
+            },
+            {
+                "code": "510050",
+                "date": "2026-07-31",
+                "vol": 100.0,
+                "amount": 250.0,
+            },
+        ],
+    )
+
+    def loader(code, *, start_time, end_time):
+        if code == "512600":
+            return _bars(
+                [
+                    ("2026-07-30", 1.5, 0.0),
+                    ("2026-07-31", 1.6, 1.2),
+                ]
+            )
+        return _bars([("2026-07-31", 2.5, 0.0)])
+
+    result = qfq.sync_etf_adj_all(target_date="2026-07-31", db=db, bars_loader=loader)
+
+    scope = result["by_scope"]["etf"]
+    assert scope["coverage"]["sentinel_rows_excluded"] == 2
+    factor_dates = sorted(
+        str(row["date"])[:10]
+        for row in db["etf_adj_qfq_a"].rows
+        if row["code"] == "512600"
+    )
+    assert factor_dates == ["2026-07-30", "2026-07-31"]
+
+    from freshquant.data.qfq_reader import apply_qfq_to_bars
+
+    bars = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2015-12-03 10:00:00"),
+                "open": 1.4,
+                "high": 1.4,
+                "low": 1.4,
+                "close": 1.4,
+                "volume": sentinel,
+                "amount": sentinel,
+            },
+            {
+                "datetime": pd.Timestamp("2016-04-26 10:00:00"),
+                "open": 1.3,
+                "high": 1.3,
+                "low": 1.3,
+                "close": 1.3,
+                "volume": sentinel,
+                "amount": sentinel,
+            },
+            {
+                "datetime": pd.Timestamp("2026-07-30 10:00:00"),
+                "open": 1.5,
+                "high": 1.5,
+                "low": 1.5,
+                "close": 1.5,
+                "volume": 100.0,
+                "amount": 200.0,
+            },
+            {
+                "datetime": pd.Timestamp("2026-07-31 10:00:00"),
+                "open": 1.6,
+                "high": 1.6,
+                "low": 1.6,
+                "close": 1.6,
+                "volume": 100.0,
+                "amount": 200.0,
+            },
+        ]
+    )
+    adjusted, metadata = apply_qfq_to_bars(
+        bars,
+        scope="etf",
+        code="512600",
+        datetime_col="datetime",
+        db=db,
+        skip_sentinel_placeholder_bars=True,
+    )
+    assert len(adjusted) == 2
+    assert adjusted["datetime"].dt.strftime("%Y-%m-%d").tolist() == [
+        "2026-07-30",
+        "2026-07-31",
+    ]
+    assert adjusted["close"].round(4).tolist() == [1.2, 1.6]
+    assert metadata.scope == "etf"


### PR DESCRIPTION
## 背景

ETF 512600 在 KlineSlim 日线请求（realtimeCache=1&barCount=20000）返回 HTTP 503：
`{"ok":false,"error_code":"QFQ_DATA_NOT_READY","message":"...missing_dates=[2015-12-03,...,2021-08-13]"}`（43 个历史日期缺口，101/116 两机同源复现）。

## 根因

- 源日线含 43 个 QASU sentinel 占位行（`vol/volume` 与 `amount` 均为 `5.877471754e-39`，OHLC 全等）。
- QFQ 快照构建侧按设计排除这些日期（audit: rows=2882, sentinel_rows_excluded=43）。
- 但读取端 `freshquant/data/qfq_reader.py` 的覆盖校验要求请求窗口内每个日期都有因子，缺一天整体抛 `QFQDataNotReadyError`；
  `freshquant/rear/stock/routes.py` 的实时降级只处理 `missing_dates == {今天}`，历史缺口直接 503。

## 目标

- 读取端把"缺失日期在源 bar 中为无效/占位数据"的情形按可跳过处理（与快照构建 sentinel 排除语义一致），不再整体 503。
- 历史无效缺口也进入 realtimeCache 容错路径（不再限定 missing_dates 必须等于今天）。
- 保持 512800、600000 等正常标的行为不变；非占位历史缺口仍 fail closed。

## 范围

- `freshquant/data/qfq_reader.py`：`apply_qfq_to_bars` 新增 `skip_sentinel_placeholder_bars`（默认 False，其余调用方行为不变）；
  缺失因子日期全部可证明为源 bar sentinel 占位行时剔除这些行后继续返回，不回退 `adj=1.0`；`read_qfq_factor` 保持严格。
- `freshquant/rear/stock/routes.py`：`_is_current_date_qfq_gap` -> `_has_qfq_gap`，任意缺失日期进入回退路径，回退失败仍返回原始 503。
- K 线读取路径启用跳过：`quote/etf.py`（日线/分钟）、`quote/stock.py`、`data/stock.py`。
- 回归测试：`test_qfq_reader.py`、`test_stock_data_route_cache.py`、`test_xtdata_qfq.py`（512600 型历史缺口，纯 fixture/内存数据，不依赖真实 Mongo）。
- `docs/current/**` 同步（architecture/interfaces/modules/reference）。

## 非目标

- 不修改快照构建侧 sentinel 排除逻辑。
- 不修改 CLX / StrategyConsumer / QuantAxis 适配层（其调用 `apply_qfq_to_bars` 不带新参数，保持严格 fail-closed）。
- 不改前端 KlineSlim barCount（默认 20000 是触发条件而非缺陷）。
- 不修复与本问题无关的 pre-existing 本地环境测试差异（2 个 order_management_reconcile 用例在 Windows 本地与 CI ubuntu 表现不同，CI 基线为绿）。

## 验收标准

- `GET /api/stock_data?period=1d&symbol=sh512600&realtimeCache=1&barCount=20000` 返回 200，且不含 43 个占位日期（约 2882 行）。
- 512800 / 600000 日线、512600 5m/15m/30m/60m 大 barCount 请求保持 200。
- 相关 pytest、pre-commit、docs-current-guard 通过。

## 部署影响

- 变更落在 `freshquant/rear/**`（API server）与 K 线读取路径：需重建并重部署 `fq_apiserver`（101/116 两机）。
- 无需改动 market_data worker / QFQ A/B 快照数据。