### PR TITLE
feat: cap Guardian holding-add buys at half of remaining stage capacity

### DIFF
--- a/docs/current/configuration.md
+++ b/docs/current/configuration.md
@@ -269,11 +269,11 @@ Guardian 当前有两条买入路径：
   - 不应用 `BUY-1/BUY-2/BUY-3` 倍数
 - 持仓内加仓 `holding_add`
   - 基础金额来自 `get_trade_amount(symbol)`，当前口径可落到单标的 `instrument_strategy.lot_amount`，否则回退系统 `guardian.stock.lot_amount`
-  - 触发买入层级后，金额计算为 `base_amount * multiplier`
-  - 当前倍数：`BUY-1=2`、`BUY-2=3`、`BUY-3=4`
-  - 数量计算同样是 `int(amount / price / 100) * 100`
+  - 数量决策：`build_holding_add_decision()` 先按当前价格所在区间识别最近阶段 CAP（`effective_stage_cap`），可用仓位 = `effective_stage_cap - 当前实时市值`，本次买入量按可用仓位的一半截断（`capacity_ratio=0.5`），即 `min(base_quantity, floor(可用仓位×0.5 / price / 100) × 100)`
+  - `price <= BUY-3` 阶段同样适用半容量规则，无特例分支；`new_open` 仍按完整剩余容量（`capacity_ratio=1.0`）计算
+  - 不使用买入倍率（历史 `BUY-1=2 / BUY-2=3 / BUY-3=4` 已移除），每次买入不超过基础金额，也不一次补满 CAP
 
-因此“首次开仓且触发买入层级倍数”在当前实现里不是同一路径：首次开仓不会叠加层级倍数，层级倍数只用于已有持仓时的 `holding_add`。
+因此“首次开仓且触发买入层级”在当前实现里不是同一路径：首次开仓按完整剩余容量计算，持仓加仓按剩余容量的一半截断。
 
 ## 前端设置页
 

--- a/docs/current/modules/strategy-guardian.md
+++ b/docs/current/modules/strategy-guardian.md
@@ -40,6 +40,7 @@ Guardian 当前会把“本次卖量实际由哪些 entry 贡献出来”一起�
 
 - 持仓加仓
   - `_handle_holding_buy`
+  - 数量决策由 `GuardianBuyGridService.build_holding_add_decision()` 完成：先按当前价格所在区间识别最近阶段 CAP（`effective_stage_cap`），以 `effective_stage_cap - 当前实时市值` 得到可用仓位，再按可用仓位的一半截断本次买入量（`capacity_ratio=0.5`，100 股整手向下取整）；`price <= BUY-3` 阶段同样适用该半容量规则，无特例分支
 - `_handle_holding_buy` 的 `timing_check` / `price_threshold_check` 优先读取 order management `om_execution_fills` 的最新真实成交 `trade_time/price` 作为基准，价格阈值继续沿用 `threshold` 配置，避免卖出后又按剩余 Guardian slice 锚点做反向差价
 - 若最新 `execution_fill` 早于当前 open Guardian slices 的最新时间锚点，Guardian 会把它视为历史旧成交并忽略，继续走 Guardian slice fallback，避免把旧成交误用到 `manual_locked / external_inferred / reset` 之后的当前持仓
 - 若当前 symbol 缺失 execution fill，`_handle_holding_buy` 会回退到最低 open Guardian slice 作为价格基准，并按该 slice 的 `grid_interval` 推导“下一档”价格作为买入阈值；Trace 会在 `decision_context.threshold.fill_reference_source / threshold_rule_source / grid_interval` 标明来源与规则
@@ -73,11 +74,14 @@ Guardian buy grid 当前区分两类语义：
 - `guardian_buy_grid_configs.buy_enabled`
   - 手工配置态，表示某层级是否允许参与 Guardian 买入层级判断
 - `guardian_buy_grid_states.buy_active`
-  - 运行态，表示某层级在当前买入周期内是否仍处于可触发状态
+  - 只读审计态，不再作为买入准入条件；`_resolve_hit_levels()` 只按 `buy_enabled` 与 `price <= BUY-N` 判断命中，`buy_active=false` 不会阻止符合条件的买入
 
 当前正式真义是 fail-closed：
-- 缺失 `guardian_buy_grid_state` 时，按 `buy_active=[false,false,false]` 处理
-- 只有显式 `reset_after_sell_trade` 或价格配置更新触发的 rearm 才会把三层重新置为激活
+- 缺失或非法 `max_position_amounts` 时跳过本次 Grid 买入（`grid_position_cap_unconfigured` / `grid_position_config_invalid`）
+- 当前阶段开关 `buy_enabled[N]` 关闭时不买入，也不改变价格阶段映射（`grid_stage_disabled`）
+- 实时仓位或全局单标的上限读不到时跳过（`position_capacity_unavailable`）
+- 阶段剩余容量（按 `capacity_ratio` 折算后）不足一手时不买入（`grid_position_capacity_exhausted`）
+- `guardian_buy_grid_states` 保留字段与 `last_hit_*` 审计记录；`reset_after_sell_trade` 或价格配置更新仍会把 `buy_active` 重置为全激活，仅作审计信息
 
 ## 配置
 

--- a/freshquant/strategy/guardian.py
+++ b/freshquant/strategy/guardian.py
@@ -518,6 +518,7 @@ class StrategyGuardian(metaclass=SingletonType):
                         "remaining_amount": decision.get("remaining_amount"),
                         "base_quantity": decision.get("base_quantity"),
                         "capacity_quantity": decision.get("capacity_quantity"),
+                        "capacity_ratio": decision.get("capacity_ratio"),
                         "set_new_open_cooldown": True,
                     }
                 }
@@ -598,6 +599,7 @@ class StrategyGuardian(metaclass=SingletonType):
                     "remaining_amount": decision.get("remaining_amount"),
                     "base_quantity": decision.get("base_quantity"),
                     "capacity_quantity": decision.get("capacity_quantity"),
+                    "capacity_ratio": decision.get("capacity_ratio"),
                     "set_new_open_cooldown": set_new_open_cooldown,
                 }
             }
@@ -717,6 +719,7 @@ class StrategyGuardian(metaclass=SingletonType):
                     "remaining_amount": decision.get("remaining_amount"),
                     "base_quantity": decision.get("base_quantity"),
                     "capacity_quantity": decision.get("capacity_quantity"),
+                    "capacity_ratio": decision.get("capacity_ratio"),
                 }
             }
 

--- a/freshquant/strategy/guardian_buy_grid.py
+++ b/freshquant/strategy/guardian_buy_grid.py
@@ -294,7 +294,11 @@ class GuardianBuyGridService:
         grid_level = hit_levels[-1] if hit_levels else None
         if config:
             quantity, context = self._resolve_capped_quantity(
-                normalized, source_price, base_amount, config
+                normalized,
+                source_price,
+                base_amount,
+                config,
+                capacity_ratio=0.5,
             )
         else:
             quantity, context = _amount_to_quantity(base_amount, source_price), {}
@@ -409,7 +413,14 @@ class GuardianBuyGridService:
             return None
         return {level: _coerce_float(config.get(level)) for level in BUY_LEVELS}
 
-    def _resolve_capped_quantity(self, code, price, base_amount, config):
+    def _resolve_capped_quantity(
+        self,
+        code,
+        price,
+        base_amount,
+        config,
+        capacity_ratio=1.0,
+    ):
         raw_caps = config.get("max_position_amounts")
         if raw_caps is None:
             return 0, {"skip_reason": "grid_position_cap_unconfigured"}
@@ -441,12 +452,15 @@ class GuardianBuyGridService:
         effective_cap = global_limit if cap is None else min(float(cap), global_limit)
         remaining = max(effective_cap - current_value, 0.0)
         base_quantity = _amount_to_quantity(base_amount, price)
-        capacity_quantity = _amount_to_quantity(remaining, price)
+        capacity_quantity = _amount_to_quantity(
+            remaining * capacity_ratio, price
+        )
         context = {
             "stage": stage,
             "effective_stage_cap": effective_cap,
             "current_market_value": current_value,
             "remaining_amount": remaining,
+            "capacity_ratio": capacity_ratio,
             "base_quantity": base_quantity,
             "capacity_quantity": capacity_quantity,
         }

--- a/freshquant/strategy/guardian_buy_grid.py
+++ b/freshquant/strategy/guardian_buy_grid.py
@@ -452,9 +452,7 @@ class GuardianBuyGridService:
         effective_cap = global_limit if cap is None else min(float(cap), global_limit)
         remaining = max(effective_cap - current_value, 0.0)
         base_quantity = _amount_to_quantity(base_amount, price)
-        capacity_quantity = _amount_to_quantity(
-            remaining * capacity_ratio, price
-        )
+        capacity_quantity = _amount_to_quantity(remaining * capacity_ratio, price)
         context = {
             "stage": stage,
             "effective_stage_cap": effective_cap,

--- a/freshquant/tests/test_guardian_buy_grid.py
+++ b/freshquant/tests/test_guardian_buy_grid.py
@@ -305,7 +305,102 @@ def test_position_cap_limits_each_buy_to_base_amount_and_remaining_capacity():
     assert decision["stage"] == "BUY-1_TO_BUY-2"
     assert decision["effective_stage_cap"] == 350000
     assert decision["remaining_amount"] == 20000
-    assert decision["quantity"] == 2100
+    assert decision["capacity_ratio"] == 0.5
+    assert decision["capacity_quantity"] == 1000
+    assert decision["quantity"] == 1000
+
+
+def test_holding_add_half_capacity_applies_to_buy3_below_stage():
+    database = FakeDatabase(
+        {
+            "guardian_buy_grid_configs": FakeCollection(
+                [
+                    {
+                        "code": "000001",
+                        "BUY-1": 10.0,
+                        "BUY-2": 9.0,
+                        "BUY-3": 8.0,
+                        "max_position_amounts": [200000, 350000, 500000],
+                        "buy_enabled": [True, True, True],
+                        "enabled": True,
+                    }
+                ]
+            )
+        }
+    )
+    service = _build_service(database)
+    service._load_position_capacity = lambda _code: (750000.0, 800000.0)
+
+    decision = service.build_holding_add_decision("000001", 7.5)
+
+    assert decision["stage"] == "BUY-3_BELOW"
+    assert decision["effective_stage_cap"] == 800000
+    assert decision["remaining_amount"] == 50000
+    assert decision["capacity_ratio"] == 0.5
+    assert decision["capacity_quantity"] == 3300
+    assert decision["quantity"] == 3300
+
+
+def test_new_open_uses_full_capacity_ratio():
+    database = FakeDatabase(
+        {
+            "guardian_buy_grid_configs": FakeCollection(
+                [
+                    {
+                        "code": "000001",
+                        "BUY-1": 10.0,
+                        "BUY-2": 9.0,
+                        "BUY-3": 8.0,
+                        "max_position_amounts": [200000, 350000, 500000],
+                        "buy_enabled": [True, True, True],
+                        "enabled": True,
+                    }
+                ]
+            )
+        }
+    )
+    service = _build_service(database)
+    service._load_position_capacity = lambda _code: (0.0, 800000.0)
+
+    decision = service.build_new_open_decision("000001", 9.5)
+
+    assert decision["path"] == "new_open"
+    assert decision["stage"] == "BUY-1_TO_BUY-2"
+    assert decision["remaining_amount"] == 350000
+    assert decision["capacity_ratio"] == 1.0
+    assert decision["capacity_quantity"] == 36800
+    assert decision["quantity"] == 10500
+
+
+def test_holding_add_half_capacity_below_one_lot_skips():
+    database = FakeDatabase(
+        {
+            "guardian_buy_grid_configs": FakeCollection(
+                [
+                    {
+                        "code": "000001",
+                        "BUY-1": 10.0,
+                        "BUY-2": 9.0,
+                        "BUY-3": 8.0,
+                        "max_position_amounts": [200000, 350000, 500000],
+                        "buy_enabled": [True, True, True],
+                        "enabled": True,
+                    }
+                ]
+            )
+        }
+    )
+    service = _build_service(database)
+    service._load_position_capacity = lambda _code: (349000.0, 800000.0)
+
+    decision = service.build_holding_add_decision("000001", 9.5)
+
+    assert decision["stage"] == "BUY-1_TO_BUY-2"
+    assert decision["remaining_amount"] == 1000
+    assert decision["capacity_ratio"] == 0.5
+    assert decision["capacity_quantity"] == 0
+    assert decision["quantity"] == 0
+    assert decision["skip_reason"] == "grid_position_capacity_exhausted"
 
 
 def test_new_open_with_existing_grid_and_missing_caps_fails_closed():

--- a/freshquant/tests/test_guardian_runtime_observability.py
+++ b/freshquant/tests/test_guardian_runtime_observability.py
@@ -250,6 +250,7 @@ def test_guardian_submit_intent_emits_trace_step(monkeypatch):
                 "remaining_amount": 0.0,
                 "base_quantity": 5200,
                 "capacity_quantity": 0,
+                "capacity_ratio": 0.5,
             },
         ),
     ],
@@ -300,6 +301,7 @@ def test_guardian_zero_quantity_uses_grid_skip_reason_and_cap_context(
         "remaining_amount",
         "base_quantity",
         "capacity_quantity",
+        "capacity_ratio",
     ):
         assert field in context
         assert context[field] == decision_fields.get(field)
@@ -325,6 +327,7 @@ def test_guardian_successful_buy_carries_cap_decision_strategy_context(
         "remaining_amount": 20000.0,
         "base_quantity": 5100,
         "capacity_quantity": 2100,
+        "capacity_ratio": 0.5,
     }
     monkeypatch.setattr("freshquant.strategy.guardian.redis_db", FakeRedis())
     monkeypatch.setattr(
@@ -365,6 +368,7 @@ def test_guardian_successful_buy_carries_cap_decision_strategy_context(
         "remaining_amount",
         "base_quantity",
         "capacity_quantity",
+        "capacity_ratio",
     ):
         assert context[field] == decision[field]
 


### PR DESCRIPTION
## 背景
持仓加仓（holding-add）时，应先计算当前最近的 CAP 仓位限制剩余可用仓位，本次买入资金不超过可用仓位的一半；price <= BUY-3 统一适用，不增加特例。

## 变更
- \reshquant/strategy/guardian_buy_grid.py\：加仓买入量按最近一级 CAP 剩余可用仓位的一半封顶
- \reshquant/strategy/guardian.py\：同步 context 拷贝块
- 测试：\	est_guardian_buy_grid.py\（+97）、\	est_guardian_runtime_observability.py\
- 文档：\docs/current/configuration.md\、\docs/current/modules/strategy-guardian.md\（含修正旧倍率残留语义）

## 验收
- 62 个相关单测通过（本地验证）
- CI：governance / pre-commit / pytest shards 全绿

## 部署影响
- \reshquant/strategy/**\ → Guardian 宿主机 surface；合并后需重部署 Guardian 并确认 fqnext_guardian_event RUNNING。