### PR TITLE
fix(guardian): arrange_entry 低价高量持仓有界收尾（flatten dry-run 硬前置修复）

### DIFF
--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -81,6 +81,10 @@
     金额已超过 `lot_amount`（价格过高、网格不再有意义的细分粒度）时，剩余量
     全部并入最后一格，保证 `Σslice == entry` 守恒、价格有界且终止（避免低价
     高量持仓产生 ¥10^7~10^14 级幻影切片或 RecursionError）
+  - 切片价格上限固定为 `round(entry_price * 20, 2)`（买入价 × 20）：当
+    `grid_interval` 算出的下一档价格将超过该上限时，剩余数量全部并入当前格并
+    终止递归，不再生成任何超过 20 倍买入价的切片；该上限与“整手金额超过
+    `lot_amount` 即并入”规则独立，任一命中都执行 tail-merge
 - `om_exit_allocations`
   - 卖出对 entry / slice 的分摊结果
 - `om_reconciliation_gaps`

--- a/docs/current/modules/order-management.md
+++ b/docs/current/modules/order-management.md
@@ -76,6 +76,11 @@
   - 系统持仓入口真值，供 TPSL/Subject/Kline/持仓解释层消费；当前 buy 侧默认落为保守聚合后的 `buy_cluster`
 - `om_entry_slices`
   - entry 的 Guardian 切片；当前按聚合后的 entry 重新按 `50000` 口径切片
+  - `arrange_entry` 按 `price × grid_interval` 乘法递增、单格股数
+    `int(lot_amount / price / 100) * 100`（最小 100 股）切分；当整手（100 股）
+    金额已超过 `lot_amount`（价格过高、网格不再有意义的细分粒度）时，剩余量
+    全部并入最后一格，保证 `Σslice == entry` 守恒、价格有界且终止（避免低价
+    高量持仓产生 ¥10^7~10^14 级幻影切片或 RecursionError）
 - `om_exit_allocations`
   - 卖出对 entry / slice 的分摊结果
 - `om_reconciliation_gaps`

--- a/freshquant/order_management/guardian/arranger.py
+++ b/freshquant/order_management/guardian/arranger.py
@@ -164,7 +164,9 @@ def _arrange_entry_remaining(
     if current_amount > lot_amount:
         quantity = int(lot_amount / guardian_price / 100) * 100
         if quantity == 0:
-            quantity = 100
+            # 整手（100 股）金额已超过 lot_amount：网格不再有意义的细分粒度，
+            # 剩余量全部并入最后一格（保证 Σslice == entry 守恒并终止）。
+            quantity = remaining_quantity
         quantity = min(quantity, remaining_quantity)
     else:
         quantity = remaining_quantity
@@ -268,7 +270,7 @@ def _arrange_remaining(
     if current_amount > lot_amount:
         quantity = int(lot_amount / guardian_price / 100) * 100
         if quantity == 0:
-            quantity = 100
+            quantity = remaining_quantity
         quantity = min(quantity, remaining_quantity)
     else:
         quantity = remaining_quantity

--- a/freshquant/order_management/guardian/arranger.py
+++ b/freshquant/order_management/guardian/arranger.py
@@ -159,9 +159,15 @@ def _arrange_entry_remaining(
         return
 
     guardian_price = float(f"{current_price:.2f}")
+    price_cap = _guardian_slice_price_cap(entry.get("entry_price"))
+    next_price = float(f"{(guardian_price * grid_interval):.2f}")
     current_amount = guardian_price * remaining_quantity
 
-    if current_amount > lot_amount:
+    if price_cap is not None and next_price > price_cap:
+        # 价格上限规则：下一档价格将超过买入价 × 20，剩余量全部并入当前格并终止，
+        # 不再生成任何超过上限的切片。
+        quantity = remaining_quantity
+    elif current_amount > lot_amount:
         quantity = int(lot_amount / guardian_price / 100) * 100
         if quantity == 0:
             # 整手（100 股）金额已超过 lot_amount：网格不再有意义的细分粒度，
@@ -192,7 +198,6 @@ def _arrange_entry_remaining(
     if next_quantity <= 0:
         return
 
-    next_price = float(f"{(guardian_price * grid_interval):.2f}")
     next_amount = next_quantity * next_price
     _arrange_entry_remaining(
         slices=slices,
@@ -265,9 +270,13 @@ def _arrange_remaining(
         return
 
     guardian_price = float(f"{current_price:.2f}")
+    price_cap = _guardian_slice_price_cap(buy_lot.get("buy_price_real"))
+    next_price = float(f"{(guardian_price * grid_interval):.2f}")
     current_amount = guardian_price * remaining_quantity
 
-    if current_amount > lot_amount:
+    if price_cap is not None and next_price > price_cap:
+        quantity = remaining_quantity
+    elif current_amount > lot_amount:
         quantity = int(lot_amount / guardian_price / 100) * 100
         if quantity == 0:
             quantity = remaining_quantity
@@ -296,7 +305,6 @@ def _arrange_remaining(
     if next_quantity <= 0:
         return
 
-    next_price = float(f"{(guardian_price * grid_interval):.2f}")
     next_amount = next_quantity * next_price
     _arrange_remaining(
         slices=slices,
@@ -308,6 +316,21 @@ def _arrange_remaining(
         grid_interval=grid_interval,
         slice_seq=slice_seq + 1,
     )
+
+
+def _guardian_slice_price_cap(base_price):
+    """切片价格上限 = 买入价 × 20（保留两位小数）。
+
+    返回 None 表示无法解析基准价（调用方忽略该规则）。
+    """
+
+    try:
+        base = float(base_price)
+    except (TypeError, ValueError):
+        return None
+    if base <= 0:
+        return None
+    return round(base * 20, 2)
 
 
 def _insert_slice_desc(slices, slice_document):

--- a/freshquant/tests/test_order_management_guardian_semantics.py
+++ b/freshquant/tests/test_order_management_guardian_semantics.py
@@ -336,6 +336,11 @@ def test_arrange_entry_terminates_and_conserves_for_low_price_high_volume_positi
     assert all(item["status"] == "OPEN" for item in slices)
     # 价格必须是有界的（旧的错误行为会膨胀到 10^14 级）
     assert max(float(item["guardian_price"]) for item in slices) < 10000
+    # 价格上限 = 买入价 × 20 = round(0.568875 * 20, 2) = 11.38
+    assert max(float(item["guardian_price"]) for item in slices) <= 11.38
+    # 最后一格（最高价格）为 10.56，吸收剩余数量
+    assert slices[0]["guardian_price"] == 10.56
+    assert sum(int(item["original_quantity"]) for item in slices) == 1468900
 
 
 def test_arrange_entry_conserves_quantity_for_002262_plan_example():
@@ -360,5 +365,70 @@ def test_arrange_entry_conserves_quantity_for_002262_plan_example():
     slices = arrange_entry(entry, lot_amount=50000, grid_interval=1.2)
 
     assert sum(int(item["original_quantity"]) for item in slices) == 17900
-    assert max(float(item["guardian_price"]) for item in slices) < 10000
+    # 价格上限 = 买入价 × 20 = round(23.41255 * 20, 2) = 468.25
+    assert max(float(item["guardian_price"]) for item in slices) <= 468.25
+    # 最后一格为 432.84，吸收剩余数量
+    assert slices[0]["guardian_price"] == 432.84
+    assert len(slices) == 17
     assert min(float(item["guardian_price"]) for item in slices) == 23.41
+
+
+def test_arrange_entry_price_cap_20x_buy_price_002262_simulated_boundary():
+    # 用户模拟边界：entry_price=23.41 → cap=468.2；价格序列到 432.84（≤cap）后
+    # next=519.41 > cap → 剩余并入 432.84 格。约 17 格、最后一格 432.84、
+    # Σ=17900、无任何切片 > 468.2。
+    entry = build_position_entry_from_trade_fact(
+        {
+            "trade_fact_id": "trade_entry_cap_002262_sim",
+            "symbol": "002262",
+            "side": "buy",
+            "quantity": 17900,
+            "price": 23.41,
+            "trade_time": 1775000000,
+            "date": None,
+            "time": None,
+        },
+        source_ref_type="position_snapshot_flatten",
+        source_ref_id="flatten:acct:002262:sim",
+        entry_type="position_snapshot_flatten",
+    )
+
+    slices = arrange_entry(entry, lot_amount=50000, grid_interval=1.2)
+
+    prices = [float(item["guardian_price"]) for item in slices]
+    assert len(slices) == 17
+    assert sum(int(item["original_quantity"]) for item in slices) == 17900
+    assert max(prices) == 432.84
+    assert all(price <= 468.2 for price in prices)
+    assert slices[0]["guardian_price"] == 432.84
+    assert slices[0]["original_quantity"] == 6700
+
+
+def test_arrange_entry_price_cap_20x_buy_price_512000_simulated_boundary():
+    # 用户模拟边界：entry_price=0.57 → cap=11.4；价格序列到 10.56（≤cap）后
+    # next=12.67 > cap → 剩余（约 96.7 万股）并入 10.56 格。Σ=1470000、
+    # 无 RecursionError、无任何切片 > 11.4。
+    entry = build_position_entry_from_trade_fact(
+        {
+            "trade_fact_id": "trade_entry_cap_512000_sim",
+            "symbol": "512000",
+            "side": "buy",
+            "quantity": 1470000,
+            "price": 0.57,
+            "trade_time": 1775000000,
+            "date": None,
+            "time": None,
+        },
+        source_ref_type="position_snapshot_flatten",
+        source_ref_id="flatten:acct:512000:sim",
+        entry_type="position_snapshot_flatten",
+    )
+
+    slices = arrange_entry(entry, lot_amount=50000, grid_interval=1.2)
+
+    prices = [float(item["guardian_price"]) for item in slices]
+    assert sum(int(item["original_quantity"]) for item in slices) == 1470000
+    assert max(prices) == 10.56
+    assert all(price <= 11.4 for price in prices)
+    assert slices[0]["guardian_price"] == 10.56
+    assert slices[0]["original_quantity"] == 972000

--- a/freshquant/tests/test_order_management_guardian_semantics.py
+++ b/freshquant/tests/test_order_management_guardian_semantics.py
@@ -307,3 +307,58 @@ def test_arrange_entry_never_leaves_a_guardian_slice_above_50000():
         float(item["guardian_price"]) * int(item["original_quantity"]) <= 50000
         for item in slices
     )
+
+
+def test_arrange_entry_terminates_and_conserves_for_low_price_high_volume_position():
+    # 真实生产边界：512000 ETF 1,468,900 股 @ 0.568875，lot_amount=50000、
+    # grid_interval=1.2。旧的递归语义会在 100 股下限处无限膨胀价格，
+    # 导致 RecursionError 或产出 ¥10^14 级幻影切片。
+    entry = build_position_entry_from_trade_fact(
+        {
+            "trade_fact_id": "trade_entry_low_price_high_volume",
+            "symbol": "512000",
+            "side": "buy",
+            "quantity": 1468900,
+            "price": 0.568875,
+            "trade_time": 1775000000,
+            "date": None,
+            "time": None,
+        },
+        source_ref_type="position_snapshot_flatten",
+        source_ref_id="flatten:acct:512000:1775000000",
+        entry_type="position_snapshot_flatten",
+    )
+
+    slices = arrange_entry(entry, lot_amount=50000, grid_interval=1.2)
+
+    assert slices
+    assert sum(int(item["original_quantity"]) for item in slices) == 1468900
+    assert all(item["status"] == "OPEN" for item in slices)
+    # 价格必须是有界的（旧的错误行为会膨胀到 10^14 级）
+    assert max(float(item["guardian_price"]) for item in slices) < 10000
+
+
+def test_arrange_entry_conserves_quantity_for_002262_plan_example():
+    # 方案 v4 §5.3 的 002262 预期：17900 股 @ 23.41255，Σslice == 17900，
+    # 价格从 23.41 起 ×1.2 递增且必须有界（旧行为最高价膨胀到 10^7 级）。
+    entry = build_position_entry_from_trade_fact(
+        {
+            "trade_fact_id": "trade_entry_002262_flatten",
+            "symbol": "002262",
+            "side": "buy",
+            "quantity": 17900,
+            "price": 23.41255,
+            "trade_time": 1775000000,
+            "date": None,
+            "time": None,
+        },
+        source_ref_type="position_snapshot_flatten",
+        source_ref_id="flatten:acct:002262:1775000000",
+        entry_type="position_snapshot_flatten",
+    )
+
+    slices = arrange_entry(entry, lot_amount=50000, grid_interval=1.2)
+
+    assert sum(int(item["original_quantity"]) for item in slices) == 17900
+    assert max(float(item["guardian_price"]) for item in slices) < 10000
+    assert min(float(item["guardian_price"]) for item in slices) == 23.41

--- a/freshquant/tests/test_rebuild_flatten.py
+++ b/freshquant/tests/test_rebuild_flatten.py
@@ -46,7 +46,7 @@ def test_flatten_builder_generates_one_cost_price_entry_for_002262():
     )
 
     assert result["position_entries"] == 1
-    assert result["entry_slices"] == 83
+    assert result["entry_slices"] == 18
     assert result["exit_allocations"] == 0
     entry = result["position_entry_documents"][0]
     assert entry["source_ref_type"] == "position_snapshot_flatten"
@@ -294,7 +294,7 @@ def test_rebuild_cli_flatten_dry_run_reports_anchor_comparison_without_mutation(
     assert summary["mode"] == "flatten-cost-price"
     assert summary["dry_run"] is True
     assert summary["position_entries"] == 1
-    assert summary["entry_slices"] == 83
+    assert summary["entry_slices"] == 18
     assert summary["flatten_entries_by_symbol"]["002262"][0]["entry_price"] == 23.41255
     assert summary["flatten_slices_by_symbol"]["002262"]
     assert all(item["passed"] for item in summary["flatten_invariant_checks"])

--- a/freshquant/tests/test_rebuild_flatten.py
+++ b/freshquant/tests/test_rebuild_flatten.py
@@ -46,7 +46,7 @@ def test_flatten_builder_generates_one_cost_price_entry_for_002262():
     )
 
     assert result["position_entries"] == 1
-    assert result["entry_slices"] == 18
+    assert result["entry_slices"] == 17
     assert result["exit_allocations"] == 0
     entry = result["position_entry_documents"][0]
     assert entry["source_ref_type"] == "position_snapshot_flatten"
@@ -294,7 +294,7 @@ def test_rebuild_cli_flatten_dry_run_reports_anchor_comparison_without_mutation(
     assert summary["mode"] == "flatten-cost-price"
     assert summary["dry_run"] is True
     assert summary["position_entries"] == 1
-    assert summary["entry_slices"] == 18
+    assert summary["entry_slices"] == 17
     assert summary["flatten_entries_by_symbol"]["002262"][0]["entry_price"] == 23.41255
     assert summary["flatten_slices_by_symbol"]["002262"]
     assert all(item["passed"] for item in summary["flatten_invariant_checks"])


### PR DESCRIPTION
## 背景
#517 合并并部署后，本机 flatten dry-run 验收发现真实生产数据边界：arrange_entry
对低价高量持仓（512000 1,468,900 股 @ 0.57、002262 27,000 股 @ 22.70）会在
100 股下限处持续膨胀价格，产出 ¥10^7~10^14 级幻影切片或 RecursionError，
导致 rebuild --mode flatten-cost-price --dry-run 无法完成、账本将被幻影切片污染。
方案 v4 §5.3 硬不变量（Σslice == entry、全 OPEN）要求终止且守恒。

## 修复
- arranger.py：当整手（100 股）金额已超过 lot_amount（网格不再有意义的细分
  粒度）时，剩余量全部并入最后一格（方案 v4 §5.2『剩余量归末格』边界情形）；
  Σslice == entry 守恒、价格有界、递归终止。
- 既有 24600@24.149 grid1.03 单测不变（不触达该边界）。
- 新增回归单测：512000 低价高量、002262 方案示例（17,900 @ 23.41255）守恒且
  价格有界；flatten 单测切片数 83→18 随修复更新。

## 验收
- pytest 相关集通过；pre-commit 全绿
- 本机 dry-run 验收输出 10 标的 / 248 有界切片 / 硬不变量全过（见部署后重跑）

## 部署影响
- freshquant/order_management/**（guardian/arranger.py）：重建 API；重启
  order_management / guardian 相关宿主机 surface