### PR TITLE
fix(stock): resolve TDX 待买 group file via blocknew.cfg

### DIFF
--- a/docker/compose.parallel.yaml
+++ b/docker/compose.parallel.yaml
@@ -88,7 +88,7 @@ services:
         target: /freshquant/ops-snapshot
         read_only: true
       - type: bind
-        source: ${FQPACK_TDX_SYNC_DIR:-D:/tdx_biduan}
+        source: ${FQPACK_TDX_SYNC_DIR:-D:/new_tdx}
         target: /opt/tdx
     depends_on:
       fq_mongodb:

--- a/docs/current/configuration.md
+++ b/docs/current/configuration.md
@@ -192,7 +192,8 @@ CLX 不新增独立 Mongo/Redis 连接配置；API 与 Dagster 继续读取 Fres
 - Shouban30 与 CLX 写 `.blk` 时先读 `bootstrap_config.tdx.home`，未配置时回退 `TDX_HOME`；当前宿主机正式目录为 `D:/new_tdx`，对应文件分别是 `T0002/blocknew/30RYZT.blk` 与 `T0002/blocknew/CLX_18.blk`
 - KlineSlim 的 `stock_pools` 同步自选股读取同一个 TDX home 下的 `T0002/blocknew/ZXG.blk`，支持通达信前缀代码解码后按既有 `stock_pools` 与当前 `xt_positions` 持仓去重追加到 `freshquant.stock_pools`
 - Docker `fq_apiserver` 从正式 `env_file` `D:/fqpack/config/fqnext.compose.env` 读取 `FRESHQUANT_TDX__HOME=/opt/tdx`，以此解析容器内路径；`CLX_18.blk` 位于 `/opt/tdx/T0002/blocknew/CLX_18.blk`
-- Compose 定义仍保留 `${FQPACK_TDX_SYNC_DIR:-D:/tdx_biduan}` 兼容回退；正式 `deploy-production.yml` job env 与人工部署入口都必须在调用 Compose 的同一进程显式设置 `FQPACK_TDX_SYNC_DIR=D:/new_tdx`。service `env_file` 不参与 Compose 插值，兼容回退不作为正式宿主机目录真值
+- Compose 定义默认 `${FQPACK_TDX_SYNC_DIR:-D:/new_tdx}` 把 `D:/new_tdx` 挂载为 API 容器 `/opt/tdx`；正式 `deploy-production.yml` job env 与人工部署入口仍会在调用 Compose 的同一进程显式设置 `FQPACK_TDX_SYNC_DIR=D:/new_tdx`。service `env_file` 不参与 Compose 插值，`FQPACK_TDX_SYNC_DIR` 只影响 `/opt/tdx` 挂载源
+- KlineSlim 的 `must_pool` 同步待买通过 `T0002/blocknew/blocknew.cfg` 按显示名「待买」解析真实 BLK 文件名（当前宿主机为 `DM.blk`），cfg 缺失或未登记时回退 `待买.blk`
 - `FQ_RUNTIME_LOG_DIR` 可以覆盖 `runtime.log_dir`
 - `XTQUANT_PORT` 可以覆盖 `xtdata.port`
 

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -37,7 +37,7 @@ docker compose -f docker/compose.parallel.yaml up -d --build
 
 - `deploy-production.yml` 由 `push main` 直接触发，不需要额外审批。
 - `deploy-production.yml` 现在只调用 `script/ci/run_production_deploy.ps1`，不再在 workflow YAML 内手工展开 canonical main sync、`uv sync` 和 `run_formal_deploy.py`。
-- `deploy-production.yml` 的 job env 显式设置 `FQPACK_TDX_SYNC_DIR=D:/new_tdx`，保证后续 Compose 插值把正式通达信目录挂载到 API 容器；仓库 Compose 内的 `D:/tdx_biduan` 兼容回退不作为 production 真值。
+- `deploy-production.yml` 的 job env 显式设置 `FQPACK_TDX_SYNC_DIR=D:/new_tdx`，保证后续 Compose 插值把正式通达信目录挂载到 API 容器；仓库 Compose 默认值也已是 `D:/new_tdx`（可用 `FQPACK_TDX_SYNC_DIR` 覆盖），不再使用空的 `D:/tdx_biduan` 回退。
 - `deploy-production.yml` 当前只要求 canonical repo root 能 fetch 到最新 `origin/main`；它不再要求 canonical repo root 本身先 `pull --ff-only` 到远程 main。
 - `deploy-production.yml` 会先创建或 reset `D:\fqpack\freshquant-2026.2.23` 这个 local main sync root 到目标 SHA，再直接执行那里的最新 `script/ci/run_production_deploy.ps1`。
 - `script/ci/run_production_deploy.ps1` 保留 bootstrap/re-exec 逻辑，作为人工正式 deploy 或 local main sync root 直接入口时的兜底；workflow 正式路径已经不再依赖 canonical repo root 上的脚本版本。

--- a/docs/current/interfaces.md
+++ b/docs/current/interfaces.md
@@ -72,6 +72,7 @@ python -m freshquant.rear.api_server --port 5000
   - `/api/get_stock_pools_list`
 - `POST /api/sync_stock_pools_from_tdx_self_select`
   - `POST /api/sync_must_pool_from_tdx_self_select`
+  - `must_pool` 同步从 `blocknew.cfg` 按显示名「待买」解析真实 BLK 文件名（如 `DM.blk`），解析失败回退 `待买.blk`
   - `/api/get_stock_pre_pools_list`
   - `/api/get_stock_must_pools_list`
 - `/api/add_to_stock_pools_by_code`

--- a/docs/current/modules/kline-webui.md
+++ b/docs/current/modules/kline-webui.md
@@ -13,6 +13,7 @@
   - `/api/stock_data_v2`
   - `/api/stock_data_chanlun_structure`
   - `POST /api/sync_stock_pools_from_tdx_self_select`
+  - `POST /api/sync_must_pool_from_tdx_self_select`（按 `blocknew.cfg` 解析「待买」分组真实文件名，回退 `待买.blk`）
   - `/api/subject-management/<symbol>`
   - `/api/subject-management/<symbol>/guardian-buy-grid`
   - `/api/order-management/stoploss/bind`

--- a/docs/current/reference/stock-pools-and-positions.md
+++ b/docs/current/reference/stock-pools-and-positions.md
@@ -101,7 +101,7 @@
   - 同步只写 `stock_pools`，不写 `must_pool`，不触发下单；左侧 `stock_pools` 分组仍会过滤已在“持仓股”分组出现的标的
 - KlineSlim 从通达信「待买」分组导入 `must_pool`
   - `/kline-slim` 左侧 `must_pool` 分组的 `同步待买` 按钮调用 `POST /api/sync_must_pool_from_tdx_self_select?days=30`
-  - 后端读取当前 TDX home 下的 `T0002/blocknew/待买.blk`，解码通达信前缀代码，排除当前 `xt_positions` 持仓后，增量导入 `must_pool`
+  - 后端先解析 `T0002/blocknew/blocknew.cfg`，按显示名「待买」找到真实 BLK 文件名（当前宿主机为 `DM.blk`），cfg 缺失或未登记时回退 `T0002/blocknew/待买.blk`；读取后解码通达信前缀代码，排除当前 `xt_positions` 持仓后，增量导入 `must_pool`
   - 导入为增量合并：已存在 `must_pool` 记录保留 `stop_loss_price / initial_lot_amount / lot_amount` 交易参数，仅合并 `tdx_must_pool` 来源 provenance；不在「待买」分组中的既有 `must_pool` 记录不会被删除
   - 新增记录 `stop_loss_price` 保持未配置（`None`），`lot_amount / initial_lot_amount` 走 `get_trade_amount` 默认值；`forever` 固定为 `true`
   - 导入只写 `must_pool`，不写 `stock_pools`，不触发下单

--- a/freshquant/stock_service.py
+++ b/freshquant/stock_service.py
@@ -11,6 +11,10 @@ import pymongo
 import freshquant.util.df_helper as df_helper
 from freshquant.bootstrap_config import bootstrap_config
 from freshquant.carnation.enum_instrument import InstrumentType
+from freshquant.clx_daily_selection.tdx_export import (
+    BLOCKNEW_CFG_NAME,
+    _parse_blocknew_cfg_groups,
+)
 from freshquant.data.astock import must_pool
 from freshquant.db import DBfreshquant
 from freshquant.instrument.general import query_instrument_type
@@ -40,6 +44,7 @@ TDX_SELF_SELECT_SUPPORTED_INSTRUMENT_TYPES = {
     InstrumentType.ETF_CN,
 }
 TDX_MUST_POOL_FILENAME = "待买.blk"
+TDX_MUST_POOL_DISPLAY_NAME = "待买"
 TDX_MUST_POOL_CATEGORY = "待买"
 TDX_MUST_POOL_SOURCE = "tdx_must_pool"
 
@@ -90,6 +95,48 @@ def _require_tdx_home(tdx_home=None):
 
 def _tdx_self_select_path(tdx_home=None, filename=TDX_SELF_SELECT_FILENAME):
     return _require_tdx_home(tdx_home) / "T0002" / "blocknew" / filename
+
+
+def read_tdx_blocknew_cfg_mapping(tdx_home=None):
+    """Parse ``T0002/blocknew/blocknew.cfg`` into ``{display_name: file_name}``.
+
+    TDX stores block groups under arbitrary file names: ``blocknew.cfg`` maps
+    each display name (e.g. ``待买``) to its actual file name (e.g. ``DM``).
+    Reuses the shared parser from ``freshquant.clx_daily_selection.tdx_export``
+    (each record is 120 bytes: 50-byte GBK display name + 70-byte file name
+    prefix, stored without the ``.blk`` extension). Returns an empty dict when
+    the cfg file is absent or unreadable.
+    """
+    cfg_path = _require_tdx_home(tdx_home) / "T0002" / "blocknew" / BLOCKNEW_CFG_NAME
+    if not cfg_path.exists():
+        return {}
+    mapping = {}
+    for display_name, block_key in _parse_blocknew_cfg_groups(cfg_path.read_bytes()):
+        display_name = display_name.strip()
+        block_key = block_key.strip()
+        if display_name and block_key:
+            mapping[display_name] = block_key
+    return mapping
+
+
+def resolve_tdx_block_filename(
+    tdx_home=None,
+    display_name=TDX_MUST_POOL_DISPLAY_NAME,
+    fallback_filename=TDX_MUST_POOL_FILENAME,
+):
+    """Resolve the actual ``.blk`` file name for a TDX block display name.
+
+    The group file cannot be assumed to share its display name: ``blocknew.cfg``
+    maps ``待买 -> DM`` on the current host, so the hardcoded ``待买.blk`` would
+    not exist. Falls back to ``fallback_filename`` when the cfg is missing or
+    the display name is not registered.
+    """
+    file_name = read_tdx_blocknew_cfg_mapping(tdx_home=tdx_home).get(display_name)
+    if not file_name:
+        return fallback_filename
+    if not str(file_name).lower().endswith(".blk"):
+        return f"{file_name}.blk"
+    return file_name
 
 
 def decode_tdx_self_select_code(line):
@@ -267,23 +314,34 @@ def sync_must_pool_from_tdx_self_select(
     days=30,
     *,
     tdx_home=None,
-    filename=TDX_MUST_POOL_FILENAME,
+    filename=None,
     category=TDX_MUST_POOL_CATEGORY,
     source=TDX_MUST_POOL_SOURCE,
 ):
     """Import freshquant.must_pool from the TDX ``待买`` self-select group.
 
     Reuses the same TDX ``.blk`` reading/decoding chain as
-    ``sync_stock_pools_from_tdx_self_select``: it reads the group file
-    (default ``T0002/blocknew/待买.blk``), decodes prefixed codes, skips
-    current ``xt_positions`` holdings, and upserts every valid code into
-    ``must_pool`` with a ``tdx_must_pool`` membership.
+    ``sync_stock_pools_from_tdx_self_select``: it reads the 待买 group file,
+    decodes prefixed codes, skips current ``xt_positions`` holdings, and
+    upserts every valid code into ``must_pool`` with a ``tdx_must_pool``
+    membership.
+
+    The group file name is resolved from ``T0002/blocknew/blocknew.cfg`` by the
+    display name ``待买`` (TDX may store it as e.g. ``DM.blk``); when the cfg
+    is missing or the display name is not registered, it falls back to
+    ``T0002/blocknew/待买.blk``.
 
     Unlike the stock_pools overwrite sync, this is an additive import:
     existing ``must_pool`` records keep their trading parameters
     (``stop_loss_price`` / ``initial_lot_amount`` / ``lot_amount``) and are
     never deleted when they are absent from the TDX group.
     """
+    if not filename:
+        filename = resolve_tdx_block_filename(
+            tdx_home=tdx_home,
+            display_name=TDX_MUST_POOL_DISPLAY_NAME,
+            fallback_filename=TDX_MUST_POOL_FILENAME,
+        )
     codes = read_tdx_self_select_codes(tdx_home=tdx_home, filename=filename)
     now = pendulum.now()
     expire_at = now.add(days=int(days or 30))

--- a/freshquant/tests/test_docker_runtime_policy.py
+++ b/freshquant/tests/test_docker_runtime_policy.py
@@ -64,7 +64,7 @@ def test_compose_builds_rear_image_once() -> None:
 
 def test_compose_apiserver_mounts_tdx_sync_dir() -> None:
     text = Path("docker/compose.parallel.yaml").read_text(encoding="utf-8")
-    assert "${FQPACK_TDX_SYNC_DIR:-D:/tdx_biduan}" in text
+    assert "${FQPACK_TDX_SYNC_DIR:-D:/new_tdx}" in text
     assert "target: /opt/tdx" in text
 
 

--- a/freshquant/tests/test_stock_service_tdx_self_select.py
+++ b/freshquant/tests/test_stock_service_tdx_self_select.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from freshquant import stock_service
+from freshquant.clx_daily_selection.tdx_export import _encode_blocknew_cfg_group
 
 
 class FakeStockPoolsCollection:
@@ -39,6 +40,23 @@ class FakeStockPoolsCollection:
 
     def find(self, query=None, projection=None):
         return list(self.docs)
+
+
+def _write_blocknew_cfg(tmp_path, pairs):
+    """Write a TDX blocknew.cfg using the shared 120-byte record encoder.
+
+    Each record is 120 bytes: 50-byte GBK display name + 70-byte file name
+    prefix (without the ``.blk`` extension), matching the canonical encoder in
+    ``freshquant.clx_daily_selection.tdx_export``.
+    """
+    cfg_path = Path(tmp_path) / "T0002" / "blocknew" / "blocknew.cfg"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    raw = b"".join(
+        _encode_blocknew_cfg_group(display_name, file_name)
+        for display_name, file_name in pairs
+    )
+    cfg_path.write_bytes(raw)
+    return cfg_path
 
 
 def test_decode_tdx_self_select_code_accepts_tdx_and_plain_codes():
@@ -282,3 +300,80 @@ def test_sync_must_pool_from_tdx_self_select_skips_current_holdings(
     assert result["synced_codes"] == ["000002"]
     assert result["skipped_holding_codes"] == ["300127"]
     assert [call["code"] for call in calls] == ["000002"]
+
+
+def test_read_tdx_blocknew_cfg_mapping_maps_display_to_file(tmp_path):
+    _write_blocknew_cfg(tmp_path, [("待买", "DM"), ("clx_18", "CLX_18")])
+
+    assert stock_service.read_tdx_blocknew_cfg_mapping(tdx_home=tmp_path) == {
+        "待买": "DM",
+        "clx_18": "CLX_18",
+    }
+
+
+def test_read_tdx_blocknew_cfg_mapping_missing_cfg_returns_empty(tmp_path):
+    assert stock_service.read_tdx_blocknew_cfg_mapping(tdx_home=tmp_path) == {}
+
+
+def test_resolve_tdx_block_filename_maps_display_to_file(tmp_path):
+    _write_blocknew_cfg(tmp_path, [("待买", "DM")])
+
+    assert stock_service.resolve_tdx_block_filename(tdx_home=tmp_path) == "DM.blk"
+
+
+def test_resolve_tdx_block_filename_falls_back_without_cfg(tmp_path):
+    assert stock_service.resolve_tdx_block_filename(tdx_home=tmp_path) == "待买.blk"
+
+
+def test_sync_must_pool_reads_dai_mai_group_by_mapped_file(monkeypatch, tmp_path):
+    _write_blocknew_cfg(tmp_path, [("待买", "DM")])
+    target = Path(tmp_path) / "T0002" / "blocknew" / "DM.blk"
+    target.write_text("0300127\n000001\n113000\n", encoding="gbk")
+    fake_db = {
+        "stock_pools": FakeStockPoolsCollection(),
+        "must_pool": FakeStockPoolsCollection(),
+        "xt_positions": FakeStockPoolsCollection(),
+    }
+    monkeypatch.setattr(stock_service, "DBfreshquant", fake_db)
+    calls = []
+    monkeypatch.setattr(
+        stock_service.must_pool,
+        "import_pool",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    result = stock_service.sync_must_pool_from_tdx_self_select(tdx_home=tmp_path)
+
+    assert result["file_name"] == "DM.blk"
+    assert result["category"] == "待买"
+    assert result["source"] == "tdx_must_pool"
+    assert result["synced_codes"] == ["300127", "000001"]
+    assert result["skipped_invalid_codes"] == ["113000"]
+    assert [call["code"] for call in calls] == ["300127", "000001"]
+    assert calls[0]["provenance"]["memberships"][0]["extra"]["file_name"] == "DM.blk"
+
+
+def test_sync_must_pool_accepts_explicit_filename_override(monkeypatch, tmp_path):
+    target = Path(tmp_path) / "T0002" / "blocknew" / "other.blk"
+    target.parent.mkdir(parents=True)
+    target.write_text("0300127\n", encoding="gbk")
+    fake_db = {
+        "stock_pools": FakeStockPoolsCollection(),
+        "must_pool": FakeStockPoolsCollection(),
+        "xt_positions": FakeStockPoolsCollection(),
+    }
+    monkeypatch.setattr(stock_service, "DBfreshquant", fake_db)
+    calls = []
+    monkeypatch.setattr(
+        stock_service.must_pool,
+        "import_pool",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    result = stock_service.sync_must_pool_from_tdx_self_select(
+        tdx_home=tmp_path,
+        filename="other.blk",
+    )
+
+    assert result["file_name"] == "other.blk"
+    assert result["synced_codes"] == ["300127"]


### PR DESCRIPTION
## 背景

前端 `/kline-slim` 左侧 must_pool 分组点击「同步待买」一直返回 500：
`FileNotFoundError: TDX self-select file not found: /opt/tdx/T0002/blocknew/待买.blk`。

根因有两层：

1. `sync_must_pool_from_tdx_self_select` 硬编码读取 `T0002/blocknew/待买.blk`，但通达信板块文件由 `blocknew.cfg` 把显示名映射到真实文件名（当前宿主机「待买」→ `DM.blk`），`待买.blk` 并不存在。
2. 本地 compose 栈未设置 `FQPACK_TDX_SYNC_DIR` 时回退到空的 `D:/tdx_biduan`，API 容器 `/opt/tdx` 读不到任何 TDX 文件。

## 目标

- 「同步待买」按通达信实际板块文件导入 `must_pool`，不再因文件名假设失败。
- 本地 compose 默认挂载真实 TDX 目录，避免空目录回退。

## 范围

- `freshquant/stock_service.py`：新增 `read_tdx_blocknew_cfg_mapping` / `resolve_tdx_block_filename`，`sync_must_pool_from_tdx_self_select` 按显示名「待买」从 `blocknew.cfg` 解析真实 BLK 文件名，cfg 缺失或未登记时回退 `待买.blk`。
- `docker/compose.parallel.yaml`：`FQPACK_TDX_SYNC_DIR` 默认值 `D:/tdx_biduan` → `D:/new_tdx`。
- 测试：新增 blocknew.cfg 解析、映射读取、回退与显式文件名覆盖用例；更新 compose 挂载策略断言。
- `docs/current/**`：configuration / deployment / interfaces / kline-webui / stock-pools-and-positions 同步当前行为。

## 非目标

- 不修改「同步自选股」（`ZXG.blk`）路径。
- 不处理与本 PR 无关的既有本地 pytest 顺序/环境性失败（`test_runtime_memory`、`test_stock_service_tdx_self_select` 持仓用例、order reconcile 用例，均已在 main 基线复现）。

## 验收标准

- 单测：`test_stock_service_tdx_self_select.py`、`test_must_pool_data.py`、`test_docker_runtime_policy.py` 全绿。
- 真实数据：`resolve_tdx_block_filename(tdx_home='D:/new_tdx') == 'DM.blk'`，解码出 `688772/688311/000829/001696`。
- API 修复后 `POST /api/sync_must_pool_from_tdx_self_select?days=30` 返回 `code=0`，must_pool 增量导入（持仓跳过）。

## 部署影响

- `freshquant/stock_service.py` 变更 → 重部署 API server（`docker/compose.parallel.yaml` 变更随 API 一起重建）。
- 部署时无需额外环境变量（默认已指向 `D:/new_tdx`）；生产 workflow 显式 `FQPACK_TDX_SYNC_DIR=D:/new_tdx` 保持不变。