### PR TITLE
ci(deploy): deploy to all three production runners via matrix

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -17,7 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         runner: [prod-101, prod-100, prod-116]
-    runs-on: [self-hosted, windows, ${{ matrix.runner }}]
+    runs-on:
+      - self-hosted
+      - windows
+      - ${{ matrix.runner }}
     env:
       FQ_DEPLOY_CANONICAL_REPO_ROOT: D:\fqpack\freshquant-2026.2.23
       FQ_DOCKER_FORCE_LOCAL_BUILD: "1"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,11 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, windows, production]
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [prod-101, prod-100, prod-116]
+    runs-on: [self-hosted, windows, ${{ matrix.runner }}]
     env:
       FQ_DEPLOY_CANONICAL_REPO_ROOT: D:\fqpack\freshquant-2026.2.23
       FQ_DOCKER_FORCE_LOCAL_BUILD: "1"

--- a/docs/current/deployment.md
+++ b/docs/current/deployment.md
@@ -36,6 +36,7 @@ docker compose -f docker/compose.parallel.yaml up -d --build
 ### 自动正式部署
 
 - `deploy-production.yml` 由 `push main` 直接触发，不需要额外审批。
+- `deploy-production.yml` 的 deploy job 使用 `[self-hosted, windows, prod-101/prod-100/prod-116]` 三机矩阵，一次 `push main` 在三台正式机器（101 本机 / 100 / 116）上分别执行正式部署；各机 runner 以唯一 label `prod-101` / `prod-100` / `prod-116` 注册，并共用 `self-hosted,windows,production`。
 - `deploy-production.yml` 现在只调用 `script/ci/run_production_deploy.ps1`，不再在 workflow YAML 内手工展开 canonical main sync、`uv sync` 和 `run_formal_deploy.py`。
 - `deploy-production.yml` 的 job env 显式设置 `FQPACK_TDX_SYNC_DIR=D:/new_tdx`，保证后续 Compose 插值把正式通达信目录挂载到 API 容器；仓库 Compose 默认值也已是 `D:/new_tdx`（可用 `FQPACK_TDX_SYNC_DIR` 覆盖），不再使用空的 `D:/tdx_biduan` 回退。
 - `deploy-production.yml` 当前只要求 canonical repo root 能 fetch 到最新 `origin/main`；它不再要求 canonical repo root 本身先 `pull --ff-only` 到远程 main。

--- a/docs/current/runtime.md
+++ b/docs/current/runtime.md
@@ -241,7 +241,7 @@
 - 宿主机 `.env` 示例默认不再携带 `ALL_PROXY`、`HTTP_PROXY`、`HTTPS_PROXY`、`NO_PROXY` 及其小写变量
 - Production Docker API 使用 `FQ_COMPOSE_ENV_FILE` 指向 `D:/fqpack/config/fqnext.compose.env`，不要依赖会被 `git clean -ffdx` 清理的仓库根 `.env`
 - GHCR 预构建镜像仅用于加速 Docker 部署，不改变运行真值；实际运行真值仍来自当前 `main`、deploy 结果与 health/runtime ops evidence
-- `deploy-production.yml` 在正式 Windows self-hosted runner 上把 deploy state / logs 固化到 `formal-deploy` artifacts 目录，但正式 deploy 真值已经改为本机 mirror，不再依赖下载部署归档或把 Docker Images 作为前置。
+- `deploy-production.yml` 在三台正式 Windows self-hosted runner（`prod-101` / `prod-100` / `prod-116`）上分别把 deploy state / logs 固化到各自 `formal-deploy` artifacts 目录，但正式 deploy 真值已经改为本机 mirror，不再依赖下载部署归档或把 Docker Images 作为前置。
 - `deploy-production.yml` 不走 `actions/checkout`，而是先把 `D:\fqpack\freshquant-2026.2.23` 这个 local main sync root reset 到目标 SHA，再直接调用那里的 `script/ci/run_production_deploy.ps1`；随后该脚本继续确保 `D:\fqpack\freshquant-2026.2.23` 这个本机 canonical repo root worktree 存在并 fast-forward 到目标 SHA。
 - canonical repo root clean 会保留 `.venv`、`.pytest_cache` 和 `logs/runtime`；这些路径分别承载 live virtualenv、pytest 本地缓存和运行日志，不作为 formal deploy 的 stale source artifact 清理对象。
 - bootstrap entrypoint 在 canonical main sync 阶段会从当前 entrypoint repo 解析 `sync_local_deploy_mirror.py`，避免 stale `canonical repo root` 工作树里的旧 helper 把 `.venv\` 清理逻辑回退到 `git clean -ffdX`。


### PR DESCRIPTION
## 背景

生产部署 workflow `deploy-production.yml` 之前依赖单一 `[self-hosted, windows, production]` runner，但 GitHub 侧 runner 注册数为 0，导致 #522/#523 部署排队数小时无法执行。

三台正式机器（本机 101 / 100 / 116）均已注册 self-hosted runner（fq-prod-101 / fq-prod-100 / fq-prod-116，唯一 label prod-101 / prod-100 / prod-116），需要一次 `push main` 同时部署三台。

## 目标

- `push main` 后 deploy job 按 `prod-101 / prod-100 / prod-116` 矩阵在三台机器上分别执行正式部署。
- 单机 runner 故障不影响其他机器（fail-fast: false）。

## 范围

- `.github/workflows/deploy-production.yml`：deploy job 增加 `strategy.matrix.runner = [prod-101, prod-100, prod-116]`，`runs-on: [self-hosted, windows, ${{ matrix.runner }}]`。
- `docs/current/deployment.md`、`docs/current/runtime.md`：同步三机矩阵事实。

## 非目标

- 不改部署脚本 `run_production_deploy.ps1` 本身。
- 不处理 100 venv 损坏等既有机器环境问题（部署脚本有 venv 自愈逻辑）。

## 验收标准

- 本 PR CI 通过（workflow 改动仅文档/策略断言，CI 中 frontend 跳过）。
- merge 后新 deploy run 在三个 matrix job 上分别执行；三台机器 `production-state.json` 更新到同一 SHA。
- 任一机器 runner 离线时，其余两台照常部署。

## 部署影响

- 本次 merge 本身会触发一次三机矩阵部署（目标 SHA = 当前 main tip）。
- 部署产物与 `FQ_DEPLOY_CANONICAL_REPO_ROOT=D:\fqpack\freshquant-2026.2.23`、`FQPACK_TDX_SYNC_DIR=D:/new_tdx` 保持不变。