### PR TITLE
fix(qfq): count source_invalid_close exclusions in update stats

### DIFF
--- a/docs/current/modules/market-data-xtdata.md
+++ b/docs/current/modules/market-data-xtdata.md
@@ -79,6 +79,7 @@ consumer 会在启动时做历史 prewarm，并在 backlog 很高时进入 catch
 - `front_ratio` 只证明缺口未跨公司行为，不参与 canonical 因子计算。若有界内部缺口两端比率变化，writer 不推断缺失日因子，而是删除该 code 在本轮 slot 的残留并记录 `{code, reason=source_adjustment_gap_unproven}`；其他 code 审计通过时 marker 仍可 ready。前后缀缺口、proof 缺失、none/front_ratio 日期轴不一致及其他 proof 错误仍中止整个 scope。
 - 完整 source 区间下载后仍无 `none` bars 的 code 同样不生成空因子或 `1.0`，并记录 `{code, reason=source_empty_bars}`。A/B 各自保留自己的 `source_exclusions[]`，rollback 随 slot 一起恢复。tail 请求为空必须先用完整 BFQ 区间复核；`front_ratio` proof 为空不属于该分类，继续 fail closed。
 - primary `none` loader 完成单调前缀分页后仍报告 `history_prefix_no_progress` 时，该 code 记录 `{code, reason=source_prefix_unavailable}` 并从本轮 slot 隔离；同一错误来自 `front_ratio` proof loader 时仍中止 scope。普通 unbounded prefix/suffix、proof 缺失和日期轴不一致不进入该分类。
+- 无效收盘数据（`failure=source_invalid_close`，如收盘价缺失或非法）的 code 同样从本轮 slot 隔离并记录 `{code, reason=source_invalid_close}`；`qfq_worker build` 的 scope stats 按 `{reason}_excluded` 键动态统计全部排除原因（含 `source_invalid_close_excluded`），其余 code 审计通过时 marker 仍可 ready。
 - XTData 长区间下载只返回近期后缀时，QFQ client 会以当前最早缓存日的前一日为边界继续向前分页，直至覆盖请求起点；任一页未把最早日期向前推进时立即报错，不发布不完整快照。
 - Stock / ETF 在线 reader 统一使用 `freshquant.data.qfq_reader`：每个请求重新解析 marker 指向的 active slot，严格验证 snapshot、请求日期覆盖、正因子、重复键、source exclusion 与 snapshot-bound override；失败统一为 `QFQ_DATA_NOT_READY`，Stock Kline API 映射 HTTP 503。K 线读取路径对源 bar 中的 QASU sentinel 占位行（`vol/volume` 与 `amount` 均为 `5.877471754e-39`）按快照构建同一语义跳过：缺失因子日期全部可证明为占位行时剔除这些行后继续返回，不回退 `adj=1.0`。
 - StrategyConsumer 先落 raw realtime bar，再执行严格 QFQ 派生；Redis Kline key/payload 和常驻窗口绑定 effective adjustment version，版本变化后旧缓存 miss、窗口 reload。

--- a/freshquant/market_data/xtdata/qfq.py
+++ b/freshquant/market_data/xtdata/qfq.py
@@ -2793,7 +2793,8 @@ def _update_scope(
                 source_exclusions.append(
                     {"code": normalize_code(code), "reason": exclusion_reason}
                 )
-                stats[f"{exclusion_reason}_excluded"] += 1
+                stats_key = f"{exclusion_reason}_excluded"
+                stats[stats_key] = stats.get(stats_key, 0) + 1
                 _record_source_exclusion(
                     coverage_summary, code=code, reason=exclusion_reason
                 )

--- a/freshquant/tests/test_xtdata_qfq.py
+++ b/freshquant/tests/test_xtdata_qfq.py
@@ -1721,6 +1721,45 @@ def test_update_excludes_primary_history_prefix_no_progress():
     assert {row["code"] for row in db["stock_adj_qfq_b"].rows} == {"000001"}
 
 
+def test_update_counts_source_invalid_close_exclusion():
+    dates = ["2026-01-02", "2026-01-05"]
+    codes = ("000001", "000002")
+    db = _DB(
+        stock_list=[{"code": code} for code in codes],
+        stock_day=[{"code": code, "date": dates[0]} for code in codes],
+    )
+    invalid_close = False
+
+    def loader(code, **_kwargs):
+        if invalid_close and code == "000002":
+            raise qfq.QFQSyncError(
+                "invalid close value",
+                stats={"failure": "source_invalid_close"},
+            )
+        return _bars(
+            [(value, 10.0, 0.0 if value == dates[0] else 10.0) for value in dates]
+        )
+
+    qfq.sync_stock_adj_all(target_date=dates[0], db=db, bars_loader=loader)
+    db["stock_day"].rows.extend({"code": code, "date": dates[1]} for code in codes)
+    invalid_close = True
+
+    result = qfq.sync_stock_adj_all(
+        target_date=dates[-1],
+        db=db,
+        bars_loader=loader,
+        min_grace_seconds=0,
+    )
+
+    exclusion = {"code": "000002", "reason": "source_invalid_close"}
+    scope = result["by_scope"]["stock"]
+    assert scope["stats"]["source_invalid_close_excluded"] == 1
+    assert scope["coverage"]["source_invalid_close"] == [exclusion]
+    assert scope["marker"]["slots"]["a"]["source_exclusions"] == []
+    assert scope["marker"]["slots"]["b"]["source_exclusions"] == [exclusion]
+    assert {row["code"] for row in db["stock_adj_qfq_b"].rows} == {"000001"}
+
+
 def test_update_rejects_snapshot_when_all_codes_are_source_excluded():
     dates = ["2026-01-02", "2026-01-05"]
     codes = ("000001", "000002")


### PR DESCRIPTION
## 背景

在 116 上执行 QFQ 前复权数据重建（`qfq_worker build --scope stock --target-date 2026-08-07 --full`）时复现崩溃：

```
File "qfq.py", line 2796, in _update_scope
    stats[f"{exclusion_reason}_excluded"] += 1
KeyError: 'source_invalid_close_excluded'
```

`stats` 只预初始化了 `source_empty_bars / source_prefix_unavailable / source_adjustment_gap_unproven` 三个排除键；当股票因 `source_invalid_close`（无效收盘数据）被排除时，自增计数触发 KeyError，导致整个 scope 更新失败。116 的本地数据大量命中该原因（slot b 因此 failed）。

## 目标

- `qfq_worker build` 遇到 `source_invalid_close` 排除时正常计数并完成构建。

## 范围

- `freshquant/market_data/xtdata/qfq.py`：`stats` 自增改为 `stats.get(key, 0) + 1`，动态支持全部排除原因。
- `freshquant/tests/test_xtdata_qfq.py`：新增 `test_update_counts_source_invalid_close_exclusion` 回归用例（构造 `failure=source_invalid_close` 的 loader）。

## 非目标

- 不改 QFQ 因子算法本身。
- 不处理 100/116 adj_refresh_worker 的既有 Fatal（本修复是前置阻塞）。

## 验收标准

- 新回归用例通过；`test_xtdata_qfq.py / test_xtdata_qfq_worker.py / test_qfq_reader.py` 全绿。
- 部署后 100/116 执行 `qfq_worker build --scope stock --target-date 2026-08-07 --full` 成功，`qfq_worker status --scope stock` 显示 slot ready 且 factor_asof=2026-08-07。

## 部署影响

- 代码变更命中 `freshquant/market_data/**` → merge 后由三机矩阵 workflow 自动重部署三台（API + market_data 运行面）。
- 部署后需在 100/116 重新执行 QFQ 全量构建。