### PR TITLE
fix(deploy): host restart 前等待 Mongo/Redis/XTData 依赖健康，消除容器重建窗口竞态

### DIFF
--- a/freshquant/tests/test_formal_deploy_orchestrator.py
+++ b/freshquant/tests/test_formal_deploy_orchestrator.py
@@ -403,7 +403,9 @@ def test_orchestrator_runs_docker_and_host_surfaces_in_order(
         "--build",
         "fq_apiserver",
     ]
-    assert commands[2][:10] == [
+    wait_command = commands[2]
+    assert "script/ci/wait_for_deploy_dependencies.py" in wait_command
+    assert commands[3][:10] == [
         "powershell",
         "-ExecutionPolicy",
         "Bypass",
@@ -415,11 +417,11 @@ def test_orchestrator_runs_docker_and_host_surfaces_in_order(
         "market_data",
         "-BridgeIfServiceUnavailable",
     ]
-    assert commands[2][-2:] == [
+    assert commands[3][-2:] == [
         "-SupervisorConfigRepoRoot",
         str(Path(".").resolve()),
     ]
-    assert commands[3] == [
+    assert commands[4] == [
         sys.executable,
         "script/freshquant_health_check.py",
         "--surface",

--- a/freshquant/tests/test_wait_for_deploy_dependencies.py
+++ b/freshquant/tests/test_wait_for_deploy_dependencies.py
@@ -1,9 +1,23 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
+import importlib.util
 import socket
+import sys
 import threading
+from pathlib import Path
 
-from script.ci.wait_for_deploy_dependencies import wait_for_dependencies
+
+def load_module():
+    module_path = Path("script/ci/wait_for_deploy_dependencies.py")
+    spec = importlib.util.spec_from_file_location(
+        "wait_for_deploy_dependencies", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _free_port() -> int:
@@ -13,6 +27,7 @@ def _free_port() -> int:
 
 
 def test_wait_for_dependencies_returns_ok_when_ports_ready() -> None:
+    wait_for_dependencies = load_module().wait_for_dependencies
     with socket.socket() as listener:
         listener.bind(("127.0.0.1", 0))
         listener.listen(1)
@@ -30,6 +45,7 @@ def test_wait_for_dependencies_returns_ok_when_ports_ready() -> None:
 
 
 def test_wait_for_dependencies_returns_unready_after_timeout() -> None:
+    wait_for_dependencies = load_module().wait_for_dependencies
     port = _free_port()
     result = wait_for_dependencies(
         host="127.0.0.1",
@@ -44,6 +60,7 @@ def test_wait_for_dependencies_returns_unready_after_timeout() -> None:
 
 
 def test_wait_for_dependencies_recovers_when_port_opens_later() -> None:
+    wait_for_dependencies = load_module().wait_for_dependencies
     port = _free_port()
     opened = threading.Event()
 

--- a/freshquant/tests/test_wait_for_deploy_dependencies.py
+++ b/freshquant/tests/test_wait_for_deploy_dependencies.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+import socket
+import threading
+
+from script.ci.wait_for_deploy_dependencies import wait_for_dependencies
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def test_wait_for_dependencies_returns_ok_when_ports_ready() -> None:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = int(listener.getsockname()[1])
+        result = wait_for_dependencies(
+            host="127.0.0.1",
+            ports=[port],
+            timeout_seconds=5.0,
+            poll_interval_seconds=0.1,
+            connect_timeout_seconds=0.5,
+        )
+    assert result["ok"] is True
+    assert result["ready"] is True
+    assert result["ports"] == [port]
+
+
+def test_wait_for_dependencies_returns_unready_after_timeout() -> None:
+    port = _free_port()
+    result = wait_for_dependencies(
+        host="127.0.0.1",
+        ports=[port],
+        timeout_seconds=1.0,
+        poll_interval_seconds=0.1,
+        connect_timeout_seconds=0.2,
+    )
+    assert result["ok"] is False
+    assert result["ready"] is False
+    assert result["unready_ports"] == [port]
+
+
+def test_wait_for_dependencies_recovers_when_port_opens_later() -> None:
+    port = _free_port()
+    opened = threading.Event()
+
+    def open_later() -> None:
+        opened.wait(timeout=2.0)
+        with socket.socket() as listener:
+            listener.bind(("127.0.0.1", port))
+            listener.listen(1)
+            listener.settimeout(1.0)
+            try:
+                listener.accept()
+            except OSError:
+                pass
+
+    thread = threading.Thread(target=open_later, daemon=True)
+    thread.start()
+    try:
+        result = wait_for_dependencies(
+            host="127.0.0.1",
+            ports=[port],
+            timeout_seconds=5.0,
+            poll_interval_seconds=0.1,
+            connect_timeout_seconds=0.3,
+        )
+    finally:
+        opened.set()
+        thread.join(timeout=3.0)
+    assert result["ok"] is True
+    assert result["ready"] is True

--- a/script/ci/run_formal_deploy.py
+++ b/script/ci/run_formal_deploy.py
@@ -252,6 +252,21 @@ def build_host_command(command: list[str], repo_root: Path) -> list[str]:
     return [*command, "-SupervisorConfigRepoRoot", str(repo_root)]
 
 
+def build_wait_dependencies_command(
+    python_executable: str,
+    *,
+    timeout_seconds: float = 180.0,
+) -> list[str]:
+    """Wait for Mongo / Redis / XTData TCP ports before the host restart."""
+
+    return [
+        python_executable,
+        "script/ci/wait_for_deploy_dependencies.py",
+        "--timeout-seconds",
+        str(timeout_seconds),
+    ]
+
+
 def build_plan(
     plan_module, bootstrap: bool, changed_paths: list[str]
 ) -> dict[str, Any]:
@@ -336,6 +351,17 @@ def run_formal_deploy(
                     list(plan["docker_command"]),
                     repo_root=repo_root,
                     output_path=run_dir / "10-docker-deploy.log",
+                )
+
+            if plan["host_command"]:
+                wait_command = build_wait_dependencies_command(
+                    resolved_python_executable,
+                )
+                commands.append(wait_command)
+                execute_command(
+                    wait_command,
+                    repo_root=repo_root,
+                    output_path=run_dir / "12-dependency-wait.log",
                 )
 
             if plan["host_command"]:

--- a/script/ci/wait_for_deploy_dependencies.py
+++ b/script/ci/wait_for_deploy_dependencies.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+
+"""Wait for deploy-critical host dependencies to accept TCP connections.
+
+The host runtime restart (EnsureServiceAndRestartSurfaces) starts supervisor
+programs that read Mongo / Redis / XTData at process start.  When Docker
+containers are rebuilt in the same deploy window, those dependencies can be
+briefly unreachable, making producer/consumer exit immediately after start
+and exhausting the settle-retry budget.  This script polls the dependency
+TCP ports before the host restart so programs start with dependencies ready.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import sys
+import time
+from typing import Iterable
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORTS = (27027, 6380, 58610)
+DEFAULT_TIMEOUT_SECONDS = 180.0
+DEFAULT_POLL_INTERVAL_SECONDS = 5.0
+DEFAULT_CONNECT_TIMEOUT_SECONDS = 2.0
+
+
+def _port_ready(host: str, port: int, connect_timeout_seconds: float) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=connect_timeout_seconds):
+            return True
+    except OSError:
+        return False
+
+
+def wait_for_dependencies(
+    *,
+    host: str,
+    ports: Iterable[int],
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+    connect_timeout_seconds: float,
+) -> dict[str, object]:
+    normalized_ports = [int(port) for port in ports]
+    deadline = time.time() + float(timeout_seconds)
+    last_unready = list(normalized_ports)
+    while time.time() < deadline:
+        unready = [
+            port
+            for port in normalized_ports
+            if not _port_ready(host, port, connect_timeout_seconds)
+        ]
+        last_unready = unready
+        if not unready:
+            return {
+                "ok": True,
+                "host": host,
+                "ports": normalized_ports,
+                "ready": True,
+                "elapsed_seconds": round(
+                    float(timeout_seconds) - max(deadline - time.time(), 0.0),
+                    2,
+                ),
+            }
+        time.sleep(poll_interval_seconds)
+    return {
+        "ok": False,
+        "host": host,
+        "ports": normalized_ports,
+        "ready": False,
+        "unready_ports": last_unready,
+        "timeout_seconds": float(timeout_seconds),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Wait for host deploy dependencies (Mongo / Redis / XTData)."
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST, help="Dependency host.")
+    parser.add_argument(
+        "--port",
+        action="append",
+        type=int,
+        default=[],
+        help="TCP port to probe (repeatable).",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Total wait budget in seconds.",
+    )
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=float,
+        default=DEFAULT_POLL_INTERVAL_SECONDS,
+        help="Poll interval in seconds.",
+    )
+    parser.add_argument(
+        "--connect-timeout-seconds",
+        type=float,
+        default=DEFAULT_CONNECT_TIMEOUT_SECONDS,
+        help="Per-probe connect timeout in seconds.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    ports = list(args.port) or list(DEFAULT_PORTS)
+    result = wait_for_dependencies(
+        host=args.host,
+        ports=ports,
+        timeout_seconds=args.timeout_seconds,
+        poll_interval_seconds=args.poll_interval_seconds,
+        connect_timeout_seconds=args.connect_timeout_seconds,
+    )
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## 背景

#529D 统一部署：101 成功，但 100/116 的 Deploy Production job 连续 4 次在 host reconcile 阶段失败，签名一致：
`fqnext_realtime_xtdata_producer did not reach RUNNING; last state=Exited`。

根因（机器事实，100/116 一致）：
- 部署流程先重建 Docker 容器（Mongo/Redis 在容器内），随后宿主机重启 supervisor 程序；
- 窗口内 producer 启动时 Mongo（127.0.0.1:27027）恰好不可达 → `ServerSelectionTimeoutError`（30s）→ 进程真实 Exited；
- `fqnext_host_runtime.py restart_programs` 的 settle-retry 预算（2×30s）耗尽判失败；
- 随后 supervisor autorestart 在依赖就绪后把程序拉起（新代码 trading/screening 双布尔已生效，手动 Verify passed=True）。

#527 只解决了“程序启动慢/瞬时抖动”类 settle 竞态，**未覆盖“启动时依赖未就绪导致真实 Exited”**——这是本次暴露的确定性缺口，重跑无法解决。

## 变更

- 新增 `script/ci/wait_for_deploy_dependencies.py`：轮询 Mongo(27027) / Redis(6380) / XTData(58610) TCP 端口，默认 180s 超时、5s 间隔、2s 单次连接超时；失败非零退出。
- `run_formal_deploy.py`：在 docker deploy（10-docker-deploy.log）与 host restart（11-host-deploy.log）之间插入依赖等待步骤（12-dependency-wait.log），确保 producer/consumer 启动时依赖已就绪。
- 新增 `test_wait_for_deploy_dependencies.py`（端口就绪/超时/延迟打开三用例）；`test_formal_deploy_orchestrator.py` 断言命令顺序 docker → wait → host → health → verify。

## 验证

- pytest：test_wait_for_deploy_dependencies / test_formal_deploy_orchestrator / test_deploy_production_workflow 24 passed。
- pre-commit（black/isort/mypy）全绿。

## 部署影响

部署编排改动；合并后重跑 100/116 的 Deploy Production job 验证 settle 通过；随后三台账本 allocation_integrity 零错误验收并收口 #529/#530/#531。
