### PR TITLE
fix(deploy): restart 前终止 shim 整棵进程树，消除孤儿解释器占用资源导致的首次启动失败

### DIFF
--- a/freshquant/tests/test_fqnext_host_runtime.py
+++ b/freshquant/tests/test_fqnext_host_runtime.py
@@ -283,6 +283,7 @@ def test_restart_programs_retries_start_when_first_attempt_exits(
 ) -> None:
     module = load_module()
     start_calls: list[tuple[str, bool]] = []
+    tree_kill_calls: list[int] = []
     running_wait_calls = {"value": 0}
     process_infos = iter(
         [
@@ -303,6 +304,7 @@ def test_restart_programs_retries_start_when_first_attempt_exits(
         return True
 
     server.supervisor.startProcess = fake_start_process
+    monkeypatch.setattr(module, "terminate_process_tree", tree_kill_calls.append)
 
     monkeypatch.setattr(
         module, "get_process_info", lambda _server, _name: next(process_infos)
@@ -338,6 +340,7 @@ def test_restart_programs_retries_start_when_first_attempt_exits(
         ("fqnext_realtime_xtdata_producer", False),
         ("fqnext_realtime_xtdata_producer", False),
     ]
+    assert tree_kill_calls == [11]
     assert results == [
         {
             "name": "fqnext_realtime_xtdata_producer",

--- a/script/fqnext_host_runtime.py
+++ b/script/fqnext_host_runtime.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import argparse
 import configparser
 import json
+import os
 import re
+import subprocess
 import time
 import xmlrpc.client
 from pathlib import Path
@@ -125,6 +127,31 @@ def build_server_proxy(rpc_url: str) -> xmlrpc.client.ServerProxy:
 
 def get_process_info(server: xmlrpc.client.ServerProxy, name: str) -> dict[str, object]:
     return cast(dict[str, object], cast(Any, server.supervisor.getProcessInfo(name)))
+
+
+def terminate_process_tree(pid: int) -> None:
+    """Force-terminate a Windows process tree (shim + real interpreter child).
+
+    The venv ``.venv/Scripts/python.exe`` is a shim that spawns the real
+    interpreter as a child process.  ``supervisor.stopProcess`` only stops
+    the supervisor-tracked shim pid, so the real interpreter can survive as
+    an orphan holding XTData / Redis / Mongo resources; the next
+    ``startProcess`` then exits immediately and exhausts the settle budget.
+    ``taskkill /T /F`` removes the whole tree so the restart starts clean.
+    """
+
+    if int(pid or 0) <= 0:
+        return
+    if os.name != "nt":
+        return
+    try:
+        subprocess.run(
+            ["taskkill", "/PID", str(int(pid)), "/T", "/F"],
+            capture_output=True,
+            timeout=15,
+        )
+    except Exception:  # pragma: no cover - best-effort cleanup
+        pass
 
 
 def wait_for_state(
@@ -293,6 +320,8 @@ def restart_programs(
                 wait_for_state(
                     server, program, "STOPPED", timeout_seconds=timeout_seconds
                 )
+                terminate_process_tree(int(str(before.get("pid") or 0)))
+                time.sleep(1.0)
 
             after: dict[str, object] | None = None
             last_error: RuntimeError | None = None


### PR DESCRIPTION
## 背景

#529D 部署收口后，100/116 的 Deploy Production job 仍红（第 5 次）：即使 #538 已保证依赖端口就绪，`fqnext_realtime_xtdata_producer` 在 stop→start 后仍 Exited。

根因（机器事实）：`.venv/Scripts/python.exe` 是 shim，spawn 真实解释器（uv/Python312）为子进程；`supervisor.stopProcess` 只终止 supervisor 追踪的 shim pid，真实解释器作为孤儿残留，占用 XTData/Redis/Mongo 资源 → 下一次 `startProcess` 的新进程启动即 Exited，settle 预算（2×30s）耗尽；随后 supervisor autorestart 在孤儿退出后拉起成功。

## 变更

- `fqnext_host_runtime.py` 新增 `terminate_process_tree(pid)`：Windows 下 `taskkill /PID <pid> /T /F` 终止整棵进程树（shim + 真实解释器）；非 Windows / pid<=0 / 失败时静默跳过。
- `restart_programs`：stopProcess + wait STOPPED 之后、startProcess 之前，调用 `terminate_process_tree(before.pid)` 并 sleep 1s，确保孤儿解释器退出、资源释放后再启动。
- `test_fqnext_host_runtime.py`：断言 restart 流程在 stop 后调用树清理（`tree_kill_calls == [11]`）。

## 验证

- pytest test_fqnext_host_runtime.py：20 passed。
- pre-commit（black/isort/mypy）全绿。

## 部署影响

部署编排改动；合并后触发三机矩阵部署，预期 100/116 host reconcile 不再因孤儿进程占用资源而 Exited；随后收口验收。
